### PR TITLE
chore: bump nestjs-doctor-vscode to 0.1.1

### DIFF
--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "nestjs-doctor-vscode",
   "displayName": "NestJS Doctor",
   "description": "Static analysis for NestJS — inline diagnostics and health score",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "rolobits",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Bump version so the publish-vscode workflow publishes the updated metadata (icon, badges, keywords, README) to the VS Code Marketplace.