### PR TITLE
fix: treat @Resolver and @WebSocketGateway as implicit @Injectable

### DIFF
--- a/.changeset/graphql-resolver-injectable.md
+++ b/.changeset/graphql-resolver-injectable.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Treat `@Resolver` and `@WebSocketGateway` as implicit `@Injectable` to prevent false positives in GraphQL and WebSocket apps.

--- a/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
+++ b/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
@@ -56,6 +56,17 @@ export function isService(cls: ClassDeclaration): boolean {
 	return hasDecorator(cls, "Injectable");
 }
 
+// NestJS treats @Resolver and @WebSocketGateway as implicit @Injectable —
+// they participate in dependency injection without requiring an explicit @Injectable() decorator.
+export function isInjectable(cls: ClassDeclaration): boolean {
+	return (
+		hasDecorator(cls, "Injectable") ||
+		hasDecorator(cls, "Controller") ||
+		hasDecorator(cls, "Resolver") ||
+		hasDecorator(cls, "WebSocketGateway")
+	);
+}
+
 export function isModule(cls: ClassDeclaration): boolean {
 	return hasDecorator(cls, "Module");
 }

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/prefer-constructor-injection.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/prefer-constructor-injection.ts
@@ -1,4 +1,4 @@
-import { isController, isService } from "../../../nest-class-inspector.js";
+import { isInjectable } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
 export const preferConstructorInjection: Rule = {
@@ -13,7 +13,7 @@ export const preferConstructorInjection: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!(isService(cls) || isController(cls))) {
+			if (!isInjectable(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-missing-injectable.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-missing-injectable.ts
@@ -55,7 +55,13 @@ export const noMissingInjectable: ProjectRule = {
 					const hasConstructorDependencies =
 						(ctorDecl?.getParameters().length ?? 0) > 0;
 
-					if (!cls.getDecorator("Injectable") && hasConstructorDependencies) {
+					// @Resolver and @WebSocketGateway implicitly apply @Injectable() metadata in NestJS,
+					// so classes with these decorators don't need an explicit @Injectable() decorator.
+					const hasImplicitInjectable =
+						cls.getDecorator("Injectable") ||
+						cls.getDecorator("Resolver") ||
+						cls.getDecorator("WebSocketGateway");
+					if (!hasImplicitInjectable && hasConstructorDependencies) {
 						context.report({
 							filePath,
 							message: `Class '${providerName}' is listed in '${mod.name}' providers but is missing @Injectable() decorator.`,

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/require-inject-decorator.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/require-inject-decorator.ts
@@ -1,4 +1,4 @@
-import { hasDecorator } from "../../../nest-class-inspector.js";
+import { isInjectable } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
 export const requireInjectDecorator: Rule = {
@@ -13,9 +13,7 @@ export const requireInjectDecorator: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (
-				!(hasDecorator(cls, "Injectable") || hasDecorator(cls, "Controller"))
-			) {
+			if (!isInjectable(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
@@ -28,7 +28,9 @@ export const noUnusedProviders: ProjectRule = {
 			}
 		}
 
-		// Also collect controller dependencies
+		// Resolvers and gateways inject services via constructor just like controllers,
+		// so their dependencies must be counted to avoid false "unused provider" warnings.
+		const CONSUMER_DECORATORS = ["Controller", "Resolver", "WebSocketGateway"];
 		for (const filePath of context.files) {
 			const sourceFile = context.project.getSourceFile(filePath);
 			if (!sourceFile) {
@@ -36,7 +38,10 @@ export const noUnusedProviders: ProjectRule = {
 			}
 
 			for (const cls of sourceFile.getClasses()) {
-				if (!cls.getDecorator("Controller")) {
+				const isConsumer = CONSUMER_DECORATORS.some(
+					(d) => cls.getDecorator(d) !== undefined
+				);
+				if (!isConsumer) {
 					continue;
 				}
 				const ctor = cls.getConstructors()[0];

--- a/packages/nestjs-doctor/tests/fixtures/graphql-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/graphql-app/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { PostsModule } from "./posts/posts.module";
+import { RecipesModule } from "./recipes/recipes.module";
+
+@Module({
+	imports: [RecipesModule, PostsModule],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/graphql-app/src/posts/posts-analytics.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/graphql-app/src/posts/posts-analytics.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class PostsAnalyticsService {
+	getStats(postId: string) {
+		return { postId, views: 0, likes: 0 };
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/graphql-app/src/posts/posts.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/graphql-app/src/posts/posts.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { PostsAnalyticsService } from "./posts-analytics.service";
+import { PostsResolver } from "./posts.resolver";
+import { PostsService } from "./posts.service";
+
+@Module({
+	providers: [PostsResolver, PostsService, PostsAnalyticsService],
+})
+export class PostsModule {}

--- a/packages/nestjs-doctor/tests/fixtures/graphql-app/src/posts/posts.resolver.ts
+++ b/packages/nestjs-doctor/tests/fixtures/graphql-app/src/posts/posts.resolver.ts
@@ -1,0 +1,36 @@
+import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { PostsAnalyticsService } from "./posts-analytics.service";
+import { PostsService } from "./posts.service";
+
+@Resolver("Post")
+export class PostsResolver {
+	constructor(
+		private readonly postsService: PostsService,
+		private readonly analyticsService: PostsAnalyticsService,
+	) {}
+
+	@Query()
+	post(@Args("id") id: string) {
+		return this.postsService.findOneById(id);
+	}
+
+	@Query()
+	posts() {
+		return this.postsService.findAll();
+	}
+
+	@Mutation()
+	createPost(@Args("title") title: string) {
+		return this.postsService.create(title);
+	}
+
+	@Mutation()
+	removePost(@Args("id") id: string) {
+		return this.postsService.remove(id);
+	}
+
+	@Query()
+	postStats(@Args("id") id: string) {
+		return this.analyticsService.getStats(id);
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/graphql-app/src/posts/posts.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/graphql-app/src/posts/posts.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class PostsService {
+	findOneById(id: string) {
+		return { id, title: "Post" };
+	}
+
+	findAll() {
+		return [{ id: "1", title: "Post" }];
+	}
+
+	create(title: string) {
+		return { id: "2", title };
+	}
+
+	remove(id: string) {
+		return { id, removed: true };
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/graphql-app/src/recipes/recipes.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/graphql-app/src/recipes/recipes.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { RecipesResolver } from "./recipes.resolver";
+import { RecipesService } from "./recipes.service";
+
+@Module({
+	providers: [RecipesResolver, RecipesService],
+})
+export class RecipesModule {}

--- a/packages/nestjs-doctor/tests/fixtures/graphql-app/src/recipes/recipes.resolver.ts
+++ b/packages/nestjs-doctor/tests/fixtures/graphql-app/src/recipes/recipes.resolver.ts
@@ -1,0 +1,45 @@
+import {
+	Args,
+	Mutation,
+	Parent,
+	Query,
+	ResolveField,
+	Resolver,
+} from "@nestjs/graphql";
+import { RecipesService } from "./recipes.service";
+
+class Recipe {
+	id!: string;
+	title!: string;
+	description!: string;
+}
+
+@Resolver(() => Recipe)
+export class RecipesResolver {
+	constructor(private readonly recipesService: RecipesService) {}
+
+	@Query()
+	recipe(@Args("id") id: string) {
+		return this.recipesService.findOneById(id);
+	}
+
+	@Query()
+	recipes() {
+		return this.recipesService.findAll();
+	}
+
+	@Mutation()
+	addRecipe(@Args("title") title: string) {
+		return this.recipesService.create(title);
+	}
+
+	@Mutation()
+	removeRecipe(@Args("id") id: string) {
+		return this.recipesService.remove(id);
+	}
+
+	@ResolveField()
+	description(@Parent() recipe: Recipe) {
+		return `A description for ${recipe.title}`;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/graphql-app/src/recipes/recipes.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/graphql-app/src/recipes/recipes.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class RecipesService {
+	findOneById(id: string) {
+		return { id, title: "Recipe" };
+	}
+
+	findAll() {
+		return [{ id: "1", title: "Recipe" }];
+	}
+
+	create(title: string) {
+		return { id: "2", title };
+	}
+
+	remove(id: string) {
+		return true;
+	}
+}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -250,6 +250,58 @@ describe("scanner integration", () => {
 		expect(secretDiags).toHaveLength(0);
 	});
 
+	it("produces a clean result for graphql-app (resolvers are implicit injectables)", async () => {
+		const targetPath = resolve(FIXTURES, "graphql-app/src");
+		const scanConfig = await resolveScanConfig(targetPath);
+		const context = await buildAnalysisContext(targetPath, scanConfig);
+		const rawOutput = diagnose(context);
+		const { result } = buildResult(
+			context,
+			rawOutput,
+			scanConfig.customRuleWarnings
+		);
+
+		// Should NOT flag @Resolver as missing @Injectable
+		expect(
+			result.diagnostics.filter(
+				(d) => d.rule === "correctness/no-missing-injectable"
+			)
+		).toHaveLength(0);
+
+		// Should NOT flag resolver constructor params
+		expect(
+			result.diagnostics.filter(
+				(d) => d.rule === "correctness/require-inject-decorator"
+			)
+		).toHaveLength(0);
+
+		// Should NOT flag RecipesService as unused (it's injected by the resolver)
+		expect(
+			result.diagnostics.filter(
+				(d) => d.rule === "performance/no-unused-providers"
+			)
+		).toHaveLength(0);
+
+		// Overall clean
+		expect(result.score.value).toBeGreaterThanOrEqual(90);
+		expect(result.diagnostics).toHaveLength(0);
+	});
+
+	it("counts modules correctly in graphql-app", async () => {
+		const targetPath = resolve(FIXTURES, "graphql-app/src");
+		const scanConfig = await resolveScanConfig(targetPath);
+		const context = await buildAnalysisContext(targetPath, scanConfig);
+		const rawOutput = diagnose(context);
+		const { result } = buildResult(
+			context,
+			rawOutput,
+			scanConfig.customRuleWarnings
+		);
+
+		// Should detect 3 modules: AppModule, RecipesModule, PostsModule
+		expect(result.project.moduleCount).toBe(3);
+	});
+
 	it("diagnoseMonorepo falls back to single scan for non-monorepo", async () => {
 		const targetPath = resolve(FIXTURES, "basic-app/src");
 		const result = await diagnoseMonorepo(targetPath);


### PR DESCRIPTION
## Summary

NestJS automatically applies `@Injectable()` metadata to classes decorated with `@Resolver()` (from `@nestjs/graphql`) and `@WebSocketGateway()` (from `@nestjs/websockets`). This PR updates the engine to recognize these decorators as implicit injectables, preventing false positives from rules like `no-missing-injectable`, `require-inject-decorator`, `no-unused-providers`, and `prefer-constructor-injection`.

- Added `@Resolver` and `@WebSocketGateway` recognition to `isInjectable()` in the class inspector
- Updated all affected rules to account for implicit injectable semantics
- Added a `graphql-app` test fixture with resolver and service classes
- Added integration tests verifying clean results for GraphQL apps

Closes #78