### PR TITLE
docs: update module graph for cross-file import resolution

### DIFF
--- a/.changeset/cross-file-resolution-docs.md
+++ b/.changeset/cross-file-resolution-docs.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Update module graph docs for cross-file import resolution

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -1,3 +1,4 @@
+import { dirname, resolve } from "node:path";
 import type {
 	CallExpression,
 	ClassDeclaration,
@@ -10,6 +11,7 @@ import { SyntaxKind } from "ts-morph";
 import type { ProviderInfo } from "./type-resolver.js";
 
 const FORWARD_REF_REGEX = /=>\s*(\w+)/;
+const JS_EXT_REGEX = /\.js$/;
 
 export interface ModuleNode {
 	classDeclaration: ClassDeclaration;
@@ -107,7 +109,7 @@ export function buildModuleGraph(
 	return { modules, edges, providerToModule };
 }
 
-const MAX_RESOLVE_DEPTH = 3;
+const MAX_RESOLVE_DEPTH = 5;
 
 const DYNAMIC_MODULE_METHODS = new Set([
 	"forRoot",
@@ -268,6 +270,81 @@ function extractNamesFromCallExpression(
 	return [];
 }
 
+function resolveModuleSpecifier(
+	specifier: string,
+	sourceFile: SourceFile
+): SourceFile | undefined {
+	if (!specifier.startsWith(".")) {
+		return undefined;
+	}
+
+	const dir = dirname(sourceFile.getFilePath());
+	const resolved = resolve(dir, specifier);
+	const project = sourceFile.getProject();
+
+	// Try .ts, /index.ts, exact match, and .js → .ts
+	const candidates = [
+		`${resolved}.ts`,
+		`${resolved}/index.ts`,
+		resolved,
+		resolved.replace(JS_EXT_REGEX, ".ts"),
+	];
+
+	for (const candidate of candidates) {
+		const target = project.getSourceFile(candidate);
+		if (target) {
+			return target;
+		}
+	}
+
+	return undefined;
+}
+
+function resolveImportedSourceFile(
+	name: string,
+	sourceFile: SourceFile
+): { sourceFile: SourceFile; localName: string } | undefined {
+	// Check import declarations: import { foo } from './other' or import { foo as bar } from './other'
+	for (const importDecl of sourceFile.getImportDeclarations()) {
+		for (const namedImport of importDecl.getNamedImports()) {
+			const importedName = namedImport.getAliasNode()
+				? namedImport.getAliasNode()!.getText()
+				: namedImport.getName();
+			if (importedName === name) {
+				const specifier = importDecl.getModuleSpecifierValue();
+				const target = resolveModuleSpecifier(specifier, sourceFile);
+				if (target) {
+					// Return the original exported name (not the alias)
+					return { sourceFile: target, localName: namedImport.getName() };
+				}
+				return undefined;
+			}
+		}
+	}
+
+	// Check re-exports: export { X } from './other'
+	for (const exportDecl of sourceFile.getExportDeclarations()) {
+		if (!exportDecl.getModuleSpecifierValue()) {
+			continue;
+		}
+		for (const namedExport of exportDecl.getNamedExports()) {
+			const exportedName = namedExport.getAliasNode()
+				? namedExport.getAliasNode()!.getText()
+				: namedExport.getName();
+			if (exportedName === name) {
+				const specifier = exportDecl.getModuleSpecifierValue()!;
+				const target = resolveModuleSpecifier(specifier, sourceFile);
+				if (target) {
+					return { sourceFile: target, localName: namedExport.getName() };
+				}
+				return undefined;
+			}
+		}
+	}
+
+	return undefined;
+}
+
 function resolveIdentifier(
 	name: string,
 	sourceFile: SourceFile,
@@ -277,6 +354,7 @@ function resolveIdentifier(
 		return [];
 	}
 
+	// Same-file variable lookup
 	for (const stmt of sourceFile.getStatements()) {
 		if (stmt.getKind() !== SyntaxKind.VariableStatement) {
 			continue;
@@ -292,7 +370,61 @@ function resolveIdentifier(
 		}
 	}
 
+	// Cross-file fallback
+	const imported = resolveImportedSourceFile(name, sourceFile);
+	if (imported) {
+		return resolveIdentifier(
+			imported.localName,
+			imported.sourceFile,
+			depth + 1
+		);
+	}
+
 	return [];
+}
+
+function resolveArrowFunctionBody(
+	name: string,
+	sourceFile: SourceFile,
+	depth: number
+): string[] | undefined {
+	for (const stmt of sourceFile.getStatements()) {
+		if (stmt.getKind() !== SyntaxKind.VariableStatement) {
+			continue;
+		}
+		const varStmt = stmt.asKindOrThrow(SyntaxKind.VariableStatement);
+		for (const decl of varStmt.getDeclarations()) {
+			if (decl.getName() !== name) {
+				continue;
+			}
+			const init = decl.getInitializer();
+			if (!init || init.getKind() !== SyntaxKind.ArrowFunction) {
+				continue;
+			}
+			const arrow = init.asKindOrThrow(SyntaxKind.ArrowFunction);
+			const body = arrow.getBody();
+
+			// Concise body: () => [AuthModule, HealthModule]
+			if (body.getKind() !== SyntaxKind.Block) {
+				return extractNamesFromExpression(body, sourceFile, depth);
+			}
+
+			// Block body: () => { return [...] }
+			const names: string[] = [];
+			for (const returnStmt of body.getDescendantsOfKind(
+				SyntaxKind.ReturnStatement
+			)) {
+				const returnExpr = returnStmt.getExpression();
+				if (returnExpr) {
+					names.push(
+						...extractNamesFromExpression(returnExpr, sourceFile, depth)
+					);
+				}
+			}
+			return names;
+		}
+	}
+	return undefined;
 }
 
 function resolveFunctionCall(
@@ -304,6 +436,7 @@ function resolveFunctionCall(
 		return [];
 	}
 
+	// Same-file FunctionDeclaration
 	for (const stmt of sourceFile.getStatements()) {
 		if (stmt.getKind() !== SyntaxKind.FunctionDeclaration) {
 			continue;
@@ -325,6 +458,22 @@ function resolveFunctionCall(
 			}
 		}
 		return names;
+	}
+
+	// Same-file arrow function variable: const getImports = () => [...]
+	const arrowResult = resolveArrowFunctionBody(funcName, sourceFile, depth);
+	if (arrowResult) {
+		return arrowResult;
+	}
+
+	// Cross-file fallback
+	const imported = resolveImportedSourceFile(funcName, sourceFile);
+	if (imported) {
+		return resolveFunctionCall(
+			imported.localName,
+			imported.sourceFile,
+			depth + 1
+		);
 	}
 
 	return [];

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "cross-file-imports",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/admin.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/admin.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { AdminService } from "./admin.service";
+
+@Module({
+  providers: [AdminService],
+  exports: [AdminService],
+})
+export class AdminModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/admin.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/admin.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class AdminService {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { AdminModule } from "./admin.module";
+import { getServiceCommonImports } from "./shared/common-imports";
+import { AppService } from "./app.service";
+
+@Module({
+  imports: getServiceCommonImports().concat([AdminModule]),
+  providers: [AppService],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/app.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/app.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class AppService {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/auth.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/auth.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { AuthService } from "./auth.service";
+
+@Module({
+  providers: [AuthService],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/auth.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/auth.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class AuthService {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/database.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/database.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { DatabaseService } from "./database.service";
+
+@Module({
+  providers: [DatabaseService],
+  exports: [DatabaseService],
+})
+export class DatabaseModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/database.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/database.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class DatabaseService {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/health.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/health.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { HealthService } from "./health.service";
+
+@Module({
+  providers: [HealthService],
+  exports: [HealthService],
+})
+export class HealthModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/health.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/health.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class HealthService {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/shared/base-imports.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/shared/base-imports.ts
@@ -1,0 +1,6 @@
+import { AuthModule } from "../auth.module";
+import { HealthModule } from "../health.module";
+
+export function getBaseImports() {
+  return [AuthModule, HealthModule];
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/shared/common-imports.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-imports/src/shared/common-imports.ts
@@ -1,0 +1,6 @@
+import { DatabaseModule } from "../database.module";
+import { getBaseImports } from "./base-imports";
+
+export function getServiceCommonImports() {
+  return getBaseImports().concat([DatabaseModule]);
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "cross-file-monorepo",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/app.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from "@nestjs/common";
+import type { AppService } from "./app.service";
+
+@Controller()
+export class AppController {
+	constructor(private readonly appService: AppService) {}
+
+	@Get()
+	getStatus() {
+		return this.appService.getStatus();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/app.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+import { getServiceAppCommonImports } from "./libs/app-shared";
+import { AdminAuthModule } from "./modules/admin-auth/admin-auth.module";
+import { QueueModule } from "./modules/queue/queue.module";
+
+const SERVICE_NAME = "admin-api";
+
+@Module({
+	imports: getServiceAppCommonImports({ serviceName: SERVICE_NAME }).concat([
+		AdminAuthModule,
+		QueueModule,
+	]),
+	controllers: [AppController],
+	providers: [AppService],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/app.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/app.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from "@nestjs/common";
+import type { ConfigService } from "./modules/config/config.service";
+import type { DatabaseService } from "./modules/database/database.service";
+import type { LoggerService } from "./modules/logger/logger.service";
+import type { QueueService } from "./modules/queue/queue.service";
+
+@Injectable()
+export class AppService {
+	constructor(
+		private readonly configService: ConfigService,
+		private readonly loggerService: LoggerService,
+		private readonly databaseService: DatabaseService,
+		private readonly queueService: QueueService
+	) {}
+
+	getStatus(): { service: string; status: string } {
+		return {
+			service: this.configService.get("serviceName"),
+			status: "running",
+		};
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/libs/app-shared.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/libs/app-shared.ts
@@ -1,0 +1,10 @@
+import { DatabaseModule } from "../modules/database/database.module";
+import { getAppCommonImports } from "./common-imports";
+
+export function getServiceAppCommonImports(options: {
+	serviceName: string;
+}) {
+	return getAppCommonImports({ serviceName: options.serviceName }).concat([
+		DatabaseModule,
+	]);
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/libs/common-imports.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/libs/common-imports.ts
@@ -1,0 +1,7 @@
+import { ConfigModule } from "../modules/config/config.module";
+import { HealthModule } from "../modules/health/health.module";
+import { LoggerModule } from "../modules/logger/logger.module";
+
+export function getAppCommonImports(_options?: { serviceName?: string }) {
+	return [ConfigModule.forRoot({ isGlobal: true }), LoggerModule, HealthModule];
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/admin-auth/admin-auth.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/admin-auth/admin-auth.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param } from "@nestjs/common";
+import type { AdminAuthService } from "./admin-auth.service";
+
+@Controller("admin/auth")
+export class AdminAuthController {
+	constructor(private readonly adminAuthService: AdminAuthService) {}
+
+	@Get("validate/:token")
+	validate(@Param("token") token: string) {
+		return this.adminAuthService.validate(token);
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/admin-auth/admin-auth.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/admin-auth/admin-auth.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { AdminAuthController } from "./admin-auth.controller";
+import { AdminAuthService } from "./admin-auth.service";
+
+@Module({
+	controllers: [AdminAuthController],
+	providers: [AdminAuthService],
+})
+export class AdminAuthModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/admin-auth/admin-auth.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/admin-auth/admin-auth.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class AdminAuthService {
+	validate(token: string): boolean {
+		return token.length > 0;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/config/config.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/config/config.module.ts
@@ -1,0 +1,17 @@
+import { Module } from "@nestjs/common";
+import type { DynamicModule } from "@nestjs/common";
+import { ConfigService } from "./config.service";
+
+@Module({
+	providers: [ConfigService],
+	exports: [ConfigService],
+})
+export class ConfigModule {
+	static forRoot(_options?: Record<string, unknown>): DynamicModule {
+		return {
+			module: ConfigModule,
+			providers: [ConfigService],
+			exports: [ConfigService],
+		};
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/config/config.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/config/config.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class ConfigService {
+	get(key: string): string {
+		return `config-${key}`;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/database/database.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/database/database.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { DatabaseService } from "./database.service";
+
+@Module({
+	providers: [DatabaseService],
+	exports: [DatabaseService],
+})
+export class DatabaseModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/database/database.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/database/database.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class DatabaseService {
+	query(sql: string): unknown[] {
+		return [{ sql }];
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/health/health.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/health/health.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from "@nestjs/common";
+import type { HealthService } from "./health.service";
+
+@Controller("health")
+export class HealthController {
+	constructor(private readonly healthService: HealthService) {}
+
+	@Get()
+	check() {
+		return this.healthService.check();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/health/health.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { HealthController } from "./health.controller";
+import { HealthService } from "./health.service";
+
+@Module({
+	controllers: [HealthController],
+	providers: [HealthService],
+})
+export class HealthModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/health/health.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/health/health.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class HealthService {
+	check(): { status: string } {
+		return { status: "ok" };
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/logger/logger.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/logger/logger.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { LoggerService } from "./logger.service";
+
+@Module({
+	providers: [LoggerService],
+	exports: [LoggerService],
+})
+export class LoggerModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/logger/logger.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/logger/logger.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class LoggerService {
+	log(message: string): void {
+		process.stdout.write(`[LOG] ${message}\n`);
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/queue/queue.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/queue/queue.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { QueueService } from "./queue.service";
+
+@Module({
+	providers: [QueueService],
+	exports: [QueueService],
+})
+export class QueueModule {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/queue/queue.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/queue/queue.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class QueueService {
+	enqueue(job: string): { queued: boolean } {
+		return { queued: job.length > 0 };
+	}
+}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -346,6 +346,79 @@ describe("scanner integration", () => {
 		expect(circularDiags).toHaveLength(0);
 	});
 
+	it("resolves cross-file function calls in module graph", async () => {
+		const targetPath = resolve(FIXTURES, "cross-file-imports/src");
+		const scanConfig = await resolveScanConfig(targetPath);
+		const context = await buildAnalysisContext(targetPath, scanConfig);
+		const rawOutput = diagnose(context);
+		const { result } = buildResult(
+			context,
+			rawOutput,
+			scanConfig.customRuleWarnings
+		);
+
+		// Should detect 5 modules: AppModule, AuthModule, HealthModule, DatabaseModule, AdminModule
+		expect(result.project.moduleCount).toBe(5);
+
+		// AppModule should have edges to all 4 imported modules
+		const appEdges = context.moduleGraph.edges.get("AppModule");
+		expect(appEdges).toBeDefined();
+		expect(appEdges?.has("AuthModule")).toBe(true);
+		expect(appEdges?.has("HealthModule")).toBe(true);
+		expect(appEdges?.has("DatabaseModule")).toBe(true);
+		expect(appEdges?.has("AdminModule")).toBe(true);
+
+		// No false circular deps
+		const circularDiags = result.diagnostics.filter(
+			(d) => d.rule === "architecture/no-circular-module-deps"
+		);
+		expect(circularDiags).toHaveLength(0);
+
+		// Clean score
+		expect(result.score.value).toBeGreaterThanOrEqual(90);
+	});
+
+	it("resolves cross-file monorepo-style chained imports in module graph", async () => {
+		const targetPath = resolve(FIXTURES, "cross-file-monorepo/src");
+		const scanConfig = await resolveScanConfig(targetPath);
+		const context = await buildAnalysisContext(targetPath, scanConfig);
+		const rawOutput = diagnose(context);
+		const { result } = buildResult(
+			context,
+			rawOutput,
+			scanConfig.customRuleWarnings
+		);
+
+		// Should detect 7 modules: AppModule + 6 imported
+		expect(result.project.moduleCount).toBe(7);
+
+		// AppModule should have edges to all 6 imported modules
+		const appEdges = context.moduleGraph.edges.get("AppModule");
+		expect(appEdges).toBeDefined();
+		expect(appEdges?.has("ConfigModule")).toBe(true);
+		expect(appEdges?.has("LoggerModule")).toBe(true);
+		expect(appEdges?.has("HealthModule")).toBe(true);
+		expect(appEdges?.has("DatabaseModule")).toBe(true);
+		expect(appEdges?.has("AdminAuthModule")).toBe(true);
+		expect(appEdges?.has("QueueModule")).toBe(true);
+
+		// No false circular deps
+		const circularDiags = result.diagnostics.filter(
+			(d) => d.rule === "architecture/no-circular-module-deps"
+		);
+		expect(circularDiags).toHaveLength(0);
+
+		// No orphan modules
+		const orphanDiags = result.diagnostics.filter(
+			(d) => d.rule === "architecture/no-orphan-modules"
+		);
+		expect(orphanDiags).toHaveLength(0);
+
+		// Clean score with zero diagnostics
+		expect(result.score.value).toBeGreaterThanOrEqual(90);
+		expect(result.diagnostics).toHaveLength(0);
+	});
+
 	it("diagnoseMonorepo falls back to single scan for non-monorepo", async () => {
 		const targetPath = resolve(FIXTURES, "basic-app/src");
 		const result = await diagnoseMonorepo(targetPath);

--- a/packages/nestjs-doctor/tests/unit/module-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/module-graph.test.ts
@@ -466,4 +466,341 @@ describe("module-graph", () => {
 		const app = graph.modules.get("AppModule")!;
 		expect(app.imports).toEqual([]);
 	});
+
+	// Cross-file: a function imported from another file should be resolved
+	it("resolves cross-file function call", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getImports } from './helpers';
+        @Module({ imports: getImports() })
+        export class AppModule {}
+      `,
+			"/src/helpers.ts": `
+        export function getImports() {
+          return [AuthModule, UsersModule];
+        }
+      `,
+			"/src/auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+			"/src/users.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class UsersModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("UsersModule");
+	});
+
+	// Cross-file: a variable imported from another file should be resolved
+	it("resolves cross-file variable reference", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { commonImports } from './shared';
+        @Module({ imports: commonImports })
+        export class AppModule {}
+      `,
+			"/src/shared.ts": `
+        export const commonImports = [AuthModule, UsersModule];
+      `,
+			"/src/auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+			"/src/users.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class UsersModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("UsersModule");
+	});
+
+	// Cross-file: function().concat([X]) pattern from the issue
+	it("resolves cross-file .concat() chain", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getServiceImports } from './shared';
+        @Module({ imports: getServiceImports().concat([AdminModule]) })
+        export class AppModule {}
+      `,
+			"/src/shared.ts": `
+        export function getServiceImports() {
+          return [AuthModule, DatabaseModule];
+        }
+      `,
+			"/src/auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+			"/src/database.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class DatabaseModule {}
+      `,
+			"/src/admin.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AdminModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("DatabaseModule");
+		expect(app.imports).toContain("AdminModule");
+	});
+
+	// Cross-file: chained resolution across 3 files (A calls B, B calls C)
+	it("resolves chained cross-file function calls", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getServiceImports } from './service-imports';
+        @Module({ imports: getServiceImports().concat([AdminModule]) })
+        export class AppModule {}
+      `,
+			"/src/service-imports.ts": `
+        import { getBaseImports } from './base-imports';
+        export function getServiceImports() {
+          return getBaseImports().concat([DatabaseModule]);
+        }
+      `,
+			"/src/base-imports.ts": `
+        export function getBaseImports() {
+          return [AuthModule, HealthModule];
+        }
+      `,
+			"/src/auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+			"/src/health.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class HealthModule {}
+      `,
+			"/src/database.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class DatabaseModule {}
+      `,
+			"/src/admin.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AdminModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("HealthModule");
+		expect(app.imports).toContain("DatabaseModule");
+		expect(app.imports).toContain("AdminModule");
+	});
+
+	// Cross-file: arrow function export should be resolved
+	it("resolves cross-file arrow function export", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getImports } from './helpers';
+        @Module({ imports: getImports() })
+        export class AppModule {}
+      `,
+			"/src/helpers.ts": `
+        export const getImports = () => [AuthModule, UsersModule];
+      `,
+			"/src/auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+			"/src/users.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class UsersModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("UsersModule");
+	});
+
+	// Non-relative import should be silently ignored, not crash
+	it("ignores non-relative imports gracefully", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getImports } from '@shared/helpers';
+        @Module({ imports: getImports() })
+        export class AppModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toEqual([]);
+	});
+
+	// Spread of a cross-file function call should resolve
+	it("resolves spread of cross-file function call", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getImports } from './helpers';
+        @Module({ imports: [...getImports(), LocalModule] })
+        export class AppModule {}
+      `,
+			"/src/helpers.ts": `
+        export function getImports() {
+          return [AuthModule];
+        }
+      `,
+			"/src/auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("LocalModule");
+	});
+
+	// Import alias: import { foo as bar } should resolve to the original name
+	it("resolves import alias correctly", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getImports as getAppImports } from './helpers';
+        @Module({ imports: getAppImports() })
+        export class AppModule {}
+      `,
+			"/src/helpers.ts": `
+        export function getImports() {
+          return [AuthModule, UsersModule];
+        }
+      `,
+			"/src/auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+			"/src/users.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class UsersModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("UsersModule");
+	});
+
+	// Barrel file re-export: export { X } from './other' should resolve through
+	it("resolves barrel file re-exports", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getImports } from './barrel';
+        @Module({ imports: getImports() })
+        export class AppModule {}
+      `,
+			"/src/barrel.ts": `
+        export { getImports } from './helpers';
+      `,
+			"/src/helpers.ts": `
+        export function getImports() {
+          return [AuthModule, UsersModule];
+        }
+      `,
+			"/src/auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+			"/src/users.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class UsersModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("UsersModule");
+	});
+
+	// Unresolvable file should not crash
+	it("handles unresolvable cross-file import gracefully", () => {
+		const { project, paths } = createProject({
+			"/src/app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { getImports } from './nonexistent';
+        @Module({ imports: getImports() })
+        export class AppModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toEqual([]);
+	});
+
+	// Same-file arrow function should also work
+	it("resolves same-file arrow function in imports", () => {
+		const { project, paths } = createProject({
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+
+        const getImports = () => [AuthModule, UsersModule];
+
+        @Module({
+          imports: getImports(),
+        })
+        export class AppModule {}
+      `,
+			"auth.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AuthModule {}
+      `,
+			"users.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class UsersModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const app = graph.modules.get("AppModule")!;
+		expect(app.imports).toContain("AuthModule");
+		expect(app.imports).toContain("UsersModule");
+	});
 });

--- a/packages/website/src/app/docs/pipeline/module-graph/page.mdx
+++ b/packages/website/src/app/docs/pipeline/module-graph/page.mdx
@@ -74,15 +74,18 @@ The graph builder recursively resolves import expressions to extract module name
 | `.concat()` chain | `[A].concat([B])` | both `A` and `B` |
 | Function call as value | `getImports()` | return value of function |
 | Variable as value | `commonImports` | contents of variable |
+| Cross-file function call | `getImports()` (imported from `./helpers`) | return value of function in other file |
+| Cross-file variable | `commonImports` (imported from `./shared`) | contents of variable in other file |
+| Chained cross-file calls | `getA()` calls `getB()` in another file | recursively follows the chain |
 
 **Recognized dynamic module methods:** `forRoot`, `forRootAsync`, `forFeature`, `forFeatureAsync`, `forChild`, `forChildAsync`, `register`, `registerAsync`.
 
 **Resolution rules:**
 
-- Resolution is recursive with a depth limit of 3
-- **Same-file functions:** the resolver finds the function declaration and extracts identifiers from its `return` statements
+- Resolution is recursive with a depth limit of 5
+- **Same-file functions:** the resolver finds the function declaration (or arrow function variable) and extracts identifiers from its `return` statements
 - **Same-file variables:** the resolver finds the `const`/`let`/`var` declaration and resolves its initializer
-- **Cross-file references** are not resolved (only same-file)
+- **Cross-file resolution:** if a function or variable is not found in the current file, the resolver follows `import { name } from './other-file'` declarations and `export { name } from './other-file'` re-exports to locate the definition in the external file, then continues resolving there
 - **Unresolvable expressions** (ternaries, computed values) gracefully return empty — no crash, the import is silently skipped
 
 **Why this matters:**
@@ -119,6 +122,22 @@ export class AppModule {}
 //   SharedModule, LoggingModule, AuthModule, SessionModule
 ```
 
+**Example — cross-file resolution chain:**
+
+When imports are split across multiple files, the resolver follows the chain recursively:
+
+```
+app.module.ts
+  imports: getServiceAppCommonImports({...}).concat([AdminAuthModule])
+    ↓ follows import to libs/app-shared.ts
+  getServiceAppCommonImports() → getAppCommonImports().concat([DatabaseModule])
+    ↓ follows import to libs/common-imports.ts
+  getAppCommonImports() → [ConfigModule.forRoot({...}), LoggerModule, HealthModule]
+```
+
+The graph builder resolves the full chain and extracts:
+`ConfigModule`, `LoggerModule`, `HealthModule`, `DatabaseModule`, `AdminAuthModule`
+
 ### Circular Dependency Detection
 
 `findCircularDeps()` uses DFS (depth-first search) with a recursion stack to detect cycles:
@@ -140,4 +159,5 @@ function findCircularDeps(graph: ModuleGraph): string[][] {
 - If a module does not appear in the graph, verify that it has the `@Module()` decorator and is in a file included by the [file collector](/docs/pipeline/file-collection).
 - If a dynamically-imported module (e.g. via `.forRoot()`) does not appear in the graph edges, verify the method name is one of the recognized dynamic module methods listed above.
 - Circular dependency detection works on the `imports` graph. Additionally, `traceProviderEdges` traces provider-level dependencies across module boundaries, enabling concrete suggestions about which providers to extract to break a cycle.
+- If a cross-file function or variable is not resolved, verify the function/variable is exported from its source file and imported with a named import in the module file. Only relative path imports (starting with `./` or `../`) are followed — bare specifiers (e.g., `@nestjs/common`) are skipped.
 - The `providerToModule` index is built from `@Module({ providers: [...] })`. If a provider is not listed in any module's providers array, it will not appear in this index.


### PR DESCRIPTION
## Summary

- Document cross-file import resolution in the module graph pipeline page
- Add cross-file patterns (function calls, variables, chained calls) to supported patterns table
- Fix depth limit from 3 to 5 to match `MAX_RESOLVE_DEPTH` in source
- Add cross-file resolution chain example
- Add debugging tip for cross-file resolution failures