### PR TITLE
feat: add endpoint dependency graph to report

### DIFF
--- a/.changeset/endpoint-graph.md
+++ b/.changeset/endpoint-graph.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Add endpoint dependency graph to the report. Each HTTP endpoint now shows which services, repositories, and other providers it calls, including nested dependencies and call order. The new Endpoints tab is hidden until endpoint data is available and is marked as beta.

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -25,6 +25,13 @@ export {
 	isCodeDiagnostic,
 	isSchemaDiagnostic,
 } from "../common/diagnostic.js";
+export type {
+	DependencyType,
+	EndpointGraph,
+	EndpointNode,
+	MethodCallNode,
+	MethodDependencyNode,
+} from "../common/endpoint.js";
 export {
 	ConfigurationError,
 	NestjsDoctorError,
@@ -47,6 +54,11 @@ export type {
 	SchemaRelation,
 	SerializedSchemaGraph,
 } from "../common/schema.js";
+export {
+	buildEndpointGraph,
+	traceEndpointCalls,
+	updateEndpointGraphForFile,
+} from "../engine/graph/endpoint-graph.js";
 export { updateModuleGraphForFile } from "../engine/graph/module-graph.js";
 export { updateProvidersForFile } from "../engine/graph/type-resolver.js";
 export { getRules } from "../engine/rules/index.js";

--- a/packages/nestjs-doctor/src/common/endpoint.ts
+++ b/packages/nestjs-doctor/src/common/endpoint.ts
@@ -1,0 +1,63 @@
+/**
+ * Classifies a dependency's role in the NestJS application.
+ */
+export type DependencyType =
+	| "service"
+	| "repository"
+	| "guard"
+	| "interceptor"
+	| "pipe"
+	| "filter"
+	| "gateway"
+	| "unknown";
+
+/**
+ * A per-method dependency node. Each method call becomes its own node
+ * so that call order and conditionality are visible in the graph.
+ */
+export interface MethodDependencyNode {
+	className: string;
+	conditional: boolean;
+	dependencies: MethodDependencyNode[];
+	filePath: string;
+	line: number;
+	methodName: string | null;
+	order: number;
+	totalMethods: number;
+	type: DependencyType;
+}
+
+/**
+ * Represents a single HTTP endpoint in a NestJS controller.
+ * Contains a per-method dependency tree.
+ */
+export interface EndpointNode {
+	controllerClass: string;
+	dependencies: MethodDependencyNode[];
+	filePath: string;
+	handlerMethod: string;
+	httpMethod: string;
+	line: number;
+	routePath: string;
+}
+
+/**
+ * Layer 2: method-level call trace node for deep dependency analysis.
+ * Computed on demand via traceEndpointCalls().
+ */
+export interface MethodCallNode {
+	calls: MethodCallNode[];
+	circular?: boolean;
+	className: string;
+	filePath: string;
+	line: number;
+	methodName: string;
+}
+
+/**
+ * Complete endpoint dependency graph for a NestJS project.
+ * JSON-safe — contains no Maps or AST references.
+ */
+export interface EndpointGraph {
+	endpoints: EndpointNode[];
+}

--- a/packages/nestjs-doctor/src/common/result.ts
+++ b/packages/nestjs-doctor/src/common/result.ts
@@ -1,4 +1,5 @@
 import type { Category, Diagnostic } from "./diagnostic.js";
+import type { EndpointGraph } from "./endpoint.js";
 import type { SerializedSchemaGraph } from "./schema.js";
 
 export interface Score {
@@ -31,6 +32,7 @@ export interface RuleErrorInfo {
 export interface DiagnoseResult {
 	diagnostics: Diagnostic[];
 	elapsedMs: number;
+	endpoints?: EndpointGraph;
 	project: ProjectInfo;
 	ruleErrors: RuleErrorInfo[];
 	schema?: SerializedSchemaGraph;

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -1,12 +1,17 @@
 import { join } from "node:path";
 import type { Project } from "ts-morph";
 import type { NestjsDoctorConfig } from "../common/config.js";
+import type { EndpointGraph } from "../common/endpoint.js";
 import type { ProjectInfo } from "../common/result.js";
 import type { SchemaGraph } from "../common/schema.js";
 import { loadConfigWithFallback } from "./config/loader.js";
 import { resolveScanConfig, type ScanConfig } from "./config/scan-config.js";
 import { collectFiles, collectMonorepoFiles } from "./file-collector.js";
 import { createAstParser } from "./graph/ast-parser.js";
+import {
+	buildEndpointGraph,
+	updateEndpointGraphForFile,
+} from "./graph/endpoint-graph.js";
 import {
 	buildModuleGraph,
 	type ModuleGraph,
@@ -26,6 +31,7 @@ import { extractSchema, updateSchemaForFile } from "./schema/extract.js";
 export interface AnalysisContext {
 	astProject: Project;
 	config: NestjsDoctorConfig;
+	endpointGraph: EndpointGraph;
 	fileRules: Rule[];
 	files: string[];
 	moduleGraph: ModuleGraph;
@@ -55,11 +61,13 @@ export async function buildAnalysisContext(
 	const pathAliases = loadPathAliases(targetPath);
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 	const providers = resolveProviders(astProject, files);
+	const endpointGraph = buildEndpointGraph(astProject, files, providers);
 	const schemaGraph = extractSchema(astProject, files, project.orm, targetPath);
 
 	return {
 		astProject,
 		config,
+		endpointGraph,
 		fileRules,
 		files,
 		moduleGraph,
@@ -101,6 +109,12 @@ export function updateFile(context: AnalysisContext, filePath: string): void {
 		context.pathAliases
 	);
 	updateProvidersForFile(context.providers, context.astProject, filePath);
+	updateEndpointGraphForFile(
+		context.endpointGraph,
+		context.astProject,
+		filePath,
+		context.providers
+	);
 	if (context.schemaGraph) {
 		updateSchemaForFile(
 			context.schemaGraph,
@@ -137,6 +151,7 @@ export async function buildMonorepoContext(
 				const pathAliases = loadPathAliases(projectPath);
 				const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 				const providers = resolveProviders(astProject, files);
+				const endpointGraph = buildEndpointGraph(astProject, files, providers);
 				const schemaGraph = extractSchema(
 					astProject,
 					files,
@@ -151,6 +166,7 @@ export async function buildMonorepoContext(
 					{
 						astProject,
 						config: projectConfig,
+						endpointGraph,
 						fileRules,
 						files,
 						moduleGraph,

--- a/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
@@ -1,0 +1,660 @@
+import type {
+	ClassDeclaration,
+	MethodDeclaration,
+	Node,
+	Project,
+} from "ts-morph";
+import { SyntaxKind } from "ts-morph";
+import type {
+	DependencyType,
+	EndpointGraph,
+	EndpointNode,
+	MethodCallNode,
+	MethodDependencyNode,
+} from "../../common/endpoint.js";
+import { HTTP_DECORATORS, isController } from "../nest-class-inspector.js";
+import { extractSimpleTypeName, type ProviderInfo } from "./type-resolver.js";
+
+const MAX_TRACE_DEPTH = 10;
+const QUOTE_REGEX = /^['"`]|['"`]$/g;
+const DUPLICATE_SLASH_REGEX = /\/+/g;
+const TRAILING_SLASH_REGEX = /\/$/;
+
+interface OrderedMethodUsage {
+	conditional: boolean;
+	name: string;
+	order: number;
+}
+
+interface UsedDependency {
+	className: string;
+	methodsCalled: OrderedMethodUsage[];
+}
+
+function isInsideConditionalBlock(node: Node, boundary: Node): boolean {
+	let current: Node | undefined = node;
+	while (current && current !== boundary) {
+		const parent = current.getParent();
+		if (!parent || parent === boundary) {
+			break;
+		}
+		const parentKind = parent.getKind();
+
+		if (parentKind === SyntaxKind.IfStatement) {
+			const ifStmt = parent.asKindOrThrow(SyntaxKind.IfStatement);
+			if (
+				current === ifStmt.getThenStatement() ||
+				current === ifStmt.getElseStatement()
+			) {
+				return true;
+			}
+		}
+		if (parentKind === SyntaxKind.ConditionalExpression) {
+			const condExpr = parent.asKindOrThrow(SyntaxKind.ConditionalExpression);
+			if (
+				current === condExpr.getWhenTrue() ||
+				current === condExpr.getWhenFalse()
+			) {
+				return true;
+			}
+		}
+		const kind = current.getKind();
+		if (kind === SyntaxKind.CaseClause || kind === SyntaxKind.DefaultClause) {
+			return true;
+		}
+		if (kind === SyntaxKind.CatchClause) {
+			return true;
+		}
+
+		current = parent;
+	}
+	return false;
+}
+
+function extractControllerPath(cls: ClassDeclaration): string {
+	const decorator = cls.getDecorator("Controller");
+	if (!decorator) {
+		return "";
+	}
+
+	const args = decorator.getArguments();
+	if (args.length === 0) {
+		return "";
+	}
+
+	const firstArg = args[0];
+
+	if (firstArg.getKind() === SyntaxKind.ObjectLiteralExpression) {
+		const obj = firstArg.asKindOrThrow(SyntaxKind.ObjectLiteralExpression);
+		const pathProp = obj.getProperty("path");
+		if (!pathProp) {
+			return "";
+		}
+		const assignment = pathProp.asKind(SyntaxKind.PropertyAssignment);
+		if (!assignment) {
+			return "";
+		}
+		const init = assignment.getInitializer();
+		return init ? init.getText().replace(QUOTE_REGEX, "") : "";
+	}
+
+	return firstArg.getText().replace(QUOTE_REGEX, "");
+}
+
+function extractRouteInfo(
+	method: MethodDeclaration
+): { httpMethod: string; path: string } | undefined {
+	for (const decorator of method.getDecorators()) {
+		const name = decorator.getName();
+		if (!HTTP_DECORATORS.has(name)) {
+			continue;
+		}
+
+		const args = decorator.getArguments();
+		const path =
+			args.length > 0 ? args[0].getText().replace(QUOTE_REGEX, "") : "";
+
+		return { httpMethod: name.toUpperCase(), path };
+	}
+	return undefined;
+}
+
+function composePath(controllerPath: string, methodPath: string): string {
+	const parts = [controllerPath, methodPath].filter(Boolean);
+	const joined = parts.join("/");
+	const normalized = `/${joined}`
+		.replace(DUPLICATE_SLASH_REGEX, "/")
+		.replace(TRAILING_SLASH_REGEX, "");
+	return normalized || "/";
+}
+
+function buildInjectionMap(cls: ClassDeclaration): Map<string, string> {
+	const map = new Map<string, string>();
+	const ctor = cls.getConstructors()[0];
+	if (!ctor) {
+		return map;
+	}
+
+	for (const param of ctor.getParameters()) {
+		const name = param.getName();
+		const typeNode = param.getTypeNode();
+		const typeText = typeNode ? typeNode.getText() : param.getType().getText();
+		map.set(name, extractSimpleTypeName(typeText));
+	}
+
+	return map;
+}
+
+function scanUsedDependencies(
+	method: MethodDeclaration,
+	injectionMap: Map<string, string>
+): UsedDependency[] {
+	const body = method.getBody();
+	if (!body) {
+		return [];
+	}
+
+	// Map: paramName → methodName → { isUnconditional, order }
+	const usageMap = new Map<
+		string,
+		Map<string, { isUnconditional: boolean; order: number }>
+	>();
+	let callOrder = 0;
+	const callExpressions = body.getDescendantsOfKind(SyntaxKind.CallExpression);
+
+	for (const call of callExpressions) {
+		const expr = call.getExpression();
+		if (expr.getKind() !== SyntaxKind.PropertyAccessExpression) {
+			continue;
+		}
+
+		const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+		const methodName = propAccess.getName();
+		const receiver = propAccess.getExpression();
+
+		if (receiver.getKind() !== SyntaxKind.PropertyAccessExpression) {
+			continue;
+		}
+
+		const innerAccess = receiver.asKindOrThrow(
+			SyntaxKind.PropertyAccessExpression
+		);
+		if (innerAccess.getExpression().getKind() !== SyntaxKind.ThisKeyword) {
+			continue;
+		}
+
+		const paramName = innerAccess.getName();
+		if (!injectionMap.has(paramName)) {
+			continue;
+		}
+
+		if (!usageMap.has(paramName)) {
+			usageMap.set(paramName, new Map());
+		}
+		const methodMap = usageMap.get(paramName)!;
+		const conditional = isInsideConditionalBlock(call, body);
+		const existing = methodMap.get(methodName);
+		if (existing) {
+			// Keep first order, update unconditional status
+			existing.isUnconditional = existing.isUnconditional || !conditional;
+		} else {
+			methodMap.set(methodName, {
+				isUnconditional: !conditional,
+				order: callOrder++,
+			});
+		}
+	}
+
+	const result: UsedDependency[] = [];
+	for (const [paramName, methodMap] of usageMap) {
+		const methods: OrderedMethodUsage[] = [];
+		for (const [name, info] of methodMap) {
+			methods.push({
+				name,
+				conditional: !info.isUnconditional,
+				order: info.order,
+			});
+		}
+		methods.sort((a, b) => a.order - b.order);
+		result.push({
+			className: injectionMap.get(paramName)!,
+			methodsCalled: methods,
+		});
+	}
+
+	return result;
+}
+
+function classifyDependency(name: string): DependencyType {
+	if (name.endsWith("Repository")) {
+		return "repository";
+	}
+	if (name.endsWith("Guard")) {
+		return "guard";
+	}
+	if (name.endsWith("Interceptor")) {
+		return "interceptor";
+	}
+	if (name.endsWith("Pipe")) {
+		return "pipe";
+	}
+	if (name.endsWith("Filter")) {
+		return "filter";
+	}
+	if (name.endsWith("Gateway")) {
+		return "gateway";
+	}
+	return "service";
+}
+
+function buildMethodDependencyTree(
+	usedDeps: UsedDependency[],
+	providers: Map<string, ProviderInfo>,
+	visited: Set<string>
+): MethodDependencyNode[] {
+	const nodes: MethodDependencyNode[] = [];
+	const firstSeenClass = new Set<string>();
+
+	// Build a flat list of all individual method calls across all deps
+	interface FlatCall {
+		className: string;
+		/** Reference to the full UsedDependency for scanning sub-deps */
+		dep: UsedDependency;
+		mc: OrderedMethodUsage;
+	}
+
+	const flatCalls: FlatCall[] = [];
+	const fallbackDeps: UsedDependency[] = [];
+
+	for (const dep of usedDeps) {
+		if (dep.methodsCalled.length === 0) {
+			fallbackDeps.push(dep);
+		} else {
+			for (const mc of dep.methodsCalled) {
+				flatCalls.push({ className: dep.className, mc, dep });
+			}
+		}
+	}
+
+	// Sort by global call order
+	flatCalls.sort((a, b) => a.mc.order - b.mc.order);
+
+	// Process fallback deps first (no method tracking)
+	for (const dep of fallbackDeps) {
+		if (visited.has(dep.className) || firstSeenClass.has(dep.className)) {
+			continue;
+		}
+		firstSeenClass.add(dep.className);
+		visited.add(dep.className);
+
+		const provider = providers.get(dep.className);
+		let childDeps: UsedDependency[] = [];
+		if (provider) {
+			childDeps = provider.dependencies.map((d) => ({
+				className: d,
+				methodsCalled: [],
+			}));
+		}
+
+		nodes.push({
+			className: dep.className,
+			conditional: false,
+			dependencies: buildMethodDependencyTree(
+				childDeps,
+				providers,
+				new Set(visited)
+			),
+			filePath: provider?.filePath ?? "",
+			line: 0,
+			methodName: null,
+			order: 0,
+			totalMethods: provider?.publicMethodCount ?? 0,
+			type: classifyDependency(dep.className),
+		});
+	}
+
+	// Collect all methods per class for sub-dep scanning
+	const allMethodsByClass = new Map<string, OrderedMethodUsage[]>();
+	for (const { className, dep } of flatCalls) {
+		if (!allMethodsByClass.has(className)) {
+			allMethodsByClass.set(className, dep.methodsCalled);
+		}
+	}
+
+	// Process method calls in global order
+	for (const { className, mc } of flatCalls) {
+		// Skip classes already in the ancestor chain (circular dep)
+		if (visited.has(className)) {
+			continue;
+		}
+
+		const provider = providers.get(className);
+		const isFirst = !firstSeenClass.has(className);
+		if (isFirst) {
+			firstSeenClass.add(className);
+		}
+
+		let childNodes: MethodDependencyNode[] = [];
+
+		if (isFirst && provider) {
+			const childVisited = new Set(visited);
+			childVisited.add(className);
+			const injMap = buildInjectionMap(provider.classDeclaration);
+
+			// Merge sub-deps from ALL methods of this class
+			const merged = new Map<
+				string,
+				Map<string, { isUnconditional: boolean; order: number }>
+			>();
+			let childOrder = 0;
+			const classMethods = allMethodsByClass.get(className) ?? [];
+			for (const allMc of classMethods) {
+				const method = provider.classDeclaration.getInstanceMethod(allMc.name);
+				if (!method) {
+					continue;
+				}
+				for (const used of scanUsedDependencies(method, injMap)) {
+					if (!merged.has(used.className)) {
+						merged.set(used.className, new Map());
+					}
+					const methodMap = merged.get(used.className)!;
+					for (const m of used.methodsCalled) {
+						const existing = methodMap.get(m.name);
+						if (existing) {
+							existing.isUnconditional =
+								existing.isUnconditional || !m.conditional;
+						} else {
+							methodMap.set(m.name, {
+								isUnconditional: !m.conditional,
+								order: childOrder++,
+							});
+						}
+					}
+				}
+			}
+
+			const childDeps: UsedDependency[] = [...merged.entries()].map(
+				([cn, methodMap]) => ({
+					className: cn,
+					methodsCalled: [...methodMap.entries()]
+						.map(([name, info]) => ({
+							name,
+							conditional: !info.isUnconditional,
+							order: info.order,
+						}))
+						.sort((a, b) => a.order - b.order),
+				})
+			);
+
+			childNodes = buildMethodDependencyTree(
+				childDeps,
+				providers,
+				childVisited
+			);
+		}
+
+		let line = 0;
+		if (provider) {
+			const methodDecl = provider.classDeclaration.getInstanceMethod(mc.name);
+			if (methodDecl) {
+				line = methodDecl.getStartLineNumber();
+			}
+		}
+
+		nodes.push({
+			className,
+			conditional: mc.conditional,
+			dependencies: childNodes,
+			filePath: provider?.filePath ?? "",
+			line,
+			methodName: mc.name,
+			order: mc.order,
+			totalMethods: provider?.publicMethodCount ?? 0,
+			type: classifyDependency(className),
+		});
+	}
+
+	return nodes;
+}
+
+function extractEndpointsFromFile(
+	sourceFile: NonNullable<ReturnType<Project["getSourceFile"]>>,
+	filePath: string,
+	providers: Map<string, ProviderInfo>
+): EndpointNode[] {
+	const endpoints: EndpointNode[] = [];
+
+	for (const cls of sourceFile.getClasses()) {
+		if (!isController(cls)) {
+			continue;
+		}
+
+		const controllerPath = extractControllerPath(cls);
+		const controllerName = cls.getName() ?? "AnonymousController";
+		const injectionMap = buildInjectionMap(cls);
+
+		for (const method of cls.getMethods()) {
+			const routeInfo = extractRouteInfo(method);
+			if (!routeInfo) {
+				continue;
+			}
+
+			const fullPath = composePath(controllerPath, routeInfo.path);
+			const usedDeps = scanUsedDependencies(method, injectionMap);
+			const dependencies = buildMethodDependencyTree(
+				usedDeps,
+				providers,
+				new Set()
+			);
+
+			endpoints.push({
+				controllerClass: controllerName,
+				dependencies,
+				filePath,
+				handlerMethod: method.getName(),
+				httpMethod: routeInfo.httpMethod,
+				line: method.getStartLineNumber(),
+				routePath: fullPath,
+			});
+		}
+	}
+
+	return endpoints;
+}
+
+export function buildEndpointGraph(
+	project: Project,
+	files: string[],
+	providers: Map<string, ProviderInfo>
+): EndpointGraph {
+	const endpoints: EndpointNode[] = [];
+
+	for (const filePath of files) {
+		const sourceFile = project.getSourceFile(filePath);
+		if (!sourceFile) {
+			continue;
+		}
+
+		endpoints.push(
+			...extractEndpointsFromFile(sourceFile, filePath, providers)
+		);
+	}
+
+	return { endpoints };
+}
+
+function traceMethodCalls(
+	method: MethodDeclaration,
+	injectionMap: Map<string, string>,
+	providers: Map<string, ProviderInfo>,
+	visited: Set<string>,
+	depth: number,
+	currentClass?: ClassDeclaration
+): MethodCallNode[] {
+	if (depth > MAX_TRACE_DEPTH) {
+		return [];
+	}
+
+	const body = method.getBody();
+	if (!body) {
+		return [];
+	}
+
+	const calls: MethodCallNode[] = [];
+	const callExpressions = body.getDescendantsOfKind(SyntaxKind.CallExpression);
+
+	for (const call of callExpressions) {
+		const expr = call.getExpression();
+		if (expr.getKind() !== SyntaxKind.PropertyAccessExpression) {
+			continue;
+		}
+
+		const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+		const methodName = propAccess.getName();
+		const receiver = propAccess.getExpression();
+
+		// Pattern: this.service.method() — injected dependency call
+		if (receiver.getKind() === SyntaxKind.PropertyAccessExpression) {
+			const innerAccess = receiver.asKindOrThrow(
+				SyntaxKind.PropertyAccessExpression
+			);
+			if (innerAccess.getExpression().getKind() !== SyntaxKind.ThisKeyword) {
+				continue;
+			}
+
+			const paramName = innerAccess.getName();
+			const className = injectionMap.get(paramName);
+			if (!className) {
+				continue;
+			}
+
+			const key = `${className}.${methodName}`;
+			if (visited.has(key)) {
+				calls.push({
+					calls: [],
+					circular: true,
+					className,
+					filePath: "",
+					line: 0,
+					methodName,
+				});
+				continue;
+			}
+
+			visited.add(key);
+
+			const provider = providers.get(className);
+			let childCalls: MethodCallNode[] = [];
+			let filePath = "";
+			let line = 0;
+
+			if (provider) {
+				filePath = provider.filePath;
+				const targetMethod =
+					provider.classDeclaration.getInstanceMethod(methodName);
+				if (targetMethod) {
+					line = targetMethod.getStartLineNumber();
+					const targetInjectionMap = buildInjectionMap(
+						provider.classDeclaration
+					);
+					childCalls = traceMethodCalls(
+						targetMethod,
+						targetInjectionMap,
+						providers,
+						new Set(visited),
+						depth + 1,
+						provider.classDeclaration
+					);
+				}
+			}
+
+			calls.push({
+				calls: childCalls,
+				className,
+				filePath,
+				line,
+				methodName,
+			});
+		}
+
+		// Pattern: this.method() — same-class private method call
+		// Inline children: follow into the private method and surface its dependency calls
+		else if (receiver.getKind() === SyntaxKind.ThisKeyword && currentClass) {
+			const targetMethod = currentClass.getInstanceMethod(methodName);
+			if (!targetMethod) {
+				continue;
+			}
+
+			const className = currentClass.getName() ?? "Anonymous";
+			const key = `${className}.${methodName}`;
+			if (visited.has(key)) {
+				continue;
+			}
+			visited.add(key);
+
+			const childCalls = traceMethodCalls(
+				targetMethod,
+				injectionMap,
+				providers,
+				new Set(visited),
+				depth + 1,
+				currentClass
+			);
+
+			// Inline: surface dependency calls from private methods directly
+			calls.push(...childCalls);
+		}
+	}
+
+	return calls;
+}
+
+/**
+ * Layer 2: traces method-level call chains for a specific endpoint.
+ * Returns the full recursive call tree through injected dependencies.
+ */
+export function traceEndpointCalls(
+	endpoint: EndpointNode,
+	providers: Map<string, ProviderInfo>,
+	project: Project
+): MethodCallNode[] {
+	const sourceFile = project.getSourceFile(endpoint.filePath);
+	if (!sourceFile) {
+		return [];
+	}
+
+	const cls = sourceFile
+		.getClasses()
+		.find((c) => c.getName() === endpoint.controllerClass);
+	if (!cls) {
+		return [];
+	}
+
+	const method = cls.getInstanceMethod(endpoint.handlerMethod);
+	if (!method) {
+		return [];
+	}
+
+	const injectionMap = buildInjectionMap(cls);
+	return traceMethodCalls(method, injectionMap, providers, new Set(), 0, cls);
+}
+
+export function updateEndpointGraphForFile(
+	graph: EndpointGraph,
+	project: Project,
+	filePath: string,
+	providers: Map<string, ProviderInfo>
+): void {
+	// Remove stale endpoints from this file
+	graph.endpoints = graph.endpoints.filter((e) => e.filePath !== filePath);
+
+	// Re-scan the changed file
+	const sourceFile = project.getSourceFile(filePath);
+	if (!sourceFile) {
+		return;
+	}
+
+	graph.endpoints.push(
+		...extractEndpointsFromFile(sourceFile, filePath, providers)
+	);
+}

--- a/packages/nestjs-doctor/src/engine/graph/type-resolver.ts
+++ b/packages/nestjs-doctor/src/engine/graph/type-resolver.ts
@@ -97,7 +97,7 @@ export function updateProvidersForFile(
 	}
 }
 
-function extractSimpleTypeName(typeText: string): string {
+export function extractSimpleTypeName(typeText: string): string {
 	// Handle import("...").ClassName
 	const importMatch = typeText.match(IMPORT_TYPE_REGEX);
 	if (importMatch) {

--- a/packages/nestjs-doctor/src/engine/result-builder.ts
+++ b/packages/nestjs-doctor/src/engine/result-builder.ts
@@ -1,4 +1,5 @@
 import type { Diagnostic } from "../common/diagnostic.js";
+import type { EndpointNode } from "../common/endpoint.js";
 import type {
 	DiagnoseResult,
 	DiagnoseSummary,
@@ -82,6 +83,7 @@ export function buildResult(
 	const result: DiagnoseResult = {
 		score,
 		diagnostics,
+		endpoints: context.endpointGraph,
 		project: {
 			...context.project,
 			fileCount: context.files.length,
@@ -112,6 +114,7 @@ export function buildMonorepoResult(
 	const allDiagnostics: Diagnostic[] = [];
 	const allRuleErrors: RuleErrorInfo[] = [];
 	const moduleGraphs = new Map<string, ModuleGraph>();
+	const allEndpoints: EndpointNode[] = [];
 	let totalFiles = 0;
 	const allSchemaEntities: SerializedSchemaEntity[] = [];
 	const allSchemaRelations: SchemaRelation[] = [];
@@ -125,6 +128,9 @@ export function buildMonorepoResult(
 		allDiagnostics.push(...scanResult.result.diagnostics);
 		allRuleErrors.push(...scanResult.result.ruleErrors);
 		totalFiles += scanResult.result.project.fileCount;
+		if (scanResult.result.endpoints) {
+			allEndpoints.push(...scanResult.result.endpoints.endpoints);
+		}
 		if (scanResult.result.schema) {
 			allSchemaEntities.push(...scanResult.result.schema.entities);
 			allSchemaRelations.push(...scanResult.result.schema.relations);
@@ -143,6 +149,8 @@ export function buildMonorepoResult(
 	const combined: DiagnoseResult = {
 		score: combinedScore,
 		diagnostics: allDiagnostics,
+		endpoints:
+			allEndpoints.length > 0 ? { endpoints: allEndpoints } : undefined,
 		project: {
 			name: "monorepo",
 			nestVersion: subProjects[0]?.result.project.nestVersion ?? null,

--- a/packages/nestjs-doctor/src/report/formatters/report-data.ts
+++ b/packages/nestjs-doctor/src/report/formatters/report-data.ts
@@ -86,6 +86,9 @@ export function prepareReportData(
 	const schemaJson = safeJsonForScript(
 		JSON.stringify(result.schema ?? { entities: [], relations: [], orm: "" })
 	);
+	const endpointsJson = safeJsonForScript(
+		JSON.stringify(result.endpoints ?? { endpoints: [] })
+	);
 
 	return {
 		graphJson,
@@ -98,5 +101,6 @@ export function prepareReportData(
 		fileSourcesJson,
 		providersJson,
 		schemaJson,
+		endpointsJson,
 	};
 }

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -1,6 +1,7 @@
 import { performance } from "node:perf_hooks";
 import { spinner } from "../cli/ui/spinner.js";
 import { mergeModuleGraphs } from "../engine/graph/module-graph.js";
+import type { ProviderInfo } from "../engine/graph/type-resolver.js";
 import type { MonorepoInfo } from "../engine/project-detector.js";
 import {
 	type AnalysisContext,
@@ -171,7 +172,21 @@ export class MonorepoReportPipeline extends ReportPipeline {
 			const { moduleGraphs, result } = this._monoResult;
 			const merged = mergeModuleGraphs(moduleGraphs);
 			const projects = [...moduleGraphs.keys()];
-			this._html = buildHtmlReport(merged, result.combined, { projects });
+
+			const allFiles: string[] = [];
+			const allProviders = new Map<string, ProviderInfo>();
+			for (const context of this.monorepoCtx.subProjects.values()) {
+				allFiles.push(...context.files);
+				for (const [name, info] of context.providers) {
+					allProviders.set(name, info);
+				}
+			}
+
+			this._html = buildHtmlReport(merged, result.combined, {
+				projects,
+				files: allFiles,
+				providers: allProviders,
+			});
 		});
 		return this;
 	}

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -18,8 +18,9 @@ export function getReportHtml(): string {
   <button class="tab-btn active" data-tab="summary">Summary</button>
   <button class="tab-btn" data-tab="diagnosis">Diagnosis <span class="count-badge" id="diagnosis-count-badge"></span></button>
   <button class="tab-btn" data-tab="modules">Modules Graph</button>
+  <button class="tab-btn" data-tab="endpoints" id="tab-btn-endpoints" style="display:none">Endpoints <span class="beta-badge">Beta</span></button>
+  <button class="tab-btn" data-tab="schema" id="tab-btn-schema" style="display:none">Relational Schema</button>
   <button class="tab-btn" data-tab="lab">Lab</button>
-  <button class="tab-btn" data-tab="schema" id="tab-btn-schema" style="display:none">Schema</button>
   <div class="tab-spacer"></div>
   <div class="tab-controls" id="graph-controls">
     <select id="project-filter"><option value="all">All projects</option></select>
@@ -239,6 +240,51 @@ for (let i = 0; i < lines.length; i++) {
       <div id="schema-diag-body" style="display:none">
         <div id="schema-diag-list"></div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- ── Tab: Endpoints ── -->
+<div class="tab-content" id="tab-endpoints">
+  <div id="ep-code-panel" class="ep-code-panel">
+    <div class="ep-code-panel-header">
+      <div class="ep-code-panel-title">
+        <span class="ep-code-panel-class" id="ep-code-panel-class"></span>
+        <span class="ep-code-panel-method" id="ep-code-panel-method"></span>
+      </div>
+      <div class="ep-code-panel-path" id="ep-code-panel-path"></div>
+      <button class="ep-code-panel-close" id="ep-code-panel-close">&times;</button>
+    </div>
+    <div class="ep-code-panel-body" id="ep-code-panel-body"></div>
+    <div class="ep-code-panel-resize" id="ep-code-panel-resize"></div>
+  </div>
+  <div id="endpoints-sidebar">
+    <div class="endpoints-sidebar-sticky">
+      <div class="endpoints-sidebar-header">
+        <span class="schema-sidebar-title">Endpoints</span>
+        <span class="schema-entity-count" id="endpoints-count"></span>
+        <span style="flex:1"></span>
+      </div>
+    </div>
+    <div id="endpoints-list"></div>
+  </div>
+  <div id="endpoints-main">
+    <div id="endpoints-canvas-wrap">
+      <div id="endpoints-empty-state">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+        </svg>
+        <p>Select an endpoint from the sidebar to view its dependency graph</p>
+      </div>
+      <div id="endpoints-toolbar">
+        <button class="st-btn schema-diagram-btn" id="endpoints-recenter" title="Re-center diagram">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/>
+          </svg>
+        </button>
+      </div>
+      <canvas id="endpoints-canvas"></canvas>
+      <div id="endpoints-tooltip" class="schema-tooltip" style="display:none"></div>
     </div>
   </div>
 </div>

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -1,6 +1,7 @@
 export interface ReportScriptData {
 	diagnosticsJson: string;
 	elapsedMsJson: string;
+	endpointsJson: string;
 	examplesJson: string;
 	fileSourcesJson: string;
 	graphJson: string;
@@ -23,6 +24,7 @@ const ruleExamples = ${data.examplesJson};
 const fileSources = ${data.fileSourcesJson};
 const providers = ${data.providersJson};
 const schema = ${data.schemaJson};
+const endpoints = ${data.endpointsJson};
 const isMonorepo = Object.keys(fileSources).length === 0;
 
 // ── Score helpers ──
@@ -73,6 +75,7 @@ let diagnosisRendered = false;
 let summaryRendered = false;
 let labRendered = false;
 let schemaRendered = false;
+let endpointsRendered = false;
 
 const tabBtns = document.querySelectorAll(".tab-btn");
 const tabContents = {
@@ -81,6 +84,7 @@ const tabContents = {
   summary: document.getElementById("tab-summary"),
   lab: document.getElementById("tab-lab"),
   schema: document.getElementById("tab-schema"),
+  endpoints: document.getElementById("tab-endpoints"),
 };
 const graphControls = document.getElementById("graph-controls");
 const sidebar = document.getElementById("sidebar");
@@ -106,7 +110,9 @@ function switchTab(name) {
   if (name === "summary" && !summaryRendered) { renderSummary(); summaryRendered = true; }
   if (name === "lab" && !labRendered) { renderLab(); labRendered = true; }
   if (name === "schema" && !schemaRendered) { renderSchema(); schemaRendered = true; }
+  if (name === "endpoints" && !endpointsRendered) { renderEndpoints(); endpointsRendered = true; }
   if (name === "modules") resize();
+  if (name === "endpoints" && endpointsRendered) epResize();
 }
 
 for (const btn of tabBtns) {
@@ -1770,6 +1776,11 @@ if (schema.entities.length > 0) {
   document.getElementById("tab-btn-schema").style.display = "";
 }
 
+// ── Endpoints tab visibility ──
+if (endpoints.endpoints.length > 0) {
+  document.getElementById("tab-btn-endpoints").style.display = "";
+}
+
 // ── Schema: Canvas-based interactive ER diagram ──
 
 // Row size estimation
@@ -3143,6 +3154,714 @@ function renderSchema() {
       }
     });
   }
+}
+
+// ── Endpoints tab: Canvas-based dependency graph ──
+
+var epCanvas, epCtx, epDpr, epW, epH;
+var epCamX = 0, epCamY = 0, epZoom = 1;
+var epDragging = null, epPanning = false, epPanStart = {x: 0, y: 0};
+var epDragMoved = false;
+var epHoveredNode = null;
+var epNodes = [];
+var epEdges = [];
+var epTooltipEl = null;
+var epDirty = false;
+var epSelectedEndpoint = null;
+
+var EP_TYPE_COLORS = {
+  controller: "#ea2845",
+  service: "#3b82f6",
+  repository: "#10b981",
+  guard: "#f59e0b",
+  interceptor: "#8b5cf6",
+  pipe: "#14b8a6",
+  filter: "#ef4444",
+  gateway: "#ec4899",
+  unknown: "#666"
+};
+
+function epScheduleRedraw() {
+  if (!epDirty) {
+    epDirty = true;
+    requestAnimationFrame(function() { epDirty = false; epDraw(); });
+  }
+}
+
+function epScreenToWorld(sx, sy) {
+  return {
+    x: (sx - epW / 2) / epZoom + epW / 2 - epCamX,
+    y: (sy - epH / 2) / epZoom + epH / 2 - epCamY
+  };
+}
+
+function epHitTest(wx, wy) {
+  for (var i = epNodes.length - 1; i >= 0; i--) {
+    var n = epNodes[i];
+    if (wx >= n.x - n.w / 2 && wx <= n.x + n.w / 2 &&
+        wy >= n.y - n.h / 2 && wy <= n.y + n.h / 2) return n;
+  }
+  return null;
+}
+
+function epRoundRect(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function epBuildGraph(ep) {
+  epNodes = [];
+  epEdges = [];
+  var nodeId = 0;
+
+  // Root node for the endpoint (controller method)
+  var rootNode = {
+    id: nodeId++,
+    className: ep.controllerClass,
+    type: "controller",
+    methodName: ep.handlerMethod,
+    conditional: false,
+    order: -1,
+    totalMethods: 1,
+    filePath: ep.filePath,
+    line: ep.line,
+    x: 0, y: 0, w: 180, h: 60
+  };
+  epNodes.push(rootNode);
+
+  // Walk dependency tree — each dep is a MethodDependencyNode (one method per node)
+  function walkDeps(parentNode, deps) {
+    for (var i = 0; i < deps.length; i++) {
+      var dep = deps[i];
+      var n = {
+        id: nodeId++,
+        className: dep.className,
+        type: dep.type,
+        methodName: dep.methodName,
+        conditional: dep.conditional,
+        order: dep.order,
+        totalMethods: dep.totalMethods,
+        filePath: dep.filePath,
+        line: dep.line,
+        x: 0, y: 0, w: 180, h: 60
+      };
+      epNodes.push(n);
+      epEdges.push({ from: parentNode.id, to: n.id, conditional: dep.conditional });
+      if (dep.dependencies && dep.dependencies.length > 0) {
+        walkDeps(n, dep.dependencies);
+      }
+    }
+  }
+
+  walkDeps(rootNode, ep.dependencies);
+}
+
+function epLayout() {
+  if (epNodes.length === 0) return;
+
+  if (typeof dagre !== "undefined") {
+    var g = new dagre.graphlib.Graph();
+    g.setGraph({ rankdir: "TB", nodesep: 40, ranksep: 80, marginx: 40, marginy: 40 });
+    g.setDefaultEdgeLabel(function() { return {}; });
+
+    for (var i = 0; i < epNodes.length; i++) {
+      g.setNode(epNodes[i].id, { width: epNodes[i].w, height: epNodes[i].h });
+    }
+    for (var i = 0; i < epEdges.length; i++) {
+      g.setEdge(epEdges[i].from, epEdges[i].to);
+    }
+
+    dagre.layout(g);
+
+    for (var i = 0; i < epNodes.length; i++) {
+      var laid = g.node(epNodes[i].id);
+      if (laid) {
+        epNodes[i].x = laid.x;
+        epNodes[i].y = laid.y;
+      }
+    }
+  } else {
+    // Fallback: simple vertical layout
+    for (var i = 0; i < epNodes.length; i++) {
+      epNodes[i].x = 300;
+      epNodes[i].y = 60 + i * 100;
+    }
+  }
+}
+
+function epCenterCamera() {
+  if (epNodes.length === 0) return;
+  var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (var i = 0; i < epNodes.length; i++) {
+    var n = epNodes[i];
+    minX = Math.min(minX, n.x - n.w / 2);
+    maxX = Math.max(maxX, n.x + n.w / 2);
+    minY = Math.min(minY, n.y - n.h / 2);
+    maxY = Math.max(maxY, n.y + n.h / 2);
+  }
+  var graphW = maxX - minX;
+  var graphH = maxY - minY;
+  var cx = (minX + maxX) / 2;
+  var cy = (minY + maxY) / 2;
+
+  var pad = 60;
+  var scaleX = (epW - pad * 2) / (graphW || 1);
+  var scaleY = (epH - pad * 2) / (graphH || 1);
+  epZoom = Math.min(scaleX, scaleY, 1.5);
+  epZoom = Math.max(epZoom, 0.3);
+
+  epCamX = epW / 2 - cx;
+  epCamY = epH / 2 - cy;
+}
+
+function epDraw() {
+  if (!epCtx) return;
+  epCtx.save();
+  epCtx.clearRect(0, 0, epW, epH);
+
+  if (epNodes.length === 0) {
+    epCtx.restore();
+    return;
+  }
+
+  epCtx.translate(epW / 2, epH / 2);
+  epCtx.scale(epZoom, epZoom);
+  epCtx.translate(-epW / 2 + epCamX, -epH / 2 + epCamY);
+
+  // Build node lookup by id
+  var nodeById = {};
+  for (var i = 0; i < epNodes.length; i++) nodeById[epNodes[i].id] = epNodes[i];
+
+  // Draw edges
+  for (var i = 0; i < epEdges.length; i++) {
+    var fromN = nodeById[epEdges[i].from];
+    var toN = nodeById[epEdges[i].to];
+    if (!fromN || !toN) continue;
+
+    var fx = fromN.x;
+    var fy = fromN.y + fromN.h / 2;
+    var tx = toN.x;
+    var ty = toN.y - toN.h / 2;
+
+    var edgeColor = epEdges[i].conditional ? "rgba(245, 158, 11, 0.6)" : "#555";
+    if (epEdges[i].conditional) {
+      epCtx.setLineDash([6 / epZoom, 4 / epZoom]);
+    }
+
+    epCtx.beginPath();
+    epCtx.moveTo(fx, fy);
+    // L-shaped edge if not aligned
+    if (Math.abs(fx - tx) > 2) {
+      var midY = fy + (ty - fy) / 2;
+      epCtx.lineTo(fx, midY);
+      epCtx.lineTo(tx, midY);
+    }
+    epCtx.lineTo(tx, ty);
+    epCtx.strokeStyle = edgeColor;
+    epCtx.lineWidth = 1.5 / epZoom;
+    epCtx.stroke();
+
+    // Arrow
+    var arrowSize = 5 / epZoom;
+    epCtx.beginPath();
+    epCtx.moveTo(tx - arrowSize, ty - arrowSize);
+    epCtx.lineTo(tx, ty);
+    epCtx.lineTo(tx + arrowSize, ty - arrowSize);
+    epCtx.strokeStyle = edgeColor;
+    epCtx.lineWidth = 1.5 / epZoom;
+    epCtx.stroke();
+
+    epCtx.setLineDash([]);
+  }
+
+  // Draw nodes
+  var BOX_R = 6;
+  var HDR_H = 22;
+
+  for (var i = 0; i < epNodes.length; i++) {
+    var n = epNodes[i];
+    var x = n.x - n.w / 2;
+    var y = n.y - n.h / 2;
+    var color = EP_TYPE_COLORS[n.type] || EP_TYPE_COLORS.unknown;
+    var isHovered = (epHoveredNode && epHoveredNode.id === n.id);
+
+    var isCond = n.conditional;
+    var headerColor = isCond ? "#f59e0b" : color;
+
+    // Shadow
+    if (isHovered) {
+      epCtx.save();
+      epCtx.shadowColor = "rgba(255,255,255,0.2)";
+      epCtx.shadowBlur = 10;
+    }
+
+    // Body
+    epRoundRect(epCtx, x, y, n.w, n.h, BOX_R);
+    epCtx.fillStyle = "#151515";
+    epCtx.fill();
+    if (isCond) {
+      epCtx.setLineDash([4 / epZoom, 3 / epZoom]);
+      epCtx.strokeStyle = isHovered ? "#f59e0b" : "rgba(245,158,11,0.5)";
+    } else {
+      epCtx.strokeStyle = isHovered ? "#ffffff" : "rgba(255,255,255,0.06)";
+    }
+    epCtx.lineWidth = isHovered ? 2 : 1;
+    epCtx.stroke();
+    epCtx.setLineDash([]);
+
+    if (isHovered) epCtx.restore();
+
+    // Colored header bar
+    epCtx.save();
+    epCtx.beginPath();
+    epCtx.moveTo(x + BOX_R, y);
+    epCtx.lineTo(x + n.w - BOX_R, y);
+    epCtx.quadraticCurveTo(x + n.w, y, x + n.w, y + BOX_R);
+    epCtx.lineTo(x + n.w, y + HDR_H);
+    epCtx.lineTo(x, y + HDR_H);
+    epCtx.lineTo(x, y + BOX_R);
+    epCtx.quadraticCurveTo(x, y, x + BOX_R, y);
+    epCtx.closePath();
+    epCtx.clip();
+    epCtx.fillStyle = headerColor;
+    epCtx.globalAlpha = isCond ? 0.12 : 0.15;
+    epCtx.fillRect(x, y, n.w, HDR_H);
+    epCtx.globalAlpha = 1;
+    epCtx.restore();
+
+    // Separator
+    epCtx.beginPath();
+    epCtx.moveTo(x + 1, y + HDR_H);
+    epCtx.lineTo(x + n.w - 1, y + HDR_H);
+    epCtx.strokeStyle = "rgba(255,255,255,0.06)";
+    epCtx.lineWidth = 1;
+    epCtx.stroke();
+
+    // Color dot
+    var dotSize = 6;
+    epCtx.fillStyle = headerColor;
+    epCtx.fillRect(x + 8, y + HDR_H / 2 - dotSize / 2, dotSize, dotSize);
+
+    // Class name
+    epCtx.fillStyle = "#e0e0e0";
+    epCtx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
+    epCtx.textAlign = "left";
+    epCtx.textBaseline = "middle";
+    var nameStr = n.className;
+    var nameStartX = x + 8 + dotSize + 6;
+    var maxNameW = n.w - (nameStartX - x) - 8;
+    while (epCtx.measureText(nameStr).width > maxNameW && nameStr.length > 3) {
+      nameStr = nameStr.slice(0, -1);
+    }
+    if (nameStr !== n.className) nameStr += "\\u2026";
+    epCtx.fillText(nameStr, nameStartX, y + HDR_H / 2);
+
+    // Below header: type badge + order badge + method name
+    var infoY = y + HDR_H + 8;
+
+    // Type badge
+    epCtx.font = "bold 9px -apple-system, BlinkMacSystemFont, sans-serif";
+    var typeLabel = n.type.toUpperCase();
+    var badgeW = epCtx.measureText(typeLabel).width + 10;
+    epRoundRect(epCtx, x + 8, infoY - 1, badgeW, 14, 3);
+    epCtx.fillStyle = color;
+    epCtx.globalAlpha = 0.15;
+    epCtx.fill();
+    epCtx.globalAlpha = 1;
+    epCtx.fillStyle = color;
+    epCtx.textAlign = "left";
+    epCtx.textBaseline = "middle";
+    epCtx.fillText(typeLabel, x + 13, infoY + 6);
+
+    // Order badge (#N)
+    var badgeRight = x + 8 + badgeW;
+    if (n.order >= 0) {
+      var orderLabel = "#" + (n.order + 1);
+      epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
+      var orderW = epCtx.measureText(orderLabel).width + 8;
+      epRoundRect(epCtx, badgeRight + 4, infoY, orderW, 12, 3);
+      epCtx.fillStyle = "rgba(255,255,255,0.08)";
+      epCtx.fill();
+      epCtx.fillStyle = "#999";
+      epCtx.textBaseline = "middle";
+      epCtx.fillText(orderLabel, badgeRight + 8, infoY + 6);
+    }
+
+    // Method name
+    if (n.methodName) {
+      var methodY = infoY + 18;
+      epCtx.font = "9px monospace";
+      epCtx.textAlign = "left";
+      epCtx.fillStyle = isCond ? "#f59e0b" : "#888";
+      var mText = n.methodName + (isCond ? "?()" : "()");
+      var maxMW = n.w - 16;
+      while (epCtx.measureText(mText).width > maxMW && mText.length > 3) {
+        mText = mText.slice(0, -1);
+      }
+      epCtx.fillText(mText, x + 8, methodY);
+    }
+  }
+
+  epCtx.restore();
+}
+
+function epResize() {
+  if (!epCanvas) return;
+  var container = epCanvas.parentElement;
+  if (!container) return;
+  epW = container.clientWidth;
+  epH = container.clientHeight;
+  epCanvas.width = epW * epDpr;
+  epCanvas.height = epH * epDpr;
+  epCanvas.style.width = epW + "px";
+  epCanvas.style.height = epH + "px";
+  epCtx.setTransform(epDpr, 0, 0, epDpr, 0, 0);
+  if (epNodes.length > 0) {
+    epCenterCamera();
+  }
+  epScheduleRedraw();
+}
+
+function epShowTooltip(node, screenX, screenY) {
+  if (!epTooltipEl) return;
+  var color = EP_TYPE_COLORS[node.type] || EP_TYPE_COLORS.unknown;
+  var methodHtml = "";
+  if (node.methodName) {
+    var mColor = node.conditional ? "#f59e0b" : "#ccc";
+    methodHtml = '<div style="font-family:monospace;font-size:11px;color:' + mColor + ';margin-top:4px">.' + escHtml(node.methodName) + '()</div>';
+  }
+  var condLabel = "";
+  if (node.conditional) {
+    condLabel = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">Conditionally called</div>';
+  }
+  epTooltipEl.innerHTML = '<div class="tt-name">' + escHtml(node.className) + '</div>' +
+    '<div class="tt-table" style="color:' + color + '">' + escHtml(node.type) + '</div>' +
+    methodHtml + condLabel;
+  epTooltipEl.style.display = "block";
+
+  var mainRect = epCanvas.parentElement.getBoundingClientRect();
+  var tx = screenX + 16;
+  var ty = screenY - 10;
+  epTooltipEl.style.left = tx + "px";
+  epTooltipEl.style.top = ty + "px";
+
+  requestAnimationFrame(function() {
+    var ttRect = epTooltipEl.getBoundingClientRect();
+    if (ttRect.right > mainRect.right - 8) {
+      epTooltipEl.style.left = (screenX - ttRect.width - 8) + "px";
+    }
+    if (ttRect.bottom > mainRect.bottom - 8) {
+      epTooltipEl.style.top = (screenY - ttRect.height - 8) + "px";
+    }
+  });
+}
+
+function epHideTooltip() {
+  if (epTooltipEl) epTooltipEl.style.display = "none";
+}
+
+function epShowCodePanel(node) {
+  var panel = document.getElementById("ep-code-panel");
+  if (!panel) return;
+  document.getElementById("ep-code-panel-class").textContent = node.className;
+  var methodText = node.methodName ? "." + node.methodName + "()" : "";
+  document.getElementById("ep-code-panel-method").textContent = methodText;
+  document.getElementById("ep-code-panel-path").textContent = node.filePath || "";
+  var bodyEl = document.getElementById("ep-code-panel-body");
+  bodyEl.innerHTML = "";
+  var code = node.filePath ? fileSources[node.filePath] : null;
+  if (!code) {
+    bodyEl.innerHTML = '<div class="ep-code-no-source">Source code not available</div>';
+  } else if (window.createCodeViewer) {
+    var highlightLines = node.line > 0 ? [node.line] : [];
+    window.createCodeViewer(bodyEl, code, { highlightLines: highlightLines, firstLineNumber: 1 });
+  } else {
+    bodyEl.innerHTML = '<div class="ep-code-no-source">Code viewer not available</div>';
+  }
+  panel.classList.add("open");
+}
+
+function epHideCodePanel() {
+  var panel = document.getElementById("ep-code-panel");
+  if (panel) panel.classList.remove("open");
+}
+
+function renderEndpoints() {
+  var sidebarEl = document.getElementById("endpoints-list");
+  epCanvas = document.getElementById("endpoints-canvas");
+  epTooltipEl = document.getElementById("endpoints-tooltip");
+  if (!sidebarEl || !epCanvas || endpoints.endpoints.length === 0) return;
+
+  epCtx = epCanvas.getContext("2d");
+  epDpr = window.devicePixelRatio || 1;
+
+  // Group endpoints by controller
+  var controllers = {};
+  var controllerOrder = [];
+  for (var i = 0; i < endpoints.endpoints.length; i++) {
+    var ep = endpoints.endpoints[i];
+    if (!controllers[ep.controllerClass]) {
+      controllers[ep.controllerClass] = [];
+      controllerOrder.push(ep.controllerClass);
+    }
+    controllers[ep.controllerClass].push(ep);
+  }
+
+  // Set count
+  document.getElementById("endpoints-count").textContent = endpoints.endpoints.length;
+
+  // HTTP method badge colors
+  var METHOD_COLORS = {
+    GET: "ep-method-get",
+    POST: "ep-method-post",
+    PUT: "ep-method-put",
+    PATCH: "ep-method-patch",
+    DELETE: "ep-method-delete"
+  };
+
+  // Build sidebar
+  var html = "";
+  for (var c = 0; c < controllerOrder.length; c++) {
+    var ctrlName = controllerOrder[c];
+    var ctrlEndpoints = controllers[ctrlName];
+    var ctrlId = "ep-ctrl-" + c;
+    html += '<div class="st-row" data-toggle="' + ctrlId + '">';
+    html += '<span class="st-toggle" data-toggle="' + ctrlId + '">\\u25BE</span>';
+    html += '<span class="st-icon"><svg viewBox="0 0 16 16" fill="none" stroke="var(--nest-red)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="2"/><line x1="5" y1="6" x2="11" y2="6"/><line x1="5" y1="10" x2="9" y2="10"/></svg></span>';
+    html += '<span class="st-label"><span class="st-entity-name">' + escHtml(ctrlName) + '</span></span>';
+    html += '<span class="st-count">' + ctrlEndpoints.length + '</span>';
+    html += '</div>';
+    html += '<div class="st-children st-open" id="st-' + ctrlId + '">';
+
+    for (var e = 0; e < ctrlEndpoints.length; e++) {
+      var ep = ctrlEndpoints[e];
+      var method = (ep.httpMethod || "GET").toUpperCase();
+      var badgeClass = METHOD_COLORS[method] || "ep-method-get";
+      html += '<div class="st-row ep-endpoint-row" data-ep-ctrl="' + escHtml(ctrlName) + '" data-ep-handler="' + escHtml(ep.handlerMethod) + '">';
+      html += '<span class="st-indent"></span><span class="st-indent"></span>';
+      html += '<span class="ep-method-badge ' + badgeClass + '">' + escHtml(method) + '</span>';
+      html += '<span class="st-label">' + escHtml(ep.routePath || "/") + '</span>';
+      html += '</div>';
+    }
+    html += '</div>';
+  }
+  sidebarEl.innerHTML = html;
+
+  // Sidebar click handlers
+  sidebarEl.addEventListener("click", function(e) {
+    // Toggle handling
+    var toggleEl = e.target.closest(".st-toggle");
+    if (toggleEl) {
+      var toggleId = toggleEl.dataset.toggle;
+      var childDiv = document.getElementById("st-" + toggleId);
+      if (childDiv) {
+        var isOpen = childDiv.classList.toggle("st-open");
+        toggleEl.textContent = isOpen ? "\\u25BE" : "\\u25B8";
+      }
+      // If not an endpoint row, stop
+      var row = e.target.closest(".ep-endpoint-row");
+      if (!row) return;
+    }
+
+    // Endpoint selection
+    var epRow = e.target.closest(".ep-endpoint-row");
+    if (!epRow) return;
+    var ctrlName = epRow.dataset.epCtrl;
+    var handlerName = epRow.dataset.epHandler;
+
+    // Find matching endpoint
+    var found = null;
+    for (var i = 0; i < endpoints.endpoints.length; i++) {
+      var ep = endpoints.endpoints[i];
+      if (ep.controllerClass === ctrlName && ep.handlerMethod === handlerName) {
+        found = ep;
+        break;
+      }
+    }
+    if (!found) return;
+
+    // Highlight selected
+    var allRows = sidebarEl.querySelectorAll(".ep-endpoint-row");
+    for (var i = 0; i < allRows.length; i++) {
+      allRows[i].classList.toggle("st-selected", allRows[i] === epRow);
+    }
+
+    epSelectedEndpoint = found;
+
+    // Build graph and render
+    var emptyState = document.getElementById("endpoints-empty-state");
+    if (emptyState) emptyState.style.display = "none";
+    epCanvas.style.display = "block";
+
+    epBuildGraph(found);
+    epLayout();
+    epResize();
+  });
+
+  // Canvas interactions
+  epCanvas.addEventListener("mousedown", function(e) {
+    var rect = epCanvas.getBoundingClientRect();
+    var sx = e.clientX - rect.left;
+    var sy = e.clientY - rect.top;
+    var pos = epScreenToWorld(sx, sy);
+    var hit = epHitTest(pos.x, pos.y);
+    epDragMoved = false;
+    if (hit) {
+      epDragging = hit;
+      epHideTooltip();
+    } else {
+      epPanning = true;
+      epPanStart = { x: e.clientX, y: e.clientY };
+    }
+  });
+
+  epCanvas.addEventListener("mousemove", function(e) {
+    var rect = epCanvas.getBoundingClientRect();
+    var sx = e.clientX - rect.left;
+    var sy = e.clientY - rect.top;
+    var pos = epScreenToWorld(sx, sy);
+
+    if (epDragging) {
+      epDragMoved = true;
+      epDragging.x = pos.x;
+      epDragging.y = pos.y;
+      epScheduleRedraw();
+      epHideTooltip();
+    } else if (epPanning) {
+      epDragMoved = true;
+      epCamX += (e.clientX - epPanStart.x) / epZoom;
+      epCamY += (e.clientY - epPanStart.y) / epZoom;
+      epPanStart = { x: e.clientX, y: e.clientY };
+      epScheduleRedraw();
+      epHideTooltip();
+    } else {
+      var hit = epHitTest(pos.x, pos.y);
+      if (hit !== epHoveredNode) {
+        epHoveredNode = hit;
+        epScheduleRedraw();
+        if (hit) {
+          epShowTooltip(hit, sx, sy);
+        } else {
+          epHideTooltip();
+        }
+      } else if (hit) {
+        epShowTooltip(hit, sx, sy);
+      }
+    }
+  });
+
+  epCanvas.addEventListener("mouseup", function() {
+    var clickedNode = epDragging;
+    if (!epDragMoved && clickedNode) {
+      epShowCodePanel(clickedNode);
+    }
+    epDragging = null;
+    epPanning = false;
+  });
+
+  epCanvas.addEventListener("mouseleave", function() {
+    epDragging = null;
+    epPanning = false;
+    epHoveredNode = null;
+    epHideTooltip();
+    epScheduleRedraw();
+  });
+
+  epCanvas.addEventListener("wheel", function(e) {
+    e.preventDefault();
+    var zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;
+    var newZoom = epZoom * zoomFactor;
+    newZoom = Math.max(0.2, Math.min(3, newZoom));
+
+    var rect = epCanvas.getBoundingClientRect();
+    var mx = e.clientX - rect.left;
+    var my = e.clientY - rect.top;
+
+    var wx = (mx - epW / 2) / epZoom + epW / 2 - epCamX;
+    var wy = (my - epH / 2) / epZoom + epH / 2 - epCamY;
+
+    epZoom = newZoom;
+    epCamX = epW / 2 - wx + (mx - epW / 2) / epZoom;
+    epCamY = epH / 2 - wy + (my - epH / 2) / epZoom;
+
+    epHideTooltip();
+    epScheduleRedraw();
+  }, { passive: false });
+
+  // Recenter button
+  var recenterBtn = document.getElementById("endpoints-recenter");
+  if (recenterBtn) {
+    recenterBtn.addEventListener("click", function() {
+      epCenterCamera();
+      epScheduleRedraw();
+    });
+  }
+
+  // Code panel close button
+  var closePanelBtn = document.getElementById("ep-code-panel-close");
+  if (closePanelBtn) {
+    closePanelBtn.addEventListener("click", function() {
+      epHideCodePanel();
+    });
+  }
+
+  // Resize handle for code panel
+  var epCodePanel = document.getElementById("ep-code-panel");
+  var resizeHandle = document.getElementById("ep-code-panel-resize");
+  if (resizeHandle && epCodePanel) {
+    var epResizing = false;
+    var epStartX, epStartW;
+    resizeHandle.addEventListener("mousedown", function(e) {
+      epResizing = true;
+      epStartX = e.clientX;
+      epStartW = epCodePanel.offsetWidth;
+      resizeHandle.classList.add("dragging");
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      e.preventDefault();
+    });
+    document.addEventListener("mousemove", function(e) {
+      if (!epResizing) return;
+      var w = epStartW + (e.clientX - epStartX);
+      if (w < 300) w = 300;
+      if (w > window.innerWidth * 0.8) w = window.innerWidth * 0.8;
+      epCodePanel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+      if (!epResizing) return;
+      epResizing = false;
+      resizeHandle.classList.remove("dragging");
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    });
+  }
+
+  // Escape key to close code panel
+  document.addEventListener("keydown", function(e) {
+    if (e.key === "Escape" && activeTab === "endpoints") {
+      epHideCodePanel();
+    }
+  });
+
+  // Resize handling
+  epResize();
+  window.addEventListener("resize", function() {
+    if (activeTab === "endpoints") epResize();
+  });
+
+  // Show empty state initially
+  var emptyState = document.getElementById("endpoints-empty-state");
+  if (emptyState) emptyState.style.display = "flex";
+  epCanvas.style.display = "none";
 }
 
 switchTab("summary");`;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -95,6 +95,11 @@ canvas:active { cursor: grabbing; }
 .tab-btn .count-badge.clean {
   background: rgba(74,222,128,0.15); color: var(--score-green);
 }
+.tab-btn .beta-badge {
+  font-size: 9px; padding: 1px 5px; border-radius: 4px;
+  background: rgba(251,191,36,0.15); color: #fbbf24;
+  font-weight: 600; line-height: 1.4; text-transform: uppercase; letter-spacing: 0.5px;
+}
 .tab-spacer { flex: 1; }
 .tab-controls { display: flex; align-items: center; gap: 8px; height: 100%; }
 .tab-controls select {
@@ -944,6 +949,108 @@ canvas:active { cursor: grabbing; }
   padding: 16px; color: var(--text-dim); font-size: 12px;
 }
 
+/* ── Endpoints tab ── */
+#tab-endpoints { display: none; position: fixed; top: var(--header-h); left: 0; right: 0; bottom: 0; }
+#tab-endpoints.active { display: flex; }
+#endpoints-sidebar {
+  width: 340px; min-width: 340px; height: 100%;
+  background: var(--surface); border-right: 1px solid var(--border);
+  overflow-y: auto; padding: 0;
+}
+.endpoints-sidebar-sticky {
+  position: sticky; top: 0; z-index: 1; background: var(--surface);
+}
+.endpoints-sidebar-header {
+  padding: 16px 16px 12px; display: flex; align-items: center; gap: 8px;
+  border-bottom: 1px solid var(--border);
+}
+#endpoints-list { padding: 4px 0; }
+#endpoints-main {
+  flex: 1; overflow: hidden; background: var(--bg);
+  display: flex; flex-direction: column; min-width: 0;
+}
+#endpoints-canvas-wrap {
+  flex: 1; overflow: hidden; position: relative; min-height: 0;
+}
+#endpoints-canvas {
+  position: absolute; top: 0; left: 0;
+  cursor: grab; display: block;
+}
+#endpoints-canvas:active { cursor: grabbing; }
+#endpoints-toolbar {
+  position: absolute; top: 12px; right: 12px; z-index: 10;
+  display: flex; gap: 4px;
+}
+#endpoints-empty-state {
+  display: none; position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+  flex-direction: column; align-items: center; justify-content: center;
+  color: var(--text-muted); gap: 12px; text-align: center; z-index: 5;
+}
+#endpoints-empty-state p { font-size: 14px; color: var(--text-dim); margin: 0; }
+.ep-method-badge {
+  display: inline-block; font-size: 9px; font-weight: 700;
+  padding: 1px 6px; border-radius: 3px; margin-right: 6px;
+  text-transform: uppercase; letter-spacing: 0.5px;
+  min-width: 36px; text-align: center;
+}
+.ep-method-get { background: rgba(59,130,246,0.15); color: #3b82f6; }
+.ep-method-post { background: rgba(16,185,129,0.15); color: #10b981; }
+.ep-method-put { background: rgba(245,158,11,0.15); color: #f59e0b; }
+.ep-method-patch { background: rgba(245,158,11,0.15); color: #f59e0b; }
+.ep-method-delete { background: rgba(239,68,68,0.15); color: #ef4444; }
+.ep-endpoint-row { padding-left: 4px; }
+.ep-endpoint-row:hover { background: rgba(255,255,255,0.04); }
+.ep-endpoint-row.st-selected { background: rgba(59,130,246,0.18); }
+
+/* ── Endpoint code panel ── */
+.ep-code-panel {
+  position: absolute; left: 0; top: 0; bottom: 0; width: 500px; z-index: 10;
+  background: var(--surface); border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  transform: translateX(-100%); transition: transform 0.25s ease;
+}
+.ep-code-panel.open { transform: translateX(0); }
+.ep-code-panel-header {
+  padding: 14px 16px 10px; border-bottom: 1px solid var(--border);
+  position: relative; flex-shrink: 0;
+}
+.ep-code-panel-title {
+  display: flex; align-items: center; gap: 4px;
+  font-size: 14px; font-weight: 600; color: var(--white);
+  margin-bottom: 4px;
+}
+.ep-code-panel-method { color: var(--text-muted); font-weight: 400; }
+.ep-code-panel-path {
+  font-size: 11px; font-family: monospace; color: var(--text-dim);
+  word-break: break-all;
+}
+.ep-code-panel-close {
+  position: absolute; top: 10px; right: 12px;
+  background: none; border: none; color: var(--text-dim);
+  cursor: pointer; font-size: 20px; line-height: 1;
+}
+.ep-code-panel-close:hover { color: var(--white); }
+.ep-code-panel-body {
+  flex: 1; overflow-y: auto;
+}
+.ep-code-panel-body .cm-editor { background: var(--surface); }
+.ep-code-panel-body .cm-scroller { overflow: auto; }
+.ep-code-no-source {
+  display: flex; align-items: center; justify-content: center;
+  height: 100%; color: var(--text-dim); font-size: 13px; text-align: center;
+  padding: 24px;
+}
+.ep-code-panel-resize {
+  position: absolute; right: -2px; top: 0; bottom: 0; width: 5px;
+  cursor: col-resize; z-index: 11;
+  background: transparent;
+  transition: background 0.15s;
+}
+.ep-code-panel-resize:hover,
+.ep-code-panel-resize.dragging {
+  background: var(--nest-red);
+}
+
 @media (max-width: 640px) {
   .summary-grid { grid-template-columns: 1fr; }
   .ov-score-row { flex-direction: column; align-items: flex-start; }
@@ -955,5 +1062,7 @@ canvas:active { cursor: grabbing; }
   .playground-editor { width: 100%; height: auto; border-right: none; border-bottom: 1px solid var(--border); }
   .playground-results { width: 100%; }
   #schema-sidebar { width: 260px; min-width: 260px; }
+  #endpoints-sidebar { width: 260px; min-width: 260px; }
+  .ep-code-panel { width: 100%; }
 }`;
 }

--- a/packages/nestjs-doctor/tests/unit/endpoint-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/endpoint-graph.test.ts
@@ -1,0 +1,751 @@
+import { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import { buildEndpointGraph } from "../../src/engine/graph/endpoint-graph.js";
+import { resolveProviders } from "../../src/engine/graph/type-resolver.js";
+
+function createProject(files: Record<string, string>) {
+	const project = new Project({ useInMemoryFileSystem: true });
+	const paths: string[] = [];
+	for (const [name, code] of Object.entries(files)) {
+		project.createSourceFile(name, code);
+		paths.push(name);
+	}
+	return { project, paths };
+}
+
+describe("endpoint-graph", () => {
+	it("dependency tree only includes deps used by the endpoint method chain", () => {
+		const { project, paths } = createProject({
+			"admin.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('admin')
+				export class AdminController {
+					constructor(private readonly adminService: AdminService) {}
+
+					@Get('organizations')
+					getAllOrganizations() {
+						return this.adminService.getAllOrganizations();
+					}
+				}
+			`,
+			"admin.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AdminService {
+					constructor(
+						private readonly adminRepository: AdminRepository,
+						private readonly logger: CrocovaLogger,
+						private readonly rolesService: RolesService,
+						private readonly eventsService: OrganizationEventsService,
+					) {}
+
+					getAllOrganizations() {
+						return this.adminRepository.findAllOrganizations();
+					}
+
+					deleteOrganization(id: string) {
+						this.eventsService.emit(id);
+						this.rolesService.revokeAll(id);
+						return this.adminRepository.deleteOrganization(id);
+					}
+				}
+			`,
+			"admin.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AdminRepository {
+					constructor(private readonly prisma: PrismaService) {}
+
+					findAllOrganizations() {
+						return this.prisma.findMany();
+					}
+
+					deleteOrganization(id: string) {
+						return this.prisma.delete(id);
+					}
+				}
+			`,
+			"crocova-logger.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class CrocovaLogger {
+					log(msg: string) {}
+				}
+			`,
+			"roles.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class RolesService {
+					revokeAll(id: string) {}
+				}
+			`,
+			"events.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class OrganizationEventsService {
+					emit(id: string) {}
+				}
+			`,
+			"prisma.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class PrismaService {
+					organization = {};
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find(
+			(e) => e.httpMethod === "GET" && e.routePath === "/admin/organizations"
+		);
+		expect(endpoint).toBeDefined();
+
+		// Top-level: single method node for AdminService.getAllOrganizations
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("AdminService");
+		expect(endpoint!.dependencies[0].methodName).toBe("getAllOrganizations");
+		expect(endpoint!.dependencies[0].conditional).toBe(false);
+
+		// AdminService's sub-deps: AdminRepository.findAllOrganizations (not CrocovaLogger, RolesService, etc.)
+		const adminServiceDeps = endpoint!.dependencies[0].dependencies;
+		expect(adminServiceDeps).toHaveLength(1);
+		expect(adminServiceDeps[0].className).toBe("AdminRepository");
+		expect(adminServiceDeps[0].methodName).toBe("findAllOrganizations");
+		expect(adminServiceDeps[0].conditional).toBe(false);
+
+		// AdminRepository's sub-deps: PrismaService.findMany
+		const adminRepoDeps = adminServiceDeps[0].dependencies;
+		expect(adminRepoDeps).toHaveLength(1);
+		expect(adminRepoDeps[0].className).toBe("PrismaService");
+		expect(adminRepoDeps[0].methodName).toBe("findMany");
+
+		// Method nodes have line numbers
+		expect(endpoint!.dependencies[0].line).toBeGreaterThan(0);
+		expect(adminServiceDeps[0].line).toBeGreaterThan(0);
+	});
+
+	it("populates line numbers for dependency method nodes", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					getRoot() {
+						return this.svc.hello();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					hello() { return 'hi'; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		const dep = endpoint!.dependencies[0];
+		expect(dep.className).toBe("AppService");
+		expect(dep.methodName).toBe("hello");
+		expect(dep.line).toBeGreaterThan(0);
+	});
+
+	it("sets line to 0 for fallback dependency nodes", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					getRoot() {
+						return this.svc.hello();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(private readonly helper: HelperService) {}
+					hello() { return 'hi'; }
+				}
+			`,
+			"helper.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class HelperService {
+					doWork() {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		// AppService.hello calls no sub-deps, but HelperService is a constructor dep
+		// Since hello() doesn't call this.helper.*, HelperService won't appear
+		// Let's verify the method node has a line
+		const dep = endpoint!.dependencies[0];
+		expect(dep.line).toBeGreaterThan(0);
+	});
+
+	it("falls back to all constructor deps when no method info is available", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly appService: AppService) {}
+
+					@Get()
+					getRoot() {
+						return this.appService.getHello();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(
+						private readonly configService: ConfigService,
+						private readonly cacheService: CacheService,
+					) {}
+
+					getHello() {
+						return this.configService.get('greeting');
+					}
+				}
+			`,
+			"config.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class ConfigService {
+					constructor(
+						private readonly envLoader: EnvLoader,
+						private readonly validator: ConfigValidator,
+					) {}
+
+					get(key: string) { return key; }
+				}
+			`,
+			"cache.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class CacheService {
+					get(key: string) { return key; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		// AppService.getHello is the only top-level dep
+		expect(endpoint!.dependencies).toHaveLength(1);
+		const appService = endpoint!.dependencies[0];
+		expect(appService.className).toBe("AppService");
+		expect(appService.methodName).toBe("getHello");
+
+		// Only ConfigService.get (used in getHello), NOT CacheService
+		expect(appService.dependencies).toHaveLength(1);
+		expect(appService.dependencies[0].className).toBe("ConfigService");
+		expect(appService.dependencies[0].methodName).toBe("get");
+
+		// ConfigService.get() doesn't call any injected deps, so childDeps will be empty
+		expect(appService.dependencies[0].dependencies).toHaveLength(0);
+	});
+
+	it("handles circular dependencies without infinite recursion", () => {
+		const { project, paths } = createProject({
+			"a.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('a')
+				export class AController {
+					constructor(private readonly aService: AService) {}
+
+					@Get()
+					getA() {
+						return this.aService.doA();
+					}
+				}
+			`,
+			"a.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AService {
+					constructor(private readonly bService: BService) {}
+					doA() {
+						return this.bService.doB();
+					}
+				}
+			`,
+			"b.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class BService {
+					constructor(private readonly aService: AService) {}
+					doB() {
+						return this.aService.doA();
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		// AService.doA → BService.doB, but BService → AService is visited, so stops
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("AService");
+		expect(endpoint!.dependencies[0].methodName).toBe("doA");
+		expect(endpoint!.dependencies[0].dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].dependencies[0].className).toBe(
+			"BService"
+		);
+		expect(endpoint!.dependencies[0].dependencies[0].methodName).toBe("doB");
+		// AService already visited, so no deeper recursion
+		expect(endpoint!.dependencies[0].dependencies[0].dependencies).toHaveLength(
+			0
+		);
+	});
+
+	it("marks methods inside if/else branches as conditional", () => {
+		const { project, paths } = createProject({
+			"org.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('org')
+				export class OrgController {
+					constructor(private readonly orgService: OrgService) {}
+
+					@Post()
+					create() {
+						return this.orgService.createOrganizationWithOwner();
+					}
+				}
+			`,
+			"org.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class OrgService {
+					constructor(private readonly adminRepo: AdminRepository) {}
+
+					createOrganizationWithOwner() {
+						const owner = this.adminRepo.findUserByEmail('test');
+						if (!owner) {
+							this.adminRepo.createUser({});
+						} else if (owner.status !== 'ACTIVE') {
+							this.adminRepo.activateUser(owner.id);
+						}
+						return owner;
+					}
+				}
+			`,
+			"admin.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AdminRepository {
+					findUserByEmail(email: string) { return null; }
+					createUser(data: any) { return data; }
+					activateUser(id: string) { return id; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		const orgService = endpoint!.dependencies[0];
+		expect(orgService.className).toBe("OrgService");
+		expect(orgService.methodName).toBe("createOrganizationWithOwner");
+
+		// Each method of AdminRepository is its own node in orgService.dependencies
+		const adminRepoDeps = orgService.dependencies;
+		expect(adminRepoDeps).toHaveLength(3);
+
+		// findUserByEmail is unconditional
+		const findUser = adminRepoDeps.find(
+			(d) => d.methodName === "findUserByEmail"
+		);
+		expect(findUser).toBeDefined();
+		expect(findUser!.conditional).toBe(false);
+
+		// createUser is conditional
+		const createUser = adminRepoDeps.find((d) => d.methodName === "createUser");
+		expect(createUser).toBeDefined();
+		expect(createUser!.conditional).toBe(true);
+
+		// activateUser is conditional
+		const activateUser = adminRepoDeps.find(
+			(d) => d.methodName === "activateUser"
+		);
+		expect(activateUser).toBeDefined();
+		expect(activateUser!.conditional).toBe(true);
+	});
+
+	it("marks method as unconditional when called both inside and outside conditional", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					doWork() {
+						return this.svc.process();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(private readonly repo: DataRepository) {}
+
+					process() {
+						this.repo.save('always');
+						if (Math.random() > 0.5) {
+							this.repo.save('conditional');
+						}
+						return true;
+					}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					save(data: string) { return data; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		// DataRepository.save — single method node
+		const repo = endpoint!.dependencies[0].dependencies[0];
+		expect(repo.className).toBe("DataRepository");
+		expect(repo.methodName).toBe("save");
+		// Called both conditionally and unconditionally → unconditional wins
+		expect(repo.conditional).toBe(false);
+	});
+
+	it("marks methods in switch case clauses as conditional", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					handle() {
+						return this.svc.route('type');
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(private readonly repo: DataRepository) {}
+
+					route(type: string) {
+						switch (type) {
+							case 'a':
+								return this.repo.handleA();
+							case 'b':
+								return this.repo.handleB();
+							default:
+								return this.repo.handleDefault();
+						}
+					}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					handleA() {}
+					handleB() {}
+					handleDefault() {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		// Each switch case method is its own node
+		const repoDeps = endpoint!.dependencies[0].dependencies;
+		expect(repoDeps).toHaveLength(3);
+		for (const dep of repoDeps) {
+			expect(dep.className).toBe("DataRepository");
+			expect(dep.conditional).toBe(true);
+		}
+		const methodNames = repoDeps.map((d) => d.methodName).sort();
+		expect(methodNames).toEqual(["handleA", "handleB", "handleDefault"]);
+	});
+
+	it("marks ternary branches as conditional", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					check() {
+						return this.svc.decide();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(private readonly repo: DataRepository) {}
+
+					decide() {
+						return Math.random() > 0.5
+							? this.repo.optionA()
+							: this.repo.optionB();
+					}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					optionA() {}
+					optionB() {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		const repoDeps = endpoint!.dependencies[0].dependencies;
+		expect(repoDeps).toHaveLength(2);
+		const optA = repoDeps.find((d) => d.methodName === "optionA");
+		const optB = repoDeps.find((d) => d.methodName === "optionB");
+		expect(optA!.conditional).toBe(true);
+		expect(optB!.conditional).toBe(true);
+	});
+
+	it("marks catch clause methods as conditional but try body as unconditional", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					save() {
+						return this.svc.safeSave();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(private readonly repo: DataRepository) {}
+
+					safeSave() {
+						try {
+							this.repo.save('data');
+						} catch (e) {
+							this.repo.logError(e);
+						}
+					}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					save(data: string) { return data; }
+					logError(e: any) {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		const repoDeps = endpoint!.dependencies[0].dependencies;
+		expect(repoDeps).toHaveLength(2);
+		const save = repoDeps.find((d) => d.methodName === "save");
+		const logError = repoDeps.find((d) => d.methodName === "logError");
+		expect(save!.conditional).toBe(false);
+		expect(logError!.conditional).toBe(true);
+	});
+
+	it("treats if-condition expression calls as unconditional", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					check() {
+						return this.svc.guardedAction();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(private readonly repo: DataRepository) {}
+
+					guardedAction() {
+						if (this.repo.isReady()) {
+							this.repo.execute();
+						}
+					}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					isReady() { return true; }
+					execute() {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		const repoDeps = endpoint!.dependencies[0].dependencies;
+		expect(repoDeps).toHaveLength(2);
+		const isReady = repoDeps.find((d) => d.methodName === "isReady");
+		const execute = repoDeps.find((d) => d.methodName === "execute");
+		expect(isReady!.conditional).toBe(false);
+		expect(execute!.conditional).toBe(true);
+	});
+
+	it("preserves cross-class call order", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(
+						private readonly serviceA: ServiceA,
+						private readonly serviceB: ServiceB,
+					) {}
+
+					@Post()
+					handle() {
+						this.serviceA.foo();
+						this.serviceB.bar();
+						this.serviceA.baz();
+					}
+				}
+			`,
+			"service-a.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class ServiceA {
+					constructor(private readonly repo: DataRepository) {}
+					foo() { return this.repo.find(); }
+					baz() {}
+				}
+			`,
+			"service-b.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class ServiceB {
+					bar() {}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					find() {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		// 3 dependency nodes: ServiceA.foo, ServiceB.bar, ServiceA.baz
+		expect(endpoint!.dependencies).toHaveLength(3);
+
+		expect(endpoint!.dependencies[0].className).toBe("ServiceA");
+		expect(endpoint!.dependencies[0].methodName).toBe("foo");
+		expect(endpoint!.dependencies[0].order).toBe(0);
+
+		expect(endpoint!.dependencies[1].className).toBe("ServiceB");
+		expect(endpoint!.dependencies[1].methodName).toBe("bar");
+		expect(endpoint!.dependencies[1].order).toBe(1);
+
+		expect(endpoint!.dependencies[2].className).toBe("ServiceA");
+		expect(endpoint!.dependencies[2].methodName).toBe("baz");
+		expect(endpoint!.dependencies[2].order).toBe(2);
+
+		// Only foo (first for ServiceA) has sub-deps; baz has none
+		expect(endpoint!.dependencies[0].dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].dependencies[0].className).toBe(
+			"DataRepository"
+		);
+		expect(endpoint!.dependencies[2].dependencies).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

- Scans controllers for HTTP endpoints and traces their dependency chains through injected services, repositories, guards, and other providers
- Adds a new **Endpoints** tab (marked as beta) to the HTML report with a sidebar listing endpoints by controller, a canvas-based dependency graph, and a source code panel
- Reorders report tabs: Endpoints and Relational Schema now appear before Lab
- Includes the endpoint graph in both single-project and monorepo results
