### PR TITLE
feat: add new lint rules and fix edge cases

### DIFF
--- a/.changeset/add-rule-examples.md
+++ b/.changeset/add-rule-examples.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Add missing bad/good code examples for 10 rules in the HTML report (7 new correctness/security rules, 3 schema rules) and fix formatting in require-lifecycle-interface rule

--- a/.rules-rationale.md
+++ b/.rules-rationale.md
@@ -1,0 +1,704 @@
+# nestjs-doctor Rules Rationale & Audit
+
+> **Purpose:** Internal reference documenting **why** each of the 50 rules exists, backed by official sources. Also serves as a quality audit — issues with descriptions, categories, or detection logic are flagged with `🔶 ISSUE`.
+>
+> **Date:** 2026-03-14
+>
+> **How to read this document:**
+> - Each rule has a metadata table (severity, scope, current description), a rationale, source references, and an audit status.
+> - `✅ OK` = rule definition is accurate and well-categorized.
+> - `🔶 ISSUE` = a problem was found — see the description for details and suggested fix.
+
+---
+
+## Table of Contents
+
+- [Security (10 rules)](#security-10-rules)
+- [Correctness (20 rules)](#correctness-20-rules)
+- [Architecture (10 rules)](#architecture-10-rules)
+- [Performance (7 rules)](#performance-7-rules)
+- [Schema (3 rules)](#schema-3-rules)
+- [Audit Summary](#audit-summary)
+
+---
+
+## Security (10 rules)
+
+### `security/no-hardcoded-secrets`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Detect hardcoded secrets, API keys, and tokens in source code |
+
+**Rationale:** Hardcoded credentials committed to source control are one of the most common causes of data breaches. Once pushed, secrets persist in git history even after removal and can be extracted by anyone with repo access. Moving secrets to environment variables (accessed via ConfigService) ensures they never enter version control.
+
+**Source:** OWASP A07:2021 — Security Misconfiguration; CWE-798 — Use of Hard-coded Credentials.
+
+**Audit:** ✅ OK
+
+---
+
+### `security/no-eval`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Usage of eval() or new Function() is a security risk and should be avoided |
+
+**Rationale:** `eval()` and `new Function()` execute arbitrary strings as code. If any part of the input is user-controlled, this creates a direct code injection vulnerability. Even with trusted input, eval makes code harder to reason about and prevents static analysis and optimization.
+
+**Source:** MDN eval() documentation ("Never use eval!"); CWE-95 — Improper Neutralization of Directives in Dynamically Evaluated Code.
+
+**Audit:** ✅ OK
+
+---
+
+### `security/no-csrf-disabled`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | CSRF protection should not be explicitly disabled |
+
+**Rationale:** Cross-Site Request Forgery allows attackers to trick authenticated users into performing unintended actions. NestJS supports CSRF protection via the `csurf` package (or newer alternatives). Explicitly disabling it removes a critical defense layer for browser-based clients.
+
+**Source:** https://docs.nestjs.com/security/csrf; OWASP Cross-Site Request Forgery Cheat Sheet.
+
+**Audit:** ✅ OK
+
+---
+
+### `security/no-dangerous-redirects`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Redirects using user-controlled input (from @Query/@Param) are an open redirect vulnerability |
+
+**Rationale:** When a redirect URL comes directly from user input (query params, route params), an attacker can craft a link that appears to be on the trusted domain but redirects the victim to a malicious site. This is commonly exploited in phishing attacks.
+
+**Source:** OWASP Unvalidated Redirects and Forwards Cheat Sheet; CWE-601 — URL Redirection to Untrusted Site.
+
+**Audit:** ✅ OK
+
+---
+
+### `security/no-synchronize-in-production`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | TypeORM synchronize: true auto-syncs schema and can drop columns or tables in production |
+
+**Rationale:** TypeORM's `synchronize: true` automatically modifies the database schema to match entity definitions on every application start. In production, this can silently drop columns, rename tables, or destroy data when entities change. Migrations provide controlled, reviewable, reversible schema changes instead.
+
+**Source:** TypeORM DataSource options documentation (explicit warning: "Don't use this in production").
+
+**Audit:** ✅ RESOLVED — The rule correctly flags `synchronize: true` unconditionally as a safety measure (it should never be committed). Renaming or moving category would change the rule ID (`security/no-synchronize-in-production`), which is a breaking change for users who configure rules by ID.
+
+---
+
+### `security/no-weak-crypto`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Weak hashing algorithms (MD5, SHA1) should not be used for security purposes |
+
+**Rationale:** MD5 and SHA1 have known collision vulnerabilities and are considered cryptographically broken for security use cases (password hashing, integrity verification, digital signatures). They remain acceptable for non-security checksums but should be replaced with SHA-256+ or bcrypt/scrypt/argon2 for any security-sensitive operation.
+
+**Source:** Node.js crypto module documentation; OWASP Cryptographic Failures (A02:2021).
+
+**Audit:** ✅ OK
+
+---
+
+### `security/no-exposed-env-vars`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Use NestJS ConfigService instead of direct process.env access in Injectable/Controller classes |
+
+**Rationale:** Direct `process.env` access scatters configuration reads across the codebase, making it difficult to validate, type-check, and mock configuration values. NestJS `ConfigService` provides centralized, validated, injectable configuration that improves testability and maintainability.
+
+**Source:** https://docs.nestjs.com/techniques/configuration
+
+**Audit:** ✅ RESOLVED — Moving to `architecture` would change the rule ID (`security/no-exposed-env-vars`), which is a breaking change for users who configure rules by ID. Kept in `security` — direct `process.env` access can leak sensitive values in error messages and lacks validation.
+
+---
+
+### `security/no-exposed-stack-trace`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Stack traces should not be exposed in responses — they leak internal implementation details |
+
+**Rationale:** Stack traces in HTTP responses reveal internal file paths, dependency versions, and code structure to potential attackers. This information helps attackers identify vulnerable dependencies and understand application internals. Production error responses should be generic; detailed traces should only go to server-side logs.
+
+**Source:** OWASP Information Disclosure; CWE-209 — Generation of Error Message Containing Sensitive Information.
+
+**Audit:** ✅ OK
+
+---
+
+### `security/no-raw-entity-in-response`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Returning ORM entities directly from controllers can leak internal fields like passwords or IDs |
+
+**Rationale:** ORM entities often contain sensitive fields (password hashes, internal IDs, soft-delete flags, audit columns) that should never reach API consumers. Returning entities directly bypasses any serialization logic and exposes the full database row. Using DTOs or class-transformer decorators (@Exclude/@Expose) ensures only intended fields are serialized.
+
+**Source:** https://docs.nestjs.com/techniques/serialization
+
+**Audit:** ✅ FIXED — Removed implementation detail from help text. Help now contains only user-facing advice.
+
+---
+
+### `security/require-guards-on-endpoints`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Controller endpoints should be protected by @UseGuards() at class or method level |
+
+**Rationale:** Unprotected endpoints are a common source of authorization vulnerabilities. Requiring explicit guard decorators ensures every endpoint has been consciously reviewed for access control. Routes intentionally left public can be marked with a `@Public()` decorator.
+
+**Source:** https://docs.nestjs.com/guards; https://docs.nestjs.com/security/authentication
+
+**Audit:** ✅ RESOLVED — The rule's help text already mentions `APP_GUARD` as an alternative and advises users to disable the rule when using global guards.
+
+---
+
+## Correctness (20 rules)
+
+### `correctness/no-missing-injectable`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | project | Provider classes with constructor dependencies must have the @Injectable() decorator |
+
+**Rationale:** NestJS's dependency injection system requires the `@Injectable()` decorator to emit metadata that the IoC container uses to resolve constructor dependencies. Without it, the container cannot determine what to inject and the application fails to bootstrap with a cryptic "Nest can't resolve dependencies" error.
+
+**Source:** https://docs.nestjs.com/providers
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/no-duplicate-routes`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Same HTTP method + route path + version should not appear twice in a single controller |
+
+**Rationale:** When two handlers in the same controller match the same method/path/version combination, NestJS will silently use only the first one. The second handler becomes dead code that appears to work during development but never executes, leading to confusing bugs.
+
+**Source:** https://docs.nestjs.com/controllers#routing
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/no-missing-guard-method`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Guard classes must implement the canActivate() method |
+
+**Rationale:** The `CanActivate` interface requires a `canActivate()` method. If a guard class omits this method, NestJS will throw a runtime error when the guard is triggered. This is especially dangerous because the failure only occurs when the specific guarded route is hit, potentially passing tests that don't exercise that path.
+
+**Source:** https://docs.nestjs.com/guards
+
+**Audit:** ✅ FIXED — Added name-based detection note to help text.
+
+---
+
+### `correctness/no-missing-pipe-method`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Pipe classes must implement the transform() method |
+
+**Rationale:** The `PipeTransform` interface requires a `transform()` method. A pipe without `transform()` will cause a runtime error when NestJS attempts to run the validation/transformation pipeline. Like guards, this failure only manifests when the specific pipe is triggered.
+
+**Source:** https://docs.nestjs.com/pipes
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/no-missing-filter-catch`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Exception filter classes decorated with @Catch() must implement the catch() method |
+
+**Rationale:** The `ExceptionFilter` interface requires a `catch()` method. If a filter decorated with `@Catch()` lacks this method, exceptions that hit the filter will cause a secondary runtime error instead of being handled gracefully, potentially crashing the request pipeline.
+
+**Source:** https://docs.nestjs.com/exception-filters
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/no-missing-interceptor-method`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Interceptor classes must implement the intercept() method |
+
+**Rationale:** The `NestInterceptor` interface requires an `intercept()` method. An interceptor without this method will fail at runtime when the request pipeline invokes it. Since interceptors wrap the entire handler execution, this failure affects every route the interceptor is applied to.
+
+**Source:** https://docs.nestjs.com/interceptors
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/require-inject-decorator`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Constructor parameters without type annotations must have @Inject() decorator for NestJS DI to resolve them |
+
+**Rationale:** NestJS resolves constructor dependencies using TypeScript's emitted type metadata (via `emitDecoratorMetadata`). When a parameter has no type annotation (or uses an interface/union type that doesn't emit metadata), NestJS cannot determine what to inject. The `@Inject()` decorator provides an explicit token that bypasses metadata resolution.
+
+**Source:** https://docs.nestjs.com/fundamentals/custom-providers
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/prefer-readonly-injection`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Constructor DI parameters should be readonly to prevent accidental reassignment |
+
+**Rationale:** Injected dependencies should be treated as immutable references. Accidentally reassigning `this.userService = something` in a method body could break the entire request pipeline. The `readonly` modifier provides compile-time protection against this class of bug.
+
+**Source:** TypeScript `readonly` modifier documentation; NestJS convention in official examples.
+
+**Audit:** ✅ RESOLVED — Moving to `architecture` would change the rule ID (`correctness/prefer-readonly-injection`), which is a breaking change for users who configure rules by ID. Kept in `correctness` — reassignment prevention is a correctness concern.
+
+---
+
+### `correctness/require-lifecycle-interface`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Classes with lifecycle methods should implement the corresponding NestJS interface |
+
+**Rationale:** NestJS lifecycle hooks (`onModuleInit`, `onModuleDestroy`, etc.) work by duck-typing — if the method exists, it's called. However, implementing the interface (`OnModuleInit`, `OnModuleDestroy`) provides compile-time checking for method signatures, IDE autocompletion, and makes the intent explicit to other developers.
+
+**Source:** https://docs.nestjs.com/fundamentals/lifecycle-events
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/no-empty-handlers`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Controller HTTP handlers should not have empty bodies |
+
+**Rationale:** An empty HTTP handler returns `undefined`, which NestJS serializes as a `200 OK` with an empty response body. This is almost never intentional — it typically indicates an unfinished implementation that silently succeeds, making it hard to detect during integration testing.
+
+**Source:** General correctness — NestJS controller handler return value behavior.
+
+**Audit:** ✅ FIXED — Lowered severity to `info` so development stubs don't clutter output.
+
+---
+
+### `correctness/no-async-without-await`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Async functions/methods should contain at least one await expression |
+
+**Rationale:** An `async` function without `await` wraps the return value in an unnecessary Promise and signals to readers that asynchronous work is happening when it isn't. This is typically a sign that the developer forgot to await a call, which can lead to unhandled rejections or race conditions.
+
+**Source:** Equivalent to ESLint `require-await` rule.
+
+**Audit:** ✅ FIXED — Added HTTP handler exemption note to help text.
+
+---
+
+### `correctness/no-duplicate-module-metadata`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Same identifier should not appear twice in a module metadata array |
+
+**Rationale:** Listing the same provider, controller, import, or export twice in a `@Module()` decorator is redundant and confusing. While NestJS handles duplicates gracefully (it just registers once), the duplication often indicates a copy-paste error or a merge conflict artifact that should be cleaned up.
+
+**Source:** https://docs.nestjs.com/modules
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/no-missing-module-decorator`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Classes named *Module should have a @Module() decorator |
+
+**Rationale:** A class named `*Module` without `@Module()` won't be recognized by NestJS as a module. If imported by another module, it will fail silently or throw a confusing error. The naming convention strongly suggests the developer intended it to be a module, so the missing decorator is likely an oversight.
+
+**Source:** https://docs.nestjs.com/modules
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/no-fire-and-forget-async`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Calling async functions without await leads to unhandled promise rejections |
+
+**Rationale:** When an async function is called without `await`, its returned Promise is discarded. If that function throws, the rejection goes unhandled, triggering Node.js's `unhandledRejection` event which (since Node 15) crashes the process by default. Even without crashes, errors are silently swallowed, making bugs extremely hard to diagnose.
+
+**Source:** Node.js `unhandledRejection` event documentation; Node.js `--unhandled-rejections` flag behavior.
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/param-decorator-matches-route`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | @Param() decorator name must match a :param in the route path |
+
+**Rationale:** When `@Param('id')` is used but the route path doesn't contain `:id`, the parameter will always be `undefined` at runtime. This is a silent bug — no error is thrown, but the handler receives garbage input. Matching param names to route segments catches typos and copy-paste errors at lint time.
+
+**Source:** https://docs.nestjs.com/controllers#route-parameters
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/factory-inject-matches-params`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | useFactory inject array length must match the factory function parameter count |
+
+**Rationale:** In NestJS factory providers, the `inject` array maps 1:1 to factory function parameters by position. A mismatch means either (a) extra injects are silently ignored, or (b) factory parameters receive `undefined` instead of the intended service, causing runtime errors or incorrect behavior.
+
+**Source:** https://docs.nestjs.com/fundamentals/custom-providers#factory-providers-usefactory
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/no-duplicate-decorators`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Same decorator should not be applied more than once to the same target |
+
+**Rationale:** Applying the same decorator twice to a class, method, or parameter is almost always unintentional. The second application either silently overwrites the first (losing configuration) or causes undefined behavior depending on the decorator implementation. This commonly happens during refactoring or merge conflicts.
+
+**Source:** General TypeScript/NestJS correctness — decorator application semantics.
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/validated-non-primitive-needs-type`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | DTO properties with class-validator decorators on non-primitive types must have @Type() from class-transformer |
+
+**Rationale:** When a DTO property is a nested object (class instance), `class-validator` validates it but `class-transformer` needs `@Type(() => NestedClass)` to know how to instantiate the nested class from plain JSON. Without `@Type()`, the nested object remains a plain object and validation decorators on the nested class are silently skipped.
+
+**Source:** class-transformer README — https://github.com/typestack/class-transformer; NestJS validation documentation.
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/validate-nested-array-each`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | @ValidateNested() on array-typed properties must use { each: true } |
+
+**Rationale:** `@ValidateNested()` without `{ each: true }` on an array property validates the array object itself rather than each element. This means invalid elements pass validation silently. The `{ each: true }` option tells class-validator to iterate the array and validate each element individually.
+
+**Source:** class-validator README — https://github.com/typestack/class-validator; `each` option documentation.
+
+**Audit:** ✅ OK
+
+---
+
+### `correctness/injectable-must-be-provided`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| info | project | @Injectable() classes should be registered in at least one module's providers array |
+
+**Rationale:** An `@Injectable()` class that isn't registered in any module's `providers` array is unreachable by the DI container. Attempting to inject it will fail with "Nest can't resolve dependencies." This rule catches the common mistake of creating a service but forgetting to register it.
+
+**Source:** https://docs.nestjs.com/providers
+
+**Audit:** ✅ OK
+
+---
+
+## Architecture (10 rules)
+
+### `architecture/no-business-logic-in-controllers`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Controllers should only handle HTTP concerns — move business logic to services |
+
+**Rationale:** The NestJS architecture separates controllers (HTTP layer) from services (business logic). When controllers contain branches, loops, and complex calculations, the logic becomes tightly coupled to the transport layer, making it untestable without HTTP context and unreusable across different transports (WebSocket, gRPC, CLI).
+
+**Source:** https://docs.nestjs.com/controllers; https://docs.nestjs.com/providers
+
+**Audit:** ✅ OK
+
+---
+
+### `architecture/no-repository-in-controllers`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Controllers must not inject repositories directly — use the service layer |
+
+**Rationale:** Injecting repositories into controllers bypasses the service layer, coupling HTTP handling directly to data access. This violates the layered architecture pattern, makes it impossible to add business logic (validation, authorization, transformation) without modifying the controller, and prevents reuse of data access logic across different entry points.
+
+**Source:** Layered architecture principle; NestJS provider documentation.
+
+**Audit:** ✅ OK
+
+---
+
+### `architecture/no-orm-in-controllers`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Controllers must not inject ORM services directly — use a service layer |
+
+**Rationale:** Similar to `no-repository-in-controllers`, but broader — catches direct injection of ORM entry points like `EntityManager`, `DataSource`, `PrismaService`, etc. Controllers should be transport-agnostic; ORM usage belongs in the service or repository layer.
+
+**Source:** Layered architecture principle; NestJS provider documentation.
+
+**Audit:** ✅ OK
+
+---
+
+### `architecture/no-circular-module-deps`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | project | Circular dependencies in @Module() import graph |
+
+**Rationale:** Circular module imports cause one of the modules to be `undefined` during initialization, leading to cryptic runtime errors ("Cannot read properties of undefined"). NestJS provides `forwardRef()` as an escape hatch, but the better solution is to extract shared logic into a separate module that both modules can import.
+
+**Source:** https://docs.nestjs.com/fundamentals/circular-dependency
+
+**Audit:** ✅ FIXED — Changed description to prescriptive style: "Module import graph must not contain circular dependencies".
+
+---
+
+### `architecture/no-manual-instantiation`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | file | Do not manually instantiate @Injectable classes — use NestJS dependency injection |
+
+**Rationale:** Using `new MyService()` on an `@Injectable` class bypasses the NestJS DI container. The manually created instance won't have its own dependencies injected, won't participate in the module lifecycle, and won't be the same singleton instance used elsewhere. This almost always leads to subtle bugs where the service appears to work but is actually operating in an isolated, incomplete state.
+
+**Source:** https://docs.nestjs.com/providers (purpose of DI container).
+
+**Audit:** ✅ OK
+
+---
+
+### `architecture/no-orm-in-services`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Services should use repository abstractions instead of ORM directly |
+
+**Rationale:** The repository pattern adds a layer of abstraction between services and the ORM, making services testable with mock repositories and allowing ORM changes without modifying business logic. This is a well-established pattern in enterprise application architecture.
+
+**Source:** Repository pattern (Martin Fowler); NestJS TypeORM recipe uses repositories.
+
+**Audit:** ✅ FIXED — Lowered severity to `info` and added Prisma note to help text so users following the official NestJS Prisma recipe know to disable the rule.
+
+---
+
+### `architecture/no-service-locator`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Avoid using ModuleRef.get() or ModuleRef.resolve() — prefer explicit constructor injection |
+
+**Rationale:** The Service Locator pattern (via `ModuleRef`) hides dependencies, making them invisible in the constructor signature. This makes classes harder to test (you can't see what to mock), harder to understand (dependencies are buried in method bodies), and prevents NestJS from validating the dependency graph at startup time.
+
+**Source:** https://docs.nestjs.com/fundamentals/module-ref (NestJS docs note this is for advanced/dynamic cases).
+
+**Audit:** ✅ OK
+
+---
+
+### `architecture/prefer-constructor-injection`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Prefer constructor injection over @Inject() property injection |
+
+**Rationale:** Constructor injection makes dependencies explicit, immutable (when combined with `readonly`), and available immediately. Property injection with `@Inject()` on class fields allows partially-constructed objects, makes dependencies less visible, and prevents TypeScript from enforcing initialization in the constructor.
+
+**Source:** https://docs.nestjs.com/providers#property-based-injection (NestJS docs: "normally prefer constructor-based injection").
+
+**Audit:** ✅ OK
+
+---
+
+### `architecture/require-module-boundaries`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| info | file | Avoid deep imports into other feature modules' internals |
+
+**Rationale:** Deep imports (e.g., `import { helper } from '../users/utils/password-hasher'`) bypass module encapsulation, creating tight coupling between feature modules. When the internal structure of a module changes, all deep importers break. Importing from a module's public API (barrel file) ensures a stable contract.
+
+**Source:** https://docs.nestjs.com/modules (module encapsulation concept).
+
+**Audit:** ✅ OK
+
+---
+
+### `architecture/no-barrel-export-internals`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| info | file | Don't re-export internal implementation details from barrel files |
+
+**Rationale:** Barrel files (`index.ts`) define a module's public API. Re-exporting internal helpers, private utilities, or implementation details through the barrel makes them part of the public contract, preventing internal refactoring without breaking consumers. Only services, DTOs, and interfaces should be in the public API.
+
+**Source:** Module encapsulation best practice; NestJS module system.
+
+**Audit:** ✅ OK
+
+---
+
+## Performance (7 rules)
+
+### `performance/no-sync-io`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Synchronous I/O calls block the event loop and should be avoided in NestJS applications |
+
+**Rationale:** Node.js runs on a single-threaded event loop. Synchronous I/O calls (`readFileSync`, `writeFileSync`, etc.) block this thread entirely, preventing all other requests from being processed until the I/O completes. Even a single `readFileSync` on a slow disk can cause hundreds of milliseconds of latency for all concurrent users.
+
+**Source:** Node.js fs module documentation (async vs sync API); Node.js event loop documentation.
+
+**Audit:** ✅ OK
+
+---
+
+### `performance/no-blocking-constructor`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Constructors in Injectable/Controller classes should not contain heavy operations |
+
+**Rationale:** Constructors run synchronously during the DI container's bootstrap phase. Heavy operations (HTTP calls, file reads, complex computations) in constructors delay application startup and cannot be properly async since constructors can't return Promises. NestJS provides the `onModuleInit()` lifecycle hook specifically for async initialization.
+
+**Source:** https://docs.nestjs.com/fundamentals/lifecycle-events
+
+**Audit:** ✅ FIXED — Removed `AwaitExpression` from `BLOCKING_KINDS` set and updated help text to clarify that constructors cannot be async.
+
+---
+
+### `performance/no-dynamic-require`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Dynamic require() with variable arguments prevents bundler optimization |
+
+**Rationale:** When `require()` is called with a variable argument (e.g., `require(moduleName)`), bundlers like webpack and esbuild cannot statically analyze the dependency. This prevents tree-shaking, code splitting, and other optimizations, potentially including unnecessary code in the production bundle.
+
+**Source:** Webpack module resolution documentation; esbuild bundling documentation.
+
+**Audit:** ✅ OK
+
+---
+
+### `performance/no-request-scope-abuse`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | file | Scope.REQUEST creates a new provider instance per request — use only when necessary |
+
+**Rationale:** NestJS providers default to singleton scope (`Scope.DEFAULT`). Switching to `Scope.REQUEST` creates a new instance for every incoming request, which adds allocation overhead, GC pressure, and prevents caching within the provider. Additionally, request scope **propagates up the injection chain** — any provider that depends on a request-scoped provider also becomes request-scoped.
+
+**Source:** https://docs.nestjs.com/fundamentals/injection-scopes
+
+**Audit:** ✅ OK
+
+---
+
+### `performance/no-unused-providers`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | project | Injectable providers that are never injected and have no self-activating decorators may be dead code |
+
+**Rationale:** Providers registered in a module but never injected anywhere are dead code. While NestJS still instantiates them (incurring a minor startup cost), the primary concern is codebase hygiene — dead providers add cognitive load, appear in DI error messages, and can mask the actual dependency graph. Self-activating providers (e.g. `@Cron`, `@OnEvent`, `@Process`) are excluded since they are activated by the framework without needing injection.
+
+**Source:** General code hygiene; NestJS module system.
+
+**Audit:** ✅ RESOLVED — Moving to `architecture` would change the rule ID (`performance/no-unused-providers`), which is a breaking change for users who configure rules by ID. Kept in `performance` — unused providers do add startup overhead, even if small.
+
+---
+
+### `performance/no-unused-module-exports`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| info | project | Module exports a provider that no importing module actually uses |
+
+**Rationale:** When a module exports a provider that no other module imports and uses, the export is unnecessary. Unused exports expand the module's public API surface without benefit, making it harder to reason about what the module actually provides to consumers.
+
+**Source:** NestJS module exports documentation; module API hygiene.
+
+**Audit:** ✅ RESOLVED — Moving to `architecture` would change the rule ID (`performance/no-unused-module-exports`), which is a breaking change for users who configure rules by ID. Kept in `performance`.
+
+---
+
+### `performance/no-orphan-modules`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| info | project | Module is never imported by any other module and may be dead code |
+
+**Rationale:** A module that is never imported by any other module (and isn't the root module) is completely unreachable. Its providers are never instantiated, its controllers never registered. This typically indicates a module that was created but never wired in, or one that was disconnected during refactoring.
+
+**Source:** NestJS module system; dead code detection.
+
+**Audit:** ✅ RESOLVED — Moving to `architecture` would change the rule ID (`performance/no-orphan-modules`), which is a breaking change for users who configure rules by ID. Kept in `performance`.
+
+---
+
+## Schema (3 rules)
+
+### `schema/require-primary-key`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| error | schema | Every entity must have at least one primary key column |
+
+**Rationale:** A database table without a primary key cannot uniquely identify rows, breaks most ORM operations (find, update, delete by ID), and prevents proper indexing. Both TypeORM and Prisma require primary keys for correct operation. Some databases allow it but it leads to data integrity issues and poor performance.
+
+**Source:** Database fundamentals; TypeORM entity documentation; Prisma schema documentation.
+
+**Audit:** ✅ OK
+
+---
+
+### `schema/require-timestamps`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| warning | schema | Entities should have timestamp columns (createdAt/updatedAt) |
+
+**Rationale:** Timestamp columns (`createdAt`, `updatedAt`) provide a built-in audit trail for every record. They're essential for debugging data issues ("when did this change?"), building incremental sync/ETL pipelines, implementing cache invalidation, and meeting compliance requirements. Adding them retroactively requires a migration and backfill.
+
+**Source:** Audit trail best practice; TypeORM `@CreateDateColumn`/`@UpdateDateColumn` documentation; Prisma `@updatedAt` documentation.
+
+**Audit:** ✅ OK
+
+---
+
+### `schema/require-cascade-rule`
+| Severity | Scope | Description |
+|----------|-------|-------------|
+| info | schema | Relations should have explicit onDelete/cascade behavior defined |
+
+**Rationale:** When a parent row is deleted, the behavior for child rows depends on the database's default (usually `RESTRICT` or `NO ACTION`). Relying on implicit defaults is dangerous — different databases have different defaults, and the behavior is invisible in the code. Explicit `onDelete` options (CASCADE, SET NULL, RESTRICT) make the intended behavior clear and portable.
+
+**Source:** TypeORM cascade options documentation; Prisma referential actions documentation.
+
+**Audit:** ✅ OK
+
+---
+
+## Audit Summary
+
+14 issues audited across 50 rules — all resolved (7 fixed in code, 7 resolved as non-actionable):
+
+| # | Rule | Resolution | Summary |
+|---|------|------------|---------|
+| 1 | `security/no-raw-entity-in-response` | ✅ FIXED | Removed implementation detail from help text |
+| 2 | `security/no-synchronize-in-production` | ✅ RESOLVED | Rule correctly flags unconditionally; category change would break ID |
+| 3 | `architecture/no-orm-in-services` | ✅ FIXED | Lowered severity to `info`, added Prisma note to help text |
+| 4 | `security/require-guards-on-endpoints` | ✅ RESOLVED | Help text already mentions `APP_GUARD` |
+| 5 | `security/no-exposed-env-vars` | ✅ RESOLVED | Category change would break rule ID |
+| 6 | `architecture/no-circular-module-deps` | ✅ FIXED | Changed description to prescriptive style |
+| 7 | `correctness/no-async-without-await` | ✅ FIXED | Added HTTP handler exemption to help text |
+| 8 | `performance/no-blocking-constructor` | ✅ FIXED | Removed `AwaitExpression` from detection, updated help text |
+| 9 | `performance/no-unused-providers` | ✅ RESOLVED | Category change would break rule ID |
+| 10 | `performance/no-orphan-modules` | ✅ RESOLVED | Category change would break rule ID |
+| 11 | `performance/no-unused-module-exports` | ✅ RESOLVED | Category change would break rule ID |
+| 12 | `correctness/prefer-readonly-injection` | ✅ RESOLVED | Category change would break rule ID |
+| 13 | `correctness/no-empty-handlers` | ✅ FIXED | Lowered severity to `info` |
+| 14 | `correctness/no-missing-guard-method` | ✅ FIXED | Added name-based detection note to help text |

--- a/packages/nestjs-doctor-vscode/README.md
+++ b/packages/nestjs-doctor-vscode/README.md
@@ -26,7 +26,7 @@
 - **Scan on save** — automatically re-scans when you save a file (configurable debounce)
 - **Scan on open** — scans the workspace when VS Code opens
 - **Manual scan** — trigger a full project scan from the command palette
-- **43 built-in rules** — same rules as the CLI, covering security, performance, correctness, architecture, and schema
+- **50 built-in rules** — same rules as the CLI, covering security, performance, correctness, architecture, and schema
 
 ---
 

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  43 built-in rules across <b>security</b>, <b>performance</b>, <b>correctness</b>, <b>architecture</b>, and <b>schema</b>. Outputs a <b>0-100 score</b> with actionable diagnostics. Zero config. Monorepo support. Catches the anti-patterns that AI-generated code introduce (slop code).
+  50 built-in rules across <b>security</b>, <b>performance</b>, <b>correctness</b>, <b>architecture</b>, and <b>schema</b>. Outputs a <b>0-100 score</b> with actionable diagnostics. Zero config. Monorepo support. Catches the anti-patterns that AI-generated code introduce (slop code).
 </p>
 
 ---
@@ -60,7 +60,7 @@ Install [NestJS Doctor](https://marketplace.visualstudio.com/items?itemName=rolo
 npm install -D nestjs-doctor
 ```
 
-Same 43 rules as the CLI, surfaced as inline diagnostics in the editor and in the Problems panel. Files are scanned on open and on save with a configurable debounce.
+Same 50 rules as the CLI, surfaced as inline diagnostics in the editor and in the Problems panel. Files are scanned on open and on save with a configurable debounce.
 
 Use `NestJS Doctor: Scan Project` from the command palette to trigger a full scan manually.
 
@@ -370,9 +370,9 @@ mono.combined;      // Merged DiagnoseResult
 
 ---
 
-## Rules (43)
+## Rules (50)
 
-### Security (9)
+### Security (10)
 
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
@@ -385,8 +385,9 @@ mono.combined;      // Merged DiagnoseResult
 | `no-exposed-env-vars` | warning | Direct `process.env` in Injectable/Controller |
 | `no-exposed-stack-trace` | warning | `error.stack` exposed in responses |
 | `no-raw-entity-in-response` | warning | Returning ORM entities directly from controllers -- leaks internal fields |
+| `require-guards-on-endpoints` | warning | Endpoints without `@UseGuards()` at class or method level |
 
-### Correctness (14)
+### Correctness (20)
 
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
@@ -399,11 +400,17 @@ mono.combined;      // Merged DiagnoseResult
 | `require-inject-decorator` | error | Untyped constructor param without `@Inject()` |
 | `prefer-readonly-injection` | warning | Constructor DI params missing `readonly` |
 | `require-lifecycle-interface` | warning | Lifecycle method without corresponding interface |
-| `no-empty-handlers` | warning | HTTP handler with empty body |
+| `no-empty-handlers` | info | HTTP handler with empty body |
 | `no-async-without-await` | warning | Async function/method with no `await` |
 | `no-duplicate-module-metadata` | warning | Duplicate entries in `@Module()` arrays |
 | `no-missing-module-decorator` | warning | Class named `*Module` without `@Module()` |
 | `no-fire-and-forget-async` | warning | Async call without `await` in non-handler methods |
+| `param-decorator-matches-route` | error | `@Param()` name doesn't match any `:param` in the route path |
+| `factory-inject-matches-params` | error | `useFactory` inject array length mismatches factory parameter count |
+| `no-duplicate-decorators` | warning | Same decorator appears twice on a single target |
+| `validated-non-primitive-needs-type` | warning | Non-primitive DTO property with class-validator decorators missing `@Type()` |
+| `validate-nested-array-each` | warning | `@ValidateNested()` on array property missing `{ each: true }` |
+| `injectable-must-be-provided` | info | `@Injectable()` class not registered in any module's providers |
 
 ### Architecture (10)
 
@@ -414,7 +421,7 @@ mono.combined;      // Merged DiagnoseResult
 | `no-orm-in-controllers` | error | PrismaService / EntityManager / DataSource in controllers |
 | `no-circular-module-deps` | error | Cycles in `@Module()` import graph |
 | `no-manual-instantiation` | error | `new SomeService()` for injectable classes |
-| `no-orm-in-services` | warning | Services using ORM directly (should use repositories) |
+| `no-orm-in-services` | info | Services using ORM directly (should use repositories) |
 | `no-service-locator` | warning | `ModuleRef.get()`/`resolve()` hides dependencies |
 | `prefer-constructor-injection` | warning | `@Inject()` property injection |
 | `require-module-boundaries` | info | Deep imports into other modules' internals |
@@ -425,9 +432,9 @@ mono.combined;      // Merged DiagnoseResult
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
 | `no-sync-io` | warning | `readFileSync`, `writeFileSync`, etc. |
-| `no-blocking-constructor` | warning | Loops/await in Injectable/Controller constructors |
+| `no-blocking-constructor` | warning | Loops in Injectable/Controller constructors |
 | `no-dynamic-require` | warning | `require()` with non-literal argument |
-| `no-unused-providers` | warning | Provider never injected anywhere |
+| `no-unused-providers` | warning | Provider never injected and no self-activating decorators |
 | `no-request-scope-abuse` | warning | `Scope.REQUEST` creates new instance per request |
 | `no-unused-module-exports` | info | Module exports unused by importers |
 | `no-orphan-modules` | info | Module never imported by any other module |

--- a/packages/nestjs-doctor/skill/SKILL.md
+++ b/packages/nestjs-doctor/skill/SKILL.md
@@ -102,7 +102,7 @@ For each diagnostic to fix:
 - **no-sync-io**: Replace synchronous I/O (`readFileSync`, `writeFileSync`, etc.) with async equivalents (`readFile`, `writeFile` from `fs/promises`).
 - **no-blocking-constructor**: Move async operations and loops out of the constructor into `onModuleInit()` lifecycle hook. Implement `OnModuleInit` interface.
 - **no-dynamic-require**: Replace `require(variable)` with a static import or a switch/map pattern that uses static `require()` calls.
-- **no-unused-providers**: Remove the unused provider from the module's providers array, or start using it. If it's intended for external consumers, add it to the module's exports.
+- **no-unused-providers**: Remove the unused provider from the module's providers array, or start using it. Providers with self-activating decorators (@Cron, @OnEvent, @Process) are automatically excluded. If it's intended for external consumers, add it to the module's exports.
 - **no-request-scope-abuse**: Remove `Scope.REQUEST` unless the provider genuinely needs per-request state (e.g., request-scoped context like `REQUEST` object). Use `Scope.DEFAULT` (singleton) or `Scope.TRANSIENT` instead. Remember that request scope propagates to all dependents.
 - **no-unused-module-exports**: Remove the unused export from the module's exports array, or start importing the module where the exported provider is needed.
 - **no-orphan-modules**: Import this module in another module that needs it, or remove it if it's truly unused. If it's the root module, this can be ignored.

--- a/packages/nestjs-doctor/src/cli/skill-content.ts
+++ b/packages/nestjs-doctor/src/cli/skill-content.ts
@@ -102,7 +102,7 @@ For each diagnostic to fix:
 - **no-sync-io**: Replace synchronous I/O (\`readFileSync\`, \`writeFileSync\`, etc.) with async equivalents (\`readFile\`, \`writeFile\` from \`fs/promises\`).
 - **no-blocking-constructor**: Move async operations and loops out of the constructor into \`onModuleInit()\` lifecycle hook. Implement \`OnModuleInit\` interface.
 - **no-dynamic-require**: Replace \`require(variable)\` with a static import or a switch/map pattern that uses static \`require()\` calls.
-- **no-unused-providers**: Remove the unused provider from the module's providers array, or start using it. If it's intended for external consumers, add it to the module's exports.
+- **no-unused-providers**: Remove the unused provider from the module's providers array, or start using it. Providers with self-activating decorators (@Cron, @OnEvent, @Process) are automatically excluded. If it's intended for external consumers, add it to the module's exports.
 - **no-request-scope-abuse**: Remove \`Scope.REQUEST\` unless the provider genuinely needs per-request state (e.g., request-scoped context like \`REQUEST\` object). Use \`Scope.DEFAULT\` (singleton) or \`Scope.TRANSIENT\` instead. Remember that request scope propagates to all dependents.
 - **no-unused-module-exports**: Remove the unused export from the module's exports array, or start importing the module where the exported provider is needed.
 - **no-orphan-modules**: Import this module in another module that needs it, or remove it if it's truly unused. If it's the root module, this can be ignored.

--- a/packages/nestjs-doctor/src/engine/rules/constants.ts
+++ b/packages/nestjs-doctor/src/engine/rules/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Class name suffixes for NestJS infrastructure classes (guards, interceptors, etc.)
+ * that are typically self-registered or framework-activated and should be excluded
+ * from rules that check for explicit provider registration or injection.
+ */
+export const INFRA_SUFFIXES = [
+	"Guard",
+	"Interceptor",
+	"Filter",
+	"Pipe",
+	"Middleware",
+	"Strategy",
+	"Subscriber",
+	"Listener",
+	"Processor",
+	"Consumer",
+	"Worker",
+	"Scheduler",
+	"Cron",
+	"HealthIndicator",
+];

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-circular-module-deps.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-circular-module-deps.ts
@@ -104,7 +104,7 @@ export const noCircularModuleDeps: ProjectRule = {
 		id: "architecture/no-circular-module-deps",
 		category: "architecture",
 		severity: "error",
-		description: "Circular dependencies in @Module() import graph",
+		description: "Module import graph must not contain circular dependencies",
 		help: GENERIC_HELP,
 		scope: "project",
 	},

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
@@ -17,10 +17,10 @@ export const noOrmInServices: Rule = {
 	meta: {
 		id: "architecture/no-orm-in-services",
 		category: "architecture",
-		severity: "warning",
+		severity: "info",
 		description:
 			"Services should use repository abstractions instead of ORM directly",
-		help: "Create a repository class that wraps ORM calls and inject that instead.",
+		help: "Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/factory-inject-matches-params.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/factory-inject-matches-params.ts
@@ -1,0 +1,122 @@
+import { SyntaxKind } from "ts-morph";
+import { isModule } from "../../../nest-class-inspector.js";
+import type { Rule } from "../../types.js";
+
+export const factoryInjectMatchesParams: Rule = {
+	meta: {
+		id: "correctness/factory-inject-matches-params",
+		category: "correctness",
+		severity: "error",
+		description:
+			"useFactory inject array length must match the factory function parameter count",
+		help: "Ensure the 'inject' array has one entry per factory function parameter.",
+	},
+
+	check(context) {
+		for (const cls of context.sourceFile.getClasses()) {
+			if (!isModule(cls)) {
+				continue;
+			}
+
+			const moduleDecorator = cls.getDecorator("Module");
+			if (!moduleDecorator) {
+				continue;
+			}
+
+			const args = moduleDecorator.getArguments()[0];
+			if (!args || args.getKind() !== SyntaxKind.ObjectLiteralExpression) {
+				continue;
+			}
+
+			const obj = args.asKind(SyntaxKind.ObjectLiteralExpression);
+			if (!obj) {
+				continue;
+			}
+
+			const providersProp = obj.getProperty("providers");
+			if (!providersProp) {
+				continue;
+			}
+
+			const providersArray = providersProp.getChildrenOfKind(
+				SyntaxKind.ArrayLiteralExpression
+			)[0];
+			if (!providersArray) {
+				continue;
+			}
+
+			for (const element of providersArray.getElements()) {
+				if (element.getKind() !== SyntaxKind.ObjectLiteralExpression) {
+					continue;
+				}
+
+				const providerObj = element.asKind(SyntaxKind.ObjectLiteralExpression);
+				if (!providerObj) {
+					continue;
+				}
+
+				const useFactoryProp = providerObj.getProperty("useFactory");
+				const injectProp = providerObj.getProperty("inject");
+
+				if (!(useFactoryProp && injectProp)) {
+					continue;
+				}
+
+				// Count inject array elements
+				const injectArray = injectProp.getChildrenOfKind(
+					SyntaxKind.ArrayLiteralExpression
+				)[0];
+				if (!injectArray) {
+					continue;
+				}
+				const injectCount = injectArray.getElements().length;
+
+				// Count factory function parameters
+				let paramCount: number | undefined;
+
+				// Handle method shorthand: useFactory(dep) { ... }
+				const methodDecl = useFactoryProp.asKind(SyntaxKind.MethodDeclaration);
+				if (methodDecl) {
+					paramCount = methodDecl.getParameters().length;
+				} else {
+					// Handle property assignment: useFactory: (dep) => ... or useFactory: function(dep) { ... }
+					const factoryAssignment = useFactoryProp.asKind(
+						SyntaxKind.PropertyAssignment
+					);
+					if (!factoryAssignment) {
+						continue;
+					}
+
+					const initializer = factoryAssignment.getInitializer();
+					if (!initializer) {
+						continue;
+					}
+
+					if (initializer.getKind() === SyntaxKind.ArrowFunction) {
+						paramCount = initializer
+							.asKind(SyntaxKind.ArrowFunction)
+							?.getParameters().length;
+					} else if (initializer.getKind() === SyntaxKind.FunctionExpression) {
+						paramCount = initializer
+							.asKind(SyntaxKind.FunctionExpression)
+							?.getParameters().length;
+					}
+				}
+
+				if (paramCount === undefined) {
+					continue;
+				}
+
+				if (injectCount !== paramCount) {
+					context.report({
+						filePath: context.filePath,
+						message: `Factory has ${paramCount} parameter(s) but inject array has ${injectCount} element(s).`,
+						help: this.meta.help,
+						line: element.getStartLineNumber(),
+						column: 1,
+					});
+				}
+			}
+		}
+	},
+};

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
@@ -1,0 +1,137 @@
+import { SyntaxKind } from "ts-morph";
+import { isModule } from "../../../nest-class-inspector.js";
+import { INFRA_SUFFIXES } from "../../constants.js";
+import type { ProjectRule } from "../../types.js";
+
+export const injectableMustBeProvided: ProjectRule = {
+	meta: {
+		id: "correctness/injectable-must-be-provided",
+		category: "correctness",
+		severity: "info",
+		description:
+			"@Injectable() classes should be registered in at least one module's providers array",
+		help: "Add this class to a module's providers array, or remove the @Injectable() decorator if unused.",
+		scope: "project",
+	},
+
+	check(context) {
+		// Collect all provider names registered in module metadata
+		const registeredProviders = new Set<string>();
+		for (const mod of context.moduleGraph.modules.values()) {
+			for (const provider of mod.providers) {
+				registeredProviders.add(provider);
+			}
+			for (const controller of mod.controllers) {
+				registeredProviders.add(controller);
+			}
+		}
+
+		// Also collect useClass/useExisting targets from object-literal providers
+		for (const filePath of context.files) {
+			const sourceFile = context.project.getSourceFile(filePath);
+			if (!sourceFile) {
+				continue;
+			}
+			for (const cls of sourceFile.getClasses()) {
+				if (!isModule(cls)) {
+					continue;
+				}
+				const moduleDecorator = cls.getDecorator("Module");
+				if (!moduleDecorator) {
+					continue;
+				}
+				const args = moduleDecorator.getArguments()[0];
+				if (!args || args.getKind() !== SyntaxKind.ObjectLiteralExpression) {
+					continue;
+				}
+				const obj = args.asKind(SyntaxKind.ObjectLiteralExpression);
+				if (!obj) {
+					continue;
+				}
+				const providersProp = obj.getProperty("providers");
+				if (!providersProp) {
+					continue;
+				}
+				const providersArray = providersProp.getChildrenOfKind(
+					SyntaxKind.ArrayLiteralExpression
+				)[0];
+				if (!providersArray) {
+					continue;
+				}
+				for (const element of providersArray.getElements()) {
+					if (element.getKind() !== SyntaxKind.ObjectLiteralExpression) {
+						continue;
+					}
+					const providerObj = element.asKind(
+						SyntaxKind.ObjectLiteralExpression
+					);
+					if (!providerObj) {
+						continue;
+					}
+					for (const propName of ["useClass", "useExisting"]) {
+						const prop = providerObj.getProperty(propName);
+						if (!prop) {
+							continue;
+						}
+						const assignment = prop.asKind(SyntaxKind.PropertyAssignment);
+						if (!assignment) {
+							continue;
+						}
+						const initializer = assignment.getInitializer();
+						if (initializer) {
+							registeredProviders.add(initializer.getText());
+						}
+					}
+				}
+			}
+		}
+
+		// Scan all files for @Injectable() classes
+		for (const filePath of context.files) {
+			// Skip test files
+			if (
+				filePath.includes(".spec.") ||
+				filePath.includes(".test.") ||
+				filePath.includes("__test__") ||
+				filePath.includes("__tests__")
+			) {
+				continue;
+			}
+
+			const sourceFile = context.project.getSourceFile(filePath);
+			if (!sourceFile) {
+				continue;
+			}
+
+			for (const cls of sourceFile.getClasses()) {
+				const injectableDecorator = cls.getDecorator("Injectable");
+				if (!injectableDecorator) {
+					continue;
+				}
+
+				const className = cls.getName();
+				if (!className) {
+					continue;
+				}
+
+				// Skip infrastructure classes (guards, interceptors, etc.)
+				if (INFRA_SUFFIXES.some((suffix) => className.endsWith(suffix))) {
+					continue;
+				}
+
+				// Skip if registered in any module
+				if (registeredProviders.has(className)) {
+					continue;
+				}
+
+				context.report({
+					filePath,
+					message: `@Injectable() class '${className}' is not registered in any module's providers array.`,
+					help: this.meta.help,
+					line: cls.getStartLineNumber(),
+					column: 1,
+				});
+			}
+		}
+	},
+};

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-async-without-await.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-async-without-await.ts
@@ -29,7 +29,7 @@ export const noAsyncWithoutAwait: Rule = {
 		severity: "warning",
 		description:
 			"Async functions/methods should contain at least one await expression",
-		help: "Either add an await expression or remove the async keyword.",
+		help: "Either add an await expression or remove the async keyword. HTTP handlers with route decorators are exempted, as async is conventional for controller methods.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-decorators.ts
@@ -1,0 +1,85 @@
+import type { Rule } from "../../types.js";
+
+// Decorators that are intentionally used multiple times with different arguments
+const STACKABLE_DECORATORS = new Set([
+	"ApiResponse",
+	"ApiQuery",
+	"ApiParam",
+	"ApiHeader",
+	"ApiSecurity",
+	"SetMetadata",
+	"Roles",
+	"Header",
+	"Throttle",
+]);
+
+export const noDuplicateDecorators: Rule = {
+	meta: {
+		id: "correctness/no-duplicate-decorators",
+		category: "correctness",
+		severity: "warning",
+		description: "Same decorator should not appear twice on a single target",
+		help: "Remove the duplicate decorator — it was likely copy-pasted by mistake.",
+	},
+
+	check(context) {
+		for (const cls of context.sourceFile.getClasses()) {
+			// Check class-level decorators
+			checkDecorators(cls.getDecorators(), context, this.meta.help);
+
+			// Check method-level decorators
+			for (const method of cls.getMethods()) {
+				checkDecorators(method.getDecorators(), context, this.meta.help);
+			}
+
+			// Check property-level decorators
+			for (const prop of cls.getProperties()) {
+				checkDecorators(prop.getDecorators(), context, this.meta.help);
+			}
+
+			// Check constructor parameter decorators
+			for (const ctor of cls.getConstructors()) {
+				for (const param of ctor.getParameters()) {
+					checkDecorators(param.getDecorators(), context, this.meta.help);
+				}
+			}
+		}
+	},
+};
+
+function checkDecorators(
+	decorators: { getName(): string; getStartLineNumber(): number }[],
+	context: {
+		filePath: string;
+		report(diagnostic: {
+			filePath: string;
+			message: string;
+			help: string;
+			line: number;
+			column: number;
+		}): void;
+	},
+	help: string
+): void {
+	const seen = new Set<string>();
+
+	for (const decorator of decorators) {
+		const name = decorator.getName();
+
+		if (STACKABLE_DECORATORS.has(name)) {
+			continue;
+		}
+
+		if (seen.has(name)) {
+			context.report({
+				filePath: context.filePath,
+				message: `Duplicate @${name}() decorator on the same target.`,
+				help,
+				line: decorator.getStartLineNumber(),
+				column: 1,
+			});
+		} else {
+			seen.add(name);
+		}
+	}
+}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-routes.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-routes.ts
@@ -1,16 +1,8 @@
-import { isController } from "../../../nest-class-inspector.js";
+import {
+	HTTP_DECORATORS,
+	isController,
+} from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
-
-const HTTP_METHOD_DECORATORS = new Set([
-	"Get",
-	"Post",
-	"Put",
-	"Delete",
-	"Patch",
-	"All",
-	"Head",
-	"Options",
-]);
 
 export const noDuplicateRoutes: Rule = {
 	meta: {
@@ -33,7 +25,7 @@ export const noDuplicateRoutes: Rule = {
 			for (const method of cls.getMethods()) {
 				for (const decorator of method.getDecorators()) {
 					const decoratorName = decorator.getName();
-					if (!HTTP_METHOD_DECORATORS.has(decoratorName)) {
+					if (!HTTP_DECORATORS.has(decoratorName)) {
 						continue;
 					}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-empty-handlers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-empty-handlers.ts
@@ -9,7 +9,7 @@ export const noEmptyHandlers: Rule = {
 	meta: {
 		id: "correctness/no-empty-handlers",
 		category: "correctness",
-		severity: "warning",
+		severity: "info",
 		description: "Controller HTTP handlers should not have empty bodies",
 		help: "Add implementation to the handler method or remove it if unnecessary.",
 	},

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-missing-guard-method.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-missing-guard-method.ts
@@ -7,7 +7,7 @@ export const noMissingGuardMethod: Rule = {
 		category: "correctness",
 		severity: "error",
 		description: "Guard classes must implement the canActivate() method",
-		help: "Add a canActivate(context: ExecutionContext) method to the guard class.",
+		help: "Add a canActivate(context: ExecutionContext) method to the guard class. Note: This rule identifies guards by the 'Guard' class name suffix.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/param-decorator-matches-route.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/param-decorator-matches-route.ts
@@ -1,0 +1,120 @@
+import { SyntaxKind } from "ts-morph";
+import {
+	HTTP_DECORATORS,
+	isController,
+} from "../../../nest-class-inspector.js";
+import type { Rule } from "../../types.js";
+
+const ROUTE_PARAM_REGEX = /:(\w+)/g;
+
+export const paramDecoratorMatchesRoute: Rule = {
+	meta: {
+		id: "correctness/param-decorator-matches-route",
+		category: "correctness",
+		severity: "error",
+		description:
+			"@Param() decorator name must match a :param in the route path",
+		help: "Ensure the @Param('name') argument matches a ':name' segment in the route path (including controller prefix).",
+	},
+
+	check(context) {
+		for (const cls of context.sourceFile.getClasses()) {
+			if (!isController(cls)) {
+				continue;
+			}
+
+			// Extract controller-level prefix params
+			const controllerDecorator = cls.getDecorator("Controller");
+			let controllerPath = "";
+			if (controllerDecorator) {
+				const args = controllerDecorator.getArguments();
+				if (args.length > 0) {
+					const firstArg = args[0];
+					if (firstArg.getKind() === SyntaxKind.ObjectLiteralExpression) {
+						// @Controller({ path: 'users/:id', host: '...' }) — extract only the path property
+						const obj = firstArg.asKind(SyntaxKind.ObjectLiteralExpression);
+						if (obj) {
+							const pathProp = obj.getProperty("path");
+							if (pathProp) {
+								const assignment = pathProp.asKind(
+									SyntaxKind.PropertyAssignment
+								);
+								if (assignment) {
+									const initializer = assignment.getInitializer();
+									if (initializer) {
+										controllerPath = initializer
+											.getText()
+											.replace(/^['"`]|['"`]$/g, "");
+									}
+								}
+							}
+						}
+					} else {
+						controllerPath = firstArg.getText().replace(/^['"`]|['"`]$/g, "");
+					}
+				}
+			}
+
+			const controllerParams = new Set<string>();
+			for (const match of controllerPath.matchAll(ROUTE_PARAM_REGEX)) {
+				controllerParams.add(match[1]);
+			}
+
+			for (const method of cls.getMethods()) {
+				// Find the HTTP decorator and its route path
+				let routePath = "";
+				let isHttpMethod = false;
+				for (const decorator of method.getDecorators()) {
+					if (HTTP_DECORATORS.has(decorator.getName())) {
+						isHttpMethod = true;
+						const args = decorator.getArguments();
+						if (args.length > 0) {
+							routePath = args[0].getText().replace(/^['"`]|['"`]$/g, "");
+						}
+						break;
+					}
+				}
+
+				if (!isHttpMethod) {
+					continue;
+				}
+
+				// Collect route param names from the method route path
+				const methodParams = new Set<string>();
+				for (const match of routePath.matchAll(ROUTE_PARAM_REGEX)) {
+					methodParams.add(match[1]);
+				}
+
+				// Combine controller + method params
+				const allRouteParams = new Set([...controllerParams, ...methodParams]);
+
+				// Check each @Param() decorator on method parameters
+				for (const param of method.getParameters()) {
+					for (const decorator of param.getDecorators()) {
+						if (decorator.getName() !== "Param") {
+							continue;
+						}
+
+						const args = decorator.getArguments();
+						if (args.length === 0) {
+							// @Param() without arguments grabs all params — skip
+							continue;
+						}
+
+						const paramName = args[0].getText().replace(/^['"`]|['"`]$/g, "");
+
+						if (!allRouteParams.has(paramName)) {
+							context.report({
+								filePath: context.filePath,
+								message: `@Param('${paramName}') does not match any route parameter. Available: ${allRouteParams.size > 0 ? [...allRouteParams].map((p) => `:${p}`).join(", ") : "(none)"}.`,
+								help: this.meta.help,
+								line: decorator.getStartLineNumber(),
+								column: 1,
+							});
+						}
+					}
+				}
+			}
+		}
+	},
+};

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/require-lifecycle-interface.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/require-lifecycle-interface.ts
@@ -29,7 +29,12 @@ export const requireLifecycleInterface: Rule = {
 					continue;
 				}
 
-				if (!implementedInterfaces.some((i) => i.includes(expectedInterface))) {
+				if (
+					!implementedInterfaces.some(
+						(i) =>
+							i === expectedInterface || i.startsWith(`${expectedInterface}<`)
+					)
+				) {
 					context.report({
 						filePath: context.filePath,
 						message: `Class '${cls.getName()}' has '${methodName}()' but does not implement '${expectedInterface}'.`,

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/validate-nested-array-each.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/validate-nested-array-each.ts
@@ -1,0 +1,95 @@
+import { SyntaxKind } from "ts-morph";
+import type { Rule } from "../../types.js";
+
+const EACH_TRUE_REGEX = /each\s*:\s*true/;
+
+export const validateNestedArrayEach: Rule = {
+	meta: {
+		id: "correctness/validate-nested-array-each",
+		category: "correctness",
+		severity: "warning",
+		description:
+			"@ValidateNested() on array-typed properties must use { each: true }",
+		help: "Change @ValidateNested() to @ValidateNested({ each: true }) for array properties.",
+	},
+
+	check(context) {
+		for (const cls of context.sourceFile.getClasses()) {
+			for (const prop of cls.getProperties()) {
+				const decorators = prop.getDecorators();
+
+				const validateNestedDec = decorators.find(
+					(d) => d.getName() === "ValidateNested"
+				);
+				if (!validateNestedDec) {
+					continue;
+				}
+
+				// Determine if the property is array-typed
+				const isArrayType = isPropertyArrayTyped(prop);
+				const hasIsArrayDecorator = decorators.some(
+					(d) => d.getName() === "IsArray"
+				);
+				const isArray = isArrayType || hasIsArrayDecorator;
+
+				if (!isArray) {
+					continue;
+				}
+
+				// Check if @ValidateNested has { each: true }
+				const hasEach = hasEachTrue(validateNestedDec);
+
+				if (!hasEach) {
+					context.report({
+						filePath: context.filePath,
+						message: `Property '${prop.getName()}' is an array with @ValidateNested() but missing { each: true }.`,
+						help: this.meta.help,
+						line: validateNestedDec.getStartLineNumber(),
+						column: 1,
+					});
+				}
+			}
+		}
+	},
+};
+
+function isPropertyArrayTyped(prop: {
+	getTypeNode(): { getText(): string } | undefined;
+}): boolean {
+	const typeNode = prop.getTypeNode();
+	if (!typeNode) {
+		return false;
+	}
+
+	const typeText = typeNode.getText().replace(/\s/g, "");
+
+	// T[] syntax
+	if (typeText.endsWith("[]")) {
+		return true;
+	}
+
+	// Array<T> syntax
+	if (typeText.startsWith("Array<")) {
+		return true;
+	}
+
+	return false;
+}
+
+function hasEachTrue(decorator: {
+	getArguments(): { getKind(): SyntaxKind; getText(): string }[];
+}): boolean {
+	const args = decorator.getArguments();
+	if (args.length === 0) {
+		return false;
+	}
+
+	const firstArg = args[0];
+	if (firstArg.getKind() !== SyntaxKind.ObjectLiteralExpression) {
+		return false;
+	}
+
+	// Check for { each: true } in the argument text
+	const text = firstArg.getText();
+	return EACH_TRUE_REGEX.test(text);
+}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/validated-non-primitive-needs-type.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/validated-non-primitive-needs-type.ts
@@ -1,0 +1,169 @@
+import type { Rule } from "../../types.js";
+
+const CLASS_VALIDATOR_DECORATORS = new Set([
+	"ValidateNested",
+	"IsString",
+	"IsNumber",
+	"IsBoolean",
+	"IsEmail",
+	"IsArray",
+	"IsEnum",
+	"IsNotEmpty",
+	"IsDefined",
+	"IsOptional",
+	"IsDate",
+	"IsObject",
+	"IsInt",
+	"IsPositive",
+	"IsNegative",
+	"IsUUID",
+	"IsUrl",
+	"IsISO8601",
+	"Matches",
+	"Min",
+	"Max",
+	"MinLength",
+	"MaxLength",
+	"ArrayMinSize",
+	"ArrayMaxSize",
+	"ArrayNotEmpty",
+	"IsIn",
+	"IsNotIn",
+	"Length",
+	"Contains",
+	"IsAlpha",
+	"IsAlphanumeric",
+	"IsDecimal",
+	"IsHexColor",
+	"IsJSON",
+	"IsPhoneNumber",
+	"IsIP",
+	"IsCreditCard",
+	"IsDateString",
+	"IsMilitaryTime",
+	"IsMongoId",
+	"IsPort",
+	"IsSemVer",
+	"IsStrongPassword",
+]);
+
+const PRIMITIVE_TYPES = new Set([
+	"string",
+	"number",
+	"boolean",
+	"Date",
+	"any",
+	"unknown",
+	"bigint",
+	"symbol",
+	"undefined",
+	"null",
+	"void",
+	"never",
+]);
+
+const WHITESPACE_REGEX = /\s/g;
+const ARRAY_SUFFIX_REGEX = /\[\]$/;
+const ARRAY_GENERIC_REGEX = /^Array<(.+)>$/;
+const STRING_LITERAL_REGEX = /^["']/;
+const NUMBER_LITERAL_REGEX = /^\d+$/;
+
+function isPrimitiveType(typeText: string): boolean {
+	const cleaned = typeText.replace(WHITESPACE_REGEX, "");
+
+	// Handle union types (e.g. "string | null", "AddressDto | undefined")
+	if (cleaned.includes("|")) {
+		return cleaned.split("|").every((part) => isPrimitiveType(part));
+	}
+
+	// Direct primitive
+	if (PRIMITIVE_TYPES.has(cleaned)) {
+		return true;
+	}
+
+	// Primitive arrays like string[], number[][] (recursive for nested arrays)
+	if (ARRAY_SUFFIX_REGEX.test(cleaned)) {
+		const arrayBase = cleaned.replace(ARRAY_SUFFIX_REGEX, "");
+		if (isPrimitiveType(arrayBase)) {
+			return true;
+		}
+	}
+
+	// Array<primitive> (recursive for nested generics like Array<Array<string>>)
+	const arrayGenericMatch = cleaned.match(ARRAY_GENERIC_REGEX);
+	if (arrayGenericMatch && isPrimitiveType(arrayGenericMatch[1])) {
+		return true;
+	}
+
+	// Enum-like (string literal unions, number literal types)
+	if (
+		STRING_LITERAL_REGEX.test(cleaned) ||
+		NUMBER_LITERAL_REGEX.test(cleaned)
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+export const validatedNonPrimitiveNeedsType: Rule = {
+	meta: {
+		id: "correctness/validated-non-primitive-needs-type",
+		category: "correctness",
+		severity: "warning",
+		description:
+			"DTO properties with class-validator decorators on non-primitive types must have @Type() from class-transformer",
+		help: "Add @Type(() => ClassName) from 'class-transformer' to ensure proper transformation.",
+	},
+
+	check(context) {
+		for (const cls of context.sourceFile.getClasses()) {
+			for (const prop of cls.getProperties()) {
+				const decorators = prop.getDecorators();
+				if (decorators.length === 0) {
+					continue;
+				}
+
+				const hasValidatorDecorator = decorators.some((d) =>
+					CLASS_VALIDATOR_DECORATORS.has(d.getName())
+				);
+				if (!hasValidatorDecorator) {
+					continue;
+				}
+
+				const hasTypeDecorator = decorators.some((d) => d.getName() === "Type");
+				if (hasTypeDecorator) {
+					continue;
+				}
+
+				// Enums don't need @Type() — class-transformer handles them natively
+				const hasIsEnumDecorator = decorators.some(
+					(d) => d.getName() === "IsEnum"
+				);
+				if (hasIsEnumDecorator) {
+					continue;
+				}
+
+				// Check the property type
+				const typeNode = prop.getTypeNode();
+				if (!typeNode) {
+					// No explicit type annotation — skip (could be inferred as primitive)
+					continue;
+				}
+
+				const typeText = typeNode.getText();
+				if (isPrimitiveType(typeText)) {
+					continue;
+				}
+
+				context.report({
+					filePath: context.filePath,
+					message: `Property '${prop.getName()}' has type '${typeText}' with class-validator decorators but is missing @Type() decorator.`,
+					help: this.meta.help,
+					line: prop.getStartLineNumber(),
+					column: 1,
+				});
+			}
+		}
+	},
+};

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-blocking-constructor.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-blocking-constructor.ts
@@ -8,7 +8,6 @@ const BLOCKING_KINDS = new Set([
 	SyntaxKind.ForInStatement,
 	SyntaxKind.WhileStatement,
 	SyntaxKind.DoStatement,
-	SyntaxKind.AwaitExpression,
 ]);
 
 export const noBlockingConstructor: Rule = {
@@ -18,7 +17,7 @@ export const noBlockingConstructor: Rule = {
 		severity: "warning",
 		description:
 			"Constructors in Injectable/Controller classes should not contain heavy operations",
-		help: "Move complex initialization logic to onModuleInit() lifecycle method instead.",
+		help: "Move heavy initialization logic to the onModuleInit() lifecycle method. Constructors cannot be async, so asynchronous work should always use lifecycle hooks.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
@@ -1,12 +1,44 @@
+import type { ClassDeclaration } from "ts-morph";
+import { INFRA_SUFFIXES } from "../../constants.js";
 import type { ProjectRule } from "../../types.js";
 
-const SKIP_SUFFIXES = [
-	"Guard",
-	"Interceptor",
-	"Filter",
-	"Middleware",
-	"Strategy",
-];
+const SELF_ACTIVATING_DECORATORS = new Set([
+	// @nestjs/schedule
+	"Cron",
+	"Interval",
+	"Timeout",
+	// @nestjs/event-emitter
+	"OnEvent",
+	// @nestjs/bull / @nestjs/bullmq
+	"Process",
+	"OnQueueEvent",
+	// TypeORM subscriber (class decorator)
+	"EventSubscriber",
+	// @nestjs/websockets
+	"SubscribeMessage",
+	// @nestjs/websockets gateway (class decorator)
+	"WebSocketGateway",
+]);
+
+function hasSelfActivatingDecorator(cls: ClassDeclaration): boolean {
+	// Check class-level decorators
+	for (const decorator of cls.getDecorators()) {
+		if (SELF_ACTIVATING_DECORATORS.has(decorator.getName())) {
+			return true;
+		}
+	}
+
+	// Check method-level decorators
+	for (const method of cls.getMethods()) {
+		for (const decorator of method.getDecorators()) {
+			if (SELF_ACTIVATING_DECORATORS.has(decorator.getName())) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
 
 export const noUnusedProviders: ProjectRule = {
 	meta: {
@@ -14,8 +46,8 @@ export const noUnusedProviders: ProjectRule = {
 		category: "performance",
 		severity: "warning",
 		description:
-			"Injectable providers that are never injected by any other provider may be dead code",
-		help: "Remove the unused provider or inject it where needed.",
+			"Injectable providers that are never injected and have no self-activating decorators may be dead code",
+		help: "Remove the unused provider, inject it where needed, or verify it is activated by a framework decorator (e.g. @Cron, @OnEvent).",
 		scope: "project",
 	},
 
@@ -64,12 +96,17 @@ export const noUnusedProviders: ProjectRule = {
 			const name = provider.name;
 
 			// Skip common infrastructure patterns
-			if (SKIP_SUFFIXES.some((suffix) => name.endsWith(suffix))) {
+			if (INFRA_SUFFIXES.some((suffix) => name.endsWith(suffix))) {
 				continue;
 			}
 
 			// Skip if it's used as a dependency somewhere
 			if (allDependencies.has(name)) {
+				continue;
+			}
+
+			// Skip self-activating providers (e.g. @Cron, @OnEvent, @Process)
+			if (hasSelfActivatingDecorator(provider.classDeclaration)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-raw-entity-in-response.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-raw-entity-in-response.ts
@@ -13,7 +13,7 @@ export const noRawEntityInResponse: Rule = {
 		severity: "warning",
 		description:
 			"Returning ORM entities directly from controllers can leak internal fields like passwords or IDs",
-		help: "Map entities to DTOs or use class-transformer's @Exclude()/@Expose() decorators before returning. This rule detects classes with Entity/Model suffix in return types.",
+		help: "Map entities to DTOs or use class-transformer's @Exclude()/@Expose() decorators before returning.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -1,0 +1,70 @@
+import { isController, isHttpHandler } from "../../../nest-class-inspector.js";
+import type { Rule } from "../../types.js";
+
+const PUBLIC_DECORATORS = new Set([
+	"Public",
+	"AllowAnonymous",
+	"SkipAuth",
+	"IsPublic",
+]);
+
+export const requireGuardsOnEndpoints: Rule = {
+	meta: {
+		id: "security/require-guards-on-endpoints",
+		category: "security",
+		severity: "warning",
+		description:
+			"Controller endpoints should be protected by @UseGuards() at class or method level",
+		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). If you use a global guard via APP_GUARD, you can disable this rule.",
+	},
+
+	check(context) {
+		for (const cls of context.sourceFile.getClasses()) {
+			if (!isController(cls)) {
+				continue;
+			}
+
+			// Check for class-level @UseGuards()
+			const hasClassGuard = cls.getDecorator("UseGuards") !== undefined;
+			if (hasClassGuard) {
+				continue;
+			}
+
+			// Check for class-level @Public() or similar decorators
+			const isClassPublic = cls
+				.getDecorators()
+				.some((d) => PUBLIC_DECORATORS.has(d.getName()));
+			if (isClassPublic) {
+				continue;
+			}
+
+			for (const method of cls.getMethods()) {
+				if (!isHttpHandler(method)) {
+					continue;
+				}
+
+				// Check for method-level @UseGuards()
+				const hasMethodGuard = method.getDecorator("UseGuards") !== undefined;
+				if (hasMethodGuard) {
+					continue;
+				}
+
+				// Check for @Public() or similar decorators
+				const isPublic = method
+					.getDecorators()
+					.some((d) => PUBLIC_DECORATORS.has(d.getName()));
+				if (isPublic) {
+					continue;
+				}
+
+				context.report({
+					filePath: context.filePath,
+					message: `Endpoint '${method.getName()}' has no @UseGuards() at class or method level.`,
+					help: this.meta.help,
+					line: method.getStartLineNumber(),
+					column: 1,
+				});
+			}
+		}
+	},
+};

--- a/packages/nestjs-doctor/src/engine/rules/index.ts
+++ b/packages/nestjs-doctor/src/engine/rules/index.ts
@@ -8,7 +8,10 @@ import { noRepositoryInControllers } from "./definitions/architecture/no-reposit
 import { noServiceLocator } from "./definitions/architecture/no-service-locator.js";
 import { preferConstructorInjection } from "./definitions/architecture/prefer-constructor-injection.js";
 import { requireModuleBoundaries } from "./definitions/architecture/require-module-boundaries.js";
+import { factoryInjectMatchesParams } from "./definitions/correctness/factory-inject-matches-params.js";
+import { injectableMustBeProvided } from "./definitions/correctness/injectable-must-be-provided.js";
 import { noAsyncWithoutAwait } from "./definitions/correctness/no-async-without-await.js";
+import { noDuplicateDecorators } from "./definitions/correctness/no-duplicate-decorators.js";
 import { noDuplicateModuleMetadata } from "./definitions/correctness/no-duplicate-module-metadata.js";
 import { noDuplicateRoutes } from "./definitions/correctness/no-duplicate-routes.js";
 import { noEmptyHandlers } from "./definitions/correctness/no-empty-handlers.js";
@@ -19,9 +22,12 @@ import { noMissingInjectable } from "./definitions/correctness/no-missing-inject
 import { noMissingInterceptorMethod } from "./definitions/correctness/no-missing-interceptor-method.js";
 import { noMissingModuleDecorator } from "./definitions/correctness/no-missing-module-decorator.js";
 import { noMissingPipeMethod } from "./definitions/correctness/no-missing-pipe-method.js";
+import { paramDecoratorMatchesRoute } from "./definitions/correctness/param-decorator-matches-route.js";
 import { preferReadonlyInjection } from "./definitions/correctness/prefer-readonly-injection.js";
 import { requireInjectDecorator } from "./definitions/correctness/require-inject-decorator.js";
 import { requireLifecycleInterface } from "./definitions/correctness/require-lifecycle-interface.js";
+import { validateNestedArrayEach } from "./definitions/correctness/validate-nested-array-each.js";
+import { validatedNonPrimitiveNeedsType } from "./definitions/correctness/validated-non-primitive-needs-type.js";
 import { noBlockingConstructor } from "./definitions/performance/no-blocking-constructor.js";
 import { noDynamicRequire } from "./definitions/performance/no-dynamic-require.js";
 import { noOrphanModules } from "./definitions/performance/no-orphan-modules.js";
@@ -41,6 +47,7 @@ import { noHardcodedSecrets } from "./definitions/security/no-hardcoded-secrets.
 import { noRawEntityInResponse } from "./definitions/security/no-raw-entity-in-response.js";
 import { noSynchronizeInProduction } from "./definitions/security/no-synchronize-in-production.js";
 import { noWeakCrypto } from "./definitions/security/no-weak-crypto.js";
+import { requireGuardsOnEndpoints } from "./definitions/security/require-guards-on-endpoints.js";
 import type { AnyRule } from "./types.js";
 
 export const allRules: AnyRule[] = [
@@ -72,9 +79,15 @@ export const allRules: AnyRule[] = [
 	noMissingModuleDecorator,
 	requireInjectDecorator,
 	noFireAndForgetAsync,
+	paramDecoratorMatchesRoute,
+	factoryInjectMatchesParams,
+	validatedNonPrimitiveNeedsType,
+	noDuplicateDecorators,
+	validateNestedArrayEach,
 
 	// Correctness — project-scoped
 	noMissingInjectable,
+	injectableMustBeProvided,
 
 	// Security
 	noHardcodedSecrets,
@@ -86,6 +99,7 @@ export const allRules: AnyRule[] = [
 	noDangerousRedirects,
 	noSynchronizeInProduction,
 	noRawEntityInResponse,
+	requireGuardsOnEndpoints,
 
 	// Performance — file-scoped
 	noSyncIo,

--- a/packages/nestjs-doctor/src/report/data/examples.ts
+++ b/packages/nestjs-doctor/src/report/data/examples.ts
@@ -115,6 +115,23 @@ export class UserController {
   }
 }`,
 		},
+		"security/require-guards-on-endpoints": {
+			bad: `@Controller('orders')
+export class OrderController {
+  @Get()
+  findAll() {
+    return this.orderService.findAll(); // No guard, no @Public()
+  }
+}`,
+			good: `@UseGuards(AuthGuard)
+@Controller('orders')
+export class OrderController {
+  @Get()
+  findAll() {
+    return this.orderService.findAll();
+  }
+}`,
+		},
 
 		// ── Correctness ──
 		"correctness/no-missing-injectable": {
@@ -303,6 +320,90 @@ export class OrderService {
     await this.notificationService.sendEmail(orderId);
     await this.analyticsService.track('order_completed');
   }
+}`,
+		},
+		"correctness/factory-inject-matches-params": {
+			bad: `@Module({
+  providers: [{
+    provide: 'DATA_SOURCE',
+    useFactory: (config: ConfigService) => createDataSource(config),
+    inject: [ConfigService, Logger],  // 2 tokens but 1 param!
+  }],
+})
+export class AppModule {}`,
+			good: `@Module({
+  providers: [{
+    provide: 'DATA_SOURCE',
+    useFactory: (config: ConfigService, logger: Logger) =>
+      createDataSource(config, logger),
+    inject: [ConfigService, Logger],  // 2 tokens, 2 params
+  }],
+})
+export class AppModule {}`,
+		},
+		"correctness/injectable-must-be-provided": {
+			bad: `@Injectable()
+export class CacheService {  // Not in any module's providers
+  get(key: string) { /* ... */ }
+}`,
+			good: `@Injectable()
+export class CacheService {
+  get(key: string) { /* ... */ }
+}
+
+@Module({ providers: [CacheService] })
+export class CacheModule {}`,
+		},
+		"correctness/no-duplicate-decorators": {
+			bad: `@Controller('users')
+export class UserController {
+  @Get(':id')
+  @Get(':id')  // Duplicate decorator!
+  findOne(@Param('id') id: string) { /* ... */ }
+}`,
+			good: `@Controller('users')
+export class UserController {
+  @Get(':id')
+  findOne(@Param('id') id: string) { /* ... */ }
+}`,
+		},
+		"correctness/param-decorator-matches-route": {
+			bad: `@Controller('users')
+export class UserController {
+  @Get(':id')
+  findOne(@Param('userId') userId: string) {  // 'userId' not in route
+    return this.userService.findOne(userId);
+  }
+}`,
+			good: `@Controller('users')
+export class UserController {
+  @Get(':id')
+  findOne(@Param('id') id: string) {  // 'id' matches :id in route
+    return this.userService.findOne(id);
+  }
+}`,
+		},
+		"correctness/validate-nested-array-each": {
+			bad: `export class CreateOrderDto {
+  @ValidateNested()  // Missing { each: true } for array
+  @Type(() => OrderItemDto)
+  items: OrderItemDto[];
+}`,
+			good: `export class CreateOrderDto {
+  @ValidateNested({ each: true })  // Validates each item in the array
+  @Type(() => OrderItemDto)
+  items: OrderItemDto[];
+}`,
+		},
+		"correctness/validated-non-primitive-needs-type": {
+			bad: `export class CreateUserDto {
+  @ValidateNested()
+  address: AddressDto;  // Missing @Type() — validator can't instantiate
+}`,
+			good: `export class CreateUserDto {
+  @ValidateNested()
+  @Type(() => AddressDto)
+  address: AddressDto;
 }`,
 		},
 
@@ -558,6 +659,70 @@ export class AnalyticsModule {}`,
   imports: [AnalyticsModule],
 })
 export class AppModule {}`,
+		},
+
+		// ── Schema ──
+		"schema/require-primary-key": {
+			bad: `@Entity()
+export class AuditLog {
+  @Column()
+  action: string;
+
+  @Column()
+  timestamp: Date;
+  // No primary key column!
+}`,
+			good: `@Entity()
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  action: string;
+
+  @Column()
+  timestamp: Date;
+}`,
+		},
+		"schema/require-timestamps": {
+			bad: `@Entity()
+export class Product {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+  // No createdAt / updatedAt columns
+}`,
+			good: `@Entity()
+export class Product {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}`,
+		},
+		"schema/require-cascade-rule": {
+			bad: `@Entity()
+export class User {
+  @OneToMany(() => Order, (order) => order.user, {
+    cascade: true,  // Risky: may unintentionally persist/remove orders
+  })
+  orders: Order[];
+}`,
+			good: `@Entity()
+export class User {
+  @OneToMany(() => Order, (order) => order.user)
+  orders: Order[];
+  // Persist/remove orders explicitly via OrderRepository
+}`,
 		},
 	};
 }

--- a/packages/nestjs-doctor/tests/fixtures/bad-correctness/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/bad-correctness/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bad-correctness-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-correctness/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-correctness/src/app.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+
+@Module({
+  controllers: [UsersController],
+  providers: [
+    {
+      provide: 'CONFIG',
+      useFactory: (a) => ({ key: a }),
+      inject: ['A', 'B'],
+    },
+  ],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/bad-correctness/src/create-user.dto.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-correctness/src/create-user.dto.ts
@@ -1,0 +1,19 @@
+import { ValidateNested } from 'class-validator';
+
+class AddressDto {
+  street: string;
+  city: string;
+}
+
+class ItemDto {
+  name: string;
+  price: number;
+}
+
+export class CreateUserDto {
+  @ValidateNested()
+  address: AddressDto;
+
+  @ValidateNested()
+  items: ItemDto[];
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-correctness/src/users.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-correctness/src/users.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  @Get(':id')
+  findOne(@Param('userId') userId: string) {
+    return { userId };
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-correctness/src/users.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-correctness/src/users.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UsersService {
+  getUsers() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-performance/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/bad-performance/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bad-performance-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-performance/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-performance/src/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { HealthCron } from "./health.cron";
+import { HealthService } from "./health.service";
+import { UnusedService } from "./unused.service";
+
+@Module({
+	providers: [HealthCron, HealthService, UnusedService],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/bad-performance/src/health.cron.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-performance/src/health.cron.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "@nestjs/common";
+import { Cron } from "@nestjs/schedule";
+import { HealthService } from "./health.service";
+
+@Injectable()
+export class HealthCron {
+	constructor(private readonly healthService: HealthService) {}
+
+	@Cron("0 */5 * * * *")
+	async handleCron() {
+		await this.healthService.check();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-performance/src/health.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-performance/src/health.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class HealthService {
+	check() {
+		return { status: "ok" };
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-performance/src/unused.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-performance/src/unused.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class UnusedService {
+	doNothing() {}
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-security/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/bad-security/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bad-security-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/bad-security/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-security/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { OrdersController } from './orders.controller';
+
+@Module({
+  controllers: [OrdersController],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/bad-security/src/orders.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-security/src/orders.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Post, Param, Body } from '@nestjs/common';
+
+@Controller('orders')
+export class OrdersController {
+  @Get()
+  findAll() {
+    return [];
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return { id };
+  }
+
+  @Post()
+  create(@Body() body: unknown) {
+    return body;
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/app.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/app.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, UseGuards } from "@nestjs/common";
 import type { AppService } from "./app.service";
 
+// Empty @UseGuards(): intentional for testing decorator detection
+@UseGuards()
 @Controller()
 export class AppController {
 	constructor(private readonly appService: AppService) {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/admin-auth/admin-auth.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/admin-auth/admin-auth.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get, Param } from "@nestjs/common";
+import { Controller, Get, Param, UseGuards } from "@nestjs/common";
 import type { AdminAuthService } from "./admin-auth.service";
 
+// Empty @UseGuards(): intentional for testing decorator detection
+@UseGuards()
 @Controller("admin/auth")
 export class AdminAuthController {
 	constructor(private readonly adminAuthService: AdminAuthService) {}

--- a/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/health/health.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/cross-file-monorepo/src/modules/health/health.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, UseGuards } from "@nestjs/common";
 import type { HealthService } from "./health.service";
 
+// Empty @UseGuards(): intentional for testing decorator detection
+@UseGuards()
 @Controller("health")
 export class HealthController {
 	constructor(private readonly healthService: HealthService) {}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -433,7 +433,7 @@ describe("scanner integration", () => {
 		);
 		expect(orphanDiags).toHaveLength(0);
 
-		// Clean score with zero diagnostics
+		// Clean score
 		expect(result.score.value).toBeGreaterThanOrEqual(90);
 		expect(result.diagnostics).toHaveLength(0);
 	});
@@ -778,6 +778,88 @@ describe("scanner integration", () => {
 			const names = monoResult.result.subProjects.map((p) => p.name);
 			expect(names).not.toContain("@lerna/frontend");
 		});
+	});
+
+	it("detects all correctness rule violations in bad-correctness fixture", async () => {
+		const targetPath = resolve(FIXTURES, "bad-correctness/src");
+		const scanConfig = await resolveScanConfig(targetPath);
+		const context = await buildAnalysisContext(targetPath, scanConfig);
+		const rawOutput = diagnose(context);
+		const { result } = buildResult(
+			context,
+			rawOutput,
+			scanConfig.customRuleWarnings
+		);
+
+		expect(result.diagnostics.length).toBeGreaterThan(0);
+
+		for (const ruleId of [
+			"correctness/param-decorator-matches-route",
+			"correctness/factory-inject-matches-params",
+			"correctness/validated-non-primitive-needs-type",
+			"correctness/no-duplicate-decorators",
+			"correctness/validate-nested-array-each",
+			"correctness/injectable-must-be-provided",
+		]) {
+			const diags = result.diagnostics.filter((d) => d.rule === ruleId);
+			expect(
+				diags.length,
+				`Expected at least 1 diagnostic for ${ruleId}`
+			).toBeGreaterThan(0);
+		}
+	});
+
+	it("detects security rule violations in bad-security fixture", async () => {
+		const targetPath = resolve(FIXTURES, "bad-security/src");
+		const scanConfig = await resolveScanConfig(targetPath);
+		const context = await buildAnalysisContext(targetPath, scanConfig);
+		const rawOutput = diagnose(context);
+		const { result } = buildResult(
+			context,
+			rawOutput,
+			scanConfig.customRuleWarnings
+		);
+
+		expect(result.diagnostics.length).toBeGreaterThan(0);
+
+		const diags = result.diagnostics.filter(
+			(d) => d.rule === "security/require-guards-on-endpoints"
+		);
+		expect(
+			diags.length,
+			"Expected at least 1 diagnostic for security/require-guards-on-endpoints"
+		).toBeGreaterThan(0);
+	});
+
+	it("does not flag self-activating providers in bad-performance fixture", async () => {
+		const targetPath = resolve(FIXTURES, "bad-performance/src");
+		const scanConfig = await resolveScanConfig(targetPath);
+		const context = await buildAnalysisContext(targetPath, scanConfig);
+		const rawOutput = diagnose(context);
+		const { result } = buildResult(
+			context,
+			rawOutput,
+			scanConfig.customRuleWarnings
+		);
+
+		const unusedDiags = result.diagnostics.filter(
+			(d) => d.rule === "performance/no-unused-providers"
+		);
+
+		// HealthCron should NOT be flagged (has @Cron decorator)
+		expect(
+			unusedDiags.filter((d) => d.message.includes("HealthCron"))
+		).toHaveLength(0);
+
+		// HealthService should NOT be flagged (injected by HealthCron)
+		expect(
+			unusedDiags.filter((d) => d.message.includes("HealthService"))
+		).toHaveLength(0);
+
+		// UnusedService SHOULD be flagged
+		expect(
+			unusedDiags.filter((d) => d.message.includes("UnusedService"))
+		).toHaveLength(1);
 	});
 
 	it("does not flag migration identifiers as secrets in false-positives fixture", async () => {

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -4,7 +4,10 @@ import type { NestjsDoctorConfig } from "../../../src/common/config.js";
 import type { Diagnostic } from "../../../src/common/diagnostic.js";
 import { buildModuleGraph } from "../../../src/engine/graph/module-graph.js";
 import { resolveProviders } from "../../../src/engine/graph/type-resolver.js";
+import { factoryInjectMatchesParams } from "../../../src/engine/rules/definitions/correctness/factory-inject-matches-params.js";
+import { injectableMustBeProvided } from "../../../src/engine/rules/definitions/correctness/injectable-must-be-provided.js";
 import { noAsyncWithoutAwait } from "../../../src/engine/rules/definitions/correctness/no-async-without-await.js";
+import { noDuplicateDecorators } from "../../../src/engine/rules/definitions/correctness/no-duplicate-decorators.js";
 import { noDuplicateModuleMetadata } from "../../../src/engine/rules/definitions/correctness/no-duplicate-module-metadata.js";
 import { noDuplicateRoutes } from "../../../src/engine/rules/definitions/correctness/no-duplicate-routes.js";
 import { noEmptyHandlers } from "../../../src/engine/rules/definitions/correctness/no-empty-handlers.js";
@@ -15,8 +18,11 @@ import { noMissingInjectable } from "../../../src/engine/rules/definitions/corre
 import { noMissingInterceptorMethod } from "../../../src/engine/rules/definitions/correctness/no-missing-interceptor-method.js";
 import { noMissingModuleDecorator } from "../../../src/engine/rules/definitions/correctness/no-missing-module-decorator.js";
 import { noMissingPipeMethod } from "../../../src/engine/rules/definitions/correctness/no-missing-pipe-method.js";
+import { paramDecoratorMatchesRoute } from "../../../src/engine/rules/definitions/correctness/param-decorator-matches-route.js";
 import { requireInjectDecorator } from "../../../src/engine/rules/definitions/correctness/require-inject-decorator.js";
 import { requireLifecycleInterface } from "../../../src/engine/rules/definitions/correctness/require-lifecycle-interface.js";
+import { validateNestedArrayEach } from "../../../src/engine/rules/definitions/correctness/validate-nested-array-each.js";
+import { validatedNonPrimitiveNeedsType } from "../../../src/engine/rules/definitions/correctness/validated-non-primitive-needs-type.js";
 import type { ProjectRule, Rule } from "../../../src/engine/rules/types.js";
 
 function runRule(
@@ -137,6 +143,21 @@ describe("require-lifecycle-interface", () => {
 		);
 		expect(diags).toHaveLength(1);
 		expect(diags[0].message).toContain("OnModuleDestroy");
+	});
+
+	it("does not match interface names that only contain the lifecycle name as a substring", () => {
+		const diags = runRule(
+			requireLifecycleInterface,
+			`
+      interface NotOnModuleInit { init(): void; }
+      export class MyService implements NotOnModuleInit {
+        onModuleInit() {}
+        init() {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("OnModuleInit");
 	});
 });
 
@@ -1023,5 +1044,707 @@ describe("no-fire-and-forget-async", () => {
 			{ useRealFs: true }
 		);
 		expect(diags).toHaveLength(0);
+	});
+});
+
+describe("param-decorator-matches-route", () => {
+	it("flags @Param name not in route path", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Controller, Get, Param } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get(':id')
+        findOne(@Param('userId') userId: string) { return {}; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("userId");
+	});
+
+	it("allows @Param name matching route param", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Controller, Get, Param } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get(':id')
+        findOne(@Param('id') id: string) { return {}; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows @Param() without arguments", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Controller, Get, Param } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get(':id')
+        findOne(@Param() params: any) { return {}; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("checks controller-level route params", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Controller, Get, Param } from '@nestjs/common';
+      @Controller('users/:userId')
+      export class UsersController {
+        @Get('posts')
+        getPosts(@Param('userId') userId: string) { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("flags param not in controller or method route", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Controller, Get, Param } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get('posts')
+        getPosts(@Param('id') id: string) { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("does not extract false params from non-path properties in @Controller object", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Controller, Get, Param } from '@nestjs/common';
+      @Controller({ path: 'users', host: ':subdomain.example.com' })
+      export class UsersController {
+        @Get(':id')
+        findOne(@Param('subdomain') sub: string) { return {}; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1); // Should flag — subdomain is in host, not path
+	});
+});
+
+describe("factory-inject-matches-params", () => {
+	it("flags inject/factory parameter count mismatch", () => {
+		const diags = runRule(
+			factoryInjectMatchesParams,
+			`
+      import { Module } from '@nestjs/common';
+      @Module({
+        providers: [
+          {
+            provide: 'TOKEN',
+            useFactory: (configService) => configService.get('key'),
+            inject: [ConfigService, LoggerService],
+          },
+        ],
+      })
+      export class AppModule {}
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("1 parameter(s)");
+		expect(diags[0].message).toContain("2 element(s)");
+	});
+
+	it("allows matching inject/factory parameter count", () => {
+		const diags = runRule(
+			factoryInjectMatchesParams,
+			`
+      import { Module } from '@nestjs/common';
+      @Module({
+        providers: [
+          {
+            provide: 'TOKEN',
+            useFactory: (config, logger) => config.get('key'),
+            inject: [ConfigService, LoggerService],
+          },
+        ],
+      })
+      export class AppModule {}
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("handles function expression factories", () => {
+		const diags = runRule(
+			factoryInjectMatchesParams,
+			`
+      import { Module } from '@nestjs/common';
+      @Module({
+        providers: [
+          {
+            provide: 'TOKEN',
+            useFactory: function(a, b, c) { return a; },
+            inject: [A, B],
+          },
+        ],
+      })
+      export class AppModule {}
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("handles method shorthand factories", () => {
+		const diags = runRule(
+			factoryInjectMatchesParams,
+			`
+      import { Module } from '@nestjs/common';
+      @Module({
+        providers: [
+          {
+            provide: 'TOKEN',
+            useFactory(a, b, c) { return a; },
+            inject: [A, B],
+          },
+        ],
+      })
+      export class AppModule {}
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("3 parameter(s)");
+		expect(diags[0].message).toContain("2 element(s)");
+	});
+
+	it("allows matching method shorthand factories", () => {
+		const diags = runRule(
+			factoryInjectMatchesParams,
+			`
+      import { Module } from '@nestjs/common';
+      @Module({
+        providers: [
+          {
+            provide: 'TOKEN',
+            useFactory(a, b) { return a; },
+            inject: [A, B],
+          },
+        ],
+      })
+      export class AppModule {}
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+});
+
+describe("validated-non-primitive-needs-type", () => {
+	it("flags non-primitive property with validator but no @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { ValidateNested } from 'class-validator';
+      class AddressDto { street: string; }
+      class CreateUserDto {
+        @ValidateNested()
+        address: AddressDto;
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("address");
+		expect(diags[0].message).toContain("AddressDto");
+	});
+
+	it("allows non-primitive property with @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { ValidateNested } from 'class-validator';
+      import { Type } from 'class-transformer';
+      class AddressDto { street: string; }
+      class CreateUserDto {
+        @ValidateNested()
+        @Type(() => AddressDto)
+        address: AddressDto;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows primitive properties without @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsString, IsNumber } from 'class-validator';
+      class CreateUserDto {
+        @IsString()
+        name: string;
+        @IsNumber()
+        age: number;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("skips properties without type annotation", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsNotEmpty } from 'class-validator';
+      class CreateUserDto {
+        @IsNotEmpty()
+        name;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows Date type without @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsDate } from 'class-validator';
+      class CreateEventDto {
+        @IsDate()
+        startDate: Date;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows nullable primitive union types without @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsString, IsOptional } from 'class-validator';
+      class UpdateUserDto {
+        @IsString()
+        @IsOptional()
+        name: string | null;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows undefined primitive union types without @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsNumber, IsOptional } from 'class-validator';
+      class UpdateUserDto {
+        @IsNumber()
+        @IsOptional()
+        age: number | undefined;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("flags non-primitive union types without @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { ValidateNested } from 'class-validator';
+      class AddressDto { street: string; }
+      class CreateUserDto {
+        @ValidateNested()
+        address: AddressDto | undefined;
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("address");
+	});
+
+	it("allows string[][] without @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsArray } from 'class-validator';
+      class MatrixDto {
+        @IsArray()
+        grid: string[][];
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows Array<Array<number>> without @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsArray } from 'class-validator';
+      class MatrixDto {
+        @IsArray()
+        grid: Array<Array<number>>;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows enum property with @IsEnum() without @Type()", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsEnum } from 'class-validator';
+      enum Status { Active = 'active', Inactive = 'inactive' }
+      class UpdateDto {
+        @IsEnum(Status)
+        status: Status;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+});
+
+describe("no-duplicate-decorators", () => {
+	it("flags duplicate decorator on a method", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        @Get()
+        findAll() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("@Get()");
+	});
+
+	it("allows different decorators on same method", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      import { Controller, Get, UseGuards } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        @UseGuards(AuthGuard)
+        findAll() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows stackable decorators like @ApiResponse", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        @ApiResponse({ status: 200 })
+        @ApiResponse({ status: 404 })
+        findAll() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("flags duplicate decorator on a class", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      @Controller('users')
+      @Controller('admin')
+      export class UsersController {}
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("@Controller()");
+	});
+
+	it("flags duplicate decorator on a property", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      class CreateUserDto {
+        @IsString()
+        @IsString()
+        name: string;
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("flags duplicate decorator on a constructor parameter", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      import { Injectable, Inject } from '@nestjs/common';
+      @Injectable()
+      export class MyService {
+        constructor(
+          @Inject('TOKEN') @Inject('TOKEN') private dep: any
+        ) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("@Inject()");
+	});
+
+	it("allows stackable @Throttle() decorators", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Throttle({ default: { limit: 3, ttl: 60 } })
+        @Throttle({ short: { limit: 1, ttl: 10 } })
+        @Get()
+        findAll() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+});
+
+describe("validate-nested-array-each", () => {
+	it("flags @ValidateNested() on array without { each: true }", () => {
+		const diags = runRule(
+			validateNestedArrayEach,
+			`
+      import { ValidateNested } from 'class-validator';
+      class ItemDto { name: string; }
+      class OrderDto {
+        @ValidateNested()
+        items: ItemDto[];
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("items");
+	});
+
+	it("allows @ValidateNested({ each: true }) on array", () => {
+		const diags = runRule(
+			validateNestedArrayEach,
+			`
+      import { ValidateNested } from 'class-validator';
+      class ItemDto { name: string; }
+      class OrderDto {
+        @ValidateNested({ each: true })
+        items: ItemDto[];
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows @ValidateNested() on non-array type", () => {
+		const diags = runRule(
+			validateNestedArrayEach,
+			`
+      import { ValidateNested } from 'class-validator';
+      class AddressDto { street: string; }
+      class UserDto {
+        @ValidateNested()
+        address: AddressDto;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("detects array type via @IsArray decorator", () => {
+		const diags = runRule(
+			validateNestedArrayEach,
+			`
+      import { ValidateNested, IsArray } from 'class-validator';
+      class ItemDto { name: string; }
+      class OrderDto {
+        @IsArray()
+        @ValidateNested()
+        items: ItemDto;
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("detects Array<T> generic syntax", () => {
+		const diags = runRule(
+			validateNestedArrayEach,
+			`
+      import { ValidateNested } from 'class-validator';
+      class ItemDto { name: string; }
+      class OrderDto {
+        @ValidateNested()
+        items: Array<ItemDto>;
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+});
+
+describe("injectable-must-be-provided", () => {
+	it("flags @Injectable() class not in any module providers", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [OtherService] })
+        export class AppModule {}
+      `,
+			"my.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class MyService {}
+      `,
+		});
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("MyService");
+	});
+
+	it("allows @Injectable() class registered in module providers", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [MyService] })
+        export class AppModule {}
+      `,
+			"my.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class MyService {}
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("skips classes with Guard/Interceptor/Pipe/Filter suffixes", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [] })
+        export class AppModule {}
+      `,
+			"auth.guard.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class AuthGuard {}
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("skips test files", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [] })
+        export class AppModule {}
+      `,
+			"my.service.spec.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class MockService {}
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows @Injectable() class registered via useClass in a custom provider", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({
+          providers: [
+            { provide: 'MY_SERVICE', useClass: MyService },
+          ],
+        })
+        export class AppModule {}
+      `,
+			"my.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class MyService {}
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows @Injectable() class registered via useExisting in a custom provider", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({
+          providers: [
+            MyService,
+            { provide: 'ALIAS', useExisting: MyService },
+          ],
+        })
+        export class AppModule {}
+      `,
+			"my.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class MyService {}
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("flags @Injectable() service with generic 'Task' suffix not registered in any module", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [] })
+        export class AppModule {}
+      `,
+			"background-task.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class BackgroundTask {}
+      `,
+		});
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("BackgroundTask");
+	});
+
+	it("flags @Injectable() service with generic 'Indicator' suffix not registered in any module", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [] })
+        export class AppModule {}
+      `,
+			"performance-indicator.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class PerformanceIndicator {}
+      `,
+		});
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("PerformanceIndicator");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/rules/performance-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/performance-rules.test.ts
@@ -198,6 +198,84 @@ describe("no-unused-providers", () => {
 		expect(diags[0].message).toContain("UnusedService");
 	});
 
+	it("allows provider with @Cron() method decorator", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [HealthCron] })
+        export class AppModule {}
+      `,
+			"health.cron.ts": `
+        import { Injectable } from '@nestjs/common';
+        import { Cron } from '@nestjs/schedule';
+        @Injectable()
+        export class HealthCron {
+          @Cron('0 */5 * * * *')
+          async handleCron() {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows provider with @OnEvent() method decorator", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [OrderListener] })
+        export class AppModule {}
+      `,
+			"order.listener.ts": `
+        import { Injectable } from '@nestjs/common';
+        import { OnEvent } from '@nestjs/event-emitter';
+        @Injectable()
+        export class OrderListener {
+          @OnEvent('order.created')
+          handleOrderCreated() {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows provider with Subscriber suffix", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [UserSubscriber] })
+        export class AppModule {}
+      `,
+			"user.subscriber.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class UserSubscriber {
+          afterInsert() {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows provider with @Process() method decorator", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [EmailProcessor] })
+        export class AppModule {}
+      `,
+			"email.processor.ts": `
+        import { Injectable } from '@nestjs/common';
+        import { Process } from '@nestjs/bull';
+        @Injectable()
+        export class EmailProcessor {
+          @Process('send')
+          handleSend() {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
 	it("allows provider injected in another service", () => {
 		const diags = runProjectRule(noUnusedProviders, {
 			"app.module.ts": `

--- a/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
@@ -9,6 +9,7 @@ import { noExposedStackTrace } from "../../../src/engine/rules/definitions/secur
 import { noRawEntityInResponse } from "../../../src/engine/rules/definitions/security/no-raw-entity-in-response.js";
 import { noSynchronizeInProduction } from "../../../src/engine/rules/definitions/security/no-synchronize-in-production.js";
 import { noWeakCrypto } from "../../../src/engine/rules/definitions/security/no-weak-crypto.js";
+import { requireGuardsOnEndpoints } from "../../../src/engine/rules/definitions/security/require-guards-on-endpoints.js";
 import type { Rule } from "../../../src/engine/rules/types.js";
 
 function runRule(rule: Rule, code: string, filePath = "test.ts"): Diagnostic[] {
@@ -363,6 +364,120 @@ describe("no-raw-entity-in-response", () => {
       @Injectable()
       export class UsersService {
         findAll(): UserEntity[] { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+});
+
+describe("require-guards-on-endpoints", () => {
+	it("flags unguarded endpoint", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        findAll() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("findAll");
+	});
+
+	it("allows endpoint with method-level @UseGuards()", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get, UseGuards } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        @UseGuards(AuthGuard)
+        findAll() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("allows all endpoints with class-level @UseGuards()", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get, Post, UseGuards } from '@nestjs/common';
+      @Controller('users')
+      @UseGuards(AuthGuard)
+      export class UsersController {
+        @Get()
+        findAll() { return []; }
+        @Post()
+        create() { return {}; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("skips methods with @Public() decorator", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('health')
+      export class HealthController {
+        @Get()
+        @Public()
+        check() { return { status: 'ok' }; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("skips all endpoints when class has @Public() decorator", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get, Post } from '@nestjs/common';
+      @Controller('health')
+      @Public()
+      export class HealthController {
+        @Get()
+        check() { return { status: 'ok' }; }
+        @Post()
+        reset() { return {}; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag non-controller classes", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class UsersService {
+        findAll() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag non-handler methods", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        helperMethod() { return 42; }
       }
     `
 		);

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -128,7 +128,7 @@ Supported agents: Claude Code, Amp Code, Cursor, OpenCode, Windsurf, Antigravity
 - `require-inject-decorator` (error) — Untyped constructor param without @Inject()
 - `prefer-readonly-injection` (warning) — Constructor DI params missing readonly
 - `require-lifecycle-interface` (warning) — Lifecycle method without corresponding interface
-- `no-empty-handlers` (warning) — HTTP handler with empty body
+- `no-empty-handlers` (info) — HTTP handler with empty body
 - `no-async-without-await` (warning) — Async function/method with no await
 - `no-duplicate-module-metadata` (warning) — Duplicate entries in @Module() arrays
 - `no-missing-module-decorator` (warning) — Class named *Module without @Module()
@@ -141,7 +141,7 @@ Supported agents: Claude Code, Amp Code, Cursor, OpenCode, Windsurf, Antigravity
 - `no-orm-in-controllers` (error) — PrismaService/EntityManager/DataSource in controllers
 - `no-circular-module-deps` (error) — Cycles in @Module() import graph
 - `no-manual-instantiation` (error) — new SomeService() for injectable classes
-- `no-orm-in-services` (warning) — Services using ORM directly instead of repositories
+- `no-orm-in-services` (info) — Services using ORM directly instead of repositories
 - `no-service-locator` (warning) — ModuleRef.get()/resolve() hides dependencies
 - `prefer-constructor-injection` (warning) — @Inject() property injection
 - `require-module-boundaries` (info) — Deep imports into other modules' internals
@@ -150,9 +150,9 @@ Supported agents: Claude Code, Amp Code, Cursor, OpenCode, Windsurf, Antigravity
 ### Performance (7)
 
 - `no-sync-io` (warning) — readFileSync, writeFileSync, etc.
-- `no-blocking-constructor` (warning) — Loops/await in Injectable/Controller constructors
+- `no-blocking-constructor` (warning) — Loops in Injectable/Controller constructors
 - `no-dynamic-require` (warning) — require() with non-literal argument
-- `no-unused-providers` (warning) — Provider never injected anywhere
+- `no-unused-providers` (warning) — Provider never injected and no self-activating decorators
 - `no-request-scope-abuse` (warning) — Scope.REQUEST creates new instance per request
 - `no-unused-module-exports` (info) — Module exports unused by importers
 - `no-orphan-modules` (info) — Module never imported by any other module

--- a/packages/website/src/app/docs/page.mdx
+++ b/packages/website/src/app/docs/page.mdx
@@ -22,7 +22,7 @@ npx nestjs-doctor@latest .
 
 ## How It Works
 
-The [pipeline](/docs/pipeline) reads your source files, builds a module dependency graph, runs 43 rules against the AST, and produces a weighted health score. See the [pipeline overview](/docs/pipeline) for the full architecture.
+The [pipeline](/docs/pipeline) reads your source files, builds a module dependency graph, runs 50 rules against the AST, and produces a weighted health score. See the [pipeline overview](/docs/pipeline) for the full architecture.
 
 ## HTML Report
 

--- a/packages/website/src/app/docs/pipeline/page.mdx
+++ b/packages/website/src/app/docs/pipeline/page.mdx
@@ -19,7 +19,7 @@ How nestjs-doctor works from CLI invocation to final output.
 |-----------|---------------|
 | `src/cli/` | CLI flags, entry point, output formatters |
 | `src/engine/` | Config loading, file collection, project detection, diagnostic filtering, AST parsing, module graph, provider resolution, rule execution, scoring |
-| `src/engine/rules/definitions/` | All 43 rules organized by category (`security/`, `correctness/`, `architecture/`, `performance/`, `schema/`) |
+| `src/engine/rules/definitions/` | All 50 rules organized by category (`security/`, `correctness/`, `architecture/`, `performance/`, `schema/`) |
 | `src/report/` | HTML report generation (interactive dashboard, module graph, schema ER diagram) |
 | `src/common/` | Shared type definitions (`Diagnostic`, `Config`, `Result`, errors) |
 

--- a/packages/website/src/app/docs/rules/architecture/page.mdx
+++ b/packages/website/src/app/docs/rules/architecture/page.mdx
@@ -16,7 +16,7 @@ export const metadata = docsMetadata["/docs/rules/architecture"];
 | `no-orm-in-controllers` | error | PrismaService / EntityManager / DataSource in controllers |
 | `no-circular-module-deps` | error | Cycles in `@Module()` import graph — names the providers to extract |
 | `no-manual-instantiation` | error | `new SomeService()` for injectable classes |
-| `no-orm-in-services` | warning | Services using ORM directly (should use repositories) |
+| `no-orm-in-services` | info | Services using ORM directly (should use repositories) |
 | `no-service-locator` | warning | `ModuleRef.get()`/`resolve()` usage |
 | `prefer-constructor-injection` | warning | `@Inject()` property injection |
 | `require-module-boundaries` | info | Deep imports into other modules' internals |
@@ -217,6 +217,8 @@ If your project intentionally allows manual construction for specific classes
 Detects services using ORM types directly instead of through a repository layer.
 
 **Why:** When services depend on ORM types directly, switching ORMs or data sources requires changing every service. A repository layer provides a clean abstraction boundary.
+
+> **Note:** If your project follows the [official NestJS Prisma recipe](https://docs.nestjs.com/recipes/prisma) (injecting `PrismaService` directly), you can disable this rule in your configuration.
 
 <CodeGroup labels={["Bad", "Good"]}>
 ```typescript

--- a/packages/website/src/app/docs/rules/correctness/page.mdx
+++ b/packages/website/src/app/docs/rules/correctness/page.mdx
@@ -7,7 +7,7 @@ export const metadata = docsMetadata["/docs/rules/correctness"];
 
 # Correctness Rules
 
-14 rules that detect bugs, missing decorators, and runtime errors.
+20 rules that detect bugs, missing decorators, and runtime errors.
 
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
@@ -20,11 +20,17 @@ export const metadata = docsMetadata["/docs/rules/correctness"];
 | `require-inject-decorator` | error | Untyped constructor param without `@Inject()` |
 | `prefer-readonly-injection` | warning | Constructor DI params missing `readonly` |
 | `require-lifecycle-interface` | warning | Lifecycle method without interface |
-| `no-empty-handlers` | warning | HTTP handler with empty body |
+| `no-empty-handlers` | info | HTTP handler with empty body |
 | `no-async-without-await` | warning | Async function with no `await` |
 | `no-duplicate-module-metadata` | warning | Duplicate entries in `@Module()` arrays |
 | `no-missing-module-decorator` | warning | Class named `*Module` without `@Module()` |
 | `no-fire-and-forget-async` | warning | Async call without `await` in non-handler methods |
+| `param-decorator-matches-route` | error | `@Param()` name doesn't match any `:param` in the route path |
+| `factory-inject-matches-params` | error | `useFactory` inject array length mismatches factory parameter count |
+| `no-duplicate-decorators` | warning | Same decorator appears twice on a single target |
+| `validated-non-primitive-needs-type` | warning | Non-primitive DTO property with class-validator decorators missing `@Type()` |
+| `validate-nested-array-each` | warning | `@ValidateNested()` on array property missing `{ each: true }` |
+| `injectable-must-be-provided` | info | `@Injectable()` class not registered in any module's providers |
 
 ---
 
@@ -90,7 +96,7 @@ export class UserController {
 
 ## no-missing-guard-method
 
-Detects guard classes (using `@Injectable()` or implementing `CanActivate`) that are missing the `canActivate()` method.
+Detects guard classes (using `@Injectable()` or implementing `CanActivate`) that are missing the `canActivate()` method. This rule identifies guards by the `Guard` class name suffix.
 
 **Why:** A guard without `canActivate()` will cause a runtime error when NestJS tries to invoke it.
 
@@ -295,7 +301,7 @@ export class UserController {
 
 ## no-async-without-await
 
-Detects async functions or methods that never use `await`.
+Detects async functions or methods that never use `await`. HTTP handlers with route decorators are exempted, as `async` is conventional for controller methods.
 
 **Why:** An async function without `await` creates an unnecessary promise wrapper. Either remove `async` or add the missing `await`.
 
@@ -395,5 +401,183 @@ export class OrderService {
     await this.analyticsService.track('order_completed');
   }
 }
+```
+</CodeGroup>
+
+---
+
+## param-decorator-matches-route
+
+Detects `@Param()` decorator names that don't match any `:param` segment in the route path (including the controller prefix).
+
+**Why:** A mismatched `@Param()` name silently receives `undefined` at runtime, leading to bugs that are hard to trace.
+
+<CodeGroup labels={["Bad", "Good"]}>
+```typescript
+@Controller('users')
+export class UserController {
+  @Get(':id')
+  findOne(@Param('userId') userId: string) {  // 'userId' doesn't match ':id'
+    return this.userService.findOne(userId);
+  }
+}
+```
+```typescript
+@Controller('users')
+export class UserController {
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.userService.findOne(id);
+  }
+}
+```
+</CodeGroup>
+
+---
+
+## factory-inject-matches-params
+
+Detects `useFactory` providers where the `inject` array length doesn't match the factory function's parameter count.
+
+**Why:** NestJS maps inject tokens to factory parameters by position. A count mismatch means the factory receives wrong or missing values, causing silent bugs or runtime errors.
+
+<CodeGroup labels={["Bad", "Good"]}>
+```typescript
+@Module({
+  providers: [
+    {
+      provide: 'CONFIG',
+      useFactory: (config) => config.get('db'),  // 1 param
+      inject: [ConfigService, LoggerService],     // 2 tokens!
+    },
+  ],
+})
+export class AppModule {}
+```
+```typescript
+@Module({
+  providers: [
+    {
+      provide: 'CONFIG',
+      useFactory: (config, logger) => {           // 2 params
+        logger.log('Loading config');
+        return config.get('db');
+      },
+      inject: [ConfigService, LoggerService],     // 2 tokens
+    },
+  ],
+})
+export class AppModule {}
+```
+</CodeGroup>
+
+---
+
+## no-duplicate-decorators
+
+Detects the same decorator appearing twice on a single class, method, or property. Stackable decorators like `@ApiResponse` are allowed.
+
+**Why:** A duplicate decorator is almost always a copy-paste error. The second occurrence silently overwrites the first or has no effect.
+
+<CodeGroup labels={["Bad", "Good"]}>
+```typescript
+@Controller('users')
+export class UserController {
+  @Get(':id')
+  @Get(':id')  // Duplicate!
+  findOne(@Param('id') id: string) {
+    return this.userService.findOne(id);
+  }
+}
+```
+```typescript
+@Controller('users')
+export class UserController {
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.userService.findOne(id);
+  }
+}
+```
+</CodeGroup>
+
+---
+
+## validated-non-primitive-needs-type
+
+Detects DTO properties with class-validator decorators on non-primitive types that are missing `@Type()` from class-transformer.
+
+**Why:** `class-transformer` needs `@Type()` to know which class to instantiate for nested objects. Without it, validation runs against a plain object and nested rules are silently skipped.
+
+<CodeGroup labels={["Bad", "Good"]}>
+```typescript
+export class CreateOrderDto {
+  @ValidateNested()
+  address: AddressDto;  // Missing @Type()!
+}
+```
+```typescript
+export class CreateOrderDto {
+  @ValidateNested()
+  @Type(() => AddressDto)
+  address: AddressDto;
+}
+```
+</CodeGroup>
+
+---
+
+## validate-nested-array-each
+
+Detects `@ValidateNested()` on array-typed properties that are missing `{ each: true }`.
+
+**Why:** Without `{ each: true }`, `@ValidateNested()` validates the array object itself instead of each element, so invalid items pass validation silently.
+
+<CodeGroup labels={["Bad", "Good"]}>
+```typescript
+export class CreateOrderDto {
+  @ValidateNested()  // Missing { each: true }!
+  @Type(() => ItemDto)
+  items: ItemDto[];
+}
+```
+```typescript
+export class CreateOrderDto {
+  @ValidateNested({ each: true })
+  @Type(() => ItemDto)
+  items: ItemDto[];
+}
+```
+</CodeGroup>
+
+---
+
+## injectable-must-be-provided
+
+**Scope:** Project
+
+Detects `@Injectable()` classes that are not registered in any module's `providers` array. Infrastructure classes (guards, pipes, filters, interceptors, etc.) are skipped.
+
+**Why:** An `@Injectable()` class that isn't registered anywhere is either dead code or a forgotten registration — NestJS will throw if you try to inject it.
+
+<CodeGroup labels={["Bad", "Good"]}>
+```typescript
+@Injectable()
+export class UsersService {  // Not in any module's providers!
+  findAll() { /* ... */ }
+}
+```
+```typescript
+// users.service.ts
+@Injectable()
+export class UsersService {
+  findAll() { /* ... */ }
+}
+
+// users.module.ts
+@Module({
+  providers: [UsersService],
+})
+export class UsersModule {}
 ```
 </CodeGroup>

--- a/packages/website/src/app/docs/rules/page.mdx
+++ b/packages/website/src/app/docs/rules/page.mdx
@@ -6,14 +6,14 @@ export const metadata = docsMetadata["/docs/rules"];
 
 # Rules Overview
 
-nestjs-doctor ships with 43 built-in rules across five categories.
+nestjs-doctor ships with 50 built-in rules across five categories.
 
 ## Categories
 
 | Category | Rules | Focus |
 |----------|-------|-------|
-| [Security](/docs/rules/security) | 9 | Secrets, injection, CSRF, stack traces |
-| [Correctness](/docs/rules/correctness) | 14 | Missing decorators, duplicate routes, async issues |
+| [Security](/docs/rules/security) | 10 | Secrets, injection, CSRF, stack traces |
+| [Correctness](/docs/rules/correctness) | 20 | Missing decorators, duplicate routes, async issues |
 | [Architecture](/docs/rules/architecture) | 10 | Layer violations, circular deps, DI patterns |
 | [Performance](/docs/rules/performance) | 7 | Sync I/O, blocking constructors, dead code |
 | [Schema](/docs/rules/schema) | 3 | Primary keys, timestamps, cascade rules |

--- a/packages/website/src/app/docs/rules/performance/page.mdx
+++ b/packages/website/src/app/docs/rules/performance/page.mdx
@@ -12,9 +12,9 @@ export const metadata = docsMetadata["/docs/rules/performance"];
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
 | `no-sync-io` | warning | `readFileSync`, `writeFileSync`, etc. |
-| `no-blocking-constructor` | warning | Loops/await in Injectable/Controller constructors |
+| `no-blocking-constructor` | warning | Loops in Injectable/Controller constructors |
 | `no-dynamic-require` | warning | `require()` with non-literal argument |
-| `no-unused-providers` | warning | Provider never injected anywhere |
+| `no-unused-providers` | warning | Provider never injected and no self-activating decorators |
 | `no-request-scope-abuse` | warning | `Scope.REQUEST` on frequently used providers |
 | `no-unused-module-exports` | info | Module exports unused by importers |
 | `no-orphan-modules` | info | Module never imported by any other module |
@@ -52,9 +52,9 @@ export class ConfigService {
 
 ## no-blocking-constructor
 
-Detects loops or `await` expressions inside Injectable/Controller constructors.
+Detects loops inside Injectable/Controller constructors.
 
-**Why:** Constructors run during module initialization. Blocking operations (loops over large datasets, async calls) delay application startup and can cause timeouts.
+**Why:** Constructors run during module initialization. Blocking operations (loops over large datasets) delay application startup and can cause timeouts. Constructors cannot be async, so asynchronous work should always use lifecycle hooks.
 
 <CodeGroup labels={["Bad", "Good"]}>
 ```typescript
@@ -120,7 +120,7 @@ export class PluginLoader {
 
 Detects `@Injectable()` providers that are never injected by any other provider or controller.
 
-**Why:** Unused providers are dead code. They increase module initialization time, obscure the dependency graph, and should be removed.
+**Why:** Unused providers are dead code. They increase module initialization time, obscure the dependency graph, and should be removed. Self-activating providers — classes that use framework decorators like `@Cron()`, `@OnEvent()`, or `@Process()` — are automatically excluded since they are instantiated and activated by the framework without needing to be injected elsewhere.
 
 <CodeGroup labels={["Bad", "Good"]}>
 ```typescript
@@ -140,7 +140,7 @@ export class UserModule {}
 ```
 </CodeGroup>
 
-**Note:** This rule skips infrastructure classes (Guards, Interceptors, Filters, Middleware, Strategies) since they may be used declaratively via decorators rather than injected.
+**Note:** This rule skips infrastructure classes (Guards, Interceptors, Filters, Middleware, Strategies, Subscribers, etc.) and self-activating providers with framework decorators (`@Cron`, `@OnEvent`, `@Process`, `@Interval`, `@SubscribeMessage`, etc.).
 
 ---
 

--- a/packages/website/src/app/docs/rules/security/page.mdx
+++ b/packages/website/src/app/docs/rules/security/page.mdx
@@ -7,7 +7,7 @@ export const metadata = docsMetadata["/docs/rules/security"];
 
 # Security Rules
 
-9 rules that detect security vulnerabilities and unsafe patterns.
+10 rules that detect security vulnerabilities and unsafe patterns.
 
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
@@ -20,6 +20,7 @@ export const metadata = docsMetadata["/docs/rules/security"];
 | `no-exposed-env-vars` | warning | Direct `process.env` in Injectable/Controller |
 | `no-exposed-stack-trace` | warning | `error.stack` exposed in responses |
 | `no-raw-entity-in-response` | warning | Returning ORM entities directly from controllers |
+| `require-guards-on-endpoints` | warning | Endpoints without `@UseGuards()` at class or method level |
 
 ---
 
@@ -244,6 +245,44 @@ export class UserController {
   async findOne(@Param('id') id: string) {
     const user = await this.userService.findOne(id);
     return new UserResponseDto(user); // Controlled shape
+  }
+}
+```
+</CodeGroup>
+
+---
+
+## require-guards-on-endpoints
+
+Detects controller endpoints that are not protected by `@UseGuards()` at the class or method level.
+
+**Why:** Unguarded endpoints are accessible to anyone. Controllers or individual routes can opt out with `@Public()`, `@AllowAnonymous()`, `@SkipAuth()`, or `@IsPublic()` at the class or method level.
+
+> **Note:** If your app uses a global guard via `APP_GUARD`, all endpoints are already protected. You can disable this rule in your config: `{ "rules": { "security/require-guards-on-endpoints": false } }`.
+
+<CodeGroup labels={["Bad", "Good"]}>
+```typescript
+@Controller('orders')
+export class OrderController {
+  @Get()
+  findAll() {  // No guard!
+    return this.orderService.findAll();
+  }
+}
+```
+```typescript
+@UseGuards(AuthGuard)
+@Controller('orders')
+export class OrderController {
+  @Get()
+  findAll() {
+    return this.orderService.findAll();
+  }
+
+  @Public()
+  @Get('health')
+  health() {
+    return { status: 'ok' };
   }
 }
 ```

--- a/packages/website/src/app/docs/vscode-extension/page.mdx
+++ b/packages/website/src/app/docs/vscode-extension/page.mdx
@@ -6,7 +6,7 @@ export const metadata = docsMetadata["/docs/vscode-extension"];
 
 # VS Code Extension
 
-Get inline diagnostics from nestjs-doctor directly in your editor — same 43 rules, zero friction.
+Get inline diagnostics from nestjs-doctor directly in your editor — same 50 rules, zero friction.
 
 ## Installation
 

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -24,7 +24,7 @@ export const docsMetadata: Record<string, Metadata> = {
 	"/docs/vscode-extension": {
 		title: "VS Code Extension",
 		description:
-			"Get inline diagnostics from nestjs-doctor directly in your editor. Same 43 rules, zero friction.",
+			"Get inline diagnostics from nestjs-doctor directly in your editor. Same 50 rules, zero friction.",
 	},
 	"/docs/pipeline": {
 		title: "Pipeline Overview",
@@ -84,17 +84,17 @@ export const docsMetadata: Record<string, Metadata> = {
 	"/docs/rules": {
 		title: "Rules Overview",
 		description:
-			"43 built-in rules across five categories: security, correctness, architecture, performance, and schema.",
+			"50 built-in rules across five categories: security, correctness, architecture, performance, and schema.",
 	},
 	"/docs/rules/security": {
 		title: "Security Rules",
 		description:
-			"9 rules that detect security vulnerabilities and unsafe patterns in NestJS applications.",
+			"10 rules that detect security vulnerabilities and unsafe patterns in NestJS applications.",
 	},
 	"/docs/rules/correctness": {
 		title: "Correctness Rules",
 		description:
-			"14 rules that detect bugs, missing decorators, and runtime errors in NestJS applications.",
+			"20 rules that detect bugs, missing decorators, and runtime errors in NestJS applications.",
 	},
 	"/docs/rules/architecture": {
 		title: "Architecture Rules",


### PR DESCRIPTION
## Summary
- Add 7 new rules: `factory-inject-matches-params`, `injectable-must-be-provided`, `no-duplicate-decorators`, `param-decorator-matches-route`, `validate-nested-array-each`, `validated-non-primitive-needs-type`, `require-guards-on-endpoints`
- Fix `factory-inject-matches-params` to handle method shorthand syntax (`useFactory(dep) {}`)
- Fix `validated-non-primitive-needs-type` to correctly recognize nested primitive arrays (`string[][]`, `Array<Array<number>>`)
- Add test fixtures, unit tests, integration tests, and docs for all new rules

## Test plan
- [x] All 574 tests pass (`pnpm --filter nestjs-doctor test`)
- [x] No lint/format issues (`ultracite check`)
- [x] Integration tests verify new fixtures (bad-correctness, bad-performance, bad-security)