### PR TITLE
Add name property to SKILL.MD for Claude services recognition

### DIFF
--- a/.claude/skills/nestjs-doctor/SKILL.md
+++ b/.claude/skills/nestjs-doctor/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: nestjs-doctor
 description: Scan a NestJS project with nestjs-doctor, present a health report, and fix issues interactively
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Glob, Grep, Write

--- a/packages/nestjs-doctor/skill/CREATE-RULE-SKILL.md
+++ b/packages/nestjs-doctor/skill/CREATE-RULE-SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: nestj-doctor-create-rule
+name: nestjs-doctor-create-rule
 description: Create a custom nestjs-doctor rule that detects a specific pattern or anti-pattern in a NestJS codebase
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Glob, Grep, Write

--- a/packages/nestjs-doctor/skill/CREATE-RULE-SKILL.md
+++ b/packages/nestjs-doctor/skill/CREATE-RULE-SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: nestj-doctor-create-rule
 description: Create a custom nestjs-doctor rule that detects a specific pattern or anti-pattern in a NestJS codebase
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Glob, Grep, Write

--- a/packages/nestjs-doctor/skill/SKILL.md
+++ b/packages/nestjs-doctor/skill/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: nestjs-doctor
 description: Scan a NestJS project with nestjs-doctor, present a health report, and fix issues interactively
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Glob, Grep, Write


### PR DESCRIPTION
This pull request adds metadata to skill definition files for the NestJS Doctor functionality. The most important changes are the addition of a `name` field to each skill's markdown file, which helps clearly identify each skill.

This also fixes a bug that doesn't allow you to upload the skill directly to the Claude Code Application for MacOS. 

Skill metadata additions:

* Added `name: nestjs-doctor` to `.claude/skills/nestjs-doctor/SKILL.md` and `packages/nestjs-doctor/skill/SKILL.md` to explicitly identify the main NestJS Doctor skill. [[1]](diffhunk://#diff-e3c3d238f7bc0161a5eb71be676af31bd72c700feb2b480fa7c6e48f4d35433eR2) [[2]](diffhunk://#diff-d484de29faf5203eadcaeadd3a53fc8376eacf7d6a4479e499653d3df8390b92R2)
* Added `name: nestj-doctor-create-rule` to `packages/nestjs-doctor/skill/CREATE-RULE-SKILL.md` for the custom rule creation skill.…an recognize its name