### PR TITLE
feat: endpoint graph enhancements and LSP bug fixes

### DIFF
--- a/.changeset/endpoint-graph-enhancements.md
+++ b/.changeset/endpoint-graph-enhancements.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Enrich endpoint dependency graph with branch conditions, iteration context, guard-throw patterns, swagger metadata, and inline step/throw nodes

--- a/.changeset/endpoint-graph-enhancements.md
+++ b/.changeset/endpoint-graph-enhancements.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": minor
+---
+
+Enrich endpoint dependency graph with branch conditions, iteration context, guard-throw patterns, swagger metadata, and inline step/throw nodes

--- a/packages/nestjs-doctor-lsp/package.json
+++ b/packages/nestjs-doctor-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-doctor-lsp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Language Server Protocol server for nestjs-doctor diagnostics",
   "type": "module",
   "main": "dist/server.cjs",

--- a/packages/nestjs-doctor-lsp/src/scan-worker.ts
+++ b/packages/nestjs-doctor-lsp/src/scan-worker.ts
@@ -27,7 +27,7 @@ interface NestjsDoctorApi {
 	checkAllFiles(context: ScanContext): ScanResult;
 	checkFile(context: ScanContext, filePath: string): ScanResult;
 	checkProject(context: ScanContext): ScanResult;
-	prepareScan(
+	prepareAnalysis(
 		path: string
 	): Promise<{ context: ScanContext; customRuleWarnings: string[] }>;
 	updateFile(context: ScanContext, filePath: string): void;
@@ -94,7 +94,7 @@ async function initialize() {
 		const require = createRequire(join(workspaceRoot, "package.json"));
 		const api = require("nestjs-doctor") as NestjsDoctorApi;
 
-		const { context } = await api.prepareScan(workspaceRoot);
+		const { context } = await api.prepareAnalysis(workspaceRoot);
 		ctx = context;
 
 		post({ kind: "ready" });

--- a/packages/nestjs-doctor-lsp/src/server.ts
+++ b/packages/nestjs-doctor-lsp/src/server.ts
@@ -26,7 +26,7 @@ interface Settings {
 }
 
 const defaultSettings: Settings = {
-	debounceMs: 2000,
+	debounceMs: 200,
 	enable: true,
 	scanOnOpen: true,
 	scanOnSave: true,

--- a/packages/nestjs-doctor-lsp/src/server.ts
+++ b/packages/nestjs-doctor-lsp/src/server.ts
@@ -26,7 +26,7 @@ interface Settings {
 }
 
 const defaultSettings: Settings = {
-	debounceMs: 200,
+	debounceMs: 2000,
 	enable: true,
 	scanOnOpen: true,
 	scanOnSave: true,
@@ -152,6 +152,7 @@ function spawnWorker() {
 			`NestJS Doctor worker error: ${err.message}`
 		);
 		terminateWorker();
+		setTimeout(() => spawnWorker(), 3000);
 	});
 
 	worker.on("exit", () => {

--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "nestjs-doctor-vscode",
   "displayName": "NestJS Doctor",
   "description": "Static analysis for NestJS — inline diagnostics and health score",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "rolobits",
   "engines": {
     "vscode": "^1.85.0"

--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -61,8 +61,8 @@
         },
         "nestjsDoctor.debounceMs": {
           "type": "number",
-          "default": 2000,
-          "description": "Debounce delay in ms before re-scanning after save"
+          "default": 200,
+          "description": "Debounce delay (ms) before re-scanning after a file save. Lower values give faster feedback."
         }
       }
     },

--- a/packages/nestjs-doctor-vscode/src/extension.ts
+++ b/packages/nestjs-doctor-vscode/src/extension.ts
@@ -77,9 +77,15 @@ export async function activate(context: ExtensionContext): Promise<void> {
 				if (!client) {
 					return;
 				}
-				updateStatusBar(true);
-				await client.sendRequest("nestjs-doctor/scan");
-				updateStatusBar();
+				try {
+					updateStatusBar(true);
+					await client.sendRequest("nestjs-doctor/scan");
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					output.appendLine(`NestJS Doctor scan failed: ${message}`);
+				} finally {
+					updateStatusBar();
+				}
 			}
 		);
 		context.subscriptions.push(scanCommand);

--- a/packages/nestjs-doctor/src/common/endpoint.ts
+++ b/packages/nestjs-doctor/src/common/endpoint.ts
@@ -9,22 +9,101 @@ export type DependencyType =
 	| "pipe"
 	| "filter"
 	| "gateway"
+	| "step"
+	| "throw"
 	| "unknown";
+
+export interface StepStatement {
+	assignedTo: string | null;
+	text: string;
+}
+
+/**
+ * Merged guard-throw info attached to a call node when the return value
+ * is immediately null-checked and throws an exception.
+ */
+export interface GuardThrow {
+	branchKind: string | null;
+	callSiteLine: number;
+	className: string;
+	conditionText: string | null;
+	message: string | null;
+}
 
 /**
  * A per-method dependency node. Each method call becomes its own node
  * so that call order and conditionality are visible in the graph.
  */
 export interface MethodDependencyNode {
+	/** Variable name the return value is assigned to (e.g. "existing" from `const existing = ...`) */
+	assignedTo: string | null;
+	/** Shared ID for mutually exclusive branches from the same conditional (e.g., "L358") */
+	branchGroupId: string | null;
+	/** Branch type: "if" | "else-if" | "else" | "case" | "default" | "catch" | "ternary-true" | "ternary-false" */
+	branchKind: string | null;
+	/** Line where the call to this dependency is made in the parent method */
+	callSiteLine: number;
 	className: string;
+	/** Leading comment above the call site (e.g. "Verify pool belongs to organization") */
+	comment: string | null;
 	conditional: boolean;
+	/** Condition expression text (e.g., "!owner"), null if unconditional */
+	conditionText: string | null;
 	dependencies: MethodDependencyNode[];
+	/** Last line of the method declaration (for full-function highlighting) */
+	endLine: number;
 	filePath: string;
+	/** Merged guard-throw for call nodes (fetch + null-check + throw pattern) */
+	guardThrow: GuardThrow | null;
+	/** Iteration context: "loop" | "callback" | "concurrent" | null */
+	iterationKind: "loop" | "callback" | "concurrent" | null;
+	/** Short label for the construct: "map" | "forEach" | "for-of" | "all" | etc. */
+	iterationLabel: string | null;
 	line: number;
 	methodName: string | null;
 	order: number;
+	/** Method parameter names and types (from TS signature) */
+	parameters: MethodParameterInfo[];
+	/** Return type from TS method signature (unwrapped from Promise/Observable) */
+	returnType: string | null;
+	/** Inline logic statements for step nodes (only populated when type === "step") */
+	stepStatements: StepStatement[];
+	/** Exception message for standalone throw nodes */
+	throwMessage: string | null;
 	totalMethods: number;
 	type: DependencyType;
+}
+
+export interface MethodParameterInfo {
+	name: string;
+	type: string | null;
+}
+
+export interface ApiBodyInfo {
+	description: string | null;
+	type: string | null;
+}
+
+export interface ApiParamInfo {
+	description: string | null;
+	name: string;
+	required: boolean;
+	type: string | null;
+}
+
+export interface ApiResponseInfo {
+	description: string | null;
+	status: number;
+	type: string | null;
+}
+
+export interface SwaggerMetadata {
+	body: ApiBodyInfo | null;
+	description: string | null;
+	params: ApiParamInfo[];
+	queryParams: ApiParamInfo[];
+	responses: ApiResponseInfo[];
+	summary: string | null;
 }
 
 /**
@@ -34,11 +113,17 @@ export interface MethodDependencyNode {
 export interface EndpointNode {
 	controllerClass: string;
 	dependencies: MethodDependencyNode[];
+	/** Last line of the handler method (for full-function highlighting) */
+	endLine: number;
 	filePath: string;
 	handlerMethod: string;
 	httpMethod: string;
 	line: number;
+	/** Return type from TS method signature (unwrapped from Promise/Observable) */
+	returnType: string | null;
 	routePath: string;
+	/** Swagger/OpenAPI metadata, null when no swagger decorators present */
+	swagger: SwaggerMetadata | null;
 }
 
 /**

--- a/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
@@ -1,4 +1,5 @@
 import type {
+	CallExpression,
 	ClassDeclaration,
 	MethodDeclaration,
 	Node,
@@ -6,22 +7,82 @@ import type {
 } from "ts-morph";
 import { SyntaxKind } from "ts-morph";
 import type {
+	ApiBodyInfo,
+	ApiParamInfo,
+	ApiResponseInfo,
 	DependencyType,
 	EndpointGraph,
 	EndpointNode,
+	GuardThrow,
 	MethodCallNode,
 	MethodDependencyNode,
+	MethodParameterInfo,
+	StepStatement,
+	SwaggerMetadata,
 } from "../../common/endpoint.js";
-import { HTTP_DECORATORS, isController } from "../nest-class-inspector.js";
+import {
+	HTTP_DECORATORS,
+	hasDecorator,
+	isController,
+} from "../nest-class-inspector.js";
 import { extractSimpleTypeName, type ProviderInfo } from "./type-resolver.js";
 
 const MAX_TRACE_DEPTH = 10;
 const QUOTE_REGEX = /^['"`]|['"`]$/g;
 const DUPLICATE_SLASH_REGEX = /\/+/g;
 const TRAILING_SLASH_REGEX = /\/$/;
+const GRAPHQL_DECORATORS = new Set(["Query", "Mutation", "Subscription"]);
+const SWAGGER_DECORATORS = new Set([
+	"ApiOperation",
+	"ApiParam",
+	"ApiQuery",
+	"ApiResponse",
+	"ApiBody",
+]);
+
+const ITERATION_CALLBACK_METHODS = new Set([
+	"map",
+	"forEach",
+	"filter",
+	"find",
+	"some",
+	"every",
+	"flatMap",
+	"reduce",
+]);
+
+interface IterationInfo {
+	iterationKind: "loop" | "callback" | "concurrent" | null;
+	iterationLabel: string | null;
+}
+
+interface ConditionalInfo {
+	branchKind:
+		| "if"
+		| "else-if"
+		| "else"
+		| "case"
+		| "default"
+		| "catch"
+		| "ternary-true"
+		| "ternary-false"
+		| null;
+	conditionText: string | null;
+	isConditional: boolean;
+	statementLine: number | null;
+}
 
 interface OrderedMethodUsage {
+	assignedTo: string | null;
+	branchGroupId: string | null;
+	branchKind: string | null;
+	callSiteLine: number;
+	comment: string | null;
 	conditional: boolean;
+	conditionText: string | null;
+	guardThrow: GuardThrow | null;
+	iterationKind: "loop" | "callback" | "concurrent" | null;
+	iterationLabel: string | null;
 	name: string;
 	order: number;
 }
@@ -31,7 +92,109 @@ interface UsedDependency {
 	methodsCalled: OrderedMethodUsage[];
 }
 
-function isInsideConditionalBlock(node: Node, boundary: Node): boolean {
+interface SameClassCallUsage {
+	assignedTo: string | null;
+	branchGroupId: string | null;
+	branchKind: string | null;
+	callSiteLine: number;
+	childResult: ScanResult;
+	comment: string | null;
+	conditional: boolean;
+	conditionText: string | null;
+	iterationKind: "loop" | "callback" | "concurrent" | null;
+	iterationLabel: string | null;
+	methodName: string;
+	order: number;
+}
+
+interface ThrowUsage {
+	branchGroupId: string | null;
+	branchKind: string | null;
+	callSiteLine: number;
+	comment: string | null;
+	conditional: boolean;
+	conditionText: string | null;
+	exceptionClassName: string;
+	iterationKind: "loop" | "callback" | "concurrent" | null;
+	iterationLabel: string | null;
+	merged?: boolean;
+	message: string | null;
+	order: number;
+}
+
+interface StepUsage {
+	branchGroupId: string | null;
+	branchKind: string | null;
+	callSiteLine: number;
+	comment: string | null;
+	conditional: boolean;
+	conditionText: string | null;
+	iterationKind: "loop" | "callback" | "concurrent" | null;
+	iterationLabel: string | null;
+	order: number;
+	statements: StepStatement[];
+}
+
+interface ScanResult {
+	deps: UsedDependency[];
+	sameClassCalls: SameClassCallUsage[];
+	steps: StepUsage[];
+	throws: ThrowUsage[];
+}
+
+class ScanCache {
+	private readonly scanResults = new Map<string, ScanResult>();
+	private readonly injectionMaps = new Map<string, Map<string, string>>();
+	private readonly methodLookups = new Map<
+		string,
+		MethodDeclaration | undefined
+	>();
+
+	getScan(key: string) {
+		return this.scanResults.get(key);
+	}
+	setScan(key: string, value: ScanResult) {
+		this.scanResults.set(key, value);
+	}
+
+	getInjMap(key: string) {
+		return this.injectionMaps.get(key);
+	}
+	setInjMap(key: string, value: Map<string, string>) {
+		this.injectionMaps.set(key, value);
+	}
+
+	getMethod(key: string) {
+		return this.methodLookups.has(key)
+			? this.methodLookups.get(key)
+			: undefined;
+	}
+	hasMethod(key: string) {
+		return this.methodLookups.has(key);
+	}
+	setMethod(key: string, value: MethodDeclaration | undefined) {
+		this.methodLookups.set(key, value);
+	}
+}
+
+const MAX_CONDITION_TEXT_LENGTH = 50;
+
+function normalizeConditionText(text: string): string {
+	const collapsed = text.replace(/\s+/g, " ").trim();
+	if (collapsed.length > MAX_CONDITION_TEXT_LENGTH) {
+		return `${collapsed.slice(0, MAX_CONDITION_TEXT_LENGTH)}\u2026`;
+	}
+	return collapsed;
+}
+
+function getConditionalInfo(node: Node, boundary: Node): ConditionalInfo {
+	const none: ConditionalInfo = {
+		isConditional: false,
+		conditionText: null,
+		branchKind: null,
+		statementLine: null,
+	};
+
 	let current: Node | undefined = node;
 	while (current && current !== boundary) {
 		const parent = current.getParent();
@@ -42,33 +205,389 @@ function isInsideConditionalBlock(node: Node, boundary: Node): boolean {
 
 		if (parentKind === SyntaxKind.IfStatement) {
 			const ifStmt = parent.asKindOrThrow(SyntaxKind.IfStatement);
-			if (
-				current === ifStmt.getThenStatement() ||
-				current === ifStmt.getElseStatement()
-			) {
-				return true;
+			if (current === ifStmt.getThenStatement()) {
+				// Check if this IfStatement is an else-if: is it the ElseStatement of a parent IfStatement?
+				const grandparent = parent.getParent();
+				if (grandparent && grandparent.getKind() === SyntaxKind.IfStatement) {
+					const outerIf = grandparent.asKindOrThrow(SyntaxKind.IfStatement);
+					if (parent === outerIf.getElseStatement()) {
+						return {
+							isConditional: true,
+							conditionText: normalizeConditionText(
+								ifStmt.getExpression().getText()
+							),
+							branchKind: "else-if",
+							statementLine: outerIf.getStartLineNumber(),
+						};
+					}
+				}
+				return {
+					isConditional: true,
+					conditionText: normalizeConditionText(
+						ifStmt.getExpression().getText()
+					),
+					branchKind: "if",
+					statementLine: ifStmt.getStartLineNumber(),
+				};
+			}
+			if (current === ifStmt.getElseStatement()) {
+				return {
+					isConditional: true,
+					conditionText: normalizeConditionText(
+						ifStmt.getExpression().getText()
+					),
+					branchKind: "else",
+					statementLine: ifStmt.getStartLineNumber(),
+				};
 			}
 		}
+
 		if (parentKind === SyntaxKind.ConditionalExpression) {
 			const condExpr = parent.asKindOrThrow(SyntaxKind.ConditionalExpression);
-			if (
-				current === condExpr.getWhenTrue() ||
-				current === condExpr.getWhenFalse()
-			) {
-				return true;
+			if (current === condExpr.getWhenTrue()) {
+				return {
+					isConditional: true,
+					conditionText: normalizeConditionText(
+						condExpr.getCondition().getText()
+					),
+					branchKind: "ternary-true",
+					statementLine: condExpr.getStartLineNumber(),
+				};
+			}
+			if (current === condExpr.getWhenFalse()) {
+				return {
+					isConditional: true,
+					conditionText: normalizeConditionText(
+						condExpr.getCondition().getText()
+					),
+					branchKind: "ternary-false",
+					statementLine: condExpr.getStartLineNumber(),
+				};
 			}
 		}
+
 		const kind = current.getKind();
-		if (kind === SyntaxKind.CaseClause || kind === SyntaxKind.DefaultClause) {
-			return true;
+		if (kind === SyntaxKind.CaseClause) {
+			const clause = current.asKindOrThrow(SyntaxKind.CaseClause);
+			const parentSwitch = current.getParentOrThrow().getParentOrThrow();
+			return {
+				isConditional: true,
+				conditionText: normalizeConditionText(clause.getExpression().getText()),
+				branchKind: "case",
+				statementLine: parentSwitch.getStartLineNumber(),
+			};
+		}
+		if (kind === SyntaxKind.DefaultClause) {
+			const parentSwitch = current.getParentOrThrow().getParentOrThrow();
+			return {
+				isConditional: true,
+				conditionText: null,
+				branchKind: "default",
+				statementLine: parentSwitch.getStartLineNumber(),
+			};
 		}
 		if (kind === SyntaxKind.CatchClause) {
-			return true;
+			const parentTry = current.getParentOrThrow();
+			return {
+				isConditional: true,
+				conditionText: null,
+				branchKind: "catch",
+				statementLine: parentTry.getStartLineNumber(),
+			};
 		}
 
 		current = parent;
 	}
-	return false;
+	return none;
+}
+
+const LOOP_LABEL_MAP = new Map<SyntaxKind, string>([
+	[SyntaxKind.ForStatement, "for"],
+	[SyntaxKind.ForOfStatement, "for-of"],
+	[SyntaxKind.ForInStatement, "for-in"],
+	[SyntaxKind.WhileStatement, "while"],
+	[SyntaxKind.DoStatement, "do-while"],
+]);
+
+function getIterationContext(node: Node, boundary: Node): IterationInfo {
+	const none: IterationInfo = { iterationKind: null, iterationLabel: null };
+
+	let current: Node | undefined = node;
+	while (current && current !== boundary) {
+		const parent = current.getParent();
+		if (!parent || parent === boundary) {
+			break;
+		}
+		const parentKind = parent.getKind();
+
+		// A. Loop statements
+		const loopLabel = LOOP_LABEL_MAP.get(parentKind);
+		if (loopLabel) {
+			// Verify current is the body, not the initializer/condition/expression
+			let isBody = false;
+			if (parentKind === SyntaxKind.ForStatement) {
+				const forStmt = parent.asKindOrThrow(SyntaxKind.ForStatement);
+				isBody =
+					current !== forStmt.getInitializer() &&
+					current !== forStmt.getCondition() &&
+					current !== forStmt.getIncrementor() &&
+					current === forStmt.getStatement();
+			} else if (parentKind === SyntaxKind.ForOfStatement) {
+				isBody =
+					current ===
+					parent.asKindOrThrow(SyntaxKind.ForOfStatement).getStatement();
+			} else if (parentKind === SyntaxKind.ForInStatement) {
+				isBody =
+					current ===
+					parent.asKindOrThrow(SyntaxKind.ForInStatement).getStatement();
+			} else if (parentKind === SyntaxKind.WhileStatement) {
+				isBody =
+					current ===
+					parent.asKindOrThrow(SyntaxKind.WhileStatement).getStatement();
+			} else if (parentKind === SyntaxKind.DoStatement) {
+				isBody =
+					current ===
+					parent.asKindOrThrow(SyntaxKind.DoStatement).getStatement();
+			}
+			if (isBody) {
+				return { iterationKind: "loop", iterationLabel: loopLabel };
+			}
+		}
+
+		// B. Callback to iteration method
+		const currentKind = current.getKind();
+		if (
+			currentKind === SyntaxKind.ArrowFunction ||
+			currentKind === SyntaxKind.FunctionExpression
+		) {
+			if (parentKind === SyntaxKind.CallExpression) {
+				const callExpr = parent.asKindOrThrow(SyntaxKind.CallExpression);
+				const args = callExpr.getArguments();
+				const isArg = args.some((a) => a === current);
+				if (isArg) {
+					const calleeExpr = callExpr.getExpression();
+					if (calleeExpr.getKind() === SyntaxKind.PropertyAccessExpression) {
+						const propAccess = calleeExpr.asKindOrThrow(
+							SyntaxKind.PropertyAccessExpression
+						);
+						const methodName = propAccess.getName();
+						if (ITERATION_CALLBACK_METHODS.has(methodName)) {
+							return {
+								iterationKind: "callback",
+								iterationLabel: methodName,
+							};
+						}
+					}
+				}
+			}
+
+			// D. Stop at function boundaries that are NOT iteration callbacks
+			break;
+		}
+
+		// C. Promise.all
+		if (parentKind === SyntaxKind.ArrayLiteralExpression) {
+			const grandparent = parent.getParent();
+			if (grandparent && grandparent.getKind() === SyntaxKind.CallExpression) {
+				const gpCall: CallExpression = grandparent.asKindOrThrow(
+					SyntaxKind.CallExpression
+				);
+				const gpArgs = gpCall.getArguments();
+				if (gpArgs.length > 0 && gpArgs[0] === parent) {
+					const gpExpr = gpCall.getExpression();
+					if (gpExpr.getKind() === SyntaxKind.PropertyAccessExpression) {
+						const gpProp = gpExpr.asKindOrThrow(
+							SyntaxKind.PropertyAccessExpression
+						);
+						if (
+							gpProp.getName() === "all" &&
+							gpProp.getExpression().getText().endsWith("Promise")
+						) {
+							return {
+								iterationKind: "concurrent",
+								iterationLabel: "all",
+							};
+						}
+					}
+				}
+			}
+		}
+
+		current = parent;
+	}
+	return none;
+}
+
+function extractLeadingComment(node: Node): string | null {
+	let current: Node | undefined = node;
+	while (current) {
+		const kind = current.getKind();
+		if (
+			kind === SyntaxKind.ExpressionStatement ||
+			kind === SyntaxKind.VariableStatement ||
+			kind === SyntaxKind.ReturnStatement ||
+			kind === SyntaxKind.ThrowStatement
+		) {
+			break;
+		}
+		current = current.getParent();
+	}
+	if (!current) {
+		return null;
+	}
+
+	const sourceFile = current.getSourceFile();
+	const fullStart = current.getFullStart();
+	const start = current.getStart();
+	const triviaText = sourceFile.getFullText().slice(fullStart, start);
+
+	const lines = triviaText.split("\n");
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const trimmed = lines[i].trim();
+		if (trimmed.startsWith("//")) {
+			return trimmed.slice(2).trim();
+		}
+		if (trimmed.length > 0) {
+			break;
+		}
+	}
+	return null;
+}
+
+function extractThrowClassName(throwStmt: Node): string {
+	const expr = throwStmt
+		.asKindOrThrow(SyntaxKind.ThrowStatement)
+		.getExpression();
+	if (expr && expr.getKind() === SyntaxKind.NewExpression) {
+		const newExpr = expr.asKindOrThrow(SyntaxKind.NewExpression);
+		return extractSimpleTypeName(newExpr.getExpression().getText());
+	}
+	return "Error";
+}
+
+const MAX_THROW_MESSAGE_LENGTH = 80;
+
+function extractThrowMessage(throwStmt: Node): string | null {
+	const expr = throwStmt
+		.asKindOrThrow(SyntaxKind.ThrowStatement)
+		.getExpression();
+	if (!expr || expr.getKind() !== SyntaxKind.NewExpression) {
+		return null;
+	}
+	const newExpr = expr.asKindOrThrow(SyntaxKind.NewExpression);
+	const args = newExpr.getArguments();
+	if (args.length === 0) {
+		return null;
+	}
+	const firstArg = args[0];
+	const kind = firstArg.getKind();
+	let raw: string;
+	if (
+		kind === SyntaxKind.StringLiteral ||
+		kind === SyntaxKind.NoSubstitutionTemplateLiteral
+	) {
+		raw = firstArg.asKindOrThrow(kind).getLiteralValue() as string;
+	} else if (kind === SyntaxKind.TemplateExpression) {
+		const text = firstArg.getText();
+		raw = text.startsWith("`") ? text.slice(1, -1) : text;
+	} else {
+		raw = firstArg.getText();
+	}
+	if (raw.length > MAX_THROW_MESSAGE_LENGTH) {
+		return `${raw.slice(0, MAX_THROW_MESSAGE_LENGTH)}\u2026`;
+	}
+	return raw;
+}
+
+function extractAssignedVariable(callNode: Node): string | null {
+	let current = callNode.getParent();
+	while (current) {
+		const kind = current.getKind();
+		if (
+			kind === SyntaxKind.AwaitExpression ||
+			kind === SyntaxKind.ParenthesizedExpression ||
+			kind === SyntaxKind.AsExpression ||
+			kind === SyntaxKind.NonNullExpression
+		) {
+			current = current.getParent();
+			continue;
+		}
+		if (kind === SyntaxKind.VariableDeclaration) {
+			const nameNode = current
+				.asKindOrThrow(SyntaxKind.VariableDeclaration)
+				.getNameNode();
+			if (nameNode.getKind() === SyntaxKind.Identifier) {
+				return nameNode.getText();
+			}
+			return null;
+		}
+		return null;
+	}
+	return null;
+}
+
+function resolveBaseClass(
+	cls: ClassDeclaration,
+	providers?: Map<string, ProviderInfo>
+): ClassDeclaration | undefined {
+	let nextClass: ClassDeclaration | undefined;
+	try {
+		nextClass = cls.getBaseClass();
+	} catch {
+		/* base class not resolvable via type system */
+	}
+
+	if (!nextClass && providers) {
+		const extendsExpr = cls.getExtends();
+		if (extendsExpr) {
+			const baseClassName = extractSimpleTypeName(
+				extendsExpr.getExpression().getText()
+			);
+			const baseProvider = providers.get(baseClassName);
+			if (baseProvider) {
+				nextClass = baseProvider.classDeclaration;
+			}
+		}
+	}
+
+	return nextClass;
+}
+
+function findMethodInHierarchy(
+	cls: ClassDeclaration,
+	methodName: string,
+	providers: Map<string, ProviderInfo>,
+	cache?: ScanCache
+): MethodDeclaration | undefined {
+	const className = cls.getName() ?? "";
+	const cacheKey = `${className}.${methodName}`;
+	if (cache?.hasMethod(cacheKey)) {
+		return cache.getMethod(cacheKey);
+	}
+
+	let current: ClassDeclaration | undefined = cls;
+	const visited = new Set<string>();
+
+	while (current) {
+		const name = current.getName();
+		if (name && visited.has(name)) {
+			break;
+		}
+		if (name) {
+			visited.add(name);
+		}
+
+		const method = current.getInstanceMethod(methodName);
+		if (method) {
+			cache?.setMethod(cacheKey, method);
+			return method;
+		}
+
+		current = resolveBaseClass(current, providers);
+	}
+
+	cache?.setMethod(cacheKey, undefined);
+	return undefined;
 }
 
 function extractControllerPath(cls: ClassDeclaration): string {
@@ -128,101 +647,712 @@ function composePath(controllerPath: string, methodPath: string): string {
 	return normalized || "/";
 }
 
-function buildInjectionMap(cls: ClassDeclaration): Map<string, string> {
+function getObjectLiteralStringProp(
+	obj: Node,
+	propName: string
+): string | null {
+	const objLit = obj.asKind(SyntaxKind.ObjectLiteralExpression);
+	if (!objLit) {
+		return null;
+	}
+	const prop = objLit.getProperty(propName);
+	if (!prop) {
+		return null;
+	}
+	const assignment = prop.asKind(SyntaxKind.PropertyAssignment);
+	if (!assignment) {
+		return null;
+	}
+	const init = assignment.getInitializer();
+	if (!init) {
+		return null;
+	}
+	return init.getText().replace(QUOTE_REGEX, "");
+}
+
+function getObjectLiteralNumberProp(
+	obj: Node,
+	propName: string
+): number | null {
+	const str = getObjectLiteralStringProp(obj, propName);
+	if (str === null) {
+		return null;
+	}
+	const num = Number(str);
+	return Number.isNaN(num) ? null : num;
+}
+
+function getObjectLiteralBoolProp(
+	obj: Node,
+	propName: string,
+	defaultValue: boolean
+): boolean {
+	const str = getObjectLiteralStringProp(obj, propName);
+	if (str === null) {
+		return defaultValue;
+	}
+	return str === "true";
+}
+
+function extractSwaggerMetadata(
+	method: MethodDeclaration
+): SwaggerMetadata | null {
+	let summary: string | null = null;
+	let description: string | null = null;
+	const params: ApiParamInfo[] = [];
+	const queryParams: ApiParamInfo[] = [];
+	const responses: ApiResponseInfo[] = [];
+	let body: ApiBodyInfo | null = null;
+	let found = false;
+
+	for (const decorator of method.getDecorators()) {
+		const name = decorator.getName();
+		if (!SWAGGER_DECORATORS.has(name)) {
+			continue;
+		}
+		found = true;
+
+		const args = decorator.getArguments();
+		if (args.length === 0) {
+			continue;
+		}
+		const firstArg = args[0];
+
+		if (name === "ApiOperation") {
+			summary = getObjectLiteralStringProp(firstArg, "summary");
+			description = getObjectLiteralStringProp(firstArg, "description");
+		} else if (name === "ApiParam") {
+			const paramName = getObjectLiteralStringProp(firstArg, "name");
+			if (paramName) {
+				params.push({
+					description: getObjectLiteralStringProp(firstArg, "description"),
+					name: paramName,
+					required: getObjectLiteralBoolProp(firstArg, "required", true),
+					type: getObjectLiteralStringProp(firstArg, "type"),
+				});
+			}
+		} else if (name === "ApiQuery") {
+			const paramName = getObjectLiteralStringProp(firstArg, "name");
+			if (paramName) {
+				queryParams.push({
+					description: getObjectLiteralStringProp(firstArg, "description"),
+					name: paramName,
+					required: getObjectLiteralBoolProp(firstArg, "required", false),
+					type: getObjectLiteralStringProp(firstArg, "type"),
+				});
+			}
+		} else if (name === "ApiResponse") {
+			const status = getObjectLiteralNumberProp(firstArg, "status") ?? 200;
+			let type = getObjectLiteralStringProp(firstArg, "type");
+			// Handle array syntax: [ClassName] → ClassName[]
+			if (type?.startsWith("[") && type.endsWith("]")) {
+				type = `${type.slice(1, -1)}[]`;
+			}
+			responses.push({
+				description: getObjectLiteralStringProp(firstArg, "description"),
+				status,
+				type,
+			});
+		} else if (name === "ApiBody") {
+			body = {
+				description: getObjectLiteralStringProp(firstArg, "description"),
+				type: getObjectLiteralStringProp(firstArg, "type"),
+			};
+		}
+	}
+
+	// Fallback: infer body from @Body() parameter decorator type annotation
+	if (!body) {
+		for (const param of method.getParameters()) {
+			const hasBodyDec = param
+				.getDecorators()
+				.some((d) => d.getName() === "Body");
+			if (hasBodyDec) {
+				const typeNode = param.getTypeNode();
+				if (typeNode) {
+					body = { description: null, type: typeNode.getText() };
+					found = true;
+				}
+				break;
+			}
+		}
+	}
+
+	if (!found) {
+		return null;
+	}
+	return { body, description, params, queryParams, responses, summary };
+}
+
+const PROMISE_OBSERVABLE_REGEX = /^(?:Promise|Observable)<(.+)>$/;
+
+function extractReturnType(method: MethodDeclaration): string | null {
+	const typeNode = method.getReturnTypeNode();
+	if (!typeNode) {
+		return null;
+	}
+	let text = typeNode.getText().trim();
+	// Unwrap Promise<T> and Observable<T>
+	const match = PROMISE_OBSERVABLE_REGEX.exec(text);
+	if (match) {
+		text = match[1];
+	}
+	if (text === "void" || text === "any" || text === "unknown") {
+		return null;
+	}
+	return text;
+}
+
+function extractMethodParameters(
+	method: MethodDeclaration
+): MethodParameterInfo[] {
+	return method
+		.getParameters()
+		.filter((p) => p.getName() !== "this")
+		.map((p) => ({
+			name: p.getName(),
+			type: p.getTypeNode()?.getText() ?? null,
+		}));
+}
+
+const CONDENSED_ARROW_BODY_REGEX = /=>\s*\{[^}]*\}/g;
+const CONDENSED_CALLBACK_REGEX = /\(([^)]{20,})\)\s*=>/g;
+const CONDENSED_WHITESPACE_REGEX = /\s+/g;
+
+function condensedText(raw: string): string {
+	let text = raw.replace(CONDENSED_WHITESPACE_REGEX, " ").trim();
+	text = text.replace(CONDENSED_ARROW_BODY_REGEX, "=> …");
+	text = text.replace(CONDENSED_CALLBACK_REGEX, "(…) =>");
+	if (text.length > 50) {
+		text = `${text.slice(0, 47)}…`;
+	}
+	return text;
+}
+
+function isInterestingStatement(
+	stmt: Node,
+	trackedPositions: Set<number>
+): boolean {
+	const kind = stmt.getKind();
+	if (
+		kind !== SyntaxKind.VariableStatement &&
+		kind !== SyntaxKind.ExpressionStatement
+	) {
+		return false;
+	}
+
+	const calls = [
+		...stmt.getDescendantsOfKind(SyntaxKind.CallExpression),
+		...stmt.getDescendantsOfKind(SyntaxKind.NewExpression),
+	];
+	if (calls.length === 0) {
+		return false;
+	}
+
+	// Check if ANY call overlaps with tracked positions
+	for (const c of calls) {
+		if (trackedPositions.has(c.getStart())) {
+			return false;
+		}
+	}
+
+	// Skip console.* and this.logger.* calls
+	for (const c of calls) {
+		const text = c.getText();
+		if (text.startsWith("console.") || text.startsWith("this.logger.")) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function extractStatementInfo(
+	stmt: Node
+): { assignedTo: string | null; text: string } | null {
+	if (stmt.getKind() === SyntaxKind.VariableStatement) {
+		const decls = stmt
+			.asKindOrThrow(SyntaxKind.VariableStatement)
+			.getDeclarationList()
+			.getDeclarations();
+		if (decls.length === 0) {
+			return null;
+		}
+		const first = decls[0];
+		const nameNode = first.getNameNode();
+		const name = nameNode.getText();
+		const init = first.getInitializer();
+		if (!init) {
+			return null;
+		}
+		const text = `${name} = ${condensedText(init.getText())}`;
+		return { assignedTo: name, text };
+	}
+	if (stmt.getKind() === SyntaxKind.ExpressionStatement) {
+		const expr = stmt
+			.asKindOrThrow(SyntaxKind.ExpressionStatement)
+			.getExpression();
+		return { assignedTo: null, text: condensedText(expr.getText()) };
+	}
+	return null;
+}
+
+function buildInjectionMap(
+	cls: ClassDeclaration,
+	providers?: Map<string, ProviderInfo>,
+	cache?: ScanCache
+): Map<string, string> {
+	const className = cls.getName() ?? "";
+	if (cache) {
+		const cached = cache.getInjMap(className);
+		if (cached) {
+			return cached;
+		}
+	}
+
 	const map = new Map<string, string>();
-	const ctor = cls.getConstructors()[0];
-	if (!ctor) {
-		return map;
+
+	// 1. Find constructor params — walk up the class hierarchy if needed
+	let ctorClass: ClassDeclaration | undefined = cls;
+	const visited = new Set<string>();
+
+	while (ctorClass) {
+		const className = ctorClass.getName();
+		if (className && visited.has(className)) {
+			break;
+		}
+		if (className) {
+			visited.add(className);
+		}
+
+		const ctor = ctorClass.getConstructors()[0];
+		if (ctor) {
+			for (const param of ctor.getParameters()) {
+				const name = param.getName();
+				if (!map.has(name)) {
+					const typeNode = param.getTypeNode();
+					const typeText = typeNode
+						? typeNode.getText()
+						: param.getType().getText();
+					map.set(name, extractSimpleTypeName(typeText));
+				}
+			}
+			break; // Found a constructor, stop walking
+		}
+
+		ctorClass = resolveBaseClass(ctorClass, providers);
 	}
 
-	for (const param of ctor.getParameters()) {
-		const name = param.getName();
-		const typeNode = param.getTypeNode();
-		const typeText = typeNode ? typeNode.getText() : param.getType().getText();
-		map.set(name, extractSimpleTypeName(typeText));
+	// 2. Scan property declarations with @Inject() decorator
+	for (const prop of cls.getProperties()) {
+		if (prop.getDecorator("Inject")) {
+			const name = prop.getName();
+			if (!map.has(name)) {
+				const typeNode = prop.getTypeNode();
+				if (typeNode) {
+					map.set(name, extractSimpleTypeName(typeNode.getText()));
+				}
+			}
+		}
 	}
 
+	if (cache) {
+		cache.setInjMap(className, map);
+	}
 	return map;
+}
+
+function mergeGuardThrows(
+	callEntries: Array<{
+		assignedTo: string | null;
+		order: number;
+		guardThrow: GuardThrow | null;
+	}>,
+	throws: ThrowUsage[]
+): void {
+	for (const entry of callEntries) {
+		if (!entry.assignedTo) {
+			continue;
+		}
+		const varPattern = new RegExp(`\\b${entry.assignedTo}\\b`);
+		for (const t of throws) {
+			if (t.merged) {
+				continue;
+			}
+			if (t.order <= entry.order) {
+				continue;
+			}
+			if (!(t.conditional && t.conditionText)) {
+				continue;
+			}
+			if (varPattern.test(t.conditionText)) {
+				entry.guardThrow = {
+					branchKind: t.branchKind,
+					callSiteLine: t.callSiteLine,
+					className: t.exceptionClassName,
+					conditionText: t.conditionText,
+					message: t.message,
+				};
+				t.merged = true;
+				break;
+			}
+		}
+	}
+	// Remove merged throws in-place
+	const kept = throws.filter((t) => !t.merged);
+	throws.length = 0;
+	for (const t of kept) {
+		throws.push(t);
+	}
 }
 
 function scanUsedDependencies(
 	method: MethodDeclaration,
-	injectionMap: Map<string, string>
-): UsedDependency[] {
-	const body = method.getBody();
-	if (!body) {
-		return [];
+	injectionMap: Map<string, string>,
+	cls?: ClassDeclaration,
+	visitedMethods?: Set<string>,
+	cache?: ScanCache
+): ScanResult {
+	const className = cls?.getName() ?? "";
+	const cacheKey = `${className}::${method.getName()}`;
+	if (!visitedMethods && cache) {
+		const cached = cache.getScan(cacheKey);
+		if (cached) {
+			return cached;
+		}
 	}
 
-	// Map: paramName → methodName → { isUnconditional, order }
-	const usageMap = new Map<
-		string,
-		Map<string, { isUnconditional: boolean; order: number }>
-	>();
+	const empty: ScanResult = {
+		deps: [],
+		sameClassCalls: [],
+		steps: [],
+		throws: [],
+	};
+	const body = method.getBody();
+	if (!body) {
+		return empty;
+	}
+
+	// Track visited methods to prevent infinite recursion for this.method() calls
+	const visited = visitedMethods ?? new Set<string>();
+	const currentMethodName = method.getName();
+	if (visited.has(currentMethodName)) {
+		return empty;
+	}
+	visited.add(currentMethodName);
+
+	// Pre-scan for aliases: const svc = this.paramName
+	const aliases = new Map<string, string>();
+	for (const varDecl of body.getDescendantsOfKind(
+		SyntaxKind.VariableDeclaration
+	)) {
+		const init = varDecl.getInitializer();
+		if (init && init.getKind() === SyntaxKind.PropertyAccessExpression) {
+			const pa = init.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+			if (pa.getExpression().getKind() === SyntaxKind.ThisKeyword) {
+				const pName = pa.getName();
+				if (injectionMap.has(pName)) {
+					aliases.set(varDecl.getName(), pName);
+				}
+			}
+		}
+	}
+
+	const sameClassCalls: SameClassCallUsage[] = [];
+	const throws: ThrowUsage[] = [];
+
+	// Flat array: each dependency call gets its own entry (no dedup by method name)
+	const callEntries: Array<{
+		assignedTo: string | null;
+		paramName: string;
+		methodName: string;
+		order: number;
+		callSiteLine: number;
+		comment: string | null;
+		condInfo: ConditionalInfo;
+		iterInfo: IterationInfo;
+		guardThrow: GuardThrow | null;
+	}> = [];
 	let callOrder = 0;
 	const callExpressions = body.getDescendantsOfKind(SyntaxKind.CallExpression);
+	const throwStatements = body.getDescendantsOfKind(SyntaxKind.ThrowStatement);
 
-	for (const call of callExpressions) {
+	type WorkItem =
+		| { kind: "call"; node: (typeof callExpressions)[number] }
+		| { kind: "throw"; node: (typeof throwStatements)[number] };
+
+	const workItems: WorkItem[] = [
+		...callExpressions.map((node) => ({ kind: "call" as const, node })),
+		...throwStatements.map((node) => ({ kind: "throw" as const, node })),
+	];
+	workItems.sort((a, b) => a.node.getStart() - b.node.getStart());
+
+	for (const item of workItems) {
+		if (item.kind === "throw") {
+			const condInfo = getConditionalInfo(item.node, body);
+			const iterInfo = getIterationContext(item.node, body);
+			throws.push({
+				branchGroupId: condInfo.statementLine
+					? `L${condInfo.statementLine}`
+					: null,
+				branchKind: condInfo.branchKind,
+				callSiteLine: item.node.getStartLineNumber(),
+				comment: extractLeadingComment(item.node),
+				conditional: condInfo.isConditional,
+				conditionText: condInfo.conditionText,
+				exceptionClassName: extractThrowClassName(item.node),
+				iterationKind: iterInfo.iterationKind,
+				iterationLabel: iterInfo.iterationLabel,
+				message: extractThrowMessage(item.node),
+				order: callOrder++,
+			});
+			continue;
+		}
+
+		const call = item.node;
 		const expr = call.getExpression();
 		if (expr.getKind() !== SyntaxKind.PropertyAccessExpression) {
 			continue;
 		}
 
 		const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
-		const methodName = propAccess.getName();
+		const calledMethodName = propAccess.getName();
 		const receiver = propAccess.getExpression();
 
-		if (receiver.getKind() !== SyntaxKind.PropertyAccessExpression) {
-			continue;
+		let paramName: string | undefined;
+
+		// Pattern A: this.param.method()
+		if (receiver.getKind() === SyntaxKind.PropertyAccessExpression) {
+			const innerAccess = receiver.asKindOrThrow(
+				SyntaxKind.PropertyAccessExpression
+			);
+			if (innerAccess.getExpression().getKind() === SyntaxKind.ThisKeyword) {
+				const name = innerAccess.getName();
+				if (injectionMap.has(name)) {
+					paramName = name;
+				}
+			}
 		}
 
-		const innerAccess = receiver.asKindOrThrow(
-			SyntaxKind.PropertyAccessExpression
-		);
-		if (innerAccess.getExpression().getKind() !== SyntaxKind.ThisKeyword) {
-			continue;
+		// Pattern B: alias.method() where alias = this.param
+		if (!paramName && receiver.getKind() === SyntaxKind.Identifier) {
+			const aliasName = receiver.getText();
+			const resolved = aliases.get(aliasName);
+			if (resolved) {
+				paramName = resolved;
+			}
 		}
 
-		const paramName = innerAccess.getName();
-		if (!injectionMap.has(paramName)) {
-			continue;
-		}
-
-		if (!usageMap.has(paramName)) {
-			usageMap.set(paramName, new Map());
-		}
-		const methodMap = usageMap.get(paramName)!;
-		const conditional = isInsideConditionalBlock(call, body);
-		const existing = methodMap.get(methodName);
-		if (existing) {
-			// Keep first order, update unconditional status
-			existing.isUnconditional = existing.isUnconditional || !conditional;
-		} else {
-			methodMap.set(methodName, {
-				isUnconditional: !conditional,
+		// Track the dependency call
+		if (paramName) {
+			const condInfo = getConditionalInfo(call, body);
+			const iterInfo = getIterationContext(call, body);
+			callEntries.push({
+				assignedTo: extractAssignedVariable(call),
+				paramName,
+				methodName: calledMethodName,
 				order: callOrder++,
+				callSiteLine: call.getStartLineNumber(),
+				comment: extractLeadingComment(call),
+				condInfo,
+				iterInfo,
+				guardThrow: null,
 			});
+			continue;
+		}
+
+		// Pattern C: this.method() — same-class helper call (preserve hierarchy)
+		if (receiver.getKind() === SyntaxKind.ThisKeyword && cls) {
+			const targetMethod = cls.getInstanceMethod(calledMethodName);
+			if (targetMethod && !visited.has(calledMethodName)) {
+				const condInfo = getConditionalInfo(call, body);
+				const iterInfo = getIterationContext(call, body);
+				const childResult = scanUsedDependencies(
+					targetMethod,
+					injectionMap,
+					cls,
+					new Set(visited)
+				);
+				sameClassCalls.push({
+					assignedTo: extractAssignedVariable(call),
+					branchGroupId: condInfo.statementLine
+						? `L${condInfo.statementLine}`
+						: null,
+					branchKind: condInfo.branchKind,
+					callSiteLine: call.getStartLineNumber(),
+					childResult,
+					comment: extractLeadingComment(call),
+					conditional: condInfo.isConditional,
+					conditionText: condInfo.conditionText,
+					iterationKind: iterInfo.iterationKind,
+					iterationLabel: iterInfo.iterationLabel,
+					methodName: calledMethodName,
+					order: callOrder++,
+				});
+			}
+		}
+	}
+
+	// Merge guard-throw patterns (fetch + null-check + throw)
+	mergeGuardThrows(callEntries, throws);
+
+	// Detect inline logic steps
+	const steps: StepUsage[] = [];
+	if (body.getKind() === SyntaxKind.Block) {
+		const trackedPositions = new Set<number>();
+		for (const entry of callEntries) {
+			// Find the actual CallExpression node at this position
+			for (const ce of callExpressions) {
+				if (ce.getStartLineNumber() === entry.callSiteLine) {
+					trackedPositions.add(ce.getStart());
+				}
+			}
+		}
+		for (const t of throws) {
+			for (const ts of throwStatements) {
+				if (ts.getStartLineNumber() === t.callSiteLine) {
+					trackedPositions.add(ts.getStart());
+				}
+			}
+		}
+		for (const scc of sameClassCalls) {
+			for (const ce of callExpressions) {
+				if (ce.getStartLineNumber() === scc.callSiteLine) {
+					trackedPositions.add(ce.getStart());
+				}
+			}
+		}
+
+		const bodyStatements = body.asKindOrThrow(SyntaxKind.Block).getStatements();
+		let pendingStatements: Array<{
+			info: { assignedTo: string | null; text: string };
+			stmt: Node;
+		}> = [];
+
+		const flushPending = () => {
+			if (pendingStatements.length === 0) {
+				return;
+			}
+			const firstStmt = pendingStatements[0].stmt;
+			const condInfo = getConditionalInfo(firstStmt, body);
+			const iterInfo = getIterationContext(firstStmt, body);
+			steps.push({
+				branchGroupId: condInfo.statementLine
+					? `L${condInfo.statementLine}`
+					: null,
+				branchKind: condInfo.branchKind,
+				callSiteLine: firstStmt.getStartLineNumber(),
+				comment: extractLeadingComment(firstStmt),
+				conditional: condInfo.isConditional,
+				conditionText: condInfo.conditionText,
+				iterationKind: iterInfo.iterationKind,
+				iterationLabel: iterInfo.iterationLabel,
+				order: 0, // Will be re-assigned
+				statements: pendingStatements.map((p) => p.info),
+			});
+			pendingStatements = [];
+		};
+
+		for (const stmt of bodyStatements) {
+			const stmtStart = stmt.getStart();
+			const stmtEnd = stmt.getEnd();
+
+			// Check if this statement contains any tracked item
+			let hasTracked = false;
+			for (const pos of trackedPositions) {
+				if (pos >= stmtStart && pos <= stmtEnd) {
+					hasTracked = true;
+					break;
+				}
+			}
+
+			if (hasTracked) {
+				flushPending();
+				continue;
+			}
+
+			if (isInterestingStatement(stmt, trackedPositions)) {
+				const info = extractStatementInfo(stmt);
+				if (info) {
+					pendingStatements.push({ info, stmt });
+					continue;
+				}
+			}
+			flushPending();
+		}
+		flushPending();
+	}
+
+	// Re-assign order numbers across all items by source position
+	if (steps.length > 0) {
+		type OrderItem =
+			| { kind: "call"; item: (typeof callEntries)[number] }
+			| { kind: "throw"; item: ThrowUsage }
+			| { kind: "scc"; item: SameClassCallUsage }
+			| { kind: "step"; item: StepUsage };
+
+		const allItems: OrderItem[] = [];
+		for (const e of callEntries) {
+			allItems.push({ kind: "call", item: e });
+		}
+		for (const t of throws) {
+			allItems.push({ kind: "throw", item: t });
+		}
+		for (const s of sameClassCalls) {
+			allItems.push({ kind: "scc", item: s });
+		}
+		for (const s of steps) {
+			allItems.push({ kind: "step", item: s });
+		}
+		allItems.sort((a, b) => a.item.callSiteLine - b.item.callSiteLine);
+
+		let newOrder = 0;
+		for (const ai of allItems) {
+			ai.item.order = newOrder++;
 		}
 	}
 
 	const result: UsedDependency[] = [];
-	for (const [paramName, methodMap] of usageMap) {
-		const methods: OrderedMethodUsage[] = [];
-		for (const [name, info] of methodMap) {
-			methods.push({
-				name,
-				conditional: !info.isUnconditional,
-				order: info.order,
-			});
+	const classMethodsMap = new Map<string, OrderedMethodUsage[]>();
+	for (const entry of callEntries) {
+		const className = injectionMap.get(entry.paramName)!;
+		if (!classMethodsMap.has(className)) {
+			classMethodsMap.set(className, []);
 		}
-		methods.sort((a, b) => a.order - b.order);
-		result.push({
-			className: injectionMap.get(paramName)!,
-			methodsCalled: methods,
+		const isConditional = entry.condInfo.isConditional;
+		classMethodsMap.get(className)!.push({
+			assignedTo: entry.assignedTo,
+			branchGroupId:
+				isConditional && entry.condInfo.statementLine
+					? `L${entry.condInfo.statementLine}`
+					: null,
+			branchKind: isConditional ? entry.condInfo.branchKind : null,
+			callSiteLine: entry.callSiteLine,
+			comment: entry.comment,
+			conditional: isConditional,
+			conditionText: isConditional ? entry.condInfo.conditionText : null,
+			guardThrow: entry.guardThrow,
+			iterationKind: entry.iterInfo.iterationKind,
+			iterationLabel: entry.iterInfo.iterationLabel,
+			name: entry.methodName,
+			order: entry.order,
 		});
 	}
+	for (const [className, methods] of classMethodsMap) {
+		methods.sort((a, b) => a.order - b.order);
+		result.push({ className, methodsCalled: methods });
+	}
 
-	return result;
+	const scanResult: ScanResult = {
+		deps: result,
+		sameClassCalls,
+		steps,
+		throws,
+	};
+	if (!visitedMethods && cache) {
+		cache.setScan(cacheKey, scanResult);
+	}
+	return scanResult;
 }
 
 function classifyDependency(name: string): DependencyType {
@@ -248,12 +1378,16 @@ function classifyDependency(name: string): DependencyType {
 }
 
 function buildMethodDependencyTree(
-	usedDeps: UsedDependency[],
+	scanResult: ScanResult,
+	parentClassName: string,
 	providers: Map<string, ProviderInfo>,
-	visited: Set<string>
+	visited: Set<string>,
+	cache?: ScanCache
 ): MethodDependencyNode[] {
 	const nodes: MethodDependencyNode[] = [];
 	const firstSeenClass = new Set<string>();
+	const computedChildNodes = new Map<string, MethodDependencyNode[]>();
+	const usedDeps = scanResult.deps;
 
 	// Build a flat list of all individual method calls across all deps
 	interface FlatCall {
@@ -288,37 +1422,58 @@ function buildMethodDependencyTree(
 		visited.add(dep.className);
 
 		const provider = providers.get(dep.className);
-		let childDeps: UsedDependency[] = [];
-		if (provider) {
-			childDeps = provider.dependencies.map((d) => ({
-				className: d,
-				methodsCalled: [],
-			}));
-		}
+		const fallbackChildDeps: UsedDependency[] = provider
+			? provider.dependencies.map((d) => ({
+					className: d,
+					methodsCalled: [],
+				}))
+			: [];
 
 		nodes.push({
+			assignedTo: null,
+			branchGroupId: null,
+			branchKind: null,
+			callSiteLine: 0,
 			className: dep.className,
+			comment: null,
 			conditional: false,
+			conditionText: null,
 			dependencies: buildMethodDependencyTree(
-				childDeps,
+				{
+					deps: fallbackChildDeps,
+					sameClassCalls: [],
+					steps: [],
+					throws: [],
+				},
+				dep.className,
 				providers,
-				new Set(visited)
+				new Set(visited),
+				cache
 			),
+			endLine: 0,
 			filePath: provider?.filePath ?? "",
+			guardThrow: null,
+			iterationKind: null,
+			iterationLabel: null,
 			line: 0,
 			methodName: null,
 			order: 0,
+			parameters: [],
+			returnType: null,
+			stepStatements: [],
+			throwMessage: null,
 			totalMethods: provider?.publicMethodCount ?? 0,
 			type: classifyDependency(dep.className),
 		});
 	}
 
-	// Collect all methods per class for sub-dep scanning
-	const allMethodsByClass = new Map<string, OrderedMethodUsage[]>();
-	for (const { className, dep } of flatCalls) {
-		if (!allMethodsByClass.has(className)) {
-			allMethodsByClass.set(className, dep.methodsCalled);
+	// Collect unique method names per class for sub-dep scanning
+	const uniqueMethodsByClass = new Map<string, Set<string>>();
+	for (const { className, mc } of flatCalls) {
+		if (!uniqueMethodsByClass.has(className)) {
+			uniqueMethodsByClass.set(className, new Set());
 		}
+		uniqueMethodsByClass.get(className)!.add(mc.name);
 	}
 
 	// Process method calls in global order
@@ -339,122 +1494,392 @@ function buildMethodDependencyTree(
 		if (isFirst && provider) {
 			const childVisited = new Set(visited);
 			childVisited.add(className);
-			const injMap = buildInjectionMap(provider.classDeclaration);
+			const injMap = buildInjectionMap(
+				provider.classDeclaration,
+				providers,
+				cache
+			);
 
-			// Merge sub-deps from ALL methods of this class
-			const merged = new Map<
-				string,
-				Map<string, { isUnconditional: boolean; order: number }>
-			>();
+			// Collect sub-deps from ALL methods of this class (no dedup — each call is its own entry)
+			const childCallEntries: Array<{
+				assignedTo: string | null;
+				depClassName: string;
+				methodName: string;
+				order: number;
+				callSiteLine: number;
+				comment: string | null;
+				conditional: boolean;
+				branchKind: string | null;
+				conditionText: string | null;
+				branchGroupId: string | null;
+				guardThrow: GuardThrow | null;
+				iterationKind: "loop" | "callback" | "concurrent" | null;
+				iterationLabel: string | null;
+			}> = [];
 			let childOrder = 0;
-			const classMethods = allMethodsByClass.get(className) ?? [];
-			for (const allMc of classMethods) {
-				const method = provider.classDeclaration.getInstanceMethod(allMc.name);
+			const allSameClassCalls: SameClassCallUsage[] = [];
+			const allThrows: ThrowUsage[] = [];
+			const uniqueNames =
+				uniqueMethodsByClass.get(className) ?? new Set<string>();
+			for (const methodName of uniqueNames) {
+				const method = findMethodInHierarchy(
+					provider.classDeclaration,
+					methodName,
+					providers,
+					cache
+				);
 				if (!method) {
 					continue;
 				}
-				for (const used of scanUsedDependencies(method, injMap)) {
-					if (!merged.has(used.className)) {
-						merged.set(used.className, new Map());
-					}
-					const methodMap = merged.get(used.className)!;
+				const subResult = scanUsedDependencies(
+					method,
+					injMap,
+					provider.classDeclaration,
+					undefined,
+					cache
+				);
+
+				// Interleave dep method calls, throws, and same-class calls by original order
+				type SubItem =
+					| { kind: "dep"; depClassName: string; m: OrderedMethodUsage }
+					| { kind: "throw"; t: ThrowUsage }
+					| { kind: "scc"; scc: SameClassCallUsage };
+
+				const subItems: SubItem[] = [];
+				for (const used of subResult.deps) {
 					for (const m of used.methodsCalled) {
-						const existing = methodMap.get(m.name);
-						if (existing) {
-							existing.isUnconditional =
-								existing.isUnconditional || !m.conditional;
-						} else {
-							methodMap.set(m.name, {
-								isUnconditional: !m.conditional,
-								order: childOrder++,
-							});
-						}
+						subItems.push({ kind: "dep", depClassName: used.className, m });
+					}
+				}
+				for (const t of subResult.throws) {
+					subItems.push({ kind: "throw", t });
+				}
+				for (const scc of subResult.sameClassCalls) {
+					subItems.push({ kind: "scc", scc });
+				}
+				function subItemOrder(item: SubItem): number {
+					if (item.kind === "dep") {
+						return item.m.order;
+					}
+					if (item.kind === "throw") {
+						return item.t.order;
+					}
+					return item.scc.order;
+				}
+				subItems.sort((a, b) => subItemOrder(a) - subItemOrder(b));
+
+				for (const sub of subItems) {
+					if (sub.kind === "dep") {
+						childCallEntries.push({
+							assignedTo: sub.m.assignedTo,
+							depClassName: sub.depClassName,
+							methodName: sub.m.name,
+							order: childOrder++,
+							callSiteLine: sub.m.callSiteLine,
+							comment: sub.m.comment,
+							conditional: sub.m.conditional,
+							branchKind: sub.m.conditional ? sub.m.branchKind : null,
+							conditionText: sub.m.conditional ? sub.m.conditionText : null,
+							branchGroupId: sub.m.conditional ? sub.m.branchGroupId : null,
+							guardThrow: sub.m.guardThrow,
+							iterationKind: sub.m.iterationKind,
+							iterationLabel: sub.m.iterationLabel,
+						});
+					} else if (sub.kind === "throw") {
+						allThrows.push({ ...sub.t, order: childOrder++ });
+					} else {
+						allSameClassCalls.push(sub.scc);
 					}
 				}
 			}
 
-			const childDeps: UsedDependency[] = [...merged.entries()].map(
-				([cn, methodMap]) => ({
-					className: cn,
-					methodsCalled: [...methodMap.entries()]
-						.map(([name, info]) => ({
-							name,
-							conditional: !info.isUnconditional,
-							order: info.order,
-						}))
-						.sort((a, b) => a.order - b.order),
-				})
-			);
+			// Merge guard-throw patterns in child entries
+			mergeGuardThrows(childCallEntries, allThrows);
+
+			const childClassMethodsMap = new Map<string, OrderedMethodUsage[]>();
+			for (const entry of childCallEntries) {
+				if (!childClassMethodsMap.has(entry.depClassName)) {
+					childClassMethodsMap.set(entry.depClassName, []);
+				}
+				childClassMethodsMap.get(entry.depClassName)!.push({
+					assignedTo: entry.assignedTo,
+					branchGroupId: entry.branchGroupId,
+					branchKind: entry.branchKind,
+					callSiteLine: entry.callSiteLine,
+					comment: entry.comment,
+					conditional: entry.conditional,
+					conditionText: entry.conditionText,
+					guardThrow: entry.guardThrow,
+					iterationKind: entry.iterationKind,
+					iterationLabel: entry.iterationLabel,
+					name: entry.methodName,
+					order: entry.order,
+				});
+			}
+			const childDeps: UsedDependency[] = [];
+			for (const [cn, methods] of childClassMethodsMap) {
+				methods.sort((a, b) => a.order - b.order);
+				childDeps.push({ className: cn, methodsCalled: methods });
+			}
 
 			childNodes = buildMethodDependencyTree(
-				childDeps,
+				{
+					deps: childDeps,
+					sameClassCalls: allSameClassCalls,
+					steps: [],
+					throws: allThrows,
+				},
+				className,
 				providers,
-				childVisited
+				childVisited,
+				cache
 			);
+			computedChildNodes.set(className, childNodes);
+		} else if (!isFirst) {
+			childNodes = computedChildNodes.get(className) ?? [];
 		}
 
 		let line = 0;
+		let endLine = 0;
+		let returnType: string | null = null;
+		let parameters: MethodParameterInfo[] = [];
 		if (provider) {
-			const methodDecl = provider.classDeclaration.getInstanceMethod(mc.name);
+			const methodDecl = findMethodInHierarchy(
+				provider.classDeclaration,
+				mc.name,
+				providers,
+				cache
+			);
 			if (methodDecl) {
 				line = methodDecl.getStartLineNumber();
+				endLine = methodDecl.getEndLineNumber();
+				returnType = extractReturnType(methodDecl);
+				parameters = extractMethodParameters(methodDecl);
 			}
 		}
 
 		nodes.push({
+			assignedTo: mc.assignedTo,
+			branchGroupId: mc.branchGroupId,
+			branchKind: mc.branchKind,
+			callSiteLine: mc.callSiteLine,
 			className,
+			comment: mc.comment,
 			conditional: mc.conditional,
+			conditionText: mc.conditionText,
 			dependencies: childNodes,
+			endLine,
 			filePath: provider?.filePath ?? "",
+			guardThrow: mc.guardThrow,
+			iterationKind: mc.iterationKind,
+			iterationLabel: mc.iterationLabel,
 			line,
 			methodName: mc.name,
 			order: mc.order,
+			parameters,
+			returnType,
+			stepStatements: [],
+			throwMessage: null,
 			totalMethods: provider?.publicMethodCount ?? 0,
 			type: classifyDependency(className),
 		});
 	}
 
+	// Process same-class helper calls as intermediate nodes
+	const parentProvider = providers.get(parentClassName);
+	for (const scc of scanResult.sameClassCalls) {
+		let line = 0;
+		let endLine = 0;
+		let sccReturnType: string | null = null;
+		let sccParameters: MethodParameterInfo[] = [];
+		if (parentProvider) {
+			const methodDecl = findMethodInHierarchy(
+				parentProvider.classDeclaration,
+				scc.methodName,
+				providers,
+				cache
+			);
+			if (methodDecl) {
+				line = methodDecl.getStartLineNumber();
+				endLine = methodDecl.getEndLineNumber();
+				sccReturnType = extractReturnType(methodDecl);
+				sccParameters = extractMethodParameters(methodDecl);
+			}
+		}
+
+		const childNodes = buildMethodDependencyTree(
+			scc.childResult,
+			parentClassName,
+			providers,
+			new Set(visited),
+			cache
+		);
+
+		nodes.push({
+			assignedTo: scc.assignedTo,
+			branchGroupId: scc.branchGroupId,
+			branchKind: scc.branchKind,
+			callSiteLine: scc.callSiteLine,
+			className: parentClassName,
+			comment: scc.comment,
+			conditional: scc.conditional,
+			conditionText: scc.conditionText,
+			dependencies: childNodes,
+			endLine,
+			filePath: parentProvider?.filePath ?? "",
+			guardThrow: null,
+			iterationKind: scc.iterationKind,
+			iterationLabel: scc.iterationLabel,
+			line,
+			methodName: scc.methodName,
+			order: scc.order,
+			parameters: sccParameters,
+			returnType: sccReturnType,
+			stepStatements: [],
+			throwMessage: null,
+			totalMethods: parentProvider?.publicMethodCount ?? 0,
+			type: classifyDependency(parentClassName),
+		});
+	}
+
+	// Process throw statements as leaf nodes
+	for (const t of scanResult.throws) {
+		nodes.push({
+			assignedTo: null,
+			branchGroupId: t.branchGroupId,
+			branchKind: t.branchKind,
+			callSiteLine: t.callSiteLine,
+			className: t.exceptionClassName,
+			comment: t.comment,
+			conditional: t.conditional,
+			conditionText: t.conditionText,
+			dependencies: [],
+			endLine: t.callSiteLine,
+			filePath: parentProvider?.filePath ?? "",
+			guardThrow: null,
+			iterationKind: t.iterationKind,
+			iterationLabel: t.iterationLabel,
+			line: t.callSiteLine,
+			methodName: null,
+			order: t.order,
+			parameters: [],
+			returnType: null,
+			stepStatements: [],
+			throwMessage: t.message,
+			totalMethods: 0,
+			type: "throw",
+		});
+	}
+
+	// Process inline logic step nodes
+	for (const s of scanResult.steps) {
+		nodes.push({
+			assignedTo: null,
+			branchGroupId: s.branchGroupId,
+			branchKind: s.branchKind,
+			callSiteLine: s.callSiteLine,
+			className: "local",
+			comment: s.comment,
+			conditional: s.conditional,
+			conditionText: s.conditionText,
+			dependencies: [],
+			endLine: s.callSiteLine,
+			filePath: parentProvider?.filePath ?? "",
+			guardThrow: null,
+			iterationKind: s.iterationKind,
+			iterationLabel: s.iterationLabel,
+			line: s.callSiteLine,
+			methodName: null,
+			order: s.order,
+			parameters: [],
+			returnType: null,
+			stepStatements: s.statements,
+			throwMessage: null,
+			totalMethods: 0,
+			type: "step",
+		});
+	}
+
+	// Sort all nodes by call order to preserve interleaved ordering
+	nodes.sort((a, b) => a.order - b.order);
+
 	return nodes;
+}
+
+function extractResolverRouteInfo(
+	method: MethodDeclaration
+): { httpMethod: string; path: string } | undefined {
+	for (const decorator of method.getDecorators()) {
+		const name = decorator.getName();
+		if (!GRAPHQL_DECORATORS.has(name)) {
+			continue;
+		}
+		return { httpMethod: name.toUpperCase(), path: method.getName() };
+	}
+	return undefined;
 }
 
 function extractEndpointsFromFile(
 	sourceFile: NonNullable<ReturnType<Project["getSourceFile"]>>,
 	filePath: string,
-	providers: Map<string, ProviderInfo>
+	providers: Map<string, ProviderInfo>,
+	cache?: ScanCache
 ): EndpointNode[] {
 	const endpoints: EndpointNode[] = [];
 
 	for (const cls of sourceFile.getClasses()) {
-		if (!isController(cls)) {
+		const isCtrl = isController(cls);
+		const isRes = hasDecorator(cls, "Resolver");
+
+		if (!(isCtrl || isRes)) {
 			continue;
 		}
 
-		const controllerPath = extractControllerPath(cls);
-		const controllerName = cls.getName() ?? "AnonymousController";
-		const injectionMap = buildInjectionMap(cls);
+		const controllerPath = isCtrl ? extractControllerPath(cls) : "";
+		const controllerName =
+			cls.getName() ?? (isCtrl ? "AnonymousController" : "AnonymousResolver");
+		const injectionMap = buildInjectionMap(cls, providers, cache);
 
 		for (const method of cls.getMethods()) {
-			const routeInfo = extractRouteInfo(method);
+			const routeInfo = isCtrl
+				? extractRouteInfo(method)
+				: extractResolverRouteInfo(method);
 			if (!routeInfo) {
 				continue;
 			}
 
-			const fullPath = composePath(controllerPath, routeInfo.path);
-			const usedDeps = scanUsedDependencies(method, injectionMap);
-			const dependencies = buildMethodDependencyTree(
-				usedDeps,
-				providers,
-				new Set()
+			const fullPath = isCtrl
+				? composePath(controllerPath, routeInfo.path)
+				: routeInfo.path;
+			const scanResult = scanUsedDependencies(
+				method,
+				injectionMap,
+				cls,
+				undefined,
+				cache
 			);
+			const dependencies = buildMethodDependencyTree(
+				scanResult,
+				controllerName,
+				providers,
+				new Set(),
+				cache
+			);
+
+			const swagger = extractSwaggerMetadata(method);
+			const returnType = extractReturnType(method);
 
 			endpoints.push({
 				controllerClass: controllerName,
 				dependencies,
+				endLine: method.getEndLineNumber(),
 				filePath,
 				handlerMethod: method.getName(),
 				httpMethod: routeInfo.httpMethod,
 				line: method.getStartLineNumber(),
+				returnType,
 				routePath: fullPath,
+				swagger,
 			});
 		}
 	}
@@ -468,6 +1893,7 @@ export function buildEndpointGraph(
 	providers: Map<string, ProviderInfo>
 ): EndpointGraph {
 	const endpoints: EndpointNode[] = [];
+	const cache = new ScanCache();
 
 	for (const filePath of files) {
 		const sourceFile = project.getSourceFile(filePath);
@@ -476,7 +1902,7 @@ export function buildEndpointGraph(
 		}
 
 		endpoints.push(
-			...extractEndpointsFromFile(sourceFile, filePath, providers)
+			...extractEndpointsFromFile(sourceFile, filePath, providers, cache)
 		);
 	}
 
@@ -489,7 +1915,8 @@ function traceMethodCalls(
 	providers: Map<string, ProviderInfo>,
 	visited: Set<string>,
 	depth: number,
-	currentClass?: ClassDeclaration
+	currentClass?: ClassDeclaration,
+	cache?: ScanCache
 ): MethodCallNode[] {
 	if (depth > MAX_TRACE_DEPTH) {
 		return [];
@@ -555,7 +1982,9 @@ function traceMethodCalls(
 				if (targetMethod) {
 					line = targetMethod.getStartLineNumber();
 					const targetInjectionMap = buildInjectionMap(
-						provider.classDeclaration
+						provider.classDeclaration,
+						undefined,
+						cache
 					);
 					childCalls = traceMethodCalls(
 						targetMethod,
@@ -563,7 +1992,8 @@ function traceMethodCalls(
 						providers,
 						new Set(visited),
 						depth + 1,
-						provider.classDeclaration
+						provider.classDeclaration,
+						cache
 					);
 				}
 			}
@@ -598,7 +2028,8 @@ function traceMethodCalls(
 				providers,
 				new Set(visited),
 				depth + 1,
-				currentClass
+				currentClass,
+				cache
 			);
 
 			// Inline: surface dependency calls from private methods directly
@@ -635,8 +2066,17 @@ export function traceEndpointCalls(
 		return [];
 	}
 
-	const injectionMap = buildInjectionMap(cls);
-	return traceMethodCalls(method, injectionMap, providers, new Set(), 0, cls);
+	const cache = new ScanCache();
+	const injectionMap = buildInjectionMap(cls, undefined, cache);
+	return traceMethodCalls(
+		method,
+		injectionMap,
+		providers,
+		new Set(),
+		0,
+		cls,
+		cache
+	);
 }
 
 export function updateEndpointGraphForFile(
@@ -654,7 +2094,8 @@ export function updateEndpointGraphForFile(
 		return;
 	}
 
+	const cache = new ScanCache();
 	graph.endpoints.push(
-		...extractEndpointsFromFile(sourceFile, filePath, providers)
+		...extractEndpointsFromFile(sourceFile, filePath, providers, cache)
 	);
 }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3178,6 +3178,8 @@ var EP_TYPE_COLORS = {
   pipe: "#14b8a6",
   filter: "#ef4444",
   gateway: "#ec4899",
+  step: "#64748b",
+  throw: "#f87171",
   unknown: "#666"
 };
 

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "endpoint-graph-patterns",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/graphql": "^12.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/app.module.ts
@@ -1,0 +1,33 @@
+import { Module } from "@nestjs/common";
+import { OrdersController } from "./orders.controller";
+import { OrdersService } from "./orders.service";
+import { ProductsController } from "./products.controller";
+import { ProductsService } from "./products.service";
+import { BaseService } from "./base.service";
+import { RecipesResolver } from "./recipes.resolver";
+import { RecipesService } from "./recipes.service";
+import { UsersRepository } from "./users.repository";
+import { LeadsController } from "./leads.controller";
+import { LeadsService } from "./leads.service";
+import { LeadRepository } from "./lead.repository";
+import { FuseLogger } from "./fuse-logger";
+import { LeadsHelper } from "./leads-helper";
+import { EventEmitter2 } from "./event-emitter";
+
+@Module({
+	controllers: [OrdersController, ProductsController, LeadsController],
+	providers: [
+		OrdersService,
+		ProductsService,
+		BaseService,
+		RecipesResolver,
+		RecipesService,
+		UsersRepository,
+		LeadsService,
+		LeadRepository,
+		FuseLogger,
+		LeadsHelper,
+		EventEmitter2,
+	],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/base.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/base.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from "@nestjs/common";
+import type { UsersRepository } from "./users.repository";
+
+@Injectable()
+export class BaseService {
+	constructor(private readonly repo: UsersRepository) {}
+
+	findAll() {
+		return this.repo.find();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/event-emitter.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/event-emitter.ts
@@ -1,0 +1,6 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class EventEmitter2 {
+	emit(event: string, data?: any) {}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/fuse-logger.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/fuse-logger.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class FuseLogger {
+	log(msg: string) {}
+
+	setContext(ctx: string) {}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/lead.repository.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/lead.repository.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class LeadRepository {
+	findById(id: string) {
+		return null;
+	}
+
+	update(id: string, data: any) {
+		return data;
+	}
+
+	create(data: any) {
+		return data;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/leads-helper.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/leads-helper.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class LeadsHelper {
+	parseRequestToLead(data: any) {
+		return data;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/leads.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/leads.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Post, Body } from "@nestjs/common";
+import type { LeadsService } from "./leads.service";
+
+@Controller("leads")
+export class LeadsController {
+	constructor(private readonly leadsService: LeadsService) {}
+
+	@Post()
+	post(@Body() request: any) {
+		return this.leadsService.upsert(request);
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/leads.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/leads.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from "@nestjs/common";
+import type { LeadRepository } from "./lead.repository";
+import type { FuseLogger } from "./fuse-logger";
+import type { LeadsHelper } from "./leads-helper";
+import type { EventEmitter2 } from "./event-emitter";
+
+@Injectable()
+export class LeadsService {
+	constructor(
+		private readonly logger: FuseLogger,
+		private readonly leadRepository: LeadRepository,
+		private readonly leadsHelper: LeadsHelper,
+		private readonly eventEmitter: EventEmitter2,
+	) {
+		this.logger.setContext("LeadsService");
+	}
+
+	// Pattern: upsert branches to update() or create() via same-class calls
+	async upsert(request: any) {
+		const lead = await this.leadRepository.findById(request.id);
+
+		if (lead) {
+			return await this.update(request.id, request);
+		}
+
+		return await this.create(request);
+	}
+
+	// Same-class helper: update
+	private async update(id: string, data: any) {
+		this.logger.log("Updating lead");
+		return this.leadRepository.update(id, data);
+	}
+
+	// Same-class helper: create — also calls another same-class helper (nested)
+	private async create(data: any) {
+		const lead = this.leadsHelper.parseRequestToLead(data);
+		const created = await this.leadRepository.create(lead);
+		this.notifyCreation(created);
+		return created;
+	}
+
+	// Nested same-class helper: called by create()
+	private notifyCreation(lead: any) {
+		this.eventEmitter.emit("lead.created", lead);
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/orders.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/orders.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Inject } from "@nestjs/common";
+import type { OrdersService } from "./orders.service";
+
+@Controller("orders")
+export class OrdersController {
+	@Inject(OrdersService)
+	private readonly injectedService: OrdersService;
+
+	constructor(private readonly ordersService: OrdersService) {}
+
+	// Pattern 1: same-class helper method call
+	@Get("formatted")
+	getFormatted() {
+		return this.formatResponse();
+	}
+
+	private formatResponse() {
+		return this.ordersService.findAll();
+	}
+
+	// Pattern 2: awaited call
+	@Get("awaited")
+	async getAwaited() {
+		const result = await this.ordersService.findAll();
+		return result;
+	}
+
+	// Pattern 3: callback-wrapped call
+	@Get("mapped")
+	getMapped() {
+		const ids = ["1", "2", "3"];
+		return ids.map((id) => this.ordersService.findById(id));
+	}
+
+	// Pattern 4: property injection via @Inject
+	@Get("injected")
+	getViaPropertyInjection() {
+		return this.injectedService.findAll();
+	}
+
+	// Pattern 5: chained/fluent call
+	@Get("chained")
+	getChained() {
+		return this.ordersService.findAll().then((r) => r);
+	}
+
+	// Pattern 6: aliased reference
+	@Get("aliased")
+	getAliased() {
+		const svc = this.ordersService;
+		return svc.findAll();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/orders.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/orders.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "@nestjs/common";
+import type { UsersRepository } from "./users.repository";
+
+@Injectable()
+export class OrdersService {
+	constructor(private readonly usersRepo: UsersRepository) {}
+
+	findAll() {
+		return this.usersRepo.findAll();
+	}
+
+	findById(id: string) {
+		return this.usersRepo.findById(id);
+	}
+
+	save(data: any) {
+		return this.usersRepo.save(data);
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/products.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/products.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from "@nestjs/common";
+import type { ProductsService } from "./products.service";
+
+@Controller("products")
+export class ProductsController {
+	constructor(private readonly productsService: ProductsService) {}
+
+	// Pattern 7: inherited method from base class
+	@Get()
+	getAll() {
+		return this.productsService.findAll();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/products.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/products.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from "@nestjs/common";
+import { BaseService } from "./base.service";
+
+@Injectable()
+export class ProductsService extends BaseService {
+	// inherits findAll() from BaseService
+	findSpecial() {
+		return this.repo.findSpecial();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/recipes.resolver.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/recipes.resolver.ts
@@ -1,0 +1,17 @@
+import { Resolver, Query, Mutation, Args } from "@nestjs/graphql";
+import type { RecipesService } from "./recipes.service";
+
+@Resolver()
+export class RecipesResolver {
+	constructor(private readonly recipesService: RecipesService) {}
+
+	@Query()
+	recipes() {
+		return this.recipesService.findAll();
+	}
+
+	@Mutation()
+	addRecipe(@Args("title") title: string) {
+		return this.recipesService.create(title);
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/recipes.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/recipes.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class RecipesService {
+	findAll() {
+		return [];
+	}
+
+	create(title: string) {
+		return { title };
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/users.repository.ts
+++ b/packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns/src/users.repository.ts
@@ -1,0 +1,28 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class UsersRepository {
+	findAll() {
+		return [];
+	}
+
+	findById(id: string) {
+		return { id };
+	}
+
+	save(data: any) {
+		return data;
+	}
+
+	find() {
+		return [];
+	}
+
+	findSpecial() {
+		return [];
+	}
+
+	createQueryBuilder(alias: string) {
+		return this;
+	}
+}

--- a/packages/nestjs-doctor/tests/unit/endpoint-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/endpoint-graph.test.ts
@@ -395,21 +395,32 @@ describe("endpoint-graph", () => {
 		);
 		expect(findUser).toBeDefined();
 		expect(findUser!.conditional).toBe(false);
+		expect(findUser!.branchKind).toBeNull();
+		expect(findUser!.conditionText).toBeNull();
+		expect(findUser!.branchGroupId).toBeNull();
 
-		// createUser is conditional
+		// createUser is conditional (if branch)
 		const createUser = adminRepoDeps.find((d) => d.methodName === "createUser");
 		expect(createUser).toBeDefined();
 		expect(createUser!.conditional).toBe(true);
+		expect(createUser!.branchKind).toBe("if");
+		expect(createUser!.conditionText).toBe("!owner");
 
-		// activateUser is conditional
+		// activateUser is conditional (else-if branch)
 		const activateUser = adminRepoDeps.find(
 			(d) => d.methodName === "activateUser"
 		);
 		expect(activateUser).toBeDefined();
 		expect(activateUser!.conditional).toBe(true);
+		expect(activateUser!.branchKind).toBe("else-if");
+		expect(activateUser!.conditionText).toBe("owner.status !== 'ACTIVE'");
+
+		// createUser and activateUser share the same branchGroupId
+		expect(createUser!.branchGroupId).toBeTruthy();
+		expect(createUser!.branchGroupId).toBe(activateUser!.branchGroupId);
 	});
 
-	it("marks method as unconditional when called both inside and outside conditional", () => {
+	it("shows each call separately when same method is called both inside and outside conditional", () => {
 		const { project, paths } = createProject({
 			"app.controller.ts": `
 				import { Controller, Post } from '@nestjs/common';
@@ -453,12 +464,16 @@ describe("endpoint-graph", () => {
 		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
 		expect(endpoint).toBeDefined();
 
-		// DataRepository.save — single method node
-		const repo = endpoint!.dependencies[0].dependencies[0];
-		expect(repo.className).toBe("DataRepository");
-		expect(repo.methodName).toBe("save");
-		// Called both conditionally and unconditionally → unconditional wins
-		expect(repo.conditional).toBe(false);
+		// DataRepository.save — two separate nodes (unconditional then conditional)
+		const svcDeps = endpoint!.dependencies[0].dependencies;
+		const saveCalls = svcDeps.filter(
+			(d) => d.className === "DataRepository" && d.methodName === "save"
+		);
+		expect(saveCalls).toHaveLength(2);
+		// First call is unconditional
+		expect(saveCalls[0].conditional).toBe(false);
+		// Second call is conditional
+		expect(saveCalls[1].conditional).toBe(true);
 	});
 
 	it("marks methods in switch case clauses as conditional", () => {
@@ -519,6 +534,24 @@ describe("endpoint-graph", () => {
 		}
 		const methodNames = repoDeps.map((d) => d.methodName).sort();
 		expect(methodNames).toEqual(["handleA", "handleB", "handleDefault"]);
+
+		// Verify switch/case branch details
+		const handleA = repoDeps.find((d) => d.methodName === "handleA");
+		const handleB = repoDeps.find((d) => d.methodName === "handleB");
+		const handleDefault = repoDeps.find(
+			(d) => d.methodName === "handleDefault"
+		);
+		expect(handleA!.branchKind).toBe("case");
+		expect(handleA!.conditionText).toBe("'a'");
+		expect(handleB!.branchKind).toBe("case");
+		expect(handleB!.conditionText).toBe("'b'");
+		expect(handleDefault!.branchKind).toBe("default");
+		expect(handleDefault!.conditionText).toBeNull();
+
+		// All share the same branchGroupId (same switch)
+		expect(handleA!.branchGroupId).toBeTruthy();
+		expect(handleA!.branchGroupId).toBe(handleB!.branchGroupId);
+		expect(handleA!.branchGroupId).toBe(handleDefault!.branchGroupId);
 	});
 
 	it("marks ternary branches as conditional", () => {
@@ -570,6 +603,16 @@ describe("endpoint-graph", () => {
 		const optB = repoDeps.find((d) => d.methodName === "optionB");
 		expect(optA!.conditional).toBe(true);
 		expect(optB!.conditional).toBe(true);
+
+		// Ternary branch details
+		expect(optA!.branchKind).toBe("ternary-true");
+		expect(optB!.branchKind).toBe("ternary-false");
+		expect(optA!.conditionText).toBe("Math.random() > 0.5");
+		expect(optB!.conditionText).toBe("Math.random() > 0.5");
+
+		// Both share the same branchGroupId
+		expect(optA!.branchGroupId).toBeTruthy();
+		expect(optA!.branchGroupId).toBe(optB!.branchGroupId);
 	});
 
 	it("marks catch clause methods as conditional but try body as unconditional", () => {
@@ -623,6 +666,8 @@ describe("endpoint-graph", () => {
 		const logError = repoDeps.find((d) => d.methodName === "logError");
 		expect(save!.conditional).toBe(false);
 		expect(logError!.conditional).toBe(true);
+		expect(logError!.branchKind).toBe("catch");
+		expect(logError!.conditionText).toBeNull();
 	});
 
 	it("treats if-condition expression calls as unconditional", () => {
@@ -741,11 +786,2769 @@ describe("endpoint-graph", () => {
 		expect(endpoint!.dependencies[2].methodName).toBe("baz");
 		expect(endpoint!.dependencies[2].order).toBe(2);
 
-		// Only foo (first for ServiceA) has sub-deps; baz has none
+		// Both ServiceA nodes share the same children (computed from first occurrence)
 		expect(endpoint!.dependencies[0].dependencies).toHaveLength(1);
 		expect(endpoint!.dependencies[0].dependencies[0].className).toBe(
 			"DataRepository"
 		);
-		expect(endpoint!.dependencies[2].dependencies).toHaveLength(0);
+		expect(endpoint!.dependencies[2].dependencies).toEqual(
+			endpoint!.dependencies[0].dependencies
+		);
+	});
+
+	// ─── Call pattern coverage tests ────────────────────────────────
+
+	it("traces dependencies through same-class helper methods (this.method())", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('orders')
+				export class OrdersController {
+					constructor(private readonly ordersService: OrdersService) {}
+
+					@Get()
+					findAll() {
+						return this.formatResponse();
+					}
+
+					private formatResponse() {
+						return this.ordersService.getAll();
+					}
+				}
+			`,
+			"orders.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class OrdersService {
+					getAll() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		// this.formatResponse() creates an intermediate same-class node
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("OrdersController");
+		expect(endpoint!.dependencies[0].methodName).toBe("formatResponse");
+
+		// formatResponse()'s child is OrdersService.getAll()
+		expect(endpoint!.dependencies[0].dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].dependencies[0].className).toBe(
+			"OrdersService"
+		);
+		expect(endpoint!.dependencies[0].dependencies[0].methodName).toBe("getAll");
+	});
+
+	it("tracks awaited service calls", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					async findAll() {
+						const result = await this.svc.getAll();
+						return result;
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					getAll() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("AppService");
+		expect(endpoint!.dependencies[0].methodName).toBe("getAll");
+	});
+
+	it("tracks service calls inside callbacks and closures", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					findAll() {
+						const ids = ['1', '2', '3'];
+						return ids.map(id => this.svc.findById(id));
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					findById(id: string) { return { id }; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("AppService");
+		expect(endpoint!.dependencies[0].methodName).toBe("findById");
+		expect(endpoint!.dependencies[0].iterationKind).toBe("callback");
+		expect(endpoint!.dependencies[0].iterationLabel).toBe("map");
+	});
+
+	it("detects iteration context for for-of loops", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					async processAll() {
+						const orders = [1, 2, 3];
+						for (const order of orders) {
+							await this.svc.process(order);
+						}
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					process(order: number) { return order; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies[0].iterationKind).toBe("loop");
+		expect(endpoint.dependencies[0].iterationLabel).toBe("for-of");
+	});
+
+	it("detects iteration context for traditional for loops", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					processAll() {
+						const items = [1, 2, 3];
+						for (let i = 0; i < items.length; i++) {
+							this.svc.find(items[i]);
+						}
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					find(id: number) { return id; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies[0].iterationKind).toBe("loop");
+		expect(endpoint.dependencies[0].iterationLabel).toBe("for");
+	});
+
+	it("detects iteration context for forEach callbacks", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					saveAll() {
+						const items = [1, 2, 3];
+						items.forEach(item => this.svc.save(item));
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					save(item: number) { return item; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies[0].iterationKind).toBe("callback");
+		expect(endpoint.dependencies[0].iterationLabel).toBe("forEach");
+	});
+
+	it("detects concurrent context for Promise.all with direct calls", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(
+						private readonly repoA: RepoA,
+						private readonly repoB: RepoB,
+					) {}
+
+					@Get()
+					async getAll() {
+						const [a, b] = await Promise.all([this.repoA.find(), this.repoB.find()]);
+						return { a, b };
+					}
+				}
+			`,
+			"repo-a.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class RepoA {
+					find() { return []; }
+				}
+			`,
+			"repo-b.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class RepoB {
+					find() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies).toHaveLength(2);
+		expect(endpoint.dependencies[0].iterationKind).toBe("concurrent");
+		expect(endpoint.dependencies[0].iterationLabel).toBe("all");
+		expect(endpoint.dependencies[1].iterationKind).toBe("concurrent");
+		expect(endpoint.dependencies[1].iterationLabel).toBe("all");
+	});
+
+	it("reports innermost iteration for Promise.all wrapping map", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					async findAll() {
+						const items = [1, 2, 3];
+						await Promise.all(items.map(i => this.svc.find(i)));
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					find(id: number) { return id; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies[0].iterationKind).toBe("callback");
+		expect(endpoint.dependencies[0].iterationLabel).toBe("map");
+	});
+
+	it("reports innermost iteration context for nested iterations", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					process() {
+						const groups = [{ items: [1, 2] }];
+						for (const group of groups) {
+							group.items.map(i => this.svc.find(i));
+						}
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					find(id: number) { return id; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies[0].iterationKind).toBe("callback");
+		expect(endpoint.dependencies[0].iterationLabel).toBe("map");
+	});
+
+	it("does not flag calls in loop expression as iterated", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(
+						private readonly svc: AppService,
+						private readonly other: OtherService,
+					) {}
+
+					@Get()
+					async run() {
+						for (const x of this.svc.getItems()) {
+							this.other.process(x);
+						}
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					getItems() { return []; }
+				}
+			`,
+			"other.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class OtherService {
+					process(x: any) { return x; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		const svcDep = endpoint.dependencies.find(
+			(d) => d.className === "AppService"
+		);
+		const otherDep = endpoint.dependencies.find(
+			(d) => d.className === "OtherService"
+		);
+		expect(svcDep).toBeDefined();
+		expect(svcDep!.iterationKind).toBeNull();
+		expect(otherDep).toBeDefined();
+		expect(otherDep!.iterationKind).toBe("loop");
+		expect(otherDep!.iterationLabel).toBe("for-of");
+	});
+
+	it("iteration context is orthogonal to conditional context", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					run() {
+						const condition = true;
+						if (condition) {
+							const items = [1, 2, 3];
+							items.map(i => this.svc.find(i));
+						}
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					find(id: number) { return id; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies[0].conditional).toBe(true);
+		expect(endpoint.dependencies[0].iterationKind).toBe("callback");
+		expect(endpoint.dependencies[0].iterationLabel).toBe("map");
+	});
+
+	it("does not flag calls in .then() as iterated", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(
+						private readonly svc: AppService,
+						private readonly other: OtherService,
+					) {}
+
+					@Get()
+					run() {
+						this.svc.getItems().then(items => this.other.process(items));
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					getItems() { return Promise.resolve([]); }
+				}
+			`,
+			"other.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class OtherService {
+					process(x: any) { return x; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		const otherDep = endpoint.dependencies.find(
+			(d) => d.className === "OtherService"
+		);
+		expect(otherDep).toBeDefined();
+		expect(otherDep!.iterationKind).toBeNull();
+	});
+
+	it("has null iteration context for regular calls", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					findAll() {
+						return this.svc.findAll();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					findAll() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies[0].iterationKind).toBeNull();
+		expect(endpoint.dependencies[0].iterationLabel).toBeNull();
+	});
+
+	it("detects while loop iteration context", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					async run() {
+						let hasMore = true;
+						while (hasMore) {
+							await this.svc.fetchNext();
+							hasMore = false;
+						}
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					fetchNext() { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const endpoint = graph.endpoints[0];
+		expect(endpoint.dependencies[0].iterationKind).toBe("loop");
+		expect(endpoint.dependencies[0].iterationLabel).toBe("while");
+	});
+
+	it("tracks dependencies from property-injected services (@Inject on property)", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get, Inject } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					@Inject(AppService)
+					private readonly svc: AppService;
+
+					@Get()
+					findAll() {
+						return this.svc.getAll();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					getAll() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("AppService");
+		expect(endpoint!.dependencies[0].methodName).toBe("getAll");
+	});
+
+	it("tracks the entry-point call in chained/fluent method chains", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly repo: DataRepository) {}
+
+					@Get()
+					findAll() {
+						return this.repo.createQueryBuilder('user').where('id = :id').getOne();
+					}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					createQueryBuilder(alias: string) { return this; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		// The inner this.repo.createQueryBuilder() should be tracked
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("DataRepository");
+		expect(endpoint!.dependencies[0].methodName).toBe("createQueryBuilder");
+	});
+
+	it("tracks service calls through aliased references", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					findAll() {
+						const service = this.svc;
+						return service.getAll();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					getAll() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("AppService");
+		expect(endpoint!.dependencies[0].methodName).toBe("getAll");
+	});
+
+	it("resolves inherited methods from base classes", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: UsersService) {}
+
+					@Get()
+					getUsers() {
+						return this.svc.findAll();
+					}
+				}
+			`,
+			"base.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class BaseService {
+					constructor(private readonly repo: UsersRepository) {}
+
+					findAll() {
+						return this.repo.find();
+					}
+				}
+			`,
+			"users.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UsersService extends BaseService {
+					findSpecial() {
+						return this.repo.findSpecial();
+					}
+				}
+			`,
+			"users.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UsersRepository {
+					find() { return []; }
+					findSpecial() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		// UsersService.findAll is inherited from BaseService
+		// Should still resolve and trace its sub-dependencies
+		expect(endpoint!.dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].className).toBe("UsersService");
+		expect(endpoint!.dependencies[0].methodName).toBe("findAll");
+		expect(endpoint!.dependencies[0].line).toBeGreaterThan(0);
+
+		// findAll() calls this.repo.find() — should have sub-deps
+		expect(endpoint!.dependencies[0].dependencies).toHaveLength(1);
+		expect(endpoint!.dependencies[0].dependencies[0].className).toBe(
+			"UsersRepository"
+		);
+		expect(endpoint!.dependencies[0].dependencies[0].methodName).toBe("find");
+	});
+
+	it("discovers GraphQL @Resolver endpoints with @Query and @Mutation", () => {
+		const { project, paths } = createProject({
+			"recipes.resolver.ts": `
+				import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+				@Resolver()
+				export class RecipesResolver {
+					constructor(private readonly recipesService: RecipesService) {}
+
+					@Query()
+					recipes() {
+						return this.recipesService.findAll();
+					}
+
+					@Mutation()
+					addRecipe(@Args('title') title: string) {
+						return this.recipesService.create(title);
+					}
+				}
+			`,
+			"recipes.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class RecipesService {
+					findAll() { return []; }
+					create(title: string) { return { title }; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		// Should discover 2 endpoints: recipes query + addRecipe mutation
+		expect(graph.endpoints).toHaveLength(2);
+
+		const recipesQuery = graph.endpoints.find(
+			(e) => e.handlerMethod === "recipes"
+		);
+		expect(recipesQuery).toBeDefined();
+		expect(recipesQuery!.httpMethod).toBe("QUERY");
+		expect(recipesQuery!.dependencies).toHaveLength(1);
+		expect(recipesQuery!.dependencies[0].className).toBe("RecipesService");
+		expect(recipesQuery!.dependencies[0].methodName).toBe("findAll");
+
+		const addMutation = graph.endpoints.find(
+			(e) => e.handlerMethod === "addRecipe"
+		);
+		expect(addMutation).toBeDefined();
+		expect(addMutation!.httpMethod).toBe("MUTATION");
+		expect(addMutation!.dependencies).toHaveLength(1);
+		expect(addMutation!.dependencies[0].className).toBe("RecipesService");
+		expect(addMutation!.dependencies[0].methodName).toBe("create");
+	});
+
+	// ─── Same-class call hierarchy tests ────────────────────────────
+
+	it("preserves dependency hierarchy for same-class helper methods", () => {
+		const { project, paths } = createProject({
+			"leads.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('leads')
+				export class LeadsController {
+					constructor(private readonly leadsService: LeadsService) {}
+
+					@Post()
+					post() {
+						return this.leadsService.upsert();
+					}
+				}
+			`,
+			"leads.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class LeadsService {
+					constructor(
+						private readonly leadRepository: LeadRepository,
+						private readonly logger: FuseLogger,
+						private readonly leadsHelper: LeadsHelper,
+					) {}
+
+					upsert() {
+						const lead = this.leadRepository.findById('id');
+						if (lead) {
+							return this.update('id', lead);
+						}
+						return this.create(lead);
+					}
+
+					private update(id: string, data: any) {
+						this.logger.log('updating');
+						return this.leadRepository.update(id, data);
+					}
+
+					private create(data: any) {
+						const parsed = this.leadsHelper.parseRequestToLead(data);
+						return this.leadRepository.create(parsed);
+					}
+				}
+			`,
+			"lead.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class LeadRepository {
+					findById(id: string) { return null; }
+					update(id: string, data: any) { return data; }
+					create(data: any) { return data; }
+				}
+			`,
+			"fuse-logger.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class FuseLogger {
+					log(msg: string) {}
+				}
+			`,
+			"leads-helper.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class LeadsHelper {
+					parseRequestToLead(data: any) { return data; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		// Top-level: LeadsService.upsert
+		expect(endpoint!.dependencies).toHaveLength(1);
+		const upsertNode = endpoint!.dependencies[0];
+		expect(upsertNode.className).toBe("LeadsService");
+		expect(upsertNode.methodName).toBe("upsert");
+
+		// upsert() has 3 children: findById (direct), update (same-class), create (same-class)
+		// NOT 5 flattened children
+		expect(upsertNode.dependencies).toHaveLength(3);
+
+		// #1: LeadRepository.findById — direct call, unconditional
+		const findById = upsertNode.dependencies.find(
+			(d) => d.className === "LeadRepository" && d.methodName === "findById"
+		);
+		expect(findById).toBeDefined();
+		expect(findById!.conditional).toBe(false);
+
+		// #2: this.update() — same-class call, conditional (inside if)
+		const updateNode = upsertNode.dependencies.find(
+			(d) => d.className === "LeadsService" && d.methodName === "update"
+		);
+		expect(updateNode).toBeDefined();
+		expect(updateNode!.conditional).toBe(true);
+
+		// update() has its own children: logger.log + leadRepository.update
+		expect(updateNode!.dependencies).toHaveLength(2);
+		expect(
+			updateNode!.dependencies.some(
+				(d) => d.className === "FuseLogger" && d.methodName === "log"
+			)
+		).toBe(true);
+		expect(
+			updateNode!.dependencies.some(
+				(d) => d.className === "LeadRepository" && d.methodName === "update"
+			)
+		).toBe(true);
+
+		// #3: this.create() — same-class call, unconditional
+		const createNode = upsertNode.dependencies.find(
+			(d) => d.className === "LeadsService" && d.methodName === "create"
+		);
+		expect(createNode).toBeDefined();
+		expect(createNode!.conditional).toBe(false);
+
+		// create() has its own children: leadsHelper.parseRequestToLead + leadRepository.create
+		expect(createNode!.dependencies).toHaveLength(2);
+		expect(
+			createNode!.dependencies.some(
+				(d) =>
+					d.className === "LeadsHelper" && d.methodName === "parseRequestToLead"
+			)
+		).toBe(true);
+		expect(
+			createNode!.dependencies.some(
+				(d) => d.className === "LeadRepository" && d.methodName === "create"
+			)
+		).toBe(true);
+	});
+
+	it("handles nested same-class helper calls with correct hierarchy", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					handle() {
+						return this.svc.process();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(
+						private readonly repo: DataRepository,
+						private readonly notifier: NotificationService,
+					) {}
+
+					process() {
+						const item = this.repo.findOne('id');
+						return this.saveAndNotify(item);
+					}
+
+					private saveAndNotify(item: any) {
+						this.repo.save(item);
+						this.notify(item);
+					}
+
+					private notify(item: any) {
+						this.notifier.send(item);
+					}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					findOne(id: string) { return {}; }
+					save(data: any) { return data; }
+				}
+			`,
+			"notification.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class NotificationService {
+					send(data: any) {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		const processNode = endpoint!.dependencies[0];
+		expect(processNode.className).toBe("AppService");
+		expect(processNode.methodName).toBe("process");
+
+		// process() has 2 children: repo.findOne (direct) + this.saveAndNotify (same-class)
+		expect(processNode.dependencies).toHaveLength(2);
+
+		const findOne = processNode.dependencies.find(
+			(d) => d.className === "DataRepository" && d.methodName === "findOne"
+		);
+		expect(findOne).toBeDefined();
+
+		const saveAndNotify = processNode.dependencies.find(
+			(d) => d.className === "AppService" && d.methodName === "saveAndNotify"
+		);
+		expect(saveAndNotify).toBeDefined();
+
+		// saveAndNotify() has children: repo.save + this.notify (nested same-class)
+		expect(saveAndNotify!.dependencies).toHaveLength(2);
+
+		const repoSave = saveAndNotify!.dependencies.find(
+			(d) => d.className === "DataRepository" && d.methodName === "save"
+		);
+		expect(repoSave).toBeDefined();
+
+		const notifyNode = saveAndNotify!.dependencies.find(
+			(d) => d.className === "AppService" && d.methodName === "notify"
+		);
+		expect(notifyNode).toBeDefined();
+
+		// notify() has 1 child: notifier.send
+		expect(notifyNode!.dependencies).toHaveLength(1);
+		expect(notifyNode!.dependencies[0].className).toBe("NotificationService");
+		expect(notifyNode!.dependencies[0].methodName).toBe("send");
+	});
+
+	it("truncates long condition text at 50 characters", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					check() {
+						return this.svc.decide();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(private readonly repo: DataRepository) {}
+
+					decide() {
+						if (this.repo.somethingVeryLongConditionNameThatExceedsFiftyCharacters && this.repo.anotherThing) {
+							this.repo.doAction();
+						}
+					}
+				}
+			`,
+			"data.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepository {
+					somethingVeryLongConditionNameThatExceedsFiftyCharacters = true;
+					anotherThing = true;
+					doAction() {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		const repoDeps = endpoint!.dependencies[0].dependencies;
+		const doAction = repoDeps.find((d) => d.methodName === "doAction");
+		expect(doAction).toBeDefined();
+		expect(doAction!.conditional).toBe(true);
+		expect(doAction!.branchKind).toBe("if");
+		// Condition text should be truncated to 50 chars + ellipsis
+		expect(doAction!.conditionText!.length).toBeLessThanOrEqual(51);
+		expect(doAction!.conditionText!.endsWith("\u2026")).toBe(true);
+	});
+
+	it("populates branchKind for same-class helper calls in conditional blocks", () => {
+		const { project, paths } = createProject({
+			"leads.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('leads')
+				export class LeadsController {
+					constructor(private readonly leadsService: LeadsService) {}
+
+					@Post()
+					post() {
+						return this.leadsService.upsert();
+					}
+				}
+			`,
+			"leads.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class LeadsService {
+					constructor(private readonly repo: LeadRepository) {}
+
+					upsert() {
+						const lead = this.repo.findById('id');
+						if (lead) {
+							return this.update('id', lead);
+						}
+						return this.create(lead);
+					}
+
+					private update(id: string, data: any) {
+						return this.repo.update(id, data);
+					}
+
+					private create(data: any) {
+						return this.repo.create(data);
+					}
+				}
+			`,
+			"lead.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class LeadRepository {
+					findById(id: string) { return null; }
+					update(id: string, data: any) { return data; }
+					create(data: any) { return data; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		const upsertNode = endpoint!.dependencies[0];
+		expect(upsertNode.dependencies).toHaveLength(3);
+
+		// this.update() is called inside if (lead) → branchKind should be "if"
+		const updateNode = upsertNode.dependencies.find(
+			(d) => d.className === "LeadsService" && d.methodName === "update"
+		);
+		expect(updateNode).toBeDefined();
+		expect(updateNode!.conditional).toBe(true);
+		expect(updateNode!.branchKind).toBe("if");
+		expect(updateNode!.conditionText).toBe("lead");
+
+		// this.create() is unconditional
+		const createNode = upsertNode.dependencies.find(
+			(d) => d.className === "LeadsService" && d.methodName === "create"
+		);
+		expect(createNode).toBeDefined();
+		expect(createNode!.conditional).toBe(false);
+		expect(createNode!.branchKind).toBeNull();
+	});
+
+	it("detects guard throw pattern (if-then-throw) as conditional leaf node", () => {
+		const { project, paths } = createProject({
+			"items.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('items')
+				export class ItemsController {
+					constructor(private readonly itemsService: ItemsService) {}
+
+					@Get(':id')
+					getItem() {
+						return this.itemsService.findOne('id');
+					}
+				}
+			`,
+			"items.service.ts": `
+				import { Injectable, NotFoundException } from '@nestjs/common';
+				@Injectable()
+				export class ItemsService {
+					constructor(private readonly itemsRepo: ItemsRepository) {}
+
+					findOne(id: string) {
+						const item = this.itemsRepo.findById(id);
+						if (!item) {
+							throw new NotFoundException('Item not found');
+						}
+						return item;
+					}
+				}
+			`,
+			"items.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class ItemsRepository {
+					findById(id: string) { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		expect(ep).toBeDefined();
+
+		// Service node is findOne
+		const serviceNode = ep.dependencies[0];
+		expect(serviceNode.className).toBe("ItemsService");
+		expect(serviceNode.methodName).toBe("findOne");
+
+		// Guard throw is merged into the repo call node
+		const repoNode = serviceNode.dependencies.find(
+			(d) => d.methodName === "findById"
+		);
+		expect(repoNode).toBeDefined();
+		expect(repoNode!.guardThrow).not.toBeNull();
+		expect(repoNode!.guardThrow!.className).toBe("NotFoundException");
+		expect(repoNode!.guardThrow!.conditionText).toBe("!item");
+		expect(repoNode!.guardThrow!.message).toBe("Item not found");
+
+		// No separate throw node
+		const throwNode = serviceNode.dependencies.find((d) => d.type === "throw");
+		expect(throwNode).toBeUndefined();
+	});
+
+	it("preserves source-order interleaving between calls and throws", () => {
+		const { project, paths } = createProject({
+			"orders.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('orders')
+				export class OrdersController {
+					constructor(private readonly ordersService: OrdersService) {}
+
+					@Post()
+					create() {
+						return this.ordersService.createOrder();
+					}
+				}
+			`,
+			"orders.service.ts": `
+				import { Injectable, ConflictException } from '@nestjs/common';
+				@Injectable()
+				export class OrdersService {
+					constructor(private readonly ordersRepo: OrdersRepository) {}
+
+					createOrder() {
+						const existing = this.ordersRepo.findOne();
+						if (existing) {
+							throw new ConflictException('Already exists');
+						}
+						return this.ordersRepo.create();
+					}
+				}
+			`,
+			"orders.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class OrdersRepository {
+					findOne() { return null; }
+					create() { return {}; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+
+		// Guard throw merged: findOne (with guardThrow), create — in source order
+		expect(serviceNode.dependencies).toHaveLength(2);
+		expect(serviceNode.dependencies[0].className).toBe("OrdersRepository");
+		expect(serviceNode.dependencies[0].methodName).toBe("findOne");
+		expect(serviceNode.dependencies[0].guardThrow).not.toBeNull();
+		expect(serviceNode.dependencies[0].guardThrow!.className).toBe(
+			"ConflictException"
+		);
+		expect(serviceNode.dependencies[1].className).toBe("OrdersRepository");
+		expect(serviceNode.dependencies[1].methodName).toBe("create");
+	});
+
+	it("detects throw in controller handler directly", () => {
+		const { project, paths } = createProject({
+			"auth.controller.ts": `
+				import { Controller, Post, UnauthorizedException } from '@nestjs/common';
+				@Controller('auth')
+				export class AuthController {
+					@Post('login')
+					login() {
+						throw new UnauthorizedException('Invalid credentials');
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+
+		expect(ep.dependencies).toHaveLength(1);
+		expect(ep.dependencies[0].type).toBe("throw");
+		expect(ep.dependencies[0].className).toBe("UnauthorizedException");
+		expect(ep.dependencies[0].conditional).toBe(false);
+	});
+
+	it("falls back to Error for throw without new expression", () => {
+		const { project, paths } = createProject({
+			"err.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('err')
+				export class ErrController {
+					@Get()
+					fail() {
+						throw "something went wrong";
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+
+		expect(ep.dependencies).toHaveLength(1);
+		expect(ep.dependencies[0].type).toBe("throw");
+		expect(ep.dependencies[0].className).toBe("Error");
+	});
+
+	it("detects throw in same-class helper method", () => {
+		const { project, paths } = createProject({
+			"users.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('users')
+				export class UsersController {
+					constructor(private readonly usersService: UsersService) {}
+
+					@Get(':id')
+					getUser() {
+						return this.usersService.findUser('id');
+					}
+				}
+			`,
+			"users.service.ts": `
+				import { Injectable, NotFoundException } from '@nestjs/common';
+				@Injectable()
+				export class UsersService {
+					constructor(private readonly usersRepo: UsersRepository) {}
+
+					findUser(id: string) {
+						const user = this.usersRepo.findById(id);
+						this.assertExists(user);
+						return user;
+					}
+
+					assertExists(item: unknown) {
+						if (!item) {
+							throw new NotFoundException('Not found');
+						}
+					}
+				}
+			`,
+			"users.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UsersRepository {
+					findById(id: string) { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+
+		// Should have repo + same-class helper (assertExists) as children
+		const assertNode = serviceNode.dependencies.find(
+			(d) => d.methodName === "assertExists"
+		);
+		expect(assertNode).toBeDefined();
+
+		// assertExists should contain the throw node
+		const throwNode = assertNode!.dependencies.find((d) => d.type === "throw");
+		expect(throwNode).toBeDefined();
+		expect(throwNode!.className).toBe("NotFoundException");
+		expect(throwNode!.conditional).toBe(true);
+		expect(throwNode!.branchKind).toBe("if");
+	});
+
+	it("shows each call as its own node when same method is called multiple times", () => {
+		const { project, paths } = createProject({
+			"pages.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('pages')
+				export class PagesController {
+					constructor(private readonly pagesService: PagesService) {}
+
+					@Post()
+					create() {
+						return this.pagesService.create();
+					}
+				}
+			`,
+			"pages.service.ts": `
+				import { Injectable, ConflictException } from '@nestjs/common';
+				@Injectable()
+				export class PagesService {
+					constructor(
+						private readonly repo: PagesRepository,
+						private readonly logger: LoggerService,
+					) {}
+
+					create() {
+						const existing = this.repo.findByOrganizationId('orgId');
+						if (existing) {
+							throw new ConflictException('Already exists');
+						}
+						const page = this.repo.create('orgId');
+						this.logger.log('created');
+						return this.repo.findByOrganizationId('orgId');
+					}
+				}
+			`,
+			"pages.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class PagesRepository {
+					findByOrganizationId(orgId: string) { return null; }
+					create(orgId: string) { return {}; }
+				}
+			`,
+			"logger.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class LoggerService {
+					log(msg: string) {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+
+		// Guard throw merged: 4 children in order:
+		// findByOrganizationId(#1, with guardThrow), create(#3), log(#4), findByOrganizationId(#5)
+		expect(serviceNode.dependencies).toHaveLength(4);
+		expect(serviceNode.dependencies[0].className).toBe("PagesRepository");
+		expect(serviceNode.dependencies[0].methodName).toBe("findByOrganizationId");
+		expect(serviceNode.dependencies[0].guardThrow).not.toBeNull();
+		expect(serviceNode.dependencies[0].guardThrow!.className).toBe(
+			"ConflictException"
+		);
+		expect(serviceNode.dependencies[1].className).toBe("PagesRepository");
+		expect(serviceNode.dependencies[1].methodName).toBe("create");
+		expect(serviceNode.dependencies[2].className).toBe("LoggerService");
+		expect(serviceNode.dependencies[2].methodName).toBe("log");
+		expect(serviceNode.dependencies[3].className).toBe("PagesRepository");
+		expect(serviceNode.dependencies[3].methodName).toBe("findByOrganizationId");
+	});
+
+	it("detects throw in catch block", () => {
+		const { project, paths } = createProject({
+			"safe.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('safe')
+				export class SafeController {
+					constructor(private readonly safeService: SafeService) {}
+
+					@Get()
+					getData() {
+						return this.safeService.fetch();
+					}
+				}
+			`,
+			"safe.service.ts": `
+				import { Injectable, InternalServerErrorException } from '@nestjs/common';
+				@Injectable()
+				export class SafeService {
+					constructor(private readonly repo: SafeRepository) {}
+
+					fetch() {
+						try {
+							return this.repo.load();
+						} catch (e) {
+							throw new InternalServerErrorException('Failed');
+						}
+					}
+				}
+			`,
+			"safe.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class SafeRepository {
+					load() { return {}; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+
+		const throwNode = serviceNode.dependencies.find((d) => d.type === "throw");
+		expect(throwNode).toBeDefined();
+		expect(throwNode!.className).toBe("InternalServerErrorException");
+		expect(throwNode!.conditional).toBe(true);
+		expect(throwNode!.branchKind).toBe("catch");
+	});
+
+	it("repeated method nodes share the same children", () => {
+		const { project, paths } = createProject({
+			"items.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('items')
+				export class ItemsController {
+					constructor(private readonly itemsService: ItemsService) {}
+
+					@Get()
+					getItems() {
+						return this.itemsService.getItems();
+					}
+				}
+			`,
+			"items.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class ItemsService {
+					constructor(private readonly repo: ItemsRepository) {}
+
+					getItems() {
+						const first = this.repo.findById('1');
+						const second = this.repo.findById('2');
+						return [first, second];
+					}
+				}
+			`,
+			"items.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class ItemsRepository {
+					constructor(private readonly db: DatabaseService) {}
+
+					findById(id: string) {
+						return this.db.query(id);
+					}
+				}
+			`,
+			"database.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DatabaseService {
+					query(id: string) { return {}; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+
+		// Both findById calls should appear as separate nodes
+		const findByIdNodes = serviceNode.dependencies.filter(
+			(d) => d.className === "ItemsRepository" && d.methodName === "findById"
+		);
+		expect(findByIdNodes).toHaveLength(2);
+
+		// Both should have the same non-empty children
+		expect(findByIdNodes[0].dependencies.length).toBeGreaterThan(0);
+		expect(findByIdNodes[1].dependencies.length).toBeGreaterThan(0);
+		expect(findByIdNodes[0].dependencies).toEqual(
+			findByIdNodes[1].dependencies
+		);
+	});
+
+	it("extracts assigned variable name from dependency calls", () => {
+		const { project, paths } = createProject({
+			"task.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('tasks')
+				export class TaskController {
+					constructor(private readonly taskService: TaskService) {}
+
+					@Post()
+					process() {
+						const result = await this.taskService.process();
+						return result;
+					}
+				}
+			`,
+			"task.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class TaskService {
+					constructor(private readonly taskRepo: TaskRepository) {}
+
+					process() {
+						const existing = await this.taskRepo.findById('id');
+						this.taskRepo.save(existing);
+						const items = this.taskRepo.findAll();
+						return items;
+					}
+				}
+			`,
+			"task.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class TaskRepository {
+					findById(id: string) { return null; }
+					save(item: any) { return item; }
+					findAll() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		expect(graph.endpoints).toHaveLength(1);
+
+		const ep = graph.endpoints[0];
+		// Top-level: const result = await this.taskService.process()
+		const processNode = ep.dependencies[0];
+		expect(processNode.className).toBe("TaskService");
+		expect(processNode.methodName).toBe("process");
+		expect(processNode.assignedTo).toBe("result");
+
+		// Sub-deps of TaskService.process()
+		const repoDeps = processNode.dependencies.filter(
+			(d) => d.className === "TaskRepository"
+		);
+		const findByIdNode = repoDeps.find((d) => d.methodName === "findById");
+		const saveNode = repoDeps.find((d) => d.methodName === "save");
+		const findAllNode = repoDeps.find((d) => d.methodName === "findAll");
+
+		expect(findByIdNode).toBeDefined();
+		expect(findByIdNode!.assignedTo).toBe("existing");
+
+		expect(saveNode).toBeDefined();
+		expect(saveNode!.assignedTo).toBeNull();
+
+		expect(findAllNode).toBeDefined();
+		expect(findAllNode!.assignedTo).toBe("items");
+	});
+
+	it("merges null-guard throw into dependency call", () => {
+		const { project, paths } = createProject({
+			"page.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('pages')
+				export class PageController {
+					constructor(private readonly pageService: PageService) {}
+
+					@Get(':id')
+					getPage(id: string) {
+						return this.pageService.getById(id);
+					}
+				}
+			`,
+			"page.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class PageService {
+					constructor(private readonly repo: PageRepository) {}
+
+					getById(id: string) {
+						const existing = await this.repo.findById(id);
+						if (!existing) throw new NotFoundException('Not found');
+						return existing;
+					}
+				}
+			`,
+			"page.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class PageRepository {
+					findById(id: string) { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+		const findByIdNode = serviceNode.dependencies.find(
+			(d) => d.methodName === "findById"
+		);
+		expect(findByIdNode).toBeDefined();
+		expect(findByIdNode!.guardThrow).not.toBeNull();
+		expect(findByIdNode!.guardThrow!.className).toBe("NotFoundException");
+		expect(findByIdNode!.guardThrow!.message).toBe("Not found");
+		expect(findByIdNode!.guardThrow!.conditionText).toBe("!existing");
+
+		// No separate throw node should exist
+		const throwNodes = serviceNode.dependencies.filter(
+			(d) => d.type === "throw"
+		);
+		expect(throwNodes).toHaveLength(0);
+	});
+
+	it("merges conflict-guard throw (truthiness check)", () => {
+		const { project, paths } = createProject({
+			"dup.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('dup')
+				export class DupController {
+					constructor(private readonly dupService: DupService) {}
+
+					@Post()
+					create(email: string) {
+						return this.dupService.createByEmail(email);
+					}
+				}
+			`,
+			"dup.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DupService {
+					constructor(private readonly repo: DupRepository) {}
+
+					createByEmail(email: string) {
+						const dup = await this.repo.findByEmail(email);
+						if (dup) throw new ConflictException('Already exists');
+					}
+				}
+			`,
+			"dup.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DupRepository {
+					findByEmail(email: string) { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+		const findNode = serviceNode.dependencies.find(
+			(d) => d.methodName === "findByEmail"
+		);
+		expect(findNode).toBeDefined();
+		expect(findNode!.guardThrow).not.toBeNull();
+		expect(findNode!.guardThrow!.conditionText).toBe("dup");
+		expect(findNode!.guardThrow!.className).toBe("ConflictException");
+	});
+
+	it("does not merge throw with unrelated condition", () => {
+		const { project, paths } = createProject({
+			"unrel.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('unrel')
+				export class UnrelController {
+					constructor(private readonly svc: UnrelService) {}
+
+					@Get()
+					get() {
+						return this.svc.doWork();
+					}
+				}
+			`,
+			"unrel.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UnrelService {
+					constructor(private readonly repo: UnrelRepository) {}
+
+					doWork() {
+						const a = await this.repo.find();
+						if (someOtherVar) throw new Error('unrelated');
+						return a;
+					}
+				}
+			`,
+			"unrel.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UnrelRepository {
+					find() { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+		const findNode = serviceNode.dependencies.find(
+			(d) => d.methodName === "find"
+		);
+		expect(findNode).toBeDefined();
+		expect(findNode!.guardThrow).toBeNull();
+
+		// Throw remains as separate node
+		const throwNodes = serviceNode.dependencies.filter(
+			(d) => d.type === "throw"
+		);
+		expect(throwNodes).toHaveLength(1);
+	});
+
+	it("does not merge unconditional throw", () => {
+		const { project, paths } = createProject({
+			"uncond.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('uncond')
+				export class UncondController {
+					constructor(private readonly svc: UncondService) {}
+
+					@Get()
+					get() {
+						return this.svc.doWork();
+					}
+				}
+			`,
+			"uncond.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UncondService {
+					constructor(private readonly repo: UncondRepository) {}
+
+					doWork() {
+						this.repo.find();
+						throw new Error('always');
+					}
+				}
+			`,
+			"uncond.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UncondRepository {
+					find() { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+		const findNode = serviceNode.dependencies.find(
+			(d) => d.methodName === "find"
+		);
+		expect(findNode).toBeDefined();
+		expect(findNode!.guardThrow).toBeNull();
+
+		// Unconditional throw stays separate
+		const throwNodes = serviceNode.dependencies.filter(
+			(d) => d.type === "throw"
+		);
+		expect(throwNodes).toHaveLength(1);
+		expect(throwNodes[0].throwMessage).toBe("always");
+	});
+
+	it("merges guard throw in child service method", () => {
+		const { project, paths } = createProject({
+			"nested.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('nested')
+				export class NestedController {
+					constructor(private readonly svc: NestedService) {}
+
+					@Get(':id')
+					getItem(id: string) {
+						return this.svc.getItem(id);
+					}
+				}
+			`,
+			"nested.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class NestedService {
+					constructor(private readonly repo: NestedRepository) {}
+
+					getItem(id: string) {
+						const item = await this.repo.findById(id);
+						if (!item) throw new NotFoundException('Item not found');
+						return item;
+					}
+				}
+			`,
+			"nested.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class NestedRepository {
+					findById(id: string) { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+		expect(serviceNode.className).toBe("NestedService");
+
+		// Check that the nested repo call has the guard throw merged
+		const repoNode = serviceNode.dependencies.find(
+			(d) => d.className === "NestedRepository"
+		);
+		expect(repoNode).toBeDefined();
+		expect(repoNode!.guardThrow).not.toBeNull();
+		expect(repoNode!.guardThrow!.className).toBe("NotFoundException");
+		expect(repoNode!.guardThrow!.message).toBe("Item not found");
+
+		// No standalone throw node
+		const throwNodes = serviceNode.dependencies.filter(
+			(d) => d.type === "throw"
+		);
+		expect(throwNodes).toHaveLength(0);
+	});
+
+	it("handles multiple sequential fetch-guard pairs", () => {
+		const { project, paths } = createProject({
+			"multi.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('multi')
+				export class MultiController {
+					constructor(private readonly svc: MultiService) {}
+
+					@Get()
+					get(userId: string, orgId: string) {
+						return this.svc.getData(userId, orgId);
+					}
+				}
+			`,
+			"multi.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class MultiService {
+					constructor(
+						private readonly userRepo: UserRepository,
+						private readonly orgRepo: OrgRepository,
+					) {}
+
+					getData(userId: string, orgId: string) {
+						const user = await this.userRepo.findById(userId);
+						if (!user) throw new NotFoundException('User not found');
+						const org = await this.orgRepo.findById(orgId);
+						if (!org) throw new NotFoundException('Org not found');
+						return { user, org };
+					}
+				}
+			`,
+			"user.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UserRepository {
+					findById(id: string) { return null; }
+				}
+			`,
+			"org.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class OrgRepository {
+					findById(id: string) { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+
+		const userRepoNode = serviceNode.dependencies.find(
+			(d) => d.className === "UserRepository"
+		);
+		const orgRepoNode = serviceNode.dependencies.find(
+			(d) => d.className === "OrgRepository"
+		);
+
+		expect(userRepoNode).toBeDefined();
+		expect(userRepoNode!.guardThrow).not.toBeNull();
+		expect(userRepoNode!.guardThrow!.className).toBe("NotFoundException");
+		expect(userRepoNode!.guardThrow!.message).toBe("User not found");
+
+		expect(orgRepoNode).toBeDefined();
+		expect(orgRepoNode!.guardThrow).not.toBeNull();
+		expect(orgRepoNode!.guardThrow!.className).toBe("NotFoundException");
+		expect(orgRepoNode!.guardThrow!.message).toBe("Org not found");
+
+		// No standalone throw nodes
+		const throwNodes = serviceNode.dependencies.filter(
+			(d) => d.type === "throw"
+		);
+		expect(throwNodes).toHaveLength(0);
+	});
+
+	it("extracts null message when no arguments", () => {
+		const { project, paths } = createProject({
+			"noarg.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('noarg')
+				export class NoargController {
+					constructor(private readonly svc: NoargService) {}
+
+					@Get()
+					get() {
+						return this.svc.doWork();
+					}
+				}
+			`,
+			"noarg.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class NoargService {
+					constructor(private readonly repo: NoargRepository) {}
+
+					doWork() {
+						const result = await this.repo.find();
+						if (!result) throw new NotFoundException();
+						return result;
+					}
+				}
+			`,
+			"noarg.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class NoargRepository {
+					find() { return null; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints[0];
+		const serviceNode = ep.dependencies[0];
+		const findNode = serviceNode.dependencies.find(
+			(d) => d.methodName === "find"
+		);
+		expect(findNode).toBeDefined();
+		expect(findNode!.guardThrow).not.toBeNull();
+		expect(findNode!.guardThrow!.className).toBe("NotFoundException");
+		expect(findNode!.guardThrow!.message).toBeNull();
+	});
+
+	it("extracts leading comment above dependency call sites", () => {
+		const { project, paths } = createProject({
+			"pool.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('pools')
+				export class PoolController {
+					constructor(private readonly poolService: PoolService) {}
+
+					@Get(':id')
+					getPool() {
+						return this.poolService.findPool();
+					}
+				}
+			`,
+			"pool.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class PoolService {
+					constructor(private readonly poolRepo: PoolRepository) {}
+
+					findPool() {
+						// Verify pool belongs to organization
+						const pool = this.poolRepo.findById('id');
+						// Fetch pool members
+						const members = this.poolRepo.findMembers('id');
+						this.poolRepo.noComment();
+						return { pool, members };
+					}
+				}
+			`,
+			"pool.repository.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class PoolRepository {
+					findById(id: string) { return null; }
+					findMembers(id: string) { return []; }
+					noComment() {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find(
+			(e) => e.httpMethod === "GET" && e.routePath === "/pools/:id"
+		);
+		expect(endpoint).toBeDefined();
+
+		const serviceDeps = endpoint!.dependencies[0].dependencies;
+		const findById = serviceDeps.find((d) => d.methodName === "findById");
+		const findMembers = serviceDeps.find((d) => d.methodName === "findMembers");
+		const noComment = serviceDeps.find((d) => d.methodName === "noComment");
+
+		expect(findById).toBeDefined();
+		expect(findById!.comment).toBe("Verify pool belongs to organization");
+
+		expect(findMembers).toBeDefined();
+		expect(findMembers!.comment).toBe("Fetch pool members");
+
+		expect(noComment).toBeDefined();
+		expect(noComment!.comment).toBeNull();
+	});
+
+	it("extracts swagger metadata from @ApiOperation, @ApiParam, @ApiQuery, @ApiResponse, @ApiBody", () => {
+		const { project, paths } = createProject({
+			"users.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('users')
+				export class UsersController {
+					constructor(private readonly svc: UsersService) {}
+
+					@Post(':id/profile')
+					@ApiOperation({ summary: 'Update user profile', description: 'Updates the profile of a user' })
+					@ApiParam({ name: 'id', type: 'string', description: 'User ID' })
+					@ApiQuery({ name: 'notify', type: 'boolean', description: 'Send notification', required: false })
+					@ApiBody({ type: 'UpdateProfileDto', description: 'Profile data' })
+					@ApiResponse({ status: 200, type: 'UserDto', description: 'Updated user' })
+					@ApiResponse({ status: 404, description: 'User not found' })
+					updateProfile() {
+						return this.svc.update();
+					}
+				}
+			`,
+			"users.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class UsersService {
+					update() { return {}; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find(
+			(e) => e.httpMethod === "POST" && e.routePath === "/users/:id/profile"
+		);
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.swagger).not.toBeNull();
+
+		const sw = endpoint!.swagger!;
+		expect(sw.summary).toBe("Update user profile");
+		expect(sw.description).toBe("Updates the profile of a user");
+
+		expect(sw.params).toHaveLength(1);
+		expect(sw.params[0].name).toBe("id");
+		expect(sw.params[0].type).toBe("string");
+		expect(sw.params[0].description).toBe("User ID");
+		expect(sw.params[0].required).toBe(true);
+
+		expect(sw.queryParams).toHaveLength(1);
+		expect(sw.queryParams[0].name).toBe("notify");
+		expect(sw.queryParams[0].type).toBe("boolean");
+		expect(sw.queryParams[0].required).toBe(false);
+
+		expect(sw.body).not.toBeNull();
+		expect(sw.body!.type).toBe("UpdateProfileDto");
+		expect(sw.body!.description).toBe("Profile data");
+
+		expect(sw.responses).toHaveLength(2);
+		expect(sw.responses[0].status).toBe(200);
+		expect(sw.responses[0].type).toBe("UserDto");
+		expect(sw.responses[0].description).toBe("Updated user");
+		expect(sw.responses[1].status).toBe(404);
+		expect(sw.responses[1].description).toBe("User not found");
+	});
+
+	it("returns null swagger when no swagger decorators present", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					@Get()
+					getRoot() { return 'ok'; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.swagger).toBeNull();
+	});
+
+	it("extracts returnType from TS method signature, unwrapping Promise and Observable", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get, Post, Put } from '@nestjs/common';
+				@Controller('items')
+				export class ItemsController {
+					@Get()
+					findAll(): Promise<ItemDto[]> { return []; }
+
+					@Post()
+					create(): Observable<ItemDto> { return null; }
+
+					@Put()
+					update(): ItemDto { return null; }
+
+					@Get('void')
+					noReturn(): void {}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const findAll = graph.endpoints.find((e) => e.handlerMethod === "findAll");
+		expect(findAll).toBeDefined();
+		expect(findAll!.returnType).toBe("ItemDto[]");
+
+		const create = graph.endpoints.find((e) => e.handlerMethod === "create");
+		expect(create).toBeDefined();
+		expect(create!.returnType).toBe("ItemDto");
+
+		const update = graph.endpoints.find((e) => e.handlerMethod === "update");
+		expect(update).toBeDefined();
+		expect(update!.returnType).toBe("ItemDto");
+
+		const noReturn = graph.endpoints.find(
+			(e) => e.handlerMethod === "noReturn"
+		);
+		expect(noReturn).toBeDefined();
+		expect(noReturn!.returnType).toBeNull();
+	});
+
+	it("handles array type syntax in @ApiResponse ([ClassName] → ClassName[])", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('users')
+				export class UsersController {
+					@Get()
+					@ApiResponse({ status: 200, type: '[UserDto]', description: 'List of users' })
+					findAll() { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.swagger).not.toBeNull();
+		expect(endpoint!.swagger!.responses).toHaveLength(1);
+		expect(endpoint!.swagger!.responses[0].type).toBe("UserDto[]");
+	});
+
+	it("captures multiple @ApiResponse decorators (stackable)", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('orders')
+				export class OrdersController {
+					@Post()
+					@ApiResponse({ status: 201, type: 'OrderDto', description: 'Created' })
+					@ApiResponse({ status: 400, description: 'Validation error' })
+					@ApiResponse({ status: 409, type: 'ConflictDto', description: 'Duplicate order' })
+					create() { return {}; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.swagger).not.toBeNull();
+		expect(endpoint!.swagger!.responses).toHaveLength(3);
+
+		expect(endpoint!.swagger!.responses[0].status).toBe(201);
+		expect(endpoint!.swagger!.responses[0].type).toBe("OrderDto");
+		expect(endpoint!.swagger!.responses[1].status).toBe(400);
+		expect(endpoint!.swagger!.responses[1].type).toBeNull();
+		expect(endpoint!.swagger!.responses[2].status).toBe(409);
+		expect(endpoint!.swagger!.responses[2].type).toBe("ConflictDto");
+	});
+
+	it("infers swagger.body from @Body() parameter decorator when no @ApiBody()", () => {
+		const { project, paths } = createProject({
+			"pages.controller.ts": `
+				import { Controller, Post, Body } from '@nestjs/common';
+				import { ApiOperation } from '@nestjs/swagger';
+				@Controller('pages')
+				export class PagesController {
+					@Post()
+					@ApiOperation({ summary: 'Create page' })
+					create(@Body() dto: CreatePageDto) {
+						return dto;
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.swagger).not.toBeNull();
+		expect(endpoint!.swagger!.body).not.toBeNull();
+		expect(endpoint!.swagger!.body!.type).toBe("CreatePageDto");
+		expect(endpoint!.swagger!.body!.description).toBeNull();
+	});
+
+	it("does not infer body from @Body() when @ApiBody() is present", () => {
+		const { project, paths } = createProject({
+			"pages.controller.ts": `
+				import { Controller, Post, Body } from '@nestjs/common';
+				import { ApiBody } from '@nestjs/swagger';
+				@Controller('pages')
+				export class PagesController {
+					@Post()
+					@ApiBody({ description: 'The page payload', type: 'CreatePageDto' })
+					create(@Body() dto: CreatePageDto) {
+						return dto;
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.swagger).not.toBeNull();
+		expect(endpoint!.swagger!.body).not.toBeNull();
+		expect(endpoint!.swagger!.body!.type).toBe("CreatePageDto");
+		expect(endpoint!.swagger!.body!.description).toBe("The page payload");
+	});
+
+	it("infers swagger.body from @Body() even without other swagger decorators", () => {
+		const { project, paths } = createProject({
+			"pages.controller.ts": `
+				import { Controller, Post, Body } from '@nestjs/common';
+				@Controller('pages')
+				export class PagesController {
+					@Post()
+					create(@Body() dto: CreatePageDto) {
+						return dto;
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+		expect(endpoint!.swagger).not.toBeNull();
+		expect(endpoint!.swagger!.body).not.toBeNull();
+		expect(endpoint!.swagger!.body!.type).toBe("CreatePageDto");
+	});
+
+	// ─── Method I/O (parameters + return type) tests ─────────────────
+
+	it("extracts typed parameters and return type on service dep nodes", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					create() {
+						return this.svc.create('org1', { name: 'test' });
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					create(organizationId: string, dto: CreateDto): ResultDto {
+						return {} as ResultDto;
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		const dep = endpoint!.dependencies[0];
+		expect(dep.className).toBe("AppService");
+		expect(dep.methodName).toBe("create");
+		expect(dep.parameters).toEqual([
+			{ name: "organizationId", type: "string" },
+			{ name: "dto", type: "CreateDto" },
+		]);
+		expect(dep.returnType).toBe("ResultDto");
+	});
+
+	it("unwraps Promise and Observable from dep node return types", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					find() {
+						return this.svc.findAll();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					findAll(): Promise<ItemDto[]> {
+						return Promise.resolve([]);
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		const dep = endpoint!.dependencies[0];
+		expect(dep.returnType).toBe("ItemDto[]");
+	});
+
+	it("sets returnType to null for void/any/unknown and type-less params get null type", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					doWork() {
+						return this.svc.process('x');
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					process(data): void {
+						// no return
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		const dep = endpoint!.dependencies[0];
+		expect(dep.returnType).toBeNull();
+		expect(dep.parameters).toEqual([{ name: "data", type: null }]);
+	});
+
+	it("sets parameters: [] and returnType: null on fallback dep nodes", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					getRoot() {
+						return this.svc.hello();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					constructor(private readonly repo: DataRepo) {}
+					hello(): string {
+						return 'hi';
+					}
+				}
+			`,
+			"data.repo.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DataRepo {
+					findAll(): string[] { return []; }
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		// hello() doesn't call this.repo.*, so DataRepo won't appear as a dep
+		// The service node itself should have parameters/returnType
+		const dep = endpoint!.dependencies[0];
+		expect(dep.className).toBe("AppService");
+		expect(dep.parameters).toEqual([]);
+		expect(dep.returnType).toBe("string");
+	});
+
+	it("sets parameters: [] and returnType: null on throw nodes", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Get()
+					getRoot() {
+						return this.svc.doWork();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					doWork() {
+						throw new NotFoundException('not found');
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(endpoint).toBeDefined();
+
+		const svcDep = endpoint!.dependencies[0];
+		const throwNode = svcDep.dependencies.find((d) => d.type === "throw");
+		expect(throwNode).toBeDefined();
+		expect(throwNode!.parameters).toEqual([]);
+		expect(throwNode!.returnType).toBeNull();
+	});
+
+	it("extracts parameters and return type on same-class helper calls", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+
+					@Post()
+					create() {
+						return this.svc.create();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					create(): ResultDto {
+						return this.buildResult('test');
+					}
+
+					private buildResult(name: string): ResultDto {
+						return { name } as ResultDto;
+					}
+				}
+			`,
+		});
+
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+
+		const endpoint = graph.endpoints.find((e) => e.httpMethod === "POST");
+		expect(endpoint).toBeDefined();
+
+		const svcDep = endpoint!.dependencies[0];
+		expect(svcDep.className).toBe("AppService");
+		expect(svcDep.returnType).toBe("ResultDto");
+
+		// Same-class helper call
+		const helper = svcDep.dependencies.find(
+			(d) => d.methodName === "buildResult"
+		);
+		expect(helper).toBeDefined();
+		expect(helper!.parameters).toEqual([{ name: "name", type: "string" }]);
+		expect(helper!.returnType).toBe("ResultDto");
+	});
+
+	it("creates step node from inline method call", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+					@Get()
+					handle() {
+						const pool = this.svc.findPool();
+						const member = pool.members.find((m) => m.active);
+						return member;
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					findPool() { return { members: [] }; }
+				}
+			`,
+		});
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(ep).toBeDefined();
+
+		// Should have dep call + step node
+		const stepNode = ep!.dependencies.find((d) => d.type === "step");
+		expect(stepNode).toBeDefined();
+		expect(stepNode!.className).toBe("local");
+		expect(stepNode!.stepStatements.length).toBeGreaterThan(0);
+		expect(stepNode!.stepStatements[0].assignedTo).toBe("member");
+		expect(stepNode!.dependencies).toEqual([]);
+	});
+
+	it("groups consecutive inline statements into a single step node", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+					@Get()
+					handle() {
+						const pool = this.svc.findPool();
+						const member = pool.members.find((m) => m.active);
+						const today = new Date();
+						return this.svc.save(member, today);
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					findPool() { return { members: [] }; }
+					save(m: any, d: any) { return m; }
+				}
+			`,
+		});
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(ep).toBeDefined();
+
+		const stepNodes = ep!.dependencies.filter((d) => d.type === "step");
+		expect(stepNodes).toHaveLength(1);
+		expect(stepNodes[0].stepStatements).toHaveLength(2);
+	});
+
+	it("places step node order between surrounding dep calls", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+					@Get()
+					handle() {
+						const pool = this.svc.findPool();
+						const member = pool.members.find((m) => m.active);
+						return this.svc.save(member);
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					findPool() { return { members: [] }; }
+					save(m: any) { return m; }
+				}
+			`,
+		});
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(ep).toBeDefined();
+
+		const deps = ep!.dependencies;
+		const findPool = deps.find((d) => d.methodName === "findPool");
+		const step = deps.find((d) => d.type === "step");
+		const save = deps.find((d) => d.methodName === "save");
+		expect(findPool).toBeDefined();
+		expect(step).toBeDefined();
+		expect(save).toBeDefined();
+		expect(step!.order).toBeGreaterThan(findPool!.order);
+		expect(step!.order).toBeLessThan(save!.order);
+	});
+
+	it("does not create step node for dep calls", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+					@Get()
+					handle() {
+						return this.svc.getData();
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					getData() { return 'data'; }
+				}
+			`,
+		});
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(ep).toBeDefined();
+
+		const stepNodes = ep!.dependencies.filter((d) => d.type === "step");
+		expect(stepNodes).toHaveLength(0);
+	});
+
+	it("does not create step node for trivial assignments without calls", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+					@Get()
+					handle() {
+						const user = this.svc.getUser();
+						const name = user.name;
+						return name;
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					getUser() { return { name: 'test' }; }
+				}
+			`,
+		});
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(ep).toBeDefined();
+
+		const stepNodes = ep!.dependencies.filter((d) => d.type === "step");
+		expect(stepNodes).toHaveLength(0);
+	});
+
+	it("step nodes are leaf nodes with empty dependencies", () => {
+		const { project, paths } = createProject({
+			"app.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller()
+				export class AppController {
+					constructor(private readonly svc: AppService) {}
+					@Get()
+					handle() {
+						const data = this.svc.getData();
+						const items = data.list.map((i) => i.value);
+						return items;
+					}
+				}
+			`,
+			"app.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AppService {
+					getData() { return { list: [] }; }
+				}
+			`,
+		});
+		const providers = resolveProviders(project, paths);
+		const graph = buildEndpointGraph(project, paths, providers);
+		const ep = graph.endpoints.find((e) => e.httpMethod === "GET");
+		expect(ep).toBeDefined();
+
+		const step = ep!.dependencies.find((d) => d.type === "step");
+		expect(step).toBeDefined();
+		expect(step!.dependencies).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary
- Enrich endpoint dependency graph with branch conditions, iteration context, guard-throw patterns, swagger metadata, and inline step/throw nodes
- Fix critical LSP crash on startup (`prepareScan` → `prepareAnalysis`)
- Fix VSCode scan command spinner hanging on error (add try-catch-finally)
- Align LSP debounce default to 2000ms to match VSCode setting
- Auto-respawn LSP worker after crash with 3s delay

## Test plan
- [x] 72 endpoint-graph unit tests pass (including new branch, iteration, and swagger cases)
- [x] All 643 tests pass across the monorepo
- [x] `pnpm typecheck` passes in both `nestjs-doctor-lsp` and `nestjs-doctor-vscode`
- [x] `pnpm build` succeeds in all packages