### PR TITLE
fix(lsp): Fix lsp empty publish (#111)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["website", "nestjs-doctor-vscode", "nestjs-doctor-lsp"]
+  "ignore": ["website", "nestjs-doctor-vscode"]
 }

--- a/.changeset/fix-lsp-empty-publish.md
+++ b/.changeset/fix-lsp-empty-publish.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor-lsp": patch
+---
+
+Fix empty npm publish: `nestjs-doctor-lsp@0.1.0` and `0.1.1` shipped without compiled code (only `package.json` and `LICENSE`) because the LSP build was never run before `changeset publish`. The LSP package now declares a `prepack` hook so `pnpm pack` always builds first, the root `build` script also covers the LSP, and the package rejoins the normal Changesets release flow. Resolves #111.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@10.2.0",
   "scripts": {
     "dev": "pnpm --filter nestjs-doctor run dev",
-    "build": "pnpm --filter nestjs-doctor run build",
+    "build": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run build",
     "test": "pnpm --filter nestjs-doctor run test",
     "check": "ultracite check",
     "fix": "ultracite fix",

--- a/packages/nestjs-doctor-lsp/package.json
+++ b/packages/nestjs-doctor-lsp/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- Root `build` now builds `nestjs-doctor-lsp` so `dist/` exists before `changeset publish` runs
- LSP gains a `prepack` hook (delegating to `pnpm run build`) as a defense-in-depth build trigger
- LSP rejoins the normal Changesets release flow (removed from `.changeset/config.json` `ignore`) — `ignore` is for non-npm workspaces; the LSP is published to npm and should follow the same disciplined release flow as the CLI
- New `pack-smoke.yml` workflow runs on every PR; an equivalent gate runs in `release.yml` immediately before `changesets/action` as a final pre-publish safety net

Resolves #111. v0.1.0 and v0.1.1 will be `npm deprecate`d post-merge as a manual step.

## Test plan
- [x] `pnpm --filter nestjs-doctor-lsp pack` shows `dist/server.cjs` in tarball (was missing on `main` — verified empty, ~1.2 KB)
- [x] `pnpm --filter nestjs-doctor-lsp pack` works with `dist/` pre-deleted (proves prepack safety net triggers tsdown)
- [x] `pnpm changeset status` lists `nestjs-doctor-lsp` for patch bump
- [ ] `Pack Smoke` workflow passes on this PR (visible in the PR's Checks tab)
- [ ] After Version Packages PR merges: confirm published `nestjs-doctor-lsp@0.1.2` tarball on npm has non-trivial \`unpackedSize\` (\`npm view nestjs-doctor-lsp@0.1.2 dist.unpackedSize\`, expected >50 KB)
