### PR TITLE
fix(lsp): add shebang to bin so editors can spawn the LSP

### DIFF
--- a/.changeset/fix-lsp-empty-publish.md
+++ b/.changeset/fix-lsp-empty-publish.md
@@ -2,4 +2,4 @@
 "nestjs-doctor-lsp": patch
 ---
 
-Fix empty npm publish: `nestjs-doctor-lsp@0.1.0` and `0.1.1` shipped without compiled code (only `package.json` and `LICENSE`) because the LSP build was never run before `changeset publish`. The LSP package now declares a `prepack` hook so `pnpm pack` always builds first, the root `build` script also covers the LSP, and the package rejoins the normal Changesets release flow. Resolves #111.
+Fix empty npm publish and missing bin shebang. `nestjs-doctor-lsp@0.1.0` and `0.1.1` shipped without compiled code (only `package.json` and `LICENSE`) because the LSP build was never run before `changeset publish`, and the bin entrypoint (`dist/server.cjs`) was missing a `#!/usr/bin/env node` shebang so editors couldn't spawn it via PATH. The LSP package now declares a `prepack` hook so `pnpm pack` always builds first, the root `build` script also covers the LSP, the bundler emits the shebang on the bin entry, and the package rejoins the normal Changesets release flow. Resolves #111.

--- a/packages/nestjs-doctor-lsp/tsdown.config.ts
+++ b/packages/nestjs-doctor-lsp/tsdown.config.ts
@@ -1,12 +1,19 @@
 import { defineConfig } from "tsdown";
 
-export default defineConfig({
-	entry: {
-		server: "src/server.ts",
-		"scan-worker": "src/scan-worker.ts",
+export default defineConfig([
+	{
+		entry: { server: "src/server.ts" },
+		format: ["cjs"],
+		banner: { js: "#!/usr/bin/env node" },
+		clean: true,
+		noExternal: [/^vscode-languageserver/],
+		inlineOnly: false,
 	},
-	format: ["cjs"],
-	clean: true,
-	noExternal: [/^vscode-languageserver/],
-	inlineOnly: false,
-});
+	{
+		entry: { "scan-worker": "src/scan-worker.ts" },
+		format: ["cjs"],
+		clean: false,
+		noExternal: [/^vscode-languageserver/],
+		inlineOnly: false,
+	},
+]);


### PR DESCRIPTION
After #112, `dist/server.cjs` ships without a `#!/usr/bin/env node` shebang. Editors invoke the LSP via PATH (`node_modules/.bin/nestjs-doctor-lsp` is a symlink to the bin), so without a shebang `spawn` returns `ENOEXEC` and the LSP never starts. The CLI's `tsdown.config.ts` already sets `banner: { js: "#!/usr/bin/env node" }` on its bin; the LSP didn't. This adds the same banner to the `server` entry. `scan-worker.cjs` is a Node Worker, not a CLI bin, so it stays as-is.

`.changeset/fix-lsp-empty-publish.md` is updated so 0.1.2 covers both fixes. Needs to land before #113 merges.