### PR TITLE
feat(rule): add ignoreForwardRefCycles option to no-circular-module-deps

### DIFF
--- a/.changeset/issue-110-ignore-forward-ref-cycles.md
+++ b/.changeset/issue-110-ignore-forward-ref-cycles.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Add `ignoreForwardRefCycles` option to `architecture/no-circular-module-deps`. When enabled, cycles whose every consecutive edge uses `forwardRef()` are suppressed. One-sided `forwardRef` still flags. Default behavior unchanged. Closes #110.

--- a/.rules-rationale.md
+++ b/.rules-rationale.md
@@ -464,6 +464,8 @@
 
 **Rationale:** Circular module imports cause one of the modules to be `undefined` during initialization, leading to cryptic runtime errors ("Cannot read properties of undefined"). NestJS provides `forwardRef()` as an escape hatch, but the better solution is to extract shared logic into a separate module that both modules can import.
 
+**Options:** `ignoreForwardRefCycles` (boolean, default `false`) suppresses diagnostics for cycles whose every consecutive edge is wrapped in `forwardRef()` (for a 2-module cycle, this means both directions). Default behavior is unchanged. One-sided `forwardRef()` (which still throws at runtime in NestJS) continues to be flagged. Detection is a textual callee-name match on the bare identifier `forwardRef` — aliased imports (`forwardRef as fr`) and namespace access (`Nest.forwardRef(...)`) are not detected, and the import source is not verified. Issue #110.
+
 **Source:** https://docs.nestjs.com/fundamentals/circular-dependency
 
 **Audit:** ✅ FIXED — Changed description to prescriptive style: "Module import graph must not contain circular dependencies".

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -12,7 +12,6 @@ import type { PathAliasMap } from "./tsconfig-paths.js";
 import { resolvePathAlias } from "./tsconfig-paths.js";
 import type { ProviderInfo } from "./type-resolver.js";
 
-const FORWARD_REF_REGEX = /=>\s*(\w+)/;
 const JS_EXT_REGEX = /\.js$/;
 
 export interface ModuleNode {
@@ -20,6 +19,7 @@ export interface ModuleNode {
 	controllers: string[];
 	exports: string[];
 	filePath: string;
+	forwardRefImports: Set<string>;
 	imports: string[];
 	name: string;
 	providers: string[];
@@ -51,6 +51,7 @@ function extractModulesFromFile(
 			filePath,
 			classDeclaration: cls,
 			imports: [],
+			forwardRefImports: new Set<string>(),
 			exports: [],
 			providers: [],
 			controllers: [],
@@ -59,18 +60,32 @@ function extractModulesFromFile(
 		if (args && args.getKind() === SyntaxKind.ObjectLiteralExpression) {
 			const obj = args.asKind(SyntaxKind.ObjectLiteralExpression);
 			if (obj) {
-				node.imports = extractArrayPropertyNames(obj, "imports", pathAliases);
-				node.exports = extractArrayPropertyNames(obj, "exports", pathAliases);
+				const importTags = extractArrayPropertyNames(
+					obj,
+					"imports",
+					pathAliases
+				);
+				node.imports = importTags.map((t) => t.name);
+				for (const t of importTags) {
+					if (t.viaForwardRef) {
+						node.forwardRefImports.add(t.name);
+					}
+				}
+				node.exports = extractArrayPropertyNames(
+					obj,
+					"exports",
+					pathAliases
+				).map((t) => t.name);
 				node.providers = extractArrayPropertyNames(
 					obj,
 					"providers",
 					pathAliases
-				);
+				).map((t) => t.name);
 				node.controllers = extractArrayPropertyNames(
 					obj,
 					"controllers",
 					pathAliases
-				);
+				).map((t) => t.name);
 			}
 		}
 
@@ -138,11 +153,20 @@ const DYNAMIC_MODULE_METHODS = new Set([
 	"registerAsync",
 ]);
 
+interface ExtractedName {
+	name: string;
+	viaForwardRef: boolean;
+}
+
+function plain(name: string): ExtractedName {
+	return { name, viaForwardRef: false };
+}
+
 function extractArrayPropertyNames(
 	obj: ObjectLiteralExpression,
 	propertyName: string,
 	pathAliases: PathAliasMap
-): string[] {
+): ExtractedName[] {
 	const prop = obj.getProperty(propertyName);
 	if (!prop) {
 		return [];
@@ -171,7 +195,7 @@ function extractNamesFromExpression(
 	sourceFile: SourceFile,
 	depth: number,
 	pathAliases: PathAliasMap
-): string[] {
+): ExtractedName[] {
 	if (depth > MAX_RESOLVE_DEPTH) {
 		return [];
 	}
@@ -180,7 +204,7 @@ function extractNamesFromExpression(
 
 	if (kind === SyntaxKind.ArrayLiteralExpression) {
 		const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression);
-		const names: string[] = [];
+		const names: ExtractedName[] = [];
 		for (const el of arr.getElements()) {
 			names.push(
 				...extractNamesFromElement(el, sourceFile, depth, pathAliases)
@@ -215,15 +239,7 @@ function extractNamesFromElement(
 	sourceFile: SourceFile,
 	depth: number,
 	pathAliases: PathAliasMap
-): string[] {
-	const text = el.getText();
-
-	// Handle forwardRef(() => SomeModule)
-	if (text.startsWith("forwardRef")) {
-		const match = text.match(FORWARD_REF_REGEX);
-		return match ? [match[1]] : [text];
-	}
-
+): ExtractedName[] {
 	const kind = el.getKind();
 
 	// Handle spread elements: ...getImports() or ...someArray
@@ -237,7 +253,7 @@ function extractNamesFromElement(
 		);
 	}
 
-	// Handle call expressions: ConfigModule.forRoot(), someFunction()
+	// Handle call expressions: forwardRef(() => X), ConfigModule.forRoot(), someFunction()
 	if (kind === SyntaxKind.CallExpression) {
 		return extractNamesFromCallExpression(
 			el.asKindOrThrow(SyntaxKind.CallExpression),
@@ -250,15 +266,15 @@ function extractNamesFromElement(
 	// Handle property access without call: SomeModule.SomeProperty
 	if (kind === SyntaxKind.PropertyAccessExpression) {
 		const access = el.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
-		return [access.getExpression().getText()];
+		return [plain(access.getExpression().getText())];
 	}
 
 	// Plain identifier
 	if (kind === SyntaxKind.Identifier) {
-		return [text];
+		return [plain(el.getText())];
 	}
 
-	return [text];
+	return [plain(el.getText())];
 }
 
 function extractNamesFromCallExpression(
@@ -266,8 +282,58 @@ function extractNamesFromCallExpression(
 	sourceFile: SourceFile,
 	depth: number,
 	pathAliases: PathAliasMap
-): string[] {
+): ExtractedName[] {
 	const expr = call.getExpression();
+
+	// Handle forwardRef(() => SomeModule) — AST-level callee match
+	if (
+		expr.getKind() === SyntaxKind.Identifier &&
+		expr.getText() === "forwardRef"
+	) {
+		const args = call.getArguments();
+		if (args.length === 0) {
+			return [];
+		}
+		const arg = args[0];
+		if (arg.getKind() === SyntaxKind.ArrowFunction) {
+			const arrow = arg.asKindOrThrow(SyntaxKind.ArrowFunction);
+			const body = arrow.getBody();
+			if (body.getKind() === SyntaxKind.Identifier) {
+				return [{ name: body.getText(), viaForwardRef: true }];
+			}
+			// Block body: () => { return SomeModule }
+			if (body.getKind() === SyntaxKind.Block) {
+				const block = body.asKindOrThrow(SyntaxKind.Block);
+				const names: ExtractedName[] = [];
+				for (const ret of block.getDescendantsOfKind(
+					SyntaxKind.ReturnStatement
+				)) {
+					const retExpr = ret.getExpression();
+					if (!retExpr) {
+						continue;
+					}
+					for (const e of extractNamesFromExpression(
+						retExpr,
+						sourceFile,
+						depth,
+						pathAliases
+					)) {
+						names.push({ ...e, viaForwardRef: true });
+					}
+				}
+				return names;
+			}
+			// Other expression bodies (rare): recurse and tag.
+			const inner = extractNamesFromExpression(
+				body,
+				sourceFile,
+				depth,
+				pathAliases
+			);
+			return inner.map((e) => ({ ...e, viaForwardRef: true }));
+		}
+		return [plain(arg.getText())];
+	}
 
 	// Handle .concat() chains: [A, B].concat([C, D])
 	if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
@@ -281,7 +347,7 @@ function extractNamesFromCallExpression(
 				depth,
 				pathAliases
 			);
-			const argNames: string[] = [];
+			const argNames: ExtractedName[] = [];
 			for (const arg of call.getArguments()) {
 				argNames.push(
 					...extractNamesFromExpression(arg, sourceFile, depth, pathAliases)
@@ -292,11 +358,11 @@ function extractNamesFromCallExpression(
 
 		// Handle dynamic module methods: ConfigModule.forRoot(), TypeOrmModule.forFeature()
 		if (DYNAMIC_MODULE_METHODS.has(methodName)) {
-			return [access.getExpression().getText()];
+			return [plain(access.getExpression().getText())];
 		}
 
 		// Unknown property access call — try to use the leftmost identifier
-		return [access.getExpression().getText()];
+		return [plain(access.getExpression().getText())];
 	}
 
 	// Handle plain function calls: getImports()
@@ -415,7 +481,7 @@ function resolveIdentifier(
 	sourceFile: SourceFile,
 	depth: number,
 	pathAliases: PathAliasMap
-): string[] {
+): ExtractedName[] {
 	if (depth > MAX_RESOLVE_DEPTH) {
 		return [];
 	}
@@ -460,7 +526,7 @@ function resolveArrowFunctionBody(
 	sourceFile: SourceFile,
 	depth: number,
 	pathAliases: PathAliasMap
-): string[] | undefined {
+): ExtractedName[] | undefined {
 	for (const stmt of sourceFile.getStatements()) {
 		if (stmt.getKind() !== SyntaxKind.VariableStatement) {
 			continue;
@@ -483,7 +549,7 @@ function resolveArrowFunctionBody(
 			}
 
 			// Block body: () => { return [...] }
-			const names: string[] = [];
+			const names: ExtractedName[] = [];
 			for (const returnStmt of body.getDescendantsOfKind(
 				SyntaxKind.ReturnStatement
 			)) {
@@ -510,7 +576,7 @@ function resolveFunctionCall(
 	sourceFile: SourceFile,
 	depth: number,
 	pathAliases: PathAliasMap
-): string[] {
+): ExtractedName[] {
 	if (depth > MAX_RESOLVE_DEPTH) {
 		return [];
 	}
@@ -525,7 +591,7 @@ function resolveFunctionCall(
 			continue;
 		}
 
-		const names: string[] = [];
+		const names: ExtractedName[] = [];
 		for (const returnStmt of funcDecl.getDescendantsOfKind(
 			SyntaxKind.ReturnStatement
 		)) {
@@ -644,12 +710,19 @@ export function mergeModuleGraphs(
 	for (const [projectName, graph] of graphs) {
 		for (const [name, node] of graph.modules) {
 			const prefixed = `${projectName}/${name}`;
+			const prefixedForwardRef = new Set<string>();
+			for (const ref of node.forwardRefImports) {
+				prefixedForwardRef.add(
+					graph.modules.has(ref) ? `${projectName}/${ref}` : ref
+				);
+			}
 			const mergedNode: ModuleNode = {
 				...node,
 				name: prefixed,
 				imports: node.imports.map((imp) =>
 					graph.modules.has(imp) ? `${projectName}/${imp}` : imp
 				),
+				forwardRefImports: prefixedForwardRef,
 				exports: node.exports.map((exp) =>
 					graph.modules.has(exp) ? `${projectName}/${exp}` : exp
 				),

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-circular-module-deps.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-circular-module-deps.ts
@@ -1,12 +1,43 @@
 import {
 	findCircularDeps,
+	type ModuleGraph,
 	type ProviderEdge,
 	traceProviderEdges,
 } from "../../../graph/module-graph.js";
 import type { ProjectRule, ProjectRuleContext } from "../../types.js";
 
 const GENERIC_HELP =
-	"Break the cycle by extracting shared logic into a separate module or using forwardRef().";
+	"Break the cycle by extracting the coupling providers into a shared module. forwardRef() only defers resolution at runtime — it does not address the architectural coupling. Use forwardRef() as a last resort and enable rules.architecture/no-circular-module-deps.options.ignoreForwardRefCycles to opt out of these reports.";
+
+function readIgnoreForwardRefOption(context: ProjectRuleContext): boolean {
+	const override =
+		context.config.rules?.["architecture/no-circular-module-deps"];
+	if (typeof override !== "object" || override === null) {
+		return false;
+	}
+	return override.options?.ignoreForwardRefCycles === true;
+}
+
+function isFullyMitigatedByForwardRef(
+	cycle: string[],
+	moduleGraph: ModuleGraph
+): boolean {
+	const nodes =
+		cycle.length > 1 && cycle[0] === cycle.at(-1) ? cycle.slice(0, -1) : cycle;
+	for (let i = 0; i < nodes.length; i++) {
+		const fromName = nodes[i];
+		const toName = nodes[(i + 1) % nodes.length];
+		const fromModule = moduleGraph.modules.get(fromName);
+		const toModule = moduleGraph.modules.get(toName);
+		if (!(fromModule && toModule)) {
+			return false;
+		}
+		if (!fromModule.forwardRefImports.has(toName)) {
+			return false;
+		}
+	}
+	return true;
+}
 
 function buildConcreteHelp(
 	cycle: string[],
@@ -111,8 +142,16 @@ export const noCircularModuleDeps: ProjectRule = {
 
 	check(context) {
 		const cycles = findCircularDeps(context.moduleGraph);
+		const ignoreForwardRefCycles = readIgnoreForwardRefOption(context);
 
 		for (const cycle of cycles) {
+			if (
+				ignoreForwardRefCycles &&
+				isFullyMitigatedByForwardRef(cycle, context.moduleGraph)
+			) {
+				continue;
+			}
+
 			const cycleStr = cycle.join(" -> ");
 			const firstModule = context.moduleGraph.modules.get(cycle[0]);
 			const help = buildConcreteHelp(cycle, context);

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/forward-ref-cycle/nestjs-doctor.config.json
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/forward-ref-cycle/nestjs-doctor.config.json
@@ -1,0 +1,8 @@
+{
+  "include": ["src/**/*.ts"],
+  "rules": {
+    "architecture/no-circular-module-deps": {
+      "options": { "ignoreForwardRefCycles": true }
+    }
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/forward-ref-cycle/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/forward-ref-cycle/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "forward-ref-cycle",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/common": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/forward-ref-cycle/src/a.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/forward-ref-cycle/src/a.module.ts
@@ -1,0 +1,5 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { BModule } from './b.module';
+
+@Module({ imports: [forwardRef(() => BModule)] })
+export class AModule {}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/forward-ref-cycle/src/b.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/forward-ref-cycle/src/b.module.ts
@@ -1,0 +1,5 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { AModule } from './a.module';
+
+@Module({ imports: [forwardRef(() => AModule)] })
+export class BModule {}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -193,6 +193,45 @@ describe("scanner integration", () => {
 		expect(result.project.moduleCount).toBe(3);
 	});
 
+	describe("forward-ref cycle (issue #110)", () => {
+		const fixtureRoot = resolve(FIXTURES, "false-positives/forward-ref-cycle");
+
+		it("flags mutual forwardRef cycle by default (option not set)", async () => {
+			const targetPath = resolve(fixtureRoot, "src");
+			const scanConfig = await resolveScanConfig(targetPath);
+			const context = await buildAnalysisContext(targetPath, scanConfig);
+			const rawOutput = diagnose(context);
+			const { result } = buildResult(
+				context,
+				rawOutput,
+				scanConfig.customRuleWarnings
+			);
+
+			const cycleDiags = result.diagnostics.filter(
+				(d) => d.rule === "architecture/no-circular-module-deps"
+			);
+			expect(cycleDiags.length).toBeGreaterThan(0);
+		});
+
+		it("does not flag mutual forwardRef cycle when ignoreForwardRefCycles is enabled in config", async () => {
+			const targetPath = resolve(fixtureRoot, "src");
+			const configPath = resolve(fixtureRoot, "nestjs-doctor.config.json");
+			const scanConfig = await resolveScanConfig(targetPath, configPath);
+			const context = await buildAnalysisContext(targetPath, scanConfig);
+			const rawOutput = diagnose(context);
+			const { result } = buildResult(
+				context,
+				rawOutput,
+				scanConfig.customRuleWarnings
+			);
+
+			const cycleDiags = result.diagnostics.filter(
+				(d) => d.rule === "architecture/no-circular-module-deps"
+			);
+			expect(cycleDiags).toHaveLength(0);
+		});
+	});
+
 	it("scans monorepo with multiple sub-projects", async () => {
 		const targetPath = resolve(FIXTURES, "monorepo-app");
 		const scanConfig = await resolveScanConfig(targetPath);

--- a/packages/nestjs-doctor/tests/unit/module-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/module-graph.test.ts
@@ -215,6 +215,67 @@ describe("module-graph", () => {
 		expect(aModule?.imports).toContain("BModule");
 	});
 
+	it("populates forwardRefImports for forwardRef-wrapped module imports", () => {
+		const { project, paths } = createProject({
+			"a.module.ts": `
+        import { forwardRef, Module } from '@nestjs/common';
+        @Module({ imports: [forwardRef(() => BModule)] })
+        export class AModule {}
+      `,
+			"b.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ imports: [AModule] })
+        export class BModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const a = graph.modules.get("AModule");
+		const b = graph.modules.get("BModule");
+		expect(a?.imports).toContain("BModule");
+		expect(a?.forwardRefImports).toEqual(new Set(["BModule"]));
+		expect(b?.imports).toContain("AModule");
+		expect(b?.forwardRefImports).toEqual(new Set());
+	});
+
+	it("preserves forwardRefImports across mergeModuleGraphs with project prefixing", () => {
+		const { project, paths } = createProject({
+			"a.module.ts": `
+        import { forwardRef, Module } from '@nestjs/common';
+        @Module({ imports: [forwardRef(() => BModule)] })
+        export class AModule {}
+      `,
+			"b.module.ts": `
+        import { forwardRef, Module } from '@nestjs/common';
+        @Module({ imports: [forwardRef(() => AModule)] })
+        export class BModule {}
+      `,
+		});
+		const inner = buildModuleGraph(project, paths);
+		const merged = mergeModuleGraphs(new Map([["api", inner]]));
+		const a = merged.modules.get("api/AModule");
+		expect(a?.forwardRefImports).toEqual(new Set(["api/BModule"]));
+	});
+
+	it("does not treat look-alike identifiers (forwardRefHelper) as forwardRef calls", () => {
+		const { project, paths } = createProject({
+			"helper.ts": `
+        export function forwardRefHelper(m: unknown) { return m; }
+        export class BModule {}
+      `,
+			"a.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { forwardRefHelper, BModule } from './helper';
+        @Module({ imports: [forwardRefHelper(BModule)] })
+        export class AModule {}
+      `,
+		});
+
+		const graph = buildModuleGraph(project, paths);
+		const a = graph.modules.get("AModule");
+		expect(a?.forwardRefImports).toEqual(new Set());
+	});
+
 	// Dynamic module methods like .forRoot() should resolve to the module class name
 	it("resolves Module.forRoot() dynamic module imports", () => {
 		const { project, paths } = createProject({

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -218,4 +218,104 @@ describe("no-circular-module-deps", () => {
 		expect(help).toContain("AController");
 		expect(help).toContain("BService");
 	});
+
+	it("flags mutual forwardRef cycle by default (option disabled)", () => {
+		const diags = runProjectRule(noCircularModuleDeps, {
+			"a.module.ts": `
+        import { forwardRef, Module } from '@nestjs/common';
+        @Module({ imports: [forwardRef(() => BModule)] })
+        export class AModule {}
+      `,
+			"b.module.ts": `
+        import { forwardRef, Module } from '@nestjs/common';
+        @Module({ imports: [forwardRef(() => AModule)] })
+        export class BModule {}
+      `,
+		});
+		expect(diags.length).toBeGreaterThan(0);
+	});
+
+	it("suppresses mutual forwardRef cycle when ignoreForwardRefCycles is enabled", () => {
+		const diags = runProjectRule(
+			noCircularModuleDeps,
+			{
+				"a.module.ts": `
+          import { forwardRef, Module } from '@nestjs/common';
+          @Module({ imports: [forwardRef(() => BModule)] })
+          export class AModule {}
+        `,
+				"b.module.ts": `
+          import { forwardRef, Module } from '@nestjs/common';
+          @Module({ imports: [forwardRef(() => AModule)] })
+          export class BModule {}
+        `,
+			},
+			{
+				rules: {
+					"architecture/no-circular-module-deps": {
+						options: { ignoreForwardRefCycles: true },
+					},
+				},
+			}
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags one-sided forwardRef cycle when ignoreForwardRefCycles is enabled", () => {
+		const diags = runProjectRule(
+			noCircularModuleDeps,
+			{
+				"a.module.ts": `
+          import { forwardRef, Module } from '@nestjs/common';
+          @Module({ imports: [forwardRef(() => BModule)] })
+          export class AModule {}
+        `,
+				"b.module.ts": `
+          import { Module } from '@nestjs/common';
+          @Module({ imports: [AModule] })
+          export class BModule {}
+        `,
+			},
+			{
+				rules: {
+					"architecture/no-circular-module-deps": {
+						options: { ignoreForwardRefCycles: true },
+					},
+				},
+			}
+		);
+		expect(diags.length).toBeGreaterThan(0);
+		expect(diags[0].message).toContain("Circular");
+	});
+
+	it("still flags 3-module cycle if any edge is not forwardRef-wrapped (option enabled)", () => {
+		const diags = runProjectRule(
+			noCircularModuleDeps,
+			{
+				"a.module.ts": `
+          import { forwardRef, Module } from '@nestjs/common';
+          @Module({ imports: [forwardRef(() => BModule)] })
+          export class AModule {}
+        `,
+				"b.module.ts": `
+          import { forwardRef, Module } from '@nestjs/common';
+          @Module({ imports: [forwardRef(() => CModule)] })
+          export class BModule {}
+        `,
+				"c.module.ts": `
+          import { Module } from '@nestjs/common';
+          @Module({ imports: [AModule] })
+          export class CModule {}
+        `,
+			},
+			{
+				rules: {
+					"architecture/no-circular-module-deps": {
+						options: { ignoreForwardRefCycles: true },
+					},
+				},
+			}
+		);
+		expect(diags.length).toBeGreaterThan(0);
+	});
 });

--- a/packages/website/src/app/docs/configuration/page.mdx
+++ b/packages/website/src/app/docs/configuration/page.mdx
@@ -89,6 +89,18 @@ Rule objects can also include rule-specific options. Example for `no-manual-inst
 }
 ```
 
+Some rules accept options under a nested `options` key. Example for `no-circular-module-deps`, which can opt out of cycles whose every consecutive edge is wrapped in `forwardRef()`:
+
+```json
+{
+  "rules": {
+    "architecture/no-circular-module-deps": {
+      "options": { "ignoreForwardRefCycles": true }
+    }
+  }
+}
+```
+
 ## Default Excludes
 
 These patterns are always excluded (your `exclude` config is additive):

--- a/packages/website/src/app/docs/rules/architecture/page.mdx
+++ b/packages/website/src/app/docs/rules/architecture/page.mdx
@@ -153,7 +153,7 @@ export class OrderModule {}
 
 ### Smart suggestions
 
-Instead of a generic "use forwardRef" message, this rule traces provider-level dependencies to identify *why* each module edge exists. It then suggests which specific providers to extract into a shared module to break the cycle at the weakest edge.
+The rule traces provider-level dependencies to identify *why* each module edge exists, then suggests which specific providers to extract into a shared module to break the cycle at the weakest edge. `forwardRef()` is treated as a last-resort escape hatch — it only defers resolution at runtime, it does not address the architectural coupling.
 
 **Example output:**
 
@@ -164,6 +164,26 @@ Consider extracting AuthService into a shared module — it would break the weak
 ```
 
 The rule uses `traceProviderEdges` to walk each module's providers and controllers, checking which constructor parameters resolve to providers from the target module. The edge with the fewest provider dependencies is flagged as the best candidate for extraction.
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `ignoreForwardRefCycles` | `boolean` | `false` | Suppress diagnostics for cycles where every edge in the cycle direction is wrapped in `forwardRef()`. |
+
+When enabled, a 2-module cycle in which both modules use `forwardRef(() => Other)` is suppressed. For longer cycles (A → B → C → A), every consecutive edge must be wrapped. Cycles with **any** plain edge — including one-sided `forwardRef()`, which still throws at runtime in NestJS — continue to be flagged. Default behavior is unchanged: cycles are reported as `error` regardless of `forwardRef()`.
+
+```json
+{
+  "rules": {
+    "architecture/no-circular-module-deps": {
+      "options": { "ignoreForwardRefCycles": true }
+    }
+  }
+}
+```
+
+> Detection looks for a call expression whose callee is the bare identifier `forwardRef`. The check is textual — it does not verify that the symbol resolves to `@nestjs/common`'s `forwardRef`, so a locally-defined `forwardRef` would also match. Aliased imports (`import { forwardRef as fr }`) and namespace access (`Nest.forwardRef(...)`) are not recognized — use the bare imported name to benefit from the opt-out.
 
 > Dynamic module patterns like `ConfigModule.forRoot()`, `forwardRef()`, spread syntax, and helper function calls are fully resolved during graph construction. You do not need to restructure your code to use plain identifiers for accurate cycle detection. See [Module Graph — Import Resolution](/docs/pipeline/module-graph) for the full list of supported patterns.
 


### PR DESCRIPTION
## Summary

- Adds opt-in `ignoreForwardRefCycles` option to `architecture/no-circular-module-deps`.
- When set to `true`, cycles whose every consecutive edge uses `forwardRef()` are suppressed.
- One-sided `forwardRef` still flags (NestJS still throws at runtime in that case).
- Default behavior is unchanged.
- Rewrites the rule's help text — it no longer recommends `forwardRef()` while also flagging code that uses it.

Example:

```json
{
  "rules": {
    "architecture/no-circular-module-deps": {
      "options": { "ignoreForwardRefCycles": true }
    }
  }
}
```

## Test plan

- [x] `pnpm --filter nestjs-doctor test` — 652 passing.
- [x] 9 new tests covering: forwardRef tagging, AST-level callee check rejecting look-alikes, monorepo prefix preservation, default-flagged behavior, option-suppressed mutual cycle, one-sided still flagged, 3-module cycle with one plain edge still flagged.
- [x] Integration fixture matching the reporter's exact repro (`tests/fixtures/false-positives/forward-ref-cycle`).

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)