### PR TITLE
fix(typeorm-extractor): inherit columns from abstract base classes

### DIFF
--- a/.changeset/smart-mangos-rescue.md
+++ b/.changeset/smart-mangos-rescue.md
@@ -1,0 +1,9 @@
+---
+"nestjs-doctor": patch
+---
+
+Fix false positives in `require-primary-key` and `require-timestamps` for TypeORM entities that extend an abstract base class.
+
+Previously, the TypeORM extractor only inspected properties declared directly on the entity class. If a project used a shared abstract base class (e.g. `BaseEntity`) to centralise common columns like `@PrimaryGeneratedColumn`, `@CreateDateColumn`, and `@UpdateDateColumn`, every concrete entity extending that base would be flagged — even though those columns exist in the database table.
+
+The extractor now walks the full class hierarchy and collects inherited columns and relations from all ancestor classes. A child-class property always takes precedence over a same-named property on a parent, so overrides are handled correctly.

--- a/packages/nestjs-doctor/src/engine/schema/typeorm-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/typeorm-extractor.ts
@@ -212,6 +212,53 @@ function extractRelation(
 	};
 }
 
+/**
+ * Collect columns and relations from a single class into the shared accumulators.
+ * `seenProps` prevents a child-class property from being overridden by the same
+ * name on a parent — whichever class is passed first wins.
+ */
+function collectPropsFromClass(
+	cls: ClassDeclaration,
+	entityName: string,
+	seenProps: Set<string>,
+	columns: SchemaColumn[],
+	relations: SchemaRelation[],
+	indexes: { columns: string[]; isUnique: boolean }[]
+): void {
+	for (const prop of cls.getProperties()) {
+		const propName = prop.getName();
+		if (seenProps.has(propName)) {
+			continue;
+		}
+		seenProps.add(propName);
+
+		const decorators = prop.getDecorators();
+		const hasIndex = decorators.some((d: Decorator) => d.getName() === "Index");
+		if (hasIndex) {
+			indexes.push({ columns: [propName], isUnique: false });
+		}
+
+		for (const dec of decorators) {
+			const decName = dec.getName();
+			if (COLUMN_DECORATORS.has(decName)) {
+				const col = extractColumn(propName, dec);
+				if (hasIndex) {
+					col.hasIndex = true;
+				}
+				columns.push(col);
+				break;
+			}
+			if (decName in RELATION_DECORATORS) {
+				const relation = extractRelation(entityName, propName, dec);
+				if (relation) {
+					relations.push(relation);
+				}
+				break;
+			}
+		}
+	}
+}
+
 function extractEntityFromClass(cls: ClassDeclaration): SchemaEntity | null {
 	if (!hasDecorator(cls, "Entity")) {
 		return null;
@@ -258,40 +305,20 @@ function extractEntityFromClass(cls: ClassDeclaration): SchemaEntity | null {
 		}
 	}
 
-	// Track which properties have @Index decorators
-	const indexedProps = new Set<string>();
-
-	for (const prop of cls.getProperties()) {
-		const propName = prop.getName();
-		const decorators = prop.getDecorators();
-
-		// Check for property-level @Index
-		const hasIndex = decorators.some((d) => d.getName() === "Index");
-		if (hasIndex) {
-			indexedProps.add(propName);
-			indexes.push({ columns: [propName], isUnique: false });
-		}
-
-		for (const dec of decorators) {
-			const decName = dec.getName();
-
-			if (COLUMN_DECORATORS.has(decName)) {
-				const col = extractColumn(propName, dec);
-				if (hasIndex) {
-					col.hasIndex = true;
-				}
-				columns.push(col);
-				break;
-			}
-
-			if (decName in RELATION_DECORATORS) {
-				const relation = extractRelation(name, propName, dec);
-				if (relation) {
-					relations.push(relation);
-				}
-				break;
-			}
-		}
+	// Walk the class hierarchy — entity first, then each ancestor — so that
+	// child properties take precedence over same-named properties on a base class.
+	const seenProps = new Set<string>();
+	let current: ClassDeclaration | undefined = cls;
+	while (current) {
+		collectPropsFromClass(
+			current,
+			name,
+			seenProps,
+			columns,
+			relations,
+			indexes
+		);
+		current = current.getBaseClass();
 	}
 
 	// Mark columns that appear in class-level indexes

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "typeorm-app",
+	"version": "1.0.0",
+	"dependencies": {
+		"@nestjs/core": "^10.0.0",
+		"@nestjs/common": "^10.0.0",
+		"@nestjs/platform-express": "^10.0.0",
+		"@nestjs/typeorm": "^10.0.0",
+		"typeorm": "^0.3.0",
+		"pg": "^8.0.0"
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/app.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { OrdersModule } from "./orders/orders.module";
+import { UsersModule } from "./users/users.module";
+
+@Module({
+	imports: [
+		TypeOrmModule.forRoot({
+			type: "postgres",
+			database: "app",
+			autoLoadEntities: true,
+			synchronize: false,
+		}),
+		UsersModule,
+		OrdersModule,
+	],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/base/base.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/base/base.entity.ts
@@ -1,0 +1,21 @@
+import {
+	CreateDateColumn,
+	PrimaryGeneratedColumn,
+	UpdateDateColumn,
+} from "typeorm";
+
+// Shared abstract base — the canonical TypeORM "BaseEntity" pattern. It is an
+// UNDECORATED abstract class (no @Entity), so it is never emitted as its own
+// schema node; its columns are inherited by every concrete entity that extends
+// it. Concrete children must NOT be flagged by require-primary-key /
+// require-timestamps even though they declare no id/timestamps of their own.
+export abstract class BaseEntity {
+	@PrimaryGeneratedColumn("uuid")
+	id!: string;
+
+	@CreateDateColumn()
+	createdAt!: Date;
+
+	@UpdateDateColumn()
+	updatedAt!: Date;
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/entities/problematic.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/entities/problematic.entity.ts
@@ -1,0 +1,33 @@
+import { Column, Entity, ManyToOne, PrimaryColumn } from "typeorm";
+import { User } from "../users/user.entity";
+
+// BAD: no primary key column at all       → fires schema/require-primary-key
+// BAD: no timestamp columns               → fires schema/require-timestamps
+// Does NOT extend BaseEntity, so the inheritance walk finds nothing to rescue
+// it — proving the fix preserves genuine true-positives.
+@Entity({ name: "audit_logs" })
+export class AuditLog {
+	@Column()
+	action!: string;
+
+	@Column()
+	entityType!: string;
+
+	@Column()
+	entityId!: number;
+}
+
+// Has its own primary key (so require-primary-key stays quiet), but:
+// BAD: no timestamp columns                        → fires schema/require-timestamps
+// BAD: @ManyToOne without onDelete                 → fires schema/require-cascade-rule
+@Entity({ name: "legacy_events" })
+export class LegacyEvent {
+	@PrimaryColumn()
+	id!: number;
+
+	@Column()
+	name!: string;
+
+	@ManyToOne(() => User)
+	user!: User;
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/orders/order.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/orders/order.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, ManyToOne } from "typeorm";
+import { BaseEntity } from "../base/base.entity";
+import { User } from "../users/user.entity";
+
+// CLEAN: inherits id + timestamps from BaseEntity (multi-property inheritance),
+// and its own @ManyToOne sets onDelete, so require-cascade-rule stays quiet too.
+@Entity({ name: "orders" })
+export class Order extends BaseEntity {
+	@Column("decimal")
+	total!: number;
+
+	@Column({ default: "PENDING" })
+	status!: string;
+
+	@ManyToOne(() => User, { onDelete: "CASCADE" })
+	user!: User;
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/orders/orders.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/orders/orders.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from "@nestjs/common";
+import { OrdersService } from "./orders.service";
+
+@Controller("orders")
+export class OrdersController {
+	constructor(private readonly ordersService: OrdersService) {}
+
+	@Get()
+	findAll() {
+		return this.ordersService.findAll();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/orders/orders.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/orders/orders.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Order } from "./order.entity";
+import { OrdersController } from "./orders.controller";
+import { OrdersService } from "./orders.service";
+
+@Module({
+	imports: [TypeOrmModule.forFeature([Order])],
+	controllers: [OrdersController],
+	providers: [OrdersService],
+	exports: [OrdersService],
+})
+export class OrdersModule {}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/orders/orders.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/orders/orders.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Order } from "./order.entity";
+
+@Injectable()
+export class OrdersService {
+	constructor(
+		@InjectRepository(Order)
+		private readonly ordersRepository: Repository<Order>
+	) {}
+
+	findAll() {
+		return this.ordersRepository.find();
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/users/user.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/users/user.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, OneToMany } from "typeorm";
+import { Order } from "../orders/order.entity";
+import { BaseEntity } from "../base/base.entity";
+
+// CLEAN: inherits id + createdAt + updatedAt from BaseEntity, so neither
+// require-primary-key nor require-timestamps should fire here.
+@Entity({ name: "users" })
+export class User extends BaseEntity {
+	@Column({ unique: true })
+	email!: string;
+
+	@Column({ nullable: true })
+	displayName?: string;
+
+	@OneToMany(() => Order, (order) => order.user)
+	orders!: Order[];
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/users/users.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/users/users.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param } from "@nestjs/common";
+import { UsersService } from "./users.service";
+
+@Controller("users")
+export class UsersController {
+	constructor(private readonly usersService: UsersService) {}
+
+	@Get()
+	findAll() {
+		return this.usersService.findAll();
+	}
+
+	@Get(":id")
+	findOne(@Param("id") id: string) {
+		return this.usersService.findOne(id);
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/users/users.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/users/users.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { User } from "./user.entity";
+import { UsersController } from "./users.controller";
+import { UsersService } from "./users.service";
+
+@Module({
+	imports: [TypeOrmModule.forFeature([User])],
+	controllers: [UsersController],
+	providers: [UsersService],
+	exports: [UsersService],
+})
+export class UsersModule {}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/users/users.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-app/src/users/users.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { User } from "./user.entity";
+
+@Injectable()
+export class UsersService {
+	constructor(
+		@InjectRepository(User)
+		private readonly usersRepository: Repository<User>
+	) {}
+
+	findAll() {
+		return this.usersRepository.find();
+	}
+
+	findOne(id: string) {
+		return this.usersRepository.findOne({ where: { id } });
+	}
+}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -1053,4 +1053,79 @@ describe("scanner integration", () => {
 			expect(appEdges?.has("OrdersModule")).toBe(true);
 		});
 	});
+
+	describe("typeorm-app fixture (abstract base inheritance)", () => {
+		const targetPath = resolve(FIXTURES, "typeorm-app");
+		let context: Awaited<ReturnType<typeof buildAnalysisContext>>;
+		let result: Awaited<ReturnType<typeof buildResult>>["result"];
+
+		beforeAll(async () => {
+			const scanConfig = await resolveScanConfig(targetPath);
+			context = await buildAnalysisContext(targetPath, scanConfig);
+			const rawOutput = diagnose(context);
+			({ result } = buildResult(
+				context,
+				rawOutput,
+				scanConfig.customRuleWarnings
+			));
+		});
+
+		it("detects TypeORM and inherits columns from the abstract base", () => {
+			expect(result.project.orm).toBe("typeorm");
+			expect(result.schema).toBeDefined();
+
+			// BaseEntity is an undecorated abstract class → not its own node.
+			const entityNames = result.schema!.entities.map((e) => e.name).sort();
+			expect(entityNames).toEqual(["AuditLog", "LegacyEvent", "Order", "User"]);
+
+			// User inherits id + createdAt + updatedAt from BaseEntity, on top of
+			// its own columns — the behavior this PR adds.
+			const user = result.schema!.entities.find((e) => e.name === "User")!;
+			const userCols = user.columns.map((c) => c.name).sort();
+			expect(userCols).toEqual([
+				"createdAt",
+				"displayName",
+				"email",
+				"id",
+				"updatedAt",
+			]);
+			expect(user.columns.find((c) => c.name === "id")?.isPrimary).toBe(true);
+		});
+
+		it("does NOT flag entities that inherit PK/timestamps from the base", () => {
+			const schemaDiags = result.diagnostics.filter(
+				(d) => d.category === "schema"
+			);
+			const flagged = new Set(schemaDiags.map((d) => d.entity));
+
+			// The regression this PR fixes: without hierarchy walking, User and
+			// Order would each fire require-primary-key + require-timestamps.
+			expect(flagged.has("User")).toBe(false);
+			expect(flagged.has("Order")).toBe(false);
+		});
+
+		it("still flags entities that genuinely lack PK/timestamps", () => {
+			const schemaDiags = result.diagnostics.filter(
+				(d) => d.category === "schema"
+			);
+
+			const pkEntities = schemaDiags
+				.filter((d) => d.rule === "schema/require-primary-key")
+				.map((d) => d.entity)
+				.sort();
+			expect(pkEntities).toEqual(["AuditLog"]);
+
+			const tsEntities = schemaDiags
+				.filter((d) => d.rule === "schema/require-timestamps")
+				.map((d) => d.entity)
+				.sort();
+			expect(tsEntities).toEqual(["AuditLog", "LegacyEvent"]);
+
+			const cascadeEntities = schemaDiags
+				.filter((d) => d.rule === "schema/require-cascade-rule")
+				.map((d) => d.entity)
+				.sort();
+			expect(cascadeEntities).toEqual(["LegacyEvent"]);
+		});
+	});
 });

--- a/packages/nestjs-doctor/tests/unit/schema/typeorm-extractor.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/typeorm-extractor.test.ts
@@ -480,6 +480,95 @@ export class Post {
 		expect(post!.relations[0].toEntity).toBe("User");
 	});
 
+	it("should extract columns inherited from an abstract base class", () => {
+		const { project, paths } = createProject({
+			"base.entity.ts": `
+import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from "typeorm";
+
+export abstract class BaseEntity {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}`,
+			"order.entity.ts": `
+import { Entity, Column } from "typeorm";
+import { BaseEntity } from "./base.entity";
+
+@Entity({ name: "orders" })
+export class OrderEntity extends BaseEntity {
+  @Column()
+  status: string;
+}`,
+		});
+
+		const graph = extractSchema(project, paths, "typeorm", "/test");
+		const order = graph.entities.get("OrderEntity");
+		expect(order).toBeDefined();
+		expect(order!.columns).toHaveLength(4);
+		expect(order!.columns.find((c) => c.name === "id")?.isPrimary).toBe(true);
+		expect(order!.columns.find((c) => c.name === "createdAt")).toBeDefined();
+		expect(order!.columns.find((c) => c.name === "updatedAt")).toBeDefined();
+		expect(order!.columns.find((c) => c.name === "status")).toBeDefined();
+	});
+
+	it("should extract columns through multiple levels of inheritance", () => {
+		const { project, paths } = createProject({
+			"base.entity.ts": `
+import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from "typeorm";
+
+export abstract class BaseEntity {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}`,
+			"basic.entity.ts": `
+import { Entity, Column } from "typeorm";
+import { BaseEntity } from "./base.entity";
+
+@Entity({ name: "basic" })
+export class BasicEntity extends BaseEntity {
+  @Column()
+  tenant: string;
+}`,
+			"order.entity.ts": `
+import { Entity, Column } from "typeorm";
+import { BasicEntity } from "./basic.entity";
+
+@Entity({ name: "orders" })
+export class OrderEntity extends BasicEntity {
+  @Column()
+  status: string;
+}`,
+		});
+
+		const graph = extractSchema(project, paths, "typeorm", "/test");
+
+		const basic = graph.entities.get("BasicEntity");
+		expect(basic).toBeDefined();
+		expect(basic!.columns).toHaveLength(4);
+		expect(basic!.columns.find((c) => c.name === "id")?.isPrimary).toBe(true);
+		expect(basic!.columns.find((c) => c.name === "tenant")).toBeDefined();
+
+		const order = graph.entities.get("OrderEntity");
+		expect(order).toBeDefined();
+		expect(order!.columns).toHaveLength(5);
+		expect(order!.columns.find((c) => c.name === "id")?.isPrimary).toBe(true);
+		expect(order!.columns.find((c) => c.name === "createdAt")).toBeDefined();
+		expect(order!.columns.find((c) => c.name === "updatedAt")).toBeDefined();
+		expect(order!.columns.find((c) => c.name === "tenant")).toBeDefined();
+		expect(order!.columns.find((c) => c.name === "status")).toBeDefined();
+	});
+
 	it("should extract self-referencing relation", () => {
 		const { project, paths } = createProject({
 			"category.entity.ts": `


### PR DESCRIPTION

Hello, i hope you are doing well, while using the tool (which i love) i faced this case :

## Problem

The TypeORM extractor only inspected properties declared directly on the entity class. Projects that centralise common columns (`@PrimaryGeneratedColumn`, `@CreateDateColumn`, `@UpdateDateColumn`) in a shared abstract base class would get false positives from `require-primary-key` and `require-timestamps` on every concrete entity, even though those columns exist in the database table.

## Solution

Walk the full class hierarchy when extracting an entity, collecting inherited columns and relations from all ancestor classes. A child-class property takes precedence over a same-named property on a parent.

## Tests

Added two new tests in `typeorm-extractor.test.ts`:
- Single-level inheritance: entity extends abstract base with primary key and timestamps
- Multi-level inheritance: entity → intermediate `@Entity` class → abstract base

## Incidental cleanup

I removed an unused `indexedProps` Set that was populated in the original property loop but never read — the actual index marking was already handled inline via a local `hasIndex` variable. ( unless that line was supposed to be used in the future )
