### PR TITLE
feat(cli): report only what a change introduced, and in more formats

### DIFF
--- a/.changeset/diff-scoped-scanning.md
+++ b/.changeset/diff-scoped-scanning.md
@@ -1,0 +1,28 @@
+---
+"nestjs-doctor": minor
+---
+
+Add diff-scoped scanning so a scan can report only what a change introduced.
+
+`--scope full|files|lines|changed` narrows what gets **reported**; the whole
+project is still analysed, so cross-file rules (module cycles, unused providers,
+unused exports) stay correct. `--base <ref>` picks the revision to compare
+against, `--staged` scopes to the git index for pre-commit hooks, and
+`--changed-files-from <path>` accepts a pre-computed file list for CI.
+
+`changed` scans the base revision in a temporary git worktree and subtracts the
+findings that were already there, also reporting how many the change resolved.
+Findings are matched on rule, file, message, and source text rather than line
+number, so an unrelated edit above a finding does not make it look new. When the
+base cannot be reached — a shallow CI clone, typically — the scan degrades to
+`files` and warns instead of claiming a delta it never measured.
+
+The score always reflects the whole project, whatever the scope: narrowing a
+report cannot make a codebase look healthier than it is. Results gain an
+optional `scope` field describing what was reported.
+
+Git invocations run with `GIT_DIR`, `GIT_INDEX_FILE`, and the other
+repository-scoping variables cleared. Git exports those to every hook it runs
+and a hook's children inherit them, so `--staged` from a husky `pre-commit`
+would otherwise resolve refs against the hook's repository rather than the
+scanned one.

--- a/.changeset/output-formats-and-blocking.md
+++ b/.changeset/output-formats-and-blocking.md
@@ -1,0 +1,30 @@
+---
+"nestjs-doctor": minor
+---
+
+Add SARIF, GitLab Code Quality, markdown, and GitHub Actions output, plus a
+configurable failure gate.
+
+`--format console|json|sarif|gitlab|markdown|github` selects the output shape,
+`--output <path>` writes it to a file, and `--json-compact` drops the
+indentation from the JSON-based formats. SARIF results carry explicit
+`partialFingerprints`, so a GitHub code-scanning alert survives an edit near the
+finding instead of being closed and reopened. `github` is additive: it prints
+workflow annotations and appends the report to the job summary while keeping the
+readable console output.
+
+`--blocking none|warning|error` sets the severity that fails the run,
+independently of `--min-score`. The defaults reproduce existing behaviour
+exactly — `error` for the console report, `none` for `--json` and `--score`,
+which previously failed only on `--min-score`. Passing `--blocking` explicitly
+makes every output mode behave the same.
+
+`--list-rules` prints the built-in rule catalogue (add `--json` for a
+machine-readable list).
+
+The markdown, SARIF, and GitLab builders are exported from the public API as
+`buildMarkdownReport`, `buildSarifLog`, and `buildCodeQualityReport`, alongside
+the diff-scoping and fingerprint helpers.
+
+Warnings and errors about the run itself now go to stderr, so stdout stays a
+clean machine-readable stream.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,8 +16,9 @@ reproduction you can manage. You can expect an initial response within a week.
 
 ## Scope
 
-nestjs-doctor is a static analysis tool. It reads source files and never
-executes the code it scans.
+nestjs-doctor is a static analysis tool. It reads source files and, in
+`--scope changed` mode, shells out to `git` and checks a base revision out into
+a temporary worktree. It never executes the code it scans.
 
 The one exception is **custom rules**: `customRulesDir` loads `.ts` files from
 your project and runs them in-process. Treat a config that points at a custom

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -90,19 +90,84 @@ Or wire it into `package.json`:
 }
 ```
 
-Exit codes: `1` if the score is below threshold, `2` for bad input.
+Exit codes: `1` if a gate fails, `2` for bad input.
 
 ```
 Usage: nestjs-doctor [directory] [options]
 
-  --verbose       Show file paths and line numbers per diagnostic
-  --score         Output only the numeric score (for CI)
-  --json          JSON output (for tooling)
-  --report        Generate an interactive HTML report (--graph also works)
-  --min-score <n> Minimum passing score (0-100). Exits with code 1 if below threshold
-  --config <p>    Path to config file
-  --init          Set up the /nestjs-doctor skill for AI coding agents
-  -h, --help      Show help
+  --verbose             Show file paths and line numbers per diagnostic
+  --score               Output only the numeric score (for CI)
+  --json                JSON output (for tooling)
+  --format <f>          console (default), json, sarif, gitlab, markdown, github
+  --output <path>       Write the formatted output to a file instead of stdout
+  --json-compact        Emit JSON-based formats without indentation
+  --scope <s>           full (default), files, lines, changed
+  --base <ref>          Git ref to compare against (auto-detected)
+  --staged              Scope to the staged files, for pre-commit hooks
+  --changed-files-from  Path to a newline-separated list of changed files
+  --blocking <level>    Severity that fails the run: none, warning, error
+  --min-score <n>       Minimum passing score (0-100)
+  --report              Generate an interactive HTML report (--graph also works)
+  --config <p>          Path to config file
+  --list-rules          List every built-in rule and exit
+  --init                Set up the /nestjs-doctor skill for AI coding agents
+  -h, --help            Show help
+```
+
+### Scoping to a change
+
+The whole project is always analysed — cross-file rules like
+`no-circular-module-deps` and `no-unused-providers` need it — so `--scope` only
+narrows what gets **reported**.
+
+| Scope | Reports |
+|-------|---------|
+| `full` | Every finding in the project (the default) |
+| `files` | Findings in files the change touched |
+| `lines` | Findings on the lines the change touched |
+| `changed` | Findings the change introduced, measured against the base revision |
+
+```bash
+# What did this branch introduce?
+npx nestjs-doctor . --scope changed --base origin/main
+
+# Pre-commit hook: only what you are about to commit
+npx nestjs-doctor . --staged --blocking error
+```
+
+`changed` scans the base revision in a temporary git worktree and subtracts the
+findings that were already there. Findings are matched on rule, file, message,
+and source text rather than line number, so unrelated edits above a finding
+don't make it look new. If the base can't be reached the scan degrades to
+`files` and warns rather than reporting a delta it never measured.
+
+**The score always reflects the whole project**, whatever the scope — narrowing
+the report can't make a codebase look healthier than it is. `--min-score` gates
+on that project score; `--blocking` gates on the reported findings.
+
+### Blocking
+
+| Level | Fails the run when |
+|-------|--------------------|
+| `none` | Never — advisory only |
+| `warning` | Any error or warning is reported |
+| `error` | Any error is reported |
+
+The default preserves long-standing behaviour: `error` for the console report,
+`none` for `--json` and `--score`, which historically only failed on
+`--min-score`. Pass `--blocking` explicitly to make both paths behave the same.
+
+### Other CI systems
+
+```bash
+# GitLab Code Quality widget
+npx nestjs-doctor . --format gitlab --output gl-code-quality-report.json
+
+# SARIF, for any code-scanning backend
+npx nestjs-doctor . --format sarif --output nestjs-doctor.sarif
+
+# A markdown body to post as a merge request comment
+npx nestjs-doctor . --format markdown --output comment.md
 ```
 
 ---

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -54,6 +54,27 @@ export type {
 	SchemaRelation,
 	SerializedSchemaGraph,
 } from "../common/schema.js";
+export type { ScopeInfo, ScopeMode } from "../common/scope.js";
+export { isScopeMode, SCOPE_MODES } from "../common/scope.js";
+export type { BaselineDelta } from "../engine/baseline.js";
+export { computeBaselineDelta } from "../engine/baseline.js";
+export type { DiagnosticDelta } from "../engine/fingerprint.js";
+export {
+	countIdentities,
+	diagnosticIdentity,
+	diffDiagnostics,
+	fingerprint,
+	toRelativePath,
+} from "../engine/fingerprint.js";
+export type { BaseCheckout, GitRepo, LineRange } from "../engine/git.js";
+export {
+	checkoutBase,
+	findGitRepo,
+	getChangedFiles,
+	getChangedLineRanges,
+	getStagedFiles,
+	resolveBaseRef,
+} from "../engine/git.js";
 export {
 	buildEndpointGraph,
 	traceEndpointCalls,
@@ -90,8 +111,20 @@ export {
 	prepareAnalysis,
 	resolveScanConfig,
 	updateFile,
+	withScopedDiagnostics,
 } from "../engine/scanner.js";
 export { extractSchema } from "../engine/schema/extract.js";
+export type { ResolvedScope, ScopeOptions } from "../engine/scope.js";
+export { applyScope, buildScopeInfo, resolveScope } from "../engine/scope.js";
+export type { CodeQualityIssue } from "../formatters/gitlab-report.js";
+export { buildCodeQualityReport } from "../formatters/gitlab-report.js";
+export type { MarkdownReportOptions } from "../formatters/markdown-report.js";
+export {
+	buildMarkdownReport,
+	MARKDOWN_COMMENT_MARKER,
+} from "../formatters/markdown-report.js";
+export type { SarifLog } from "../formatters/sarif-report.js";
+export { buildSarifLog } from "../formatters/sarif-report.js";
 
 function validatePath(path: string): string {
 	if (!path || path.trim() === "") {

--- a/packages/nestjs-doctor/src/cli/blocking.ts
+++ b/packages/nestjs-doctor/src/cli/blocking.ts
@@ -1,0 +1,43 @@
+import type { DiagnoseSummary } from "../common/result.js";
+
+/** Severity at or above which findings fail the run. */
+export type BlockingLevel = "none" | "warning" | "error";
+
+export const BLOCKING_LEVELS: BlockingLevel[] = ["none", "warning", "error"];
+
+export function isBlockingLevel(value: string): value is BlockingLevel {
+	return (BLOCKING_LEVELS as string[]).includes(value);
+}
+
+export const validateBlockingArg = (raw: string): string | null =>
+	isBlockingLevel(raw)
+		? null
+		: `Invalid --blocking value: "${raw}". Must be one of ${BLOCKING_LEVELS.join(", ")}.`;
+
+/**
+ * Gate level for a run. Defaults per mode: `error` for the console report,
+ * `none` for machine-readable output.
+ */
+export function resolveBlocking(
+	explicit: string | undefined,
+	isMachineReadable: boolean
+): BlockingLevel {
+	if (explicit && isBlockingLevel(explicit)) {
+		return explicit;
+	}
+	return isMachineReadable ? "none" : "error";
+}
+
+/** True when the findings in `summary` should fail the run at `level`. */
+export function shouldBlock(
+	summary: DiagnoseSummary,
+	level: BlockingLevel
+): boolean {
+	if (level === "none") {
+		return false;
+	}
+	if (level === "warning") {
+		return summary.errors + summary.warnings > 0;
+	}
+	return summary.errors > 0;
+}

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -16,6 +16,44 @@ export const flags = {
 		description: "JSON output",
 		default: false,
 	},
+	format: {
+		type: "string",
+		description:
+			"Output format: console (default), json, sarif, gitlab, markdown, github",
+	},
+	output: {
+		type: "string",
+		description: "Write the formatted output to a file instead of stdout",
+	},
+	"json-compact": {
+		type: "boolean",
+		description: "Emit JSON-based formats without indentation",
+		default: false,
+	},
+	scope: {
+		type: "string",
+		description:
+			"What to report: full (default), files (changed files), lines (changed lines), changed (introduced by the change)",
+	},
+	base: {
+		type: "string",
+		description: "Git ref to compare against for --scope (auto-detected)",
+	},
+	staged: {
+		type: "boolean",
+		description: "Scope to the staged files, for pre-commit hooks",
+		default: false,
+	},
+	"changed-files-from": {
+		type: "string",
+		description:
+			"Path to a newline-separated list of changed files to scope to (for CI)",
+	},
+	blocking: {
+		type: "string",
+		description:
+			"Severity that fails the run: none, warning, or error (default: error; none with --json/--score)",
+	},
 	"min-score": {
 		type: "string",
 		description:
@@ -36,6 +74,11 @@ export const flags = {
 		type: "boolean",
 		description:
 			"Set up the nestjs-doctor skill for AI coding agents (Claude Code, Cursor, Codex, etc.)",
+		default: false,
+	},
+	"list-rules": {
+		type: "boolean",
+		description: "List every built-in rule and exit",
 		default: false,
 	},
 } satisfies ArgsDef;

--- a/packages/nestjs-doctor/src/cli/formatters/github-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/github-reporter.ts
@@ -1,0 +1,109 @@
+import { appendFileSync } from "node:fs";
+import type { Diagnostic, Severity } from "../../common/diagnostic.js";
+import { isCodeDiagnostic } from "../../common/diagnostic.js";
+import type { DiagnoseResult } from "../../common/result.js";
+import { toRelativePath } from "../../engine/fingerprint.js";
+import {
+	buildMarkdownReport,
+	type MarkdownReportOptions,
+} from "../../formatters/markdown-report.js";
+
+/** GitHub renders at most 10 per level per step and drops the rest. */
+const MAX_ANNOTATIONS_PER_LEVEL = 10;
+
+type AnnotationLevel = "error" | "warning" | "notice";
+
+const LEVEL_BY_SEVERITY: Record<Severity, AnnotationLevel> = {
+	error: "error",
+	warning: "warning",
+	info: "notice",
+};
+
+const PERCENT_RE = /%/g;
+const CR_RE = /\r/g;
+const LF_RE = /\n/g;
+const COLON_RE = /:/g;
+const COMMA_RE = /,/g;
+
+/** Escapes a workflow-command message body. */
+export function escapeCommandData(value: string): string {
+	return value
+		.replace(PERCENT_RE, "%25")
+		.replace(CR_RE, "%0D")
+		.replace(LF_RE, "%0A");
+}
+
+/** Escapes a workflow-command property value (`:` and `,` are delimiters). */
+export function escapeCommandProperty(value: string): string {
+	return escapeCommandData(value)
+		.replace(COLON_RE, "%3A")
+		.replace(COMMA_RE, "%2C");
+}
+
+function formatAnnotation(diagnostic: Diagnostic, targetPath: string): string {
+	const level = LEVEL_BY_SEVERITY[diagnostic.severity];
+	const properties = [
+		`file=${escapeCommandProperty(toRelativePath(targetPath, diagnostic.filePath))}`,
+		`title=${escapeCommandProperty(`nestjs-doctor(${diagnostic.rule})`)}`,
+	];
+
+	if (isCodeDiagnostic(diagnostic)) {
+		properties.splice(
+			1,
+			0,
+			`line=${diagnostic.line}`,
+			`col=${diagnostic.column}`
+		);
+	}
+
+	const body = escapeCommandData(
+		`${diagnostic.message} ${diagnostic.help}`.trim()
+	);
+	return `::${level} ${properties.join(",")}::${body}`;
+}
+
+/** Workflow-command annotation lines for a result, capped per level. */
+export function buildAnnotations(
+	result: DiagnoseResult,
+	targetPath: string
+): string[] {
+	const emitted: Record<AnnotationLevel, number> = {
+		error: 0,
+		warning: 0,
+		notice: 0,
+	};
+	const lines: string[] = [];
+
+	for (const diagnostic of result.diagnostics) {
+		const level = LEVEL_BY_SEVERITY[diagnostic.severity];
+		if (emitted[level] >= MAX_ANNOTATIONS_PER_LEVEL) {
+			continue;
+		}
+		emitted[level] += 1;
+		lines.push(formatAnnotation(diagnostic, targetPath));
+	}
+
+	return lines;
+}
+
+/** Prints annotations and appends the markdown report to the job summary. */
+export function reportToGitHubActions(
+	result: DiagnoseResult,
+	options: MarkdownReportOptions
+): string {
+	for (const line of buildAnnotations(result, options.targetPath)) {
+		console.log(line);
+	}
+
+	const markdown = buildMarkdownReport(result, options);
+	const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+	if (summaryPath) {
+		try {
+			appendFileSync(summaryPath, `${markdown}\n`, "utf-8");
+		} catch {
+			// A read-only or absent summary file is not worth failing the run over.
+		}
+	}
+
+	return markdown;
+}

--- a/packages/nestjs-doctor/src/cli/formatters/json-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/json-reporter.ts
@@ -1,5 +1,0 @@
-import type { DiagnoseResult } from "../../common/result.js";
-
-export function printJsonReport(result: DiagnoseResult): void {
-	console.log(JSON.stringify(result, null, 2));
-}

--- a/packages/nestjs-doctor/src/cli/formatters/render.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/render.ts
@@ -1,0 +1,87 @@
+import type { DiagnoseResult, MonorepoResult } from "../../common/result.js";
+import { buildCodeQualityReport } from "../../formatters/gitlab-report.js";
+import { buildMarkdownReport } from "../../formatters/markdown-report.js";
+import { buildSarifLog } from "../../formatters/sarif-report.js";
+import { reportToGitHubActions } from "./github-reporter.js";
+
+/** Machine-readable shapes the CLI can emit in place of the console report. */
+export type OutputFormat =
+	| "console"
+	| "json"
+	| "sarif"
+	| "gitlab"
+	| "markdown"
+	| "github";
+
+export const OUTPUT_FORMATS: OutputFormat[] = [
+	"console",
+	"json",
+	"sarif",
+	"gitlab",
+	"markdown",
+	"github",
+];
+
+export function isOutputFormat(value: string): value is OutputFormat {
+	return (OUTPUT_FORMATS as string[]).includes(value);
+}
+
+export const validateFormatArg = (raw: string): string | null =>
+	isOutputFormat(raw)
+		? null
+		: `Invalid --format value: "${raw}". Must be one of ${OUTPUT_FORMATS.join(", ")}.`;
+
+/** Formats that replace the console report. `github` is additive, so not one. */
+export const isMachineReadableFormat = (format: OutputFormat): boolean =>
+	format !== "console" && format !== "github";
+
+interface RenderContext {
+	commitSha?: string;
+	jsonCompact: boolean;
+	monorepo?: MonorepoResult;
+	runUrl?: string;
+	targetPath: string;
+	version: string;
+	warnings: string[];
+}
+
+const stringifyJson = (value: unknown, compact: boolean): string =>
+	compact ? JSON.stringify(value) : JSON.stringify(value, null, 2);
+
+/** Renders a result, returning the payload to write. `null` for `console`. */
+export function renderResult(
+	format: OutputFormat,
+	result: DiagnoseResult,
+	context: RenderContext
+): string | null {
+	const markdownOptions = {
+		commitSha: context.commitSha,
+		monorepo: context.monorepo,
+		runUrl: context.runUrl,
+		scope: result.scope,
+		targetPath: context.targetPath,
+		version: context.version,
+		warnings: context.warnings,
+	};
+
+	switch (format) {
+		case "json":
+			return stringifyJson(result, context.jsonCompact);
+		case "sarif":
+			return stringifyJson(
+				buildSarifLog(result, context.targetPath, context.version),
+				context.jsonCompact
+			);
+		case "gitlab":
+			return stringifyJson(
+				buildCodeQualityReport(result, context.targetPath),
+				context.jsonCompact
+			);
+		case "markdown":
+			return buildMarkdownReport(result, markdownOptions);
+		case "github":
+			return reportToGitHubActions(result, markdownOptions);
+		default:
+			return null;
+	}
+}

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -5,6 +5,7 @@ import {
 	looksLikeMonorepo,
 } from "../engine/project-detector.js";
 import { flags } from "./flags.js";
+import { setCliVersion } from "./output.js";
 import { MonorepoPipeline, SingleProjectPipeline } from "./pipeline.js";
 import { type CliArgs, CliSetup } from "./setup.js";
 
@@ -28,11 +29,15 @@ const main = defineCommand({
 		...flags,
 	},
 	async run({ args }) {
+		setCliVersion(version);
+
 		const ctx = await new CliSetup(args as CliArgs, version)
 			.resolveTargetPath()
+			.handleListRules()
 			.handleInit()
 			.handleReport()
 			.validateMinScore()
+			.validateBlocking()
 			.run();
 
 		if (!ctx) {
@@ -48,6 +53,7 @@ const main = defineCommand({
 				.buildContext()
 				.runRules()
 				.buildResult()
+				.applyScope()
 				.warnCustomRules()
 				.output()
 				.run();
@@ -65,6 +71,7 @@ const main = defineCommand({
 			.buildContext()
 			.runRules()
 			.buildResult()
+			.applyScope()
 			.warnCustomRules()
 			.output()
 			.run();

--- a/packages/nestjs-doctor/src/cli/list-rules.ts
+++ b/packages/nestjs-doctor/src/cli/list-rules.ts
@@ -1,0 +1,77 @@
+import type { Category } from "../common/diagnostic.js";
+import { getRules } from "../engine/rules/index.js";
+import type { RuleMeta } from "../engine/rules/types.js";
+import { highlighter } from "./ui/highlighter.js";
+import { logger } from "./ui/logger.js";
+
+const CATEGORY_ORDER: Category[] = [
+	"security",
+	"correctness",
+	"architecture",
+	"performance",
+	"schema",
+];
+
+const colorizeSeverity = (severity: RuleMeta["severity"]): string => {
+	if (severity === "error") {
+		return highlighter.error(severity);
+	}
+	if (severity === "warning") {
+		return highlighter.warn(severity);
+	}
+	return highlighter.info(severity);
+};
+
+/** Prints the built-in rule catalogue. Custom rules need a resolved config. */
+export function listRules(asJson: boolean): void {
+	const rules = getRules().map((rule) => rule.meta);
+
+	if (asJson) {
+		console.log(
+			JSON.stringify(
+				rules.map(({ id, category, severity, description, help, scope }) => ({
+					id,
+					category,
+					severity,
+					scope: scope ?? "file",
+					description,
+					help,
+				})),
+				null,
+				2
+			)
+		);
+		return;
+	}
+
+	const byCategory = new Map<Category, RuleMeta[]>();
+	for (const meta of rules) {
+		const bucket = byCategory.get(meta.category) ?? [];
+		bucket.push(meta);
+		byCategory.set(meta.category, bucket);
+	}
+
+	const width = Math.max(...rules.map((meta) => meta.id.length));
+
+	logger.break();
+	logger.log(`${rules.length} built-in rules`);
+
+	const categories = [
+		...CATEGORY_ORDER.filter((category) => byCategory.has(category)),
+		...[...byCategory.keys()].filter(
+			(category) => !CATEGORY_ORDER.includes(category)
+		),
+	];
+
+	for (const category of categories) {
+		const metas = byCategory.get(category) ?? [];
+		logger.break();
+		logger.log(highlighter.dim(`${category} (${metas.length})`));
+		for (const meta of metas.sort((a, b) => a.id.localeCompare(b.id))) {
+			logger.log(
+				`  ${meta.id.padEnd(width)}  ${colorizeSeverity(meta.severity).padEnd(8)}  ${highlighter.dim(meta.description)}`
+			);
+		}
+	}
+	logger.break();
+}

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -1,107 +1,132 @@
-import type { DiagnoseResult } from "../common/result.js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { DiagnoseResult, MonorepoResult } from "../common/result.js";
 import type { EngineResult, MonorepoEngineResult } from "../engine/scanner.js";
+import { shouldBlock } from "./blocking.js";
 import {
 	printConsoleReport,
 	printMonorepoReport,
 } from "./formatters/console-reporter.js";
-import { printJsonReport } from "./formatters/json-reporter.js";
+import { renderResult } from "./formatters/render.js";
 import { checkMinScore } from "./min-score.js";
+import type { PipelineOptions } from "./setup.js";
 import { logger } from "./ui/logger.js";
 
-interface OutputArgs {
-	json: boolean;
-	score: boolean;
-	verbose: boolean;
-}
+const FAILURE_EXIT_CODE = 1;
 
-const enforceMinimumScoreThreshold = (
-	diagnoseResult: DiagnoseResult,
-	resolvedMinimumScore: number | undefined,
-	isMachineReadable: boolean
+/** Version of the running CLI, set once so reporters can stamp their output. */
+let cliVersion = "0.0.0";
+
+export const setCliVersion = (version: string): void => {
+	cliVersion = version;
+};
+
+const writeRendered = (
+	payload: string,
+	outputPath: string | undefined
 ): void => {
-	const score = diagnoseResult.score.value;
+	if (!outputPath) {
+		console.log(payload);
+		return;
+	}
+	const resolved = resolve(outputPath);
+	mkdirSync(dirname(resolved), { recursive: true });
+	writeFileSync(resolved, `${payload}\n`, "utf-8");
+};
+
+const resolveRunUrl = (): string | undefined => {
+	const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
+	if (!(GITHUB_SERVER_URL && GITHUB_REPOSITORY && GITHUB_RUN_ID)) {
+		return;
+	}
+	return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+};
+
+/** Applies both gates, exiting when either fails. */
+function enforceGates(
+	result: DiagnoseResult,
+	resolvedMinimumScore: number | undefined,
+	options: PipelineOptions
+): void {
+	const score = result.score.value;
+
 	if (!checkMinScore(score, resolvedMinimumScore)) {
-		if (!isMachineReadable) {
+		if (!options.isMachineReadable) {
 			logger.error(
 				`Score ${score} is below the minimum threshold of ${resolvedMinimumScore}.`
 			);
 		}
-		process.exit(1);
+		process.exit(FAILURE_EXIT_CODE);
 	}
-};
 
-const exitOnDiagnosticErrors = (diagnoseResult: DiagnoseResult): void => {
-	if (diagnoseResult.summary.errors > 0) {
-		process.exit(1);
+	if (shouldBlock(result.summary, options.blocking)) {
+		process.exit(FAILURE_EXIT_CODE);
 	}
-};
+}
+
+function emit(
+	result: DiagnoseResult,
+	targetPath: string,
+	options: PipelineOptions,
+	scopeWarnings: string[],
+	monorepo?: MonorepoResult
+): void {
+	// Always surfaced, on stderr, whatever the format: a silently degraded scope
+	// makes a report look cleaner than the code actually is.
+	for (const warning of scopeWarnings) {
+		logger.warn(warning);
+	}
+
+	if (options.score) {
+		writeRendered(String(result.score.value), options.outputPath);
+		return;
+	}
+
+	const payload = renderResult(options.format, result, {
+		commitSha: process.env.GITHUB_SHA,
+		jsonCompact: options.jsonCompact,
+		monorepo,
+		runUrl: resolveRunUrl(),
+		targetPath,
+		version: cliVersion,
+		warnings: scopeWarnings,
+	});
+
+	if (payload !== null) {
+		writeRendered(payload, options.outputPath);
+	}
+
+	// `console` and `github` still print the human-readable report; every other
+	// format replaces it.
+	if (options.format === "console" || options.format === "github") {
+		if (monorepo) {
+			printMonorepoReport(monorepo, options.verbose);
+		} else {
+			printConsoleReport(result, options.verbose);
+		}
+	}
+}
 
 export const outputMonorepoResults = (
 	monorepoScanResult: MonorepoEngineResult,
 	resolvedMinimumScore: number | undefined,
-	isMachineReadable: boolean,
-	args: OutputArgs
+	targetPath: string,
+	options: PipelineOptions,
+	scopeWarnings: string[] = []
 ): void => {
 	const { result } = monorepoScanResult;
-
-	if (args.score) {
-		console.log(result.combined.score.value);
-		enforceMinimumScoreThreshold(
-			result.combined,
-			resolvedMinimumScore,
-			isMachineReadable
-		);
-		return;
-	}
-
-	if (args.json) {
-		printJsonReport(result.combined);
-		enforceMinimumScoreThreshold(
-			result.combined,
-			resolvedMinimumScore,
-			isMachineReadable
-		);
-		return;
-	}
-
-	printMonorepoReport(result, args.verbose);
-	enforceMinimumScoreThreshold(
-		result.combined,
-		resolvedMinimumScore,
-		isMachineReadable
-	);
-	exitOnDiagnosticErrors(result.combined);
+	emit(result.combined, targetPath, options, scopeWarnings, result);
+	enforceGates(result.combined, resolvedMinimumScore, options);
 };
 
 export const outputSingleProjectResults = (
 	singleProjectScanResult: EngineResult,
 	resolvedMinimumScore: number | undefined,
-	isMachineReadable: boolean,
-	args: OutputArgs
+	targetPath: string,
+	options: PipelineOptions,
+	scopeWarnings: string[] = []
 ): void => {
 	const { result } = singleProjectScanResult;
-
-	if (args.score) {
-		console.log(result.score.value);
-		enforceMinimumScoreThreshold(
-			result,
-			resolvedMinimumScore,
-			isMachineReadable
-		);
-		return;
-	}
-
-	if (args.json) {
-		printJsonReport(result);
-		enforceMinimumScoreThreshold(
-			result,
-			resolvedMinimumScore,
-			isMachineReadable
-		);
-		return;
-	}
-
-	printConsoleReport(result, args.verbose);
-	enforceMinimumScoreThreshold(result, resolvedMinimumScore, isMachineReadable);
-	exitOnDiagnosticErrors(result);
+	emit(result, targetPath, options, scopeWarnings);
+	enforceGates(result, resolvedMinimumScore, options);
 };

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -1,5 +1,9 @@
 import { performance } from "node:perf_hooks";
+import type { Diagnostic } from "../common/diagnostic.js";
+import type { DiagnoseResult } from "../common/result.js";
+import { computeBaselineDelta } from "../engine/baseline.js";
 import type { MonorepoInfo } from "../engine/project-detector.js";
+import { withScopedDiagnostics } from "../engine/result-builder.js";
 import {
 	type AnalysisContext,
 	buildAnalysisContext,
@@ -14,19 +18,17 @@ import {
 	resolveScanConfig,
 	type ScanConfig,
 } from "../engine/scanner.js";
+import {
+	applyScope,
+	buildScopeInfo,
+	type ResolvedScope,
+	resolveScope,
+} from "../engine/scope.js";
 import { resolveMinScore } from "./min-score.js";
 import { outputMonorepoResults, outputSingleProjectResults } from "./output.js";
+import type { PipelineOptions } from "./setup.js";
 import { logger } from "./ui/logger.js";
 import { spinner } from "./ui/spinner.js";
-
-interface PipelineOptions {
-	configPath: string | undefined;
-	isMachineReadable: boolean;
-	json: boolean;
-	minScore: string | undefined;
-	score: boolean;
-	verbose: boolean;
-}
 
 type PipelineStep = () => void | Promise<void>;
 
@@ -42,11 +44,13 @@ const displayCustomRuleWarnings = (
 	}
 };
 
-/** Abstract base for scan pipelines — shared step queue, config, and warnings */
+/** Abstract base for scan pipelines — shared step queue, config, scoping, warnings */
 abstract class ScanPipeline {
 	protected readonly options: PipelineOptions;
 	protected resolvedMinimumScore: number | undefined;
 	protected scanConfig!: ScanConfig;
+	/** Warnings raised while narrowing the scope; surfaced alongside the report. */
+	protected scopeWarnings: string[] = [];
 	protected readonly steps: PipelineStep[] = [];
 	protected readonly targetPath: string;
 
@@ -55,10 +59,11 @@ abstract class ScanPipeline {
 		this.options = options;
 	}
 
+	abstract applyScope(): this;
 	abstract buildContext(): this;
-	abstract runRules(): this;
 	abstract buildResult(): this;
 	abstract output(): this;
+	abstract runRules(): this;
 
 	resolveConfig(): this {
 		this.steps.push(async () => {
@@ -84,6 +89,59 @@ abstract class ScanPipeline {
 		return this;
 	}
 
+	/** Narrows a result to the requested scope, filtering only what is reported. */
+	protected async scopeResult(
+		result: DiagnoseResult,
+		monorepo?: MonorepoInfo
+	): Promise<DiagnoseResult> {
+		if (this.options.scope === "full" && !this.options.staged) {
+			return result;
+		}
+
+		const scope: ResolvedScope = resolveScope({
+			base: this.options.base,
+			changedFilesFrom: this.options.changedFilesFrom,
+			mode: this.options.scope,
+			staged: this.options.staged,
+			targetPath: this.targetPath,
+		});
+		this.scopeWarnings.push(...scope.warnings);
+
+		if (scope.mode !== "changed") {
+			return withScopedDiagnostics(
+				result,
+				applyScope(result.diagnostics, scope),
+				buildScopeInfo(scope)
+			);
+		}
+
+		const delta = await computeBaselineDelta(
+			result.diagnostics,
+			scope,
+			this.targetPath,
+			this.scanConfig,
+			monorepo
+		);
+		this.scopeWarnings.push(...delta.warnings);
+
+		if (!delta.available) {
+			// Without a base to subtract, "introduced" is unknowable — report every
+			// finding in the changed files rather than implying a measured delta.
+			const degraded: ResolvedScope = { ...scope, mode: "files" };
+			return withScopedDiagnostics(
+				result,
+				applyScope(result.diagnostics, degraded),
+				buildScopeInfo(degraded, { baselineAvailable: false })
+			);
+		}
+
+		return withScopedDiagnostics(
+			result,
+			delta.introduced,
+			buildScopeInfo(scope, { baselineAvailable: true, fixed: delta.fixed })
+		);
+	}
+
 	async run(): Promise<void> {
 		const progress = this.options.isMachineReadable
 			? null
@@ -97,7 +155,21 @@ abstract class ScanPipeline {
 	}
 }
 
-/** Monorepo scan builder — resolveConfig, buildContext, runRules, buildResult, warn, output */
+/**
+ * Keeps a sub-project's diagnostics in step with a scoped combined result,
+ * matching by object identity.
+ */
+const restrictToKept = (
+	result: DiagnoseResult,
+	kept: Set<Diagnostic>
+): DiagnoseResult =>
+	withScopedDiagnostics(
+		result,
+		result.diagnostics.filter((diagnostic) => kept.has(diagnostic)),
+		result.scope
+	);
+
+/** Monorepo scan builder — resolveConfig, buildContext, runRules, buildResult, applyScope, warn, output */
 export class MonorepoPipeline extends ScanPipeline {
 	private readonly monorepo: MonorepoInfo;
 	private monorepoCtx!: MonorepoContext;
@@ -148,24 +220,49 @@ export class MonorepoPipeline extends ScanPipeline {
 		return this;
 	}
 
+	applyScope(): this {
+		this.steps.push(async () => {
+			const combined = await this.scopeResult(
+				this.result.result.combined,
+				this.monorepo
+			);
+			if (combined === this.result.result.combined) {
+				return;
+			}
+
+			const kept = new Set(combined.diagnostics);
+			this.result = {
+				...this.result,
+				result: {
+					...this.result.result,
+					combined,
+					subProjects: this.result.result.subProjects.map(
+						({ name, result }) => ({
+							name,
+							result: restrictToKept(result, kept),
+						})
+					),
+				},
+			};
+		});
+		return this;
+	}
+
 	output(): this {
 		this.steps.push(() => {
 			outputMonorepoResults(
 				this.result,
 				this.resolvedMinimumScore,
-				this.options.isMachineReadable,
-				{
-					json: this.options.json,
-					score: this.options.score,
-					verbose: this.options.verbose,
-				}
+				this.targetPath,
+				this.options,
+				this.scopeWarnings
 			);
 		});
 		return this;
 	}
 }
 
-/** Single-project scan builder — resolveConfig, buildContext, runRules, buildResult, warn, output */
+/** Single-project scan builder — resolveConfig, buildContext, runRules, buildResult, applyScope, warn, output */
 export class SingleProjectPipeline extends ScanPipeline {
 	private context!: AnalysisContext;
 	private rawOutput!: RawDiagnosticOutput;
@@ -199,17 +296,24 @@ export class SingleProjectPipeline extends ScanPipeline {
 		return this;
 	}
 
+	applyScope(): this {
+		this.steps.push(async () => {
+			this.result = {
+				...this.result,
+				result: await this.scopeResult(this.result.result),
+			};
+		});
+		return this;
+	}
+
 	output(): this {
 		this.steps.push(() => {
 			outputSingleProjectResults(
 				this.result,
 				this.resolvedMinimumScore,
-				this.options.isMachineReadable,
-				{
-					json: this.options.json,
-					score: this.options.score,
-					verbose: this.options.verbose,
-				}
+				this.targetPath,
+				this.options,
+				this.scopeWarnings
 			);
 		});
 		return this;

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -1,13 +1,32 @@
 import { resolve } from "node:path";
+import { isScopeMode, type ScopeMode } from "../common/scope.js";
+import {
+	type BlockingLevel,
+	resolveBlocking,
+	validateBlockingArg,
+} from "./blocking.js";
+import {
+	isMachineReadableFormat,
+	type OutputFormat,
+	validateFormatArg,
+} from "./formatters/render.js";
 import { validateMinScoreArg } from "./min-score.js";
 import { logger } from "./ui/logger.js";
 
-interface PipelineOptions {
+export interface PipelineOptions {
+	base: string | undefined;
+	blocking: BlockingLevel;
+	changedFilesFrom: string | undefined;
 	configPath: string | undefined;
+	format: OutputFormat;
 	isMachineReadable: boolean;
 	json: boolean;
+	jsonCompact: boolean;
 	minScore: string | undefined;
+	outputPath: string | undefined;
+	scope: ScopeMode;
 	score: boolean;
+	staged: boolean;
 	verbose: boolean;
 }
 
@@ -17,17 +36,58 @@ interface SetupContext {
 }
 
 export interface CliArgs {
+	base: string | undefined;
+	blocking: string | undefined;
+	"changed-files-from": string | undefined;
 	config: string | undefined;
+	format: string | undefined;
 	init: boolean;
 	json: boolean;
+	"json-compact": boolean;
+	"list-rules": boolean;
 	"min-score": string | undefined;
+	output: string | undefined;
 	path: string;
 	report: boolean;
+	scope: string | undefined;
 	score: boolean;
+	staged: boolean;
 	verbose: boolean;
 }
 
 type SetupStep = () => boolean | Promise<boolean>;
+
+const INVALID_ARG_EXIT_CODE = 2;
+
+function failWith(message: string): never {
+	logger.error(message);
+	process.exit(INVALID_ARG_EXIT_CODE);
+}
+
+/** Resolves the output format. `--format` wins; `--json` maps onto it. */
+function resolveFormat(args: CliArgs): OutputFormat {
+	if (args.format) {
+		const error = validateFormatArg(args.format);
+		if (error) {
+			failWith(error);
+		}
+		return args.format as OutputFormat;
+	}
+	return args.json ? "json" : "console";
+}
+
+function resolveScopeMode(args: CliArgs): ScopeMode {
+	if (!args.scope) {
+		// `--staged` alone means "the files I am about to commit".
+		return args.staged ? "files" : "full";
+	}
+	if (!isScopeMode(args.scope)) {
+		failWith(
+			`Invalid --scope value: "${args.scope}". Must be one of full, files, lines, changed.`
+		);
+	}
+	return args.scope as ScopeMode;
+}
 
 /** Setup builder — resolves target path, handles early-exit flags, validates args */
 export class CliSetup {
@@ -44,6 +104,18 @@ export class CliSetup {
 	resolveTargetPath(): this {
 		this.steps.push(() => {
 			this.targetPath = resolve(this.args.path ?? ".");
+			return true;
+		});
+		return this;
+	}
+
+	handleListRules(): this {
+		this.steps.push(async () => {
+			if (this.args["list-rules"]) {
+				const { listRules } = await import("./list-rules.js");
+				listRules(this.args.json || this.args.format === "json");
+				return false;
+			}
 			return true;
 		});
 		return this;
@@ -78,8 +150,20 @@ export class CliSetup {
 			if (this.args["min-score"] !== undefined) {
 				const error = validateMinScoreArg(this.args["min-score"]);
 				if (error) {
-					logger.error(error);
-					process.exit(2);
+					failWith(error);
+				}
+			}
+			return true;
+		});
+		return this;
+	}
+
+	validateBlocking(): this {
+		this.steps.push(() => {
+			if (this.args.blocking !== undefined) {
+				const error = validateBlockingArg(this.args.blocking);
+				if (error) {
+					failWith(error);
 				}
 			}
 			return true;
@@ -95,14 +179,26 @@ export class CliSetup {
 			}
 		}
 
+		const format = resolveFormat(this.args);
+		const score = this.args.score ?? false;
+		const isMachineReadable = score || isMachineReadableFormat(format);
+
 		return {
 			targetPath: this.targetPath,
 			options: {
+				base: this.args.base,
+				blocking: resolveBlocking(this.args.blocking, isMachineReadable),
+				changedFilesFrom: this.args["changed-files-from"],
 				configPath: this.args.config,
-				isMachineReadable: this.args.score || this.args.json,
-				json: this.args.json ?? false,
+				format,
+				isMachineReadable,
+				json: format === "json",
+				jsonCompact: this.args["json-compact"] ?? false,
 				minScore: this.args["min-score"],
-				score: this.args.score ?? false,
+				outputPath: this.args.output,
+				scope: resolveScopeMode(this.args),
+				score,
+				staged: this.args.staged ?? false,
 				verbose: this.args.verbose ?? false,
 			},
 		};

--- a/packages/nestjs-doctor/src/cli/ui/logger.ts
+++ b/packages/nestjs-doctor/src/cli/ui/logger.ts
@@ -4,12 +4,17 @@ const writeLogLine = (text: string): void => {
 	console.log(text);
 };
 
+// Diagnostics about the run go to stderr, keeping stdout machine-readable.
+const writeErrorLine = (text: string): void => {
+	console.error(text);
+};
+
 export const logger = {
 	error(...args: unknown[]) {
-		writeLogLine(highlighter.error(args.join(" ")));
+		writeErrorLine(highlighter.error(args.join(" ")));
 	},
 	warn(...args: unknown[]) {
-		writeLogLine(highlighter.warn(args.join(" ")));
+		writeErrorLine(highlighter.warn(args.join(" ")));
 	},
 	info(...args: unknown[]) {
 		writeLogLine(highlighter.info(args.join(" ")));

--- a/packages/nestjs-doctor/src/common/result.ts
+++ b/packages/nestjs-doctor/src/common/result.ts
@@ -1,6 +1,7 @@
 import type { Category, Diagnostic } from "./diagnostic.js";
 import type { EndpointGraph } from "./endpoint.js";
 import type { SerializedSchemaGraph } from "./schema.js";
+import type { ScopeInfo } from "./scope.js";
 
 export interface Score {
 	label: string;
@@ -36,6 +37,8 @@ export interface DiagnoseResult {
 	project: ProjectInfo;
 	ruleErrors: RuleErrorInfo[];
 	schema?: SerializedSchemaGraph;
+	/** What `diagnostics` and `summary` cover. Absent when nothing was narrowed. */
+	scope?: ScopeInfo;
 	score: Score;
 	summary: DiagnoseSummary;
 }

--- a/packages/nestjs-doctor/src/common/scope.ts
+++ b/packages/nestjs-doctor/src/common/scope.ts
@@ -1,0 +1,24 @@
+/**
+ * How much of a scan gets reported: everything, the changed files, the changed
+ * lines, or what the change introduced. Every mode analyses the whole project.
+ */
+export type ScopeMode = "full" | "files" | "lines" | "changed";
+
+export const SCOPE_MODES: ScopeMode[] = ["full", "files", "lines", "changed"];
+
+export function isScopeMode(value: string): value is ScopeMode {
+	return (SCOPE_MODES as string[]).includes(value);
+}
+
+/** Scope metadata attached to a result so consumers can see what was reported. */
+export interface ScopeInfo {
+	/** Present in `changed` mode: whether the base revision could be scanned. */
+	baselineAvailable?: boolean;
+	baseRef?: string;
+	changedFiles?: number;
+	/** Set when the requested mode could not be honoured. */
+	degradedFrom?: ScopeMode;
+	/** Present in `changed` mode: findings the change resolved. */
+	fixed?: number;
+	mode: ScopeMode;
+}

--- a/packages/nestjs-doctor/src/common/scope.ts
+++ b/packages/nestjs-doctor/src/common/scope.ts
@@ -15,6 +15,7 @@ export interface ScopeInfo {
 	/** Present in `changed` mode: whether the base revision could be scanned. */
 	baselineAvailable?: boolean;
 	baseRef?: string;
+	/** Files the scope narrowed to, not the change's total file count. */
 	changedFiles?: number;
 	/** Set when the requested mode could not be honoured. */
 	degradedFrom?: ScopeMode;

--- a/packages/nestjs-doctor/src/engine/baseline.ts
+++ b/packages/nestjs-doctor/src/engine/baseline.ts
@@ -1,0 +1,99 @@
+import type { Diagnostic } from "../common/diagnostic.js";
+import {
+	buildAnalysisContext,
+	buildMonorepoContext,
+} from "./analysis-context.js";
+import type { ScanConfig } from "./config/scan-config.js";
+import { diagnose } from "./diagnostician.js";
+import { diffDiagnostics } from "./fingerprint.js";
+import { checkoutBase, getLastGitError } from "./git.js";
+import type { MonorepoInfo } from "./project-detector.js";
+import type { ResolvedScope } from "./scope.js";
+
+export interface BaselineDelta {
+	/** False when the base could not be checked out — callers should degrade. */
+	available: boolean;
+	/** Findings the change resolved. */
+	fixed: number;
+	/** Findings with no counterpart at the base. */
+	introduced: Diagnostic[];
+	warnings: string[];
+}
+
+/** Runs the same analysis over a base checkout, using the head's config. */
+async function scanBaseline(
+	baseTargetPath: string,
+	scanConfig: ScanConfig,
+	monorepo: MonorepoInfo | undefined
+): Promise<Diagnostic[]> {
+	if (monorepo) {
+		const context = await buildMonorepoContext(
+			baseTargetPath,
+			scanConfig,
+			monorepo
+		);
+		const diagnostics: Diagnostic[] = [];
+		for (const subProject of context.subProjects.values()) {
+			diagnostics.push(...diagnose(subProject).diagnostics);
+		}
+		return diagnostics;
+	}
+
+	const context = await buildAnalysisContext(baseTargetPath, scanConfig);
+	return diagnose(context).diagnostics;
+}
+
+/**
+ * Which of HEAD's findings the change introduced. `available: false` when the
+ * base revision cannot be materialised.
+ */
+export async function computeBaselineDelta(
+	headDiagnostics: Diagnostic[],
+	scope: ResolvedScope,
+	targetPath: string,
+	scanConfig: ScanConfig,
+	monorepo?: MonorepoInfo
+): Promise<BaselineDelta> {
+	const unavailable = (warning: string): BaselineDelta => ({
+		available: false,
+		fixed: 0,
+		introduced: headDiagnostics,
+		warnings: [warning],
+	});
+
+	if (!(scope.repo && scope.baseRef)) {
+		return unavailable(
+			"--scope changed needs a base revision to compare against. Reporting every finding in the changed files instead."
+		);
+	}
+
+	const checkout = checkoutBase(scope.repo, scope.baseRef);
+	if (!checkout) {
+		const reason = getLastGitError();
+		return unavailable(
+			`Could not check out "${scope.baseRef}" to compare against (a shallow clone, typically — fetch it with \`fetch-depth: 0\`)${reason ? `: ${reason}` : ""}. Reporting every finding in the changed files instead.`
+		);
+	}
+
+	try {
+		const baseDiagnostics = await scanBaseline(
+			checkout.targetPath,
+			scanConfig,
+			monorepo
+		);
+		const { introduced, fixed } = diffDiagnostics(
+			headDiagnostics,
+			baseDiagnostics,
+			targetPath,
+			checkout.targetPath
+		);
+		return { available: true, fixed, introduced, warnings: [] };
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		return unavailable(
+			`Could not scan the base revision (${reason}). Reporting every finding in the changed files instead.`
+		);
+	} finally {
+		checkout.cleanup();
+	}
+}

--- a/packages/nestjs-doctor/src/engine/fingerprint.ts
+++ b/packages/nestjs-doctor/src/engine/fingerprint.ts
@@ -1,0 +1,113 @@
+import { createHash } from "node:crypto";
+import { relative } from "node:path";
+import type { Diagnostic } from "../common/diagnostic.js";
+import { isCodeDiagnostic } from "../common/diagnostic.js";
+
+const BACKSLASH_RE = /\\/g;
+const WHITESPACE_RE = /\s+/g;
+
+/** Separator that cannot occur in a rule id, path, or message. */
+const IDENTITY_SEPARATOR = "\u0000";
+
+/** Path of `filePath` relative to `targetPath`, always with forward slashes. */
+export function toRelativePath(targetPath: string, filePath: string): string {
+	const rel = relative(targetPath, filePath);
+	const normalized = (rel || filePath).replace(BACKSLASH_RE, "/");
+	return normalized.startsWith("../")
+		? filePath.replace(BACKSLASH_RE, "/")
+		: normalized;
+}
+
+/** The source text of the line a diagnostic points at, if it was captured. */
+function sourceLineText(diagnostic: Diagnostic): string {
+	if (!isCodeDiagnostic(diagnostic)) {
+		return "";
+	}
+	const match = diagnostic.sourceLines?.find(
+		(entry) => entry.line === diagnostic.line
+	);
+	return match ? match.text.trim().replace(WHITESPACE_RE, " ") : "";
+}
+
+/**
+ * Stable identity for a diagnostic: rule, path, message, and the anchor line's
+ * text. Excludes line and column, which shift under unrelated edits.
+ */
+export function diagnosticIdentity(
+	diagnostic: Diagnostic,
+	targetPath: string
+): string {
+	const parts = [
+		diagnostic.rule,
+		toRelativePath(targetPath, diagnostic.filePath),
+		diagnostic.message,
+		sourceLineText(diagnostic),
+	];
+
+	if (!isCodeDiagnostic(diagnostic)) {
+		parts.push(diagnostic.entity, diagnostic.schemaColumn ?? "");
+	}
+
+	return parts.join(IDENTITY_SEPARATOR);
+}
+
+/** Hex digest of {@link diagnosticIdentity} — the form reporters emit. */
+export function fingerprint(
+	diagnostic: Diagnostic,
+	targetPath: string
+): string {
+	return createHash("sha256")
+		.update(diagnosticIdentity(diagnostic, targetPath))
+		.digest("hex");
+}
+
+/** Counts identities, so repeated findings subtract one at a time. */
+export function countIdentities(
+	diagnostics: Diagnostic[],
+	targetPath: string
+): Map<string, number> {
+	const counts = new Map<string, number>();
+	for (const diagnostic of diagnostics) {
+		const key = diagnosticIdentity(diagnostic, targetPath);
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+	return counts;
+}
+
+export interface DiagnosticDelta {
+	/** Findings present at the base that are gone at HEAD. */
+	fixed: number;
+	/** Findings at HEAD with no counterpart at the base. */
+	introduced: Diagnostic[];
+}
+
+/**
+ * Subtracts the base revision's findings from HEAD's. Each side's identities
+ * are computed against its own root.
+ */
+export function diffDiagnostics(
+	head: Diagnostic[],
+	base: Diagnostic[],
+	targetPath: string,
+	baseTargetPath: string
+): DiagnosticDelta {
+	const remaining = countIdentities(base, baseTargetPath);
+	const introduced: Diagnostic[] = [];
+
+	for (const diagnostic of head) {
+		const key = diagnosticIdentity(diagnostic, targetPath);
+		const available = remaining.get(key) ?? 0;
+		if (available > 0) {
+			remaining.set(key, available - 1);
+			continue;
+		}
+		introduced.push(diagnostic);
+	}
+
+	let fixed = 0;
+	for (const count of remaining.values()) {
+		fixed += count;
+	}
+
+	return { introduced, fixed };
+}

--- a/packages/nestjs-doctor/src/engine/git.ts
+++ b/packages/nestjs-doctor/src/engine/git.ts
@@ -1,0 +1,356 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+/** A contiguous run of lines on the new side of a diff hunk. */
+export interface LineRange {
+	end: number;
+	start: number;
+}
+
+export interface GitRepo {
+	/** Scanned directory relative to {@link root}, posix, `""` at the root. */
+	prefix: string;
+	/** Absolute path of the repository root, as git reports it. */
+	root: string;
+	/** Absolute path of the directory being scanned, as the caller gave it. */
+	targetPath: string;
+}
+
+const BACKSLASH_RE = /\\/g;
+const TRAILING_SLASH_RE = /\/$/;
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+const GIT_TIMEOUT_MS = 30_000;
+const MAX_GIT_BUFFER = 64 * 1024 * 1024;
+
+const toPosix = (value: string): string => value.replace(BACKSLASH_RE, "/");
+
+/** Variables that pin git to a repository; cleared so `cwd` decides. */
+const REPO_SCOPING_GIT_VARS = [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_NAMESPACE",
+	"GIT_PREFIX",
+	"GIT_CEILING_DIRECTORIES",
+];
+
+function gitEnvironment(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	for (const name of REPO_SCOPING_GIT_VARS) {
+		delete env[name];
+	}
+	return env;
+}
+
+/** Last git failure, kept so callers can explain a degraded scope. */
+let lastGitError = "";
+
+/** stderr of the most recent failed git command, or `""` if none has failed. */
+export const getLastGitError = (): string => lastGitError;
+
+/** Runs a git command, returning stdout or `null` on any failure. */
+export function runGit(cwd: string, args: string[]): string | null {
+	try {
+		return execFileSync("git", args, {
+			cwd,
+			encoding: "utf-8",
+			env: gitEnvironment(),
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: GIT_TIMEOUT_MS,
+			maxBuffer: MAX_GIT_BUFFER,
+		});
+	} catch (error) {
+		const stderr = (error as { stderr?: Buffer | string }).stderr;
+		lastGitError = String(stderr ?? "").trim();
+		return null;
+	}
+}
+
+/** Resolves the repository that contains `targetPath`, or `null` if there is none. */
+export function findGitRepo(targetPath: string): GitRepo | null {
+	const root = runGit(targetPath, ["rev-parse", "--show-toplevel"]);
+	if (!root) {
+		return null;
+	}
+	const prefix = runGit(targetPath, ["rev-parse", "--show-prefix"]);
+	if (prefix === null) {
+		return null;
+	}
+	return {
+		prefix: toPosix(prefix.trim()).replace(TRAILING_SLASH_RE, ""),
+		root: resolve(root.trim()),
+		targetPath: resolve(targetPath),
+	};
+}
+
+/** True when `ref` names a commit that is present in the local object store. */
+export function refExists(repo: GitRepo, ref: string): boolean {
+	return (
+		runGit(repo.root, [
+			"rev-parse",
+			"--verify",
+			"--quiet",
+			`${ref}^{commit}`,
+		]) !== null
+	);
+}
+
+const CANDIDATE_BASE_REFS = [
+	"origin/main",
+	"origin/master",
+	"origin/develop",
+	"main",
+	"master",
+	"develop",
+];
+
+/**
+ * Picks the ref to compare against: explicit, then `GITHUB_BASE_REF`, then the
+ * remote's default branch, then conventional names. `null` if none resolve.
+ */
+export function resolveBaseRef(
+	repo: GitRepo,
+	explicit?: string
+): string | null {
+	if (explicit) {
+		return refExists(repo, explicit) ? explicit : null;
+	}
+
+	const envBase = process.env.GITHUB_BASE_REF?.trim();
+	if (envBase) {
+		for (const candidate of [`origin/${envBase}`, envBase]) {
+			if (refExists(repo, candidate)) {
+				return candidate;
+			}
+		}
+	}
+
+	const headRef = runGit(repo.root, [
+		"symbolic-ref",
+		"--quiet",
+		"--short",
+		"refs/remotes/origin/HEAD",
+	]);
+	if (headRef && refExists(repo, headRef.trim())) {
+		return headRef.trim();
+	}
+
+	for (const candidate of CANDIDATE_BASE_REFS) {
+		if (refExists(repo, candidate)) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Maps a repository-relative path into the scanned directory's path space,
+ * or `null` when it falls outside. Built from `targetPath`, not `root`.
+ */
+function toTargetPath(repo: GitRepo, repoRelativePath: string): string | null {
+	const normalized = toPosix(repoRelativePath.trim());
+	if (!normalized) {
+		return null;
+	}
+
+	if (!repo.prefix) {
+		return toPosix(join(repo.targetPath, normalized));
+	}
+
+	const withinPrefix = `${repo.prefix}/`;
+	if (!normalized.startsWith(withinPrefix)) {
+		return null;
+	}
+	return toPosix(join(repo.targetPath, normalized.slice(withinPrefix.length)));
+}
+
+/** Absolute paths for the entries inside the scanned directory. */
+function toAbsoluteWithinTarget(repo: GitRepo, paths: string[]): string[] {
+	const within: string[] = [];
+
+	for (const relativePath of paths) {
+		const absolute = toTargetPath(repo, relativePath);
+		if (absolute) {
+			within.push(absolute);
+		}
+	}
+
+	return within.sort();
+}
+
+/** Files added, modified, or renamed between the merge base of `base` and HEAD. */
+export function getChangedFiles(repo: GitRepo, base: string): string[] | null {
+	const output = runGit(repo.root, [
+		"diff",
+		"--name-only",
+		"--diff-filter=AMR",
+		`${base}...HEAD`,
+	]);
+	if (output === null) {
+		return null;
+	}
+	return toAbsoluteWithinTarget(repo, output.split("\n"));
+}
+
+/** Files staged in the index — the set a pre-commit hook should look at. */
+export function getStagedFiles(repo: GitRepo): string[] | null {
+	const output = runGit(repo.root, [
+		"diff",
+		"--name-only",
+		"--diff-filter=AMR",
+		"--cached",
+	]);
+	if (output === null) {
+		return null;
+	}
+	return toAbsoluteWithinTarget(repo, output.split("\n"));
+}
+
+/** Parses `--unified=0` diff output into new-side line ranges per file. */
+export function parseDiffLineRanges(
+	repo: GitRepo,
+	diff: string
+): Map<string, LineRange[]> {
+	const ranges = new Map<string, LineRange[]>();
+	let current: LineRange[] | null = null;
+
+	for (const line of diff.split("\n")) {
+		if (line.startsWith("+++ ")) {
+			const path = line.slice(4).trim();
+			if (path === "/dev/null") {
+				current = null;
+				continue;
+			}
+			const relativePath = path.startsWith("b/") ? path.slice(2) : path;
+			const absolute = toTargetPath(repo, relativePath);
+			if (!absolute) {
+				current = null;
+				continue;
+			}
+			current = ranges.get(absolute) ?? [];
+			ranges.set(absolute, current);
+			continue;
+		}
+
+		if (!current) {
+			continue;
+		}
+
+		const hunk = HUNK_HEADER_RE.exec(line);
+		if (!hunk) {
+			continue;
+		}
+
+		const start = Number(hunk[1]);
+		const count = hunk[2] === undefined ? 1 : Number(hunk[2]);
+		if (count === 0) {
+			// A pure deletion touches no new-side line.
+			continue;
+		}
+		current.push({ start, end: start + count - 1 });
+	}
+
+	return ranges;
+}
+
+/** New-side line ranges introduced between the merge base of `base` and HEAD. */
+export function getChangedLineRanges(
+	repo: GitRepo,
+	base: string
+): Map<string, LineRange[]> | null {
+	const output = runGit(repo.root, [
+		"diff",
+		"--unified=0",
+		"--diff-filter=AMR",
+		`${base}...HEAD`,
+	]);
+	if (output === null) {
+		return null;
+	}
+	return parseDiffLineRanges(repo, output);
+}
+
+/** New-side line ranges for the staged changes. */
+export function getStagedLineRanges(
+	repo: GitRepo
+): Map<string, LineRange[]> | null {
+	const output = runGit(repo.root, [
+		"diff",
+		"--unified=0",
+		"--diff-filter=AMR",
+		"--cached",
+	]);
+	if (output === null) {
+		return null;
+	}
+	return parseDiffLineRanges(repo, output);
+}
+
+export interface BaseCheckout {
+	/** Removes the temporary worktree. Safe to call more than once. */
+	cleanup(): void;
+	/** Absolute path mirroring the scanned directory at the base revision. */
+	targetPath: string;
+}
+
+/**
+ * Checks the base revision out into a detached worktree under the OS temp
+ * directory. `null` when the base is unreachable.
+ */
+export function checkoutBase(repo: GitRepo, base: string): BaseCheckout | null {
+	const mergeBase = runGit(repo.root, ["merge-base", base, "HEAD"]);
+	const revision = mergeBase?.trim() || base;
+
+	let worktreePath: string;
+	try {
+		worktreePath = mkdtempSync(join(tmpdir(), "nestjs-doctor-base-"));
+	} catch {
+		return null;
+	}
+
+	const added = runGit(repo.root, [
+		"worktree",
+		"add",
+		"--detach",
+		"--no-checkout",
+		worktreePath,
+		revision,
+	]);
+	if (added === null) {
+		rmSync(worktreePath, { recursive: true, force: true });
+		return null;
+	}
+
+	let removed = false;
+	const cleanup = (): void => {
+		if (removed) {
+			return;
+		}
+		removed = true;
+		runGit(repo.root, ["worktree", "remove", "--force", worktreePath]);
+		rmSync(worktreePath, { recursive: true, force: true });
+		runGit(repo.root, ["worktree", "prune"]);
+	};
+
+	if (runGit(worktreePath, ["checkout", "--force", revision]) === null) {
+		cleanup();
+		return null;
+	}
+
+	const targetPath = repo.prefix
+		? join(worktreePath, repo.prefix)
+		: worktreePath;
+
+	return { targetPath, cleanup };
+}
+
+/** Resolves a user-supplied path against `cwd` unless it is already absolute. */
+export function resolveAgainst(cwd: string, path: string): string {
+	return isAbsolute(path) ? path : resolve(cwd, path);
+}

--- a/packages/nestjs-doctor/src/engine/result-builder.ts
+++ b/packages/nestjs-doctor/src/engine/result-builder.ts
@@ -12,6 +12,7 @@ import type {
 	SchemaRelation,
 	SerializedSchemaEntity,
 } from "../common/schema.js";
+import type { ScopeInfo } from "../common/scope.js";
 import type { AnalysisContext, MonorepoContext } from "./analysis-context.js";
 import type { RawDiagnosticOutput } from "./diagnostician.js";
 import type { ModuleGraph } from "./graph/module-graph.js";
@@ -32,6 +33,23 @@ export interface MonorepoEngineResult {
 	customRuleWarnings: string[];
 	moduleGraphs: Map<string, ModuleGraph>;
 	result: MonorepoResult;
+}
+
+/**
+ * Replaces a result's diagnostics and recomputes the summary. The score is
+ * carried over: it measures the project, not the reported subset.
+ */
+export function withScopedDiagnostics(
+	result: DiagnoseResult,
+	diagnostics: Diagnostic[],
+	scope: ScopeInfo | undefined
+): DiagnoseResult {
+	return {
+		...result,
+		diagnostics,
+		summary: buildSummary(diagnostics),
+		...(scope ? { scope } : {}),
+	};
 }
 
 function buildSummary(diagnostics: Diagnostic[]): DiagnoseSummary {

--- a/packages/nestjs-doctor/src/engine/scanner.ts
+++ b/packages/nestjs-doctor/src/engine/scanner.ts
@@ -40,6 +40,7 @@ export {
 	buildResult,
 	type EngineResult,
 	type MonorepoEngineResult,
+	withScopedDiagnostics,
 } from "./result-builder.js";
 
 // Facades that compose both

--- a/packages/nestjs-doctor/src/engine/scope.ts
+++ b/packages/nestjs-doctor/src/engine/scope.ts
@@ -1,0 +1,230 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Diagnostic } from "../common/diagnostic.js";
+import { isCodeDiagnostic } from "../common/diagnostic.js";
+import type { ScopeInfo, ScopeMode } from "../common/scope.js";
+import {
+	findGitRepo,
+	type GitRepo,
+	getChangedFiles,
+	getChangedLineRanges,
+	getStagedFiles,
+	getStagedLineRanges,
+	type LineRange,
+	resolveAgainst,
+	resolveBaseRef,
+} from "./git.js";
+
+export interface ScopeOptions {
+	/** Git ref to compare against. Auto-detected when omitted. */
+	base?: string;
+	/** Path to a newline-separated list of changed files (CI hand-off). */
+	changedFilesFrom?: string;
+	mode: ScopeMode;
+	/** Compare against the index instead of a ref. */
+	staged?: boolean;
+	targetPath: string;
+}
+
+export interface ResolvedScope {
+	baseRef: string | null;
+	/** Absolute paths of the changed files, or `null` in `full` mode. */
+	files: Set<string> | null;
+	lineRanges: Map<string, LineRange[]> | null;
+	/** The mode actually in force — may be a degraded `requestedMode`. */
+	mode: ScopeMode;
+	repo: GitRepo | null;
+	requestedMode: ScopeMode;
+	warnings: string[];
+}
+
+const BACKSLASH_RE = /\\/g;
+const toPosix = (value: string): string => value.replace(BACKSLASH_RE, "/");
+
+function readChangedFilesList(
+	targetPath: string,
+	listPath: string
+): string[] | null {
+	try {
+		const raw = readFileSync(resolveAgainst(targetPath, listPath), "utf-8");
+		return raw
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.map((line) => toPosix(resolve(targetPath, line)));
+	} catch {
+		return null;
+	}
+}
+
+const fullScope = (
+	repo: GitRepo | null,
+	requestedMode: ScopeMode,
+	warnings: string[],
+	degraded: boolean
+): ResolvedScope => ({
+	baseRef: null,
+	files: null,
+	lineRanges: null,
+	mode: degraded ? "full" : requestedMode,
+	repo,
+	requestedMode,
+	warnings,
+});
+
+/**
+ * Works out which files, and lines, the reported set narrows to. Every failure
+ * path degrades to a wider scope with a warning.
+ */
+export function resolveScope(options: ScopeOptions): ResolvedScope {
+	const { mode, targetPath } = options;
+	const warnings: string[] = [];
+
+	if (mode === "full") {
+		return fullScope(null, "full", warnings, false);
+	}
+
+	const repo = findGitRepo(targetPath);
+	if (!repo) {
+		warnings.push(
+			`--scope ${mode} needs a git repository; ${targetPath} is not inside one. Reporting every finding instead.`
+		);
+		return fullScope(null, mode, warnings, true);
+	}
+
+	if (options.staged) {
+		const files = getStagedFiles(repo);
+		if (!files) {
+			warnings.push(
+				"--staged could not read the git index. Reporting every finding instead."
+			);
+			return fullScope(repo, mode, warnings, true);
+		}
+		return {
+			baseRef: null,
+			files: new Set(files),
+			lineRanges: mode === "lines" ? getStagedLineRanges(repo) : null,
+			mode,
+			repo,
+			requestedMode: mode,
+			warnings,
+		};
+	}
+
+	const listed = options.changedFilesFrom
+		? readChangedFilesList(targetPath, options.changedFilesFrom)
+		: null;
+	if (options.changedFilesFrom && !listed) {
+		warnings.push(
+			`Could not read the changed-file list at ${options.changedFilesFrom}. Falling back to git.`
+		);
+	}
+
+	const baseRef = resolveBaseRef(repo, options.base);
+	if (!baseRef) {
+		if (listed) {
+			// An explicit file list still narrows `files` without git. Line accuracy
+			// and the baseline delta both need the base commit, so those degrade.
+			if (mode !== "files") {
+				warnings.push(
+					`--scope ${mode} needs the base commit, which is not in this checkout (a shallow clone, typically — fetch it with \`fetch-depth: 0\`). Reporting every finding in the changed files instead.`
+				);
+			}
+			return {
+				baseRef: null,
+				files: new Set(listed),
+				lineRanges: null,
+				mode: "files",
+				repo,
+				requestedMode: mode,
+				warnings,
+			};
+		}
+		warnings.push(
+			options.base
+				? `Base ref "${options.base}" is not in this checkout. Reporting every finding instead.`
+				: "Could not work out a base ref to compare against. Reporting every finding instead."
+		);
+		return fullScope(repo, mode, warnings, true);
+	}
+
+	const changed = listed ?? getChangedFiles(repo, baseRef);
+	if (!changed) {
+		warnings.push(
+			`Could not diff against "${baseRef}". Reporting every finding instead.`
+		);
+		return fullScope(repo, mode, warnings, true);
+	}
+
+	return {
+		baseRef,
+		files: new Set(changed),
+		lineRanges: mode === "lines" ? getChangedLineRanges(repo, baseRef) : null,
+		mode,
+		repo,
+		requestedMode: mode,
+		warnings,
+	};
+}
+
+const isWithinRanges = (ranges: LineRange[], line: number): boolean =>
+	ranges.some((range) => line >= range.start && line <= range.end);
+
+/** Narrows a diagnostic set to the resolved scope. `changed` is applied by the caller. */
+export function applyScope(
+	diagnostics: Diagnostic[],
+	scope: ResolvedScope
+): Diagnostic[] {
+	if (scope.mode === "full" || !scope.files) {
+		return diagnostics;
+	}
+
+	const files = scope.files;
+	const inChangedFile = (diagnostic: Diagnostic): boolean =>
+		files.has(toPosix(diagnostic.filePath));
+
+	if (scope.mode === "lines") {
+		const ranges = scope.lineRanges;
+		if (!ranges) {
+			return diagnostics.filter(inChangedFile);
+		}
+		return diagnostics.filter((diagnostic) => {
+			if (!isCodeDiagnostic(diagnostic)) {
+				// Schema findings carry no line, so nothing can place them inside a hunk.
+				return false;
+			}
+			const fileRanges = ranges.get(toPosix(diagnostic.filePath));
+			return fileRanges ? isWithinRanges(fileRanges, diagnostic.line) : false;
+		});
+	}
+
+	return diagnostics.filter(inChangedFile);
+}
+
+/** Builds the {@link ScopeInfo} recorded on a result. */
+export function buildScopeInfo(
+	scope: ResolvedScope,
+	extra: { baselineAvailable?: boolean; fixed?: number } = {}
+): ScopeInfo | undefined {
+	if (scope.mode === "full" && scope.requestedMode === "full") {
+		return;
+	}
+
+	const info: ScopeInfo = { mode: scope.mode };
+	if (scope.mode !== scope.requestedMode) {
+		info.degradedFrom = scope.requestedMode;
+	}
+	if (scope.baseRef) {
+		info.baseRef = scope.baseRef;
+	}
+	if (scope.files) {
+		info.changedFiles = scope.files.size;
+	}
+	if (extra.baselineAvailable !== undefined) {
+		info.baselineAvailable = extra.baselineAvailable;
+	}
+	if (extra.fixed !== undefined) {
+		info.fixed = extra.fixed;
+	}
+	return info;
+}

--- a/packages/nestjs-doctor/src/formatters/gitlab-report.ts
+++ b/packages/nestjs-doctor/src/formatters/gitlab-report.ts
@@ -1,0 +1,41 @@
+import type { Diagnostic, Severity } from "../common/diagnostic.js";
+import { isCodeDiagnostic } from "../common/diagnostic.js";
+import type { DiagnoseResult } from "../common/result.js";
+import { fingerprint, toRelativePath } from "../engine/fingerprint.js";
+
+/** GitLab accepts `info | minor | major | critical | blocker`. */
+const SEVERITY_MAP: Record<Severity, string> = {
+	error: "major",
+	warning: "minor",
+	info: "info",
+};
+
+export interface CodeQualityIssue {
+	check_name: string;
+	description: string;
+	fingerprint: string;
+	location: {
+		lines: { begin: number };
+		path: string;
+	};
+	severity: string;
+}
+
+/** Renders a result in the CodeClimate subset GitLab's Code Quality reads. */
+export function buildCodeQualityReport(
+	result: DiagnoseResult,
+	targetPath: string
+): CodeQualityIssue[] {
+	return result.diagnostics.map((diagnostic: Diagnostic) => ({
+		description: `${diagnostic.message} ${diagnostic.help}`.trim(),
+		check_name: diagnostic.rule,
+		fingerprint: fingerprint(diagnostic, targetPath),
+		severity: SEVERITY_MAP[diagnostic.severity],
+		location: {
+			path: toRelativePath(targetPath, diagnostic.filePath),
+			lines: {
+				begin: isCodeDiagnostic(diagnostic) ? Math.max(1, diagnostic.line) : 1,
+			},
+		},
+	}));
+}

--- a/packages/nestjs-doctor/src/formatters/markdown-report.ts
+++ b/packages/nestjs-doctor/src/formatters/markdown-report.ts
@@ -99,7 +99,7 @@ function renderScopeNote(scope: ScopeInfo | undefined): string[] {
 	}
 	if (scope.changedFiles !== undefined) {
 		lines.push(
-			`<sub>Scope \`${scope.mode}\` over ${pluralize(scope.changedFiles, "changed file")}${scope.baseRef ? ` vs \`${scope.baseRef}\`` : ""}.</sub>`
+			`<sub>Scope \`${scope.mode}\` · ${pluralize(scope.changedFiles, "file")} in scope${scope.baseRef ? ` vs \`${scope.baseRef}\`` : ""}.</sub>`
 		);
 	}
 	return lines.length ? ["", ...lines] : [];

--- a/packages/nestjs-doctor/src/formatters/markdown-report.ts
+++ b/packages/nestjs-doctor/src/formatters/markdown-report.ts
@@ -1,0 +1,217 @@
+import type { Category, Diagnostic } from "../common/diagnostic.js";
+import { isCodeDiagnostic } from "../common/diagnostic.js";
+import type { DiagnoseResult, MonorepoResult } from "../common/result.js";
+import type { ScopeInfo } from "../common/scope.js";
+import { toRelativePath } from "../engine/fingerprint.js";
+
+/** Lets a CI job find and rewrite its own comment instead of stacking new ones. */
+export const MARKDOWN_COMMENT_MARKER = "<!-- nestjs-doctor:summary -->";
+
+const MAX_TABLE_ROWS = 50;
+const SEVERITY_ICON = { error: "🔴", warning: "🟡", info: "🔵" } as const;
+const SEVERITY_ORDER = { error: 0, warning: 1, info: 2 } as const;
+const PIPE_RE = /\|/g;
+const NEWLINE_RE = /\r?\n/g;
+
+export interface MarkdownReportOptions {
+	commitSha?: string;
+	monorepo?: MonorepoResult;
+	runUrl?: string;
+	scope?: ScopeInfo;
+	targetPath: string;
+	version: string;
+	warnings?: string[];
+}
+
+const escapeCell = (text: string): string =>
+	text.replace(PIPE_RE, "\\|").replace(NEWLINE_RE, " ");
+
+const scoreEmoji = (score: number): string => {
+	if (score >= 75) {
+		return "🟢";
+	}
+	if (score >= 50) {
+		return "🟡";
+	}
+	return "🔴";
+};
+
+const pluralize = (count: number, noun: string): string =>
+	`${count} ${noun}${count === 1 ? "" : "s"}`;
+
+const sortDiagnostics = (diagnostics: Diagnostic[]): Diagnostic[] =>
+	[...diagnostics].sort((a, b) => {
+		const bySeverity = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+		if (bySeverity !== 0) {
+			return bySeverity;
+		}
+		return a.filePath.localeCompare(b.filePath);
+	});
+
+const locationOf = (diagnostic: Diagnostic, targetPath: string): string => {
+	const path = toRelativePath(targetPath, diagnostic.filePath);
+	if (isCodeDiagnostic(diagnostic)) {
+		return `\`${path}:${diagnostic.line}\``;
+	}
+	return `\`${path}\` (${diagnostic.entity})`;
+};
+
+function renderHeadline(
+	result: DiagnoseResult,
+	scope: ScopeInfo | undefined
+): string {
+	const { score, summary } = result;
+	const counts = [
+		summary.errors ? pluralize(summary.errors, "error") : null,
+		summary.warnings ? pluralize(summary.warnings, "warning") : null,
+		summary.info ? `${summary.info} info` : null,
+	]
+		.filter(Boolean)
+		.join(", ");
+
+	const scopeNoun =
+		scope?.mode === "changed" ? "introduced by this change" : "reported";
+	const findings = summary.total
+		? `**${pluralize(summary.total, "finding")}** ${scopeNoun} (${counts}).`
+		: `No findings ${scopeNoun}. ✨`;
+
+	return `${scoreEmoji(score.value)} **Score ${score.value}/100 — ${score.label}** · ${findings}`;
+}
+
+function renderScopeNote(scope: ScopeInfo | undefined): string[] {
+	if (!scope) {
+		return [];
+	}
+
+	const lines: string[] = [];
+	if (scope.degradedFrom) {
+		lines.push(
+			"> [!WARNING]",
+			`> Could not scope to \`${scope.degradedFrom}\` — reporting \`${scope.mode}\` instead. On a shallow CI checkout, set \`fetch-depth: 0\`.`,
+			""
+		);
+	}
+	if (scope.mode === "changed" && scope.fixed) {
+		lines.push(
+			`> ✅ This change also resolved ${pluralize(scope.fixed, "existing finding")}.`,
+			""
+		);
+	}
+	if (scope.changedFiles !== undefined) {
+		lines.push(
+			`<sub>Scope \`${scope.mode}\` over ${pluralize(scope.changedFiles, "changed file")}${scope.baseRef ? ` vs \`${scope.baseRef}\`` : ""}.</sub>`
+		);
+	}
+	return lines.length ? ["", ...lines] : [];
+}
+
+function renderCategoryTable(result: DiagnoseResult): string[] {
+	const entries = (
+		Object.entries(result.summary.byCategory) as [Category, number][]
+	).filter(([, count]) => count > 0);
+
+	if (entries.length === 0) {
+		return [];
+	}
+
+	return [
+		"",
+		"| Category | Findings |",
+		"| --- | ---: |",
+		...entries.map(([category, count]) => `| ${category} | ${count} |`),
+	];
+}
+
+function renderFindingsTable(
+	result: DiagnoseResult,
+	targetPath: string
+): string[] {
+	if (result.diagnostics.length === 0) {
+		return [];
+	}
+
+	const sorted = sortDiagnostics(result.diagnostics);
+	const shown = sorted.slice(0, MAX_TABLE_ROWS);
+	const rows = shown.map(
+		(diagnostic) =>
+			`| ${SEVERITY_ICON[diagnostic.severity]} | \`${diagnostic.rule}\` | ${locationOf(diagnostic, targetPath)} | ${escapeCell(diagnostic.message)} |`
+	);
+
+	const overflow =
+		sorted.length > shown.length
+			? [
+					"",
+					`_… and ${sorted.length - shown.length} more. Run \`npx nestjs-doctor . --verbose\` locally for the full list._`,
+				]
+			: [];
+
+	return [
+		"",
+		`<details open><summary><b>Findings (${sorted.length})</b></summary>`,
+		"",
+		"| | Rule | Location | Message |",
+		"| :-: | --- | --- | --- |",
+		...rows,
+		...overflow,
+		"",
+		"</details>",
+	];
+}
+
+function renderMonorepoTable(monorepo: MonorepoResult | undefined): string[] {
+	if (!monorepo?.isMonorepo || monorepo.subProjects.length === 0) {
+		return [];
+	}
+
+	return [
+		"",
+		"<details><summary><b>Per-project scores</b></summary>",
+		"",
+		"| Project | Score | Findings |",
+		"| --- | ---: | ---: |",
+		...monorepo.subProjects.map(
+			({ name, result }) =>
+				`| \`${name}\` | ${result.score.value}/100 | ${result.summary.total} |`
+		),
+		"",
+		"</details>",
+	];
+}
+
+function renderFooter(options: MarkdownReportOptions): string[] {
+	const parts = [`nestjs-doctor v${options.version}`];
+	if (options.scope) {
+		parts.push(`scope \`${options.scope.mode}\``);
+	}
+	if (options.commitSha) {
+		parts.push(`commit \`${options.commitSha.slice(0, 7)}\``);
+	}
+	const line = options.runUrl
+		? `<sub>${parts.join(" · ")} · [run details](${options.runUrl})</sub>`
+		: `<sub>${parts.join(" · ")}</sub>`;
+	return ["", "---", line];
+}
+
+/** Renders a result as the markdown a CI job posts. */
+export function buildMarkdownReport(
+	result: DiagnoseResult,
+	options: MarkdownReportOptions
+): string {
+	const warnings = (options.warnings ?? []).filter(Boolean);
+
+	return [
+		MARKDOWN_COMMENT_MARKER,
+		"## 🩺 nestjs-doctor",
+		"",
+		renderHeadline(result, options.scope),
+		...renderScopeNote(options.scope),
+		...(warnings.length
+			? ["", "> [!NOTE]", ...warnings.map((warning) => `> ${warning}`)]
+			: []),
+		...renderCategoryTable(result),
+		...renderFindingsTable(result, options.targetPath),
+		...renderMonorepoTable(options.monorepo),
+		...renderFooter(options),
+		"",
+	].join("\n");
+}

--- a/packages/nestjs-doctor/src/formatters/sarif-report.ts
+++ b/packages/nestjs-doctor/src/formatters/sarif-report.ts
@@ -1,0 +1,201 @@
+import { pathToFileURL } from "node:url";
+import type { Diagnostic, Severity } from "../common/diagnostic.js";
+import { isCodeDiagnostic } from "../common/diagnostic.js";
+import type { DiagnoseResult } from "../common/result.js";
+import { fingerprint, toRelativePath } from "../engine/fingerprint.js";
+import { getRules } from "../engine/rules/index.js";
+
+const SARIF_VERSION = "2.1.0";
+const SARIF_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json";
+const DOCS_BASE_URL = "https://nestjs.doctor/docs/rules";
+const SRCROOT = "%SRCROOT%";
+
+type SarifLevel = "error" | "warning" | "note";
+
+const LEVEL_BY_SEVERITY: Record<Severity, SarifLevel> = {
+	error: "error",
+	warning: "warning",
+	info: "note",
+};
+
+// SARIF's `problem.severity` drives the alert grouping GitHub shows.
+const PROBLEM_SEVERITY: Record<Severity, string> = {
+	error: "error",
+	warning: "warning",
+	info: "recommendation",
+};
+
+interface SarifRule {
+	fullDescription: { text: string };
+	help: { markdown: string; text: string };
+	helpUri: string;
+	id: string;
+	name: string;
+	properties: {
+		problem: { severity: string };
+		tags: string[];
+	};
+	shortDescription: { text: string };
+}
+
+interface SarifResult {
+	level: SarifLevel;
+	locations: {
+		physicalLocation: {
+			artifactLocation: { uri: string; uriBaseId: string };
+			region: { startColumn?: number; startLine: number };
+		};
+	}[];
+	message: { text: string };
+	partialFingerprints: Record<string, string>;
+	ruleId: string;
+	ruleIndex: number;
+}
+
+export interface SarifLog {
+	$schema: string;
+	runs: {
+		columnKind: string;
+		originalUriBaseIds: Record<string, { uri: string }>;
+		results: SarifResult[];
+		tool: {
+			driver: {
+				informationUri: string;
+				name: string;
+				rules: SarifRule[];
+				semanticVersion: string;
+				version: string;
+			};
+		};
+	}[];
+	version: string;
+}
+
+const ruleCategory = (ruleId: string): string => {
+	const slash = ruleId.indexOf("/");
+	return slash === -1 ? "correctness" : ruleId.slice(0, slash);
+};
+
+const helpUri = (ruleId: string): string =>
+	`${DOCS_BASE_URL}/${ruleCategory(ruleId)}`;
+
+/**
+ * Builds the rule catalogue, synthesising an entry for any rule a diagnostic
+ * references that `getRules()` does not return.
+ */
+function buildRuleCatalogue(diagnostics: Diagnostic[]): {
+	indexById: Map<string, number>;
+	rules: SarifRule[];
+} {
+	const rules: SarifRule[] = [];
+	const indexById = new Map<string, number>();
+
+	const push = (
+		id: string,
+		description: string,
+		help: string,
+		severity: Severity
+	): void => {
+		if (indexById.has(id)) {
+			return;
+		}
+		indexById.set(id, rules.length);
+		rules.push({
+			id,
+			name: id,
+			shortDescription: { text: description },
+			fullDescription: { text: description },
+			help: { text: help, markdown: help },
+			helpUri: helpUri(id),
+			properties: {
+				tags: ["nestjs", ruleCategory(id)],
+				problem: { severity: PROBLEM_SEVERITY[severity] },
+			},
+		});
+	};
+
+	for (const rule of getRules()) {
+		push(
+			rule.meta.id,
+			rule.meta.description,
+			rule.meta.help,
+			rule.meta.severity
+		);
+	}
+	for (const diagnostic of diagnostics) {
+		push(
+			diagnostic.rule,
+			diagnostic.message,
+			diagnostic.help,
+			diagnostic.severity
+		);
+	}
+
+	return { rules, indexById };
+}
+
+/**
+ * Renders a result as a SARIF 2.1.0 log, with an explicit `partialFingerprints`
+ * on every result.
+ */
+export function buildSarifLog(
+	result: DiagnoseResult,
+	targetPath: string,
+	version: string
+): SarifLog {
+	const { rules, indexById } = buildRuleCatalogue(result.diagnostics);
+
+	const results: SarifResult[] = result.diagnostics.map((diagnostic) => {
+		const isCode = isCodeDiagnostic(diagnostic);
+		return {
+			ruleId: diagnostic.rule,
+			ruleIndex: indexById.get(diagnostic.rule) ?? 0,
+			level: LEVEL_BY_SEVERITY[diagnostic.severity],
+			message: { text: `${diagnostic.message} ${diagnostic.help}`.trim() },
+			locations: [
+				{
+					physicalLocation: {
+						artifactLocation: {
+							uri: toRelativePath(targetPath, diagnostic.filePath),
+							uriBaseId: SRCROOT,
+						},
+						// Schema findings describe an entity rather than a span, so they
+						// anchor at the top of the file that declares it.
+						region: isCode
+							? {
+									startLine: Math.max(1, diagnostic.line),
+									startColumn: Math.max(1, diagnostic.column),
+								}
+							: { startLine: 1 },
+					},
+				},
+			],
+			partialFingerprints: {
+				"nestjsDoctor/v1": fingerprint(diagnostic, targetPath),
+			},
+		};
+	});
+
+	return {
+		$schema: SARIF_SCHEMA,
+		version: SARIF_VERSION,
+		runs: [
+			{
+				tool: {
+					driver: {
+						name: "nestjs-doctor",
+						informationUri: "https://nestjs.doctor",
+						version,
+						semanticVersion: version,
+						rules,
+					},
+				},
+				originalUriBaseIds: {
+					[SRCROOT]: { uri: pathToFileURL(`${targetPath}/`).href },
+				},
+				results,
+				columnKind: "utf16CodeUnits",
+			},
+		],
+	};
+}

--- a/packages/nestjs-doctor/tests/integration/scope.test.ts
+++ b/packages/nestjs-doctor/tests/integration/scope.test.ts
@@ -1,0 +1,185 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Diagnostic } from "../../src/common/diagnostic.js";
+import { computeBaselineDelta } from "../../src/engine/baseline.js";
+import {
+	buildAnalysisContext,
+	diagnose,
+	resolveScanConfig,
+} from "../../src/engine/scanner.js";
+import { applyScope, resolveScope } from "../../src/engine/scope.js";
+
+const PATH_SEPARATOR_RE = /[/\\]/;
+
+const git = (cwd: string, ...args: string[]): void => {
+	execFileSync("git", args, { cwd, stdio: "ignore" });
+};
+
+const service = (name: string, body: string): string =>
+	`import { Injectable } from "@nestjs/common";
+import { readFileSync } from "node:fs";
+
+@Injectable()
+export class ${name} {
+${body}
+}
+`;
+
+const scanHead = async (targetPath: string) => {
+	const scanConfig = await resolveScanConfig(targetPath);
+	const context = await buildAnalysisContext(targetPath, scanConfig);
+	return { diagnostics: diagnose(context).diagnostics, scanConfig };
+};
+
+const rulesIn = (diagnostics: Diagnostic[]): string[] =>
+	[
+		...new Set(
+			diagnostics.map((d) => d.filePath.split(PATH_SEPARATOR_RE).pop())
+		),
+	].sort();
+
+describe("diff-scoped scanning", () => {
+	let root: string;
+
+	beforeAll(() => {
+		root = mkdtempSync(join(tmpdir(), "nestjs-doctor-scope-int-"));
+		git(root, "init", "-q", ".");
+		git(root, "config", "user.email", "test@example.com");
+		git(root, "config", "user.name", "Test");
+		git(root, "config", "commit.gpgsign", "false");
+
+		mkdirSync(join(root, "src"), { recursive: true });
+		writeFileSync(
+			join(root, "package.json"),
+			JSON.stringify({
+				name: "scope-fixture",
+				dependencies: {
+					"@nestjs/core": "^11.0.0",
+					"@nestjs/common": "^11.0.0",
+				},
+			})
+		);
+		// Pre-existing finding that the change must never be blamed for.
+		writeFileSync(
+			join(root, "src/legacy.service.ts"),
+			service(
+				"LegacyService",
+				'  read() {\n    return readFileSync("/tmp/a");\n  }'
+			)
+		);
+		git(root, "add", "-A");
+		git(root, "commit", "-qm", "base");
+
+		// The change: pad legacy.service.ts so its finding shifts lines without
+		// changing, and add a brand-new finding in another file.
+		writeFileSync(
+			join(root, "src/legacy.service.ts"),
+			`${"// padding\n".repeat(12)}${service("LegacyService", '  read() {\n    return readFileSync("/tmp/a");\n  }')}`
+		);
+		writeFileSync(
+			join(root, "src/fresh.service.ts"),
+			service(
+				"FreshService",
+				'  read() {\n    return readFileSync("/tmp/b");\n  }'
+			)
+		);
+		git(root, "add", "-A");
+		git(root, "commit", "-qm", "head");
+	});
+
+	afterAll(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("reports both files at full scope", async () => {
+		const { diagnostics } = await scanHead(root);
+		expect(rulesIn(diagnostics)).toContain("legacy.service.ts");
+		expect(rulesIn(diagnostics)).toContain("fresh.service.ts");
+	});
+
+	it("reports every finding in the changed files at files scope", async () => {
+		const { diagnostics } = await scanHead(root);
+		const scope = resolveScope({
+			mode: "files",
+			targetPath: root,
+			base: "HEAD~1",
+		});
+		expect(scope.mode).toBe("files");
+		// Both files changed, so `files` scope still shows the pre-existing one.
+		expect(rulesIn(applyScope(diagnostics, scope))).toEqual([
+			"fresh.service.ts",
+			"legacy.service.ts",
+		]);
+	});
+
+	it("reports only the new finding at changed scope", async () => {
+		const { diagnostics, scanConfig } = await scanHead(root);
+		const scope = resolveScope({
+			mode: "changed",
+			targetPath: root,
+			base: "HEAD~1",
+		});
+		const delta = await computeBaselineDelta(
+			diagnostics,
+			scope,
+			root,
+			scanConfig
+		);
+
+		expect(delta.available).toBe(true);
+		expect(delta.fixed).toBe(0);
+		// legacy.service.ts moved down twelve lines but is not a new problem.
+		expect(rulesIn(delta.introduced)).toEqual(["fresh.service.ts"]);
+	});
+
+	it("counts a resolved finding as fixed", async () => {
+		writeFileSync(
+			join(root, "src/legacy.service.ts"),
+			service("LegacyService", '  read() {\n    return "static";\n  }')
+		);
+		git(root, "add", "-A");
+		git(root, "commit", "-qm", "fix legacy");
+
+		const { diagnostics, scanConfig } = await scanHead(root);
+		const scope = resolveScope({
+			mode: "changed",
+			targetPath: root,
+			base: "HEAD~1",
+		});
+		const delta = await computeBaselineDelta(
+			diagnostics,
+			scope,
+			root,
+			scanConfig
+		);
+
+		expect(delta.available).toBe(true);
+		expect(delta.fixed).toBeGreaterThanOrEqual(1);
+		expect(delta.introduced).toEqual([]);
+	});
+
+	it("reports everything, and says why, when the base is unreachable", async () => {
+		const { diagnostics, scanConfig } = await scanHead(root);
+		const scope = resolveScope({
+			mode: "changed",
+			targetPath: root,
+			base: "0000000000000000000000000000000000000000",
+		});
+
+		// An unresolvable base degrades during resolution, before any scan runs.
+		expect(scope.mode).toBe("full");
+		expect(scope.warnings.join(" ")).toContain("not in this checkout");
+
+		const delta = await computeBaselineDelta(
+			diagnostics,
+			{ ...scope, mode: "changed", baseRef: null },
+			root,
+			scanConfig
+		);
+		expect(delta.available).toBe(false);
+		expect(delta.introduced).toBe(diagnostics);
+	});
+});

--- a/packages/nestjs-doctor/tests/integration/scope.test.ts
+++ b/packages/nestjs-doctor/tests/integration/scope.test.ts
@@ -14,8 +14,26 @@ import { applyScope, resolveScope } from "../../src/engine/scope.js";
 
 const PATH_SEPARATOR_RE = /[/\\]/;
 
+// The suite runs from a husky pre-commit hook, and git exports GIT_DIR and
+// friends to every hook. Inherited, they point these fixture repos at the outer
+// repository, so `add` and `commit` land in the wrong index.
+const CLEAN_GIT_ENV = { ...process.env };
+for (const name of [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_NAMESPACE",
+	"GIT_PREFIX",
+	"GIT_CEILING_DIRECTORIES",
+]) {
+	delete CLEAN_GIT_ENV[name];
+}
+
 const git = (cwd: string, ...args: string[]): void => {
-	execFileSync("git", args, { cwd, stdio: "ignore" });
+	execFileSync("git", args, { cwd, env: CLEAN_GIT_ENV, stdio: "ignore" });
 };
 
 const service = (name: string, body: string): string =>

--- a/packages/nestjs-doctor/tests/unit/blocking.test.ts
+++ b/packages/nestjs-doctor/tests/unit/blocking.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+	BLOCKING_LEVELS,
+	isBlockingLevel,
+	resolveBlocking,
+	shouldBlock,
+	validateBlockingArg,
+} from "../../src/cli/blocking.js";
+import type { DiagnoseSummary } from "../../src/common/result.js";
+
+const summary = (
+	errors: number,
+	warnings: number,
+	info = 0
+): DiagnoseSummary => ({
+	total: errors + warnings + info,
+	errors,
+	warnings,
+	info,
+	byCategory: {
+		security: 0,
+		performance: 0,
+		correctness: 0,
+		architecture: 0,
+		schema: 0,
+	},
+});
+
+describe("blocking levels", () => {
+	it("exposes exactly the three documented levels", () => {
+		expect(BLOCKING_LEVELS).toEqual(["none", "warning", "error"]);
+	});
+
+	it("recognises valid levels and rejects anything else", () => {
+		expect(isBlockingLevel("warning")).toBe(true);
+		expect(isBlockingLevel("fatal")).toBe(false);
+		expect(isBlockingLevel("")).toBe(false);
+	});
+
+	it("returns an actionable message for an invalid value", () => {
+		expect(validateBlockingArg("error")).toBeNull();
+		expect(validateBlockingArg("nope")).toContain("none, warning, error");
+	});
+});
+
+describe("resolveBlocking", () => {
+	it("defaults the console report to failing on errors", () => {
+		expect(resolveBlocking(undefined, false)).toBe("error");
+	});
+
+	it("defaults machine-readable output to never failing on findings", () => {
+		// Preserves the pre-`--blocking` behaviour: `--json` and `--score` only
+		// ever failed on `--min-score`.
+		expect(resolveBlocking(undefined, true)).toBe("none");
+	});
+
+	it("lets an explicit level override the per-mode default in both directions", () => {
+		expect(resolveBlocking("none", false)).toBe("none");
+		expect(resolveBlocking("error", true)).toBe("error");
+		expect(resolveBlocking("warning", true)).toBe("warning");
+	});
+
+	it("falls back to the default when the explicit value is not a level", () => {
+		expect(resolveBlocking("bogus", false)).toBe("error");
+	});
+});
+
+describe("shouldBlock", () => {
+	it("never blocks at level none", () => {
+		expect(shouldBlock(summary(9, 9, 9), "none")).toBe(false);
+	});
+
+	it("blocks at level error only when errors are present", () => {
+		expect(shouldBlock(summary(1, 0), "error")).toBe(true);
+		expect(shouldBlock(summary(0, 5), "error")).toBe(false);
+		expect(shouldBlock(summary(0, 0, 5), "error")).toBe(false);
+	});
+
+	it("blocks at level warning on errors or warnings, but not on info", () => {
+		expect(shouldBlock(summary(0, 1), "warning")).toBe(true);
+		expect(shouldBlock(summary(2, 0), "warning")).toBe(true);
+		expect(shouldBlock(summary(0, 0, 3), "warning")).toBe(false);
+	});
+
+	it("passes a clean summary at every level", () => {
+		for (const level of BLOCKING_LEVELS) {
+			expect(shouldBlock(summary(0, 0), level)).toBe(false);
+		}
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/fingerprint.test.ts
+++ b/packages/nestjs-doctor/tests/unit/fingerprint.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import type {
+	CodeDiagnostic,
+	Diagnostic,
+	SchemaDiagnostic,
+} from "../../src/common/diagnostic.js";
+import {
+	countIdentities,
+	diagnosticIdentity,
+	diffDiagnostics,
+	fingerprint,
+	toRelativePath,
+} from "../../src/engine/fingerprint.js";
+
+const ROOT = "/repo";
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+const code = (
+	overrides: Partial<CodeDiagnostic> & { line: number }
+): CodeDiagnostic => ({
+	rule: "performance/no-sync-io",
+	category: "performance",
+	severity: "warning",
+	filePath: "/repo/src/a.service.ts",
+	message: "Synchronous I/O call 'readFileSync()' blocks the event loop.",
+	help: "Use the async variant.",
+	column: 1,
+	sourceLines: [{ line: overrides.line, text: '    readFileSync("/tmp/a");' }],
+	...overrides,
+});
+
+const schema = (
+	overrides: Partial<SchemaDiagnostic> = {}
+): SchemaDiagnostic => ({
+	rule: "schema/require-primary-key",
+	category: "schema",
+	severity: "error",
+	filePath: "/repo/prisma/schema.prisma",
+	message: "Entity 'User' has no primary key column.",
+	help: "Add a primary key.",
+	entity: "User",
+	...overrides,
+});
+
+describe("toRelativePath", () => {
+	it("returns a posix path relative to the target", () => {
+		expect(toRelativePath("/repo", "/repo/src/a.ts")).toBe("src/a.ts");
+	});
+
+	it("keeps the absolute path when the file sits outside the target", () => {
+		expect(toRelativePath("/repo/src", "/elsewhere/b.ts")).toBe(
+			"/elsewhere/b.ts"
+		);
+	});
+});
+
+describe("diagnosticIdentity", () => {
+	it("is stable when the finding moves to a different line", () => {
+		// The whole point of the baseline: an edit higher up in the file must not
+		// turn an existing finding into a newly introduced one.
+		const before = code({ line: 7 });
+		const after = code({
+			line: 42,
+			sourceLines: [{ line: 42, text: '    readFileSync("/tmp/a");' }],
+		});
+		expect(diagnosticIdentity(after, ROOT)).toBe(
+			diagnosticIdentity(before, ROOT)
+		);
+	});
+
+	it("is stable across re-indentation of the anchor line", () => {
+		const spaced = code({
+			line: 7,
+			sourceLines: [{ line: 7, text: '\t\treadFileSync(  "/tmp/a" );' }],
+		});
+		const tight = code({
+			line: 7,
+			sourceLines: [{ line: 7, text: 'readFileSync( "/tmp/a" );' }],
+		});
+		expect(diagnosticIdentity(spaced, ROOT)).toBe(
+			diagnosticIdentity(tight, ROOT)
+		);
+	});
+
+	it("differs when the source line actually changes", () => {
+		const original = code({ line: 7 });
+		const edited = code({
+			line: 7,
+			sourceLines: [{ line: 7, text: '    readFileSync("/tmp/OTHER");' }],
+		});
+		expect(diagnosticIdentity(edited, ROOT)).not.toBe(
+			diagnosticIdentity(original, ROOT)
+		);
+	});
+
+	it("differs across files, rules, and messages", () => {
+		const base = diagnosticIdentity(code({ line: 3 }), ROOT);
+		expect(
+			diagnosticIdentity(code({ line: 3, filePath: "/repo/src/b.ts" }), ROOT)
+		).not.toBe(base);
+		expect(
+			diagnosticIdentity(code({ line: 3, rule: "performance/no-eval" }), ROOT)
+		).not.toBe(base);
+		expect(
+			diagnosticIdentity(code({ line: 3, message: "Something else." }), ROOT)
+		).not.toBe(base);
+	});
+
+	it("separates schema findings by entity and column", () => {
+		const user = diagnosticIdentity(schema(), ROOT);
+		const order = diagnosticIdentity(schema({ entity: "Order" }), ROOT);
+		const scoped = diagnosticIdentity(schema({ schemaColumn: "id" }), ROOT);
+		expect(order).not.toBe(user);
+		expect(scoped).not.toBe(user);
+	});
+
+	it("is comparable across two checkouts of the same repository", () => {
+		const head = code({ line: 7 });
+		const base = code({ line: 7, filePath: "/tmp/base-xyz/src/a.service.ts" });
+		expect(diagnosticIdentity(base, "/tmp/base-xyz")).toBe(
+			diagnosticIdentity(head, ROOT)
+		);
+	});
+});
+
+describe("fingerprint", () => {
+	it("is a hex digest that tracks the identity", () => {
+		const value = fingerprint(code({ line: 1 }), ROOT);
+		expect(value).toMatch(SHA256_HEX_RE);
+		expect(fingerprint(code({ line: 99 }), ROOT)).toBe(value);
+	});
+});
+
+describe("countIdentities", () => {
+	it("counts repeats rather than collapsing them", () => {
+		const counts = countIdentities(
+			[code({ line: 1 }), code({ line: 9 }), code({ line: 2, rule: "x/y" })],
+			ROOT
+		);
+		expect([...counts.values()].sort()).toEqual([1, 2]);
+	});
+});
+
+describe("diffDiagnostics", () => {
+	const at = (line: number, text: string): CodeDiagnostic =>
+		code({ line, sourceLines: [{ line, text }] });
+
+	it("reports nothing when head and base match", () => {
+		const head: Diagnostic[] = [at(1, "a()"), at(2, "b()")];
+		const base: Diagnostic[] = [at(50, "a()"), at(60, "b()")];
+		const delta = diffDiagnostics(head, base, ROOT, ROOT);
+		expect(delta.introduced).toEqual([]);
+		expect(delta.fixed).toBe(0);
+	});
+
+	it("reports only what the change added", () => {
+		const added = at(3, "c()");
+		const delta = diffDiagnostics(
+			[at(1, "a()"), added],
+			[at(1, "a()")],
+			ROOT,
+			ROOT
+		);
+		expect(delta.introduced).toEqual([added]);
+		expect(delta.fixed).toBe(0);
+	});
+
+	it("counts what the change removed", () => {
+		const delta = diffDiagnostics(
+			[at(1, "a()")],
+			[at(1, "a()"), at(2, "b()")],
+			ROOT,
+			ROOT
+		);
+		expect(delta.introduced).toEqual([]);
+		expect(delta.fixed).toBe(1);
+	});
+
+	it("subtracts duplicates one at a time", () => {
+		// Three identical findings that become four should report one new one —
+		// not zero (set semantics) and not four.
+		const head = [at(1, "a()"), at(2, "a()"), at(3, "a()"), at(4, "a()")];
+		const base = [at(1, "a()"), at(2, "a()"), at(3, "a()")];
+		const delta = diffDiagnostics(head, base, ROOT, ROOT);
+		expect(delta.introduced).toHaveLength(1);
+		expect(delta.fixed).toBe(0);
+	});
+
+	it("treats an empty base as everything being new", () => {
+		const head = [at(1, "a()"), at(2, "b()")];
+		expect(diffDiagnostics(head, [], ROOT, ROOT).introduced).toEqual(head);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/formatters.test.ts
+++ b/packages/nestjs-doctor/tests/unit/formatters.test.ts
@@ -233,6 +233,21 @@ describe("buildMarkdownReport", () => {
 		expect(markdown).toContain("resolved 2 existing findings");
 	});
 
+	it("counts files in scope, not files in the change", () => {
+		// The narrowed set, always smaller than a pull request's own file count.
+		const scope = {
+			mode: "changed" as const,
+			changedFiles: 5,
+			baseRef: "main",
+		};
+		const markdown = buildMarkdownReport(
+			{ ...resultWith([]), scope },
+			{ ...options, scope }
+		);
+		expect(markdown).toContain("5 files in scope");
+		expect(markdown).not.toContain("changed file");
+	});
+
 	it("warns when the requested scope could not be honoured", () => {
 		const scope = {
 			mode: "files" as const,

--- a/packages/nestjs-doctor/tests/unit/formatters.test.ts
+++ b/packages/nestjs-doctor/tests/unit/formatters.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildAnnotations,
+	escapeCommandData,
+	escapeCommandProperty,
+} from "../../src/cli/formatters/github-reporter.js";
+import {
+	isOutputFormat,
+	OUTPUT_FORMATS,
+	validateFormatArg,
+} from "../../src/cli/formatters/render.js";
+import type {
+	CodeDiagnostic,
+	Diagnostic,
+	SchemaDiagnostic,
+} from "../../src/common/diagnostic.js";
+import type { DiagnoseResult } from "../../src/common/result.js";
+import { buildCodeQualityReport } from "../../src/formatters/gitlab-report.js";
+import {
+	buildMarkdownReport,
+	MARKDOWN_COMMENT_MARKER,
+} from "../../src/formatters/markdown-report.js";
+import { buildSarifLog } from "../../src/formatters/sarif-report.js";
+
+const ROOT = "/repo";
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+const code = (
+	overrides: Partial<CodeDiagnostic> & { line: number }
+): CodeDiagnostic => ({
+	rule: "performance/no-sync-io",
+	category: "performance",
+	severity: "warning",
+	filePath: "/repo/src/a.service.ts",
+	message: "Synchronous I/O call blocks the event loop.",
+	help: "Use the async variant.",
+	column: 3,
+	...overrides,
+});
+
+const schemaDiagnostic: SchemaDiagnostic = {
+	rule: "schema/require-primary-key",
+	category: "schema",
+	severity: "error",
+	filePath: "/repo/prisma/schema.prisma",
+	message: "Entity 'User' has no primary key column.",
+	help: "Add a primary key.",
+	entity: "User",
+};
+
+const resultWith = (diagnostics: Diagnostic[]): DiagnoseResult => ({
+	score: { value: 72, label: "Fair" },
+	diagnostics,
+	project: {
+		name: "app",
+		nestVersion: "11.0.0",
+		orm: "prisma",
+		framework: "express",
+		fileCount: 10,
+		moduleCount: 3,
+	},
+	summary: {
+		total: diagnostics.length,
+		errors: diagnostics.filter((d) => d.severity === "error").length,
+		warnings: diagnostics.filter((d) => d.severity === "warning").length,
+		info: diagnostics.filter((d) => d.severity === "info").length,
+		byCategory: {
+			security: 0,
+			performance: diagnostics.filter((d) => d.category === "performance")
+				.length,
+			correctness: 0,
+			architecture: 0,
+			schema: diagnostics.filter((d) => d.category === "schema").length,
+		},
+	},
+	ruleErrors: [],
+	elapsedMs: 12,
+});
+
+describe("output formats", () => {
+	it("lists every supported format", () => {
+		expect(OUTPUT_FORMATS).toEqual([
+			"console",
+			"json",
+			"sarif",
+			"gitlab",
+			"markdown",
+			"github",
+		]);
+	});
+
+	it("validates the format argument", () => {
+		expect(isOutputFormat("sarif")).toBe(true);
+		expect(isOutputFormat("xml")).toBe(false);
+		expect(validateFormatArg("gitlab")).toBeNull();
+		expect(validateFormatArg("xml")).toContain("console, json, sarif");
+	});
+});
+
+describe("buildSarifLog", () => {
+	const log = buildSarifLog(
+		resultWith([code({ line: 8 }), schemaDiagnostic]),
+		ROOT,
+		"1.2.3"
+	);
+
+	it("emits SARIF 2.1.0 with a single run", () => {
+		expect(log.version).toBe("2.1.0");
+		expect(log.runs).toHaveLength(1);
+		expect(log.runs[0].tool.driver.version).toBe("1.2.3");
+	});
+
+	it("resolves every result's ruleIndex into the catalogue", () => {
+		const { rules, results } = {
+			rules: log.runs[0].tool.driver.rules,
+			results: log.runs[0].results,
+		};
+		for (const result of results) {
+			expect(rules[result.ruleIndex]?.id).toBe(result.ruleId);
+		}
+	});
+
+	it("maps severities onto SARIF levels", () => {
+		expect(log.runs[0].results[0].level).toBe("warning");
+		expect(log.runs[0].results[1].level).toBe("error");
+	});
+
+	it("reports repo-relative paths against a %SRCROOT% base", () => {
+		const location = log.runs[0].results[0].locations[0].physicalLocation;
+		expect(location.artifactLocation.uri).toBe("src/a.service.ts");
+		expect(location.artifactLocation.uriBaseId).toBe("%SRCROOT%");
+		expect(log.runs[0].originalUriBaseIds["%SRCROOT%"].uri).toContain("/repo/");
+	});
+
+	it("anchors a line-less schema finding at line 1, which SARIF requires", () => {
+		expect(log.runs[0].results[1].locations[0].physicalLocation.region).toEqual(
+			{
+				startLine: 1,
+			}
+		);
+	});
+
+	it("sets a partial fingerprint on every result so alerts survive edits", () => {
+		for (const result of log.runs[0].results) {
+			expect(result.partialFingerprints["nestjsDoctor/v1"]).toMatch(
+				SHA256_HEX_RE
+			);
+		}
+	});
+
+	it("synthesises a catalogue entry for a rule it does not know", () => {
+		const custom = code({ line: 2, rule: "custom/no-todo-comments" });
+		const customLog = buildSarifLog(resultWith([custom]), ROOT, "1.0.0");
+		const result = customLog.runs[0].results[0];
+		expect(customLog.runs[0].tool.driver.rules[result.ruleIndex].id).toBe(
+			"custom/no-todo-comments"
+		);
+	});
+});
+
+describe("buildCodeQualityReport", () => {
+	const issues = buildCodeQualityReport(
+		resultWith([code({ line: 8 }), schemaDiagnostic]),
+		ROOT
+	);
+
+	it("emits one entry per finding with the fields GitLab requires", () => {
+		expect(issues).toHaveLength(2);
+		for (const issue of issues) {
+			expect(issue.description).toBeTruthy();
+			expect(issue.check_name).toBeTruthy();
+			expect(issue.fingerprint).toMatch(SHA256_HEX_RE);
+			expect(issue.location.path.startsWith("/")).toBe(false);
+			expect(issue.location.lines.begin).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("maps severities onto GitLab's scale", () => {
+		expect(issues[0].severity).toBe("minor");
+		expect(issues[1].severity).toBe("major");
+	});
+});
+
+describe("buildMarkdownReport", () => {
+	const options = { targetPath: ROOT, version: "1.2.3" };
+
+	it("starts with the sticky-comment marker", () => {
+		const markdown = buildMarkdownReport(resultWith([]), options);
+		expect(markdown.startsWith(MARKDOWN_COMMENT_MARKER)).toBe(true);
+	});
+
+	it("says so plainly when there is nothing to report", () => {
+		expect(buildMarkdownReport(resultWith([]), options)).toContain(
+			"No findings"
+		);
+	});
+
+	it("lists findings with their location", () => {
+		const markdown = buildMarkdownReport(
+			resultWith([code({ line: 8 })]),
+			options
+		);
+		expect(markdown).toContain("`src/a.service.ts:8`");
+		expect(markdown).toContain("`performance/no-sync-io`");
+	});
+
+	it("escapes pipes so a message cannot break the table", () => {
+		const markdown = buildMarkdownReport(
+			resultWith([code({ line: 1, message: "a | b" })]),
+			options
+		);
+		expect(markdown).toContain("a \\| b");
+	});
+
+	it("caps the table and says how many were left out", () => {
+		const many = Array.from({ length: 60 }, (_, index) =>
+			code({ line: index + 1 })
+		);
+		const markdown = buildMarkdownReport(resultWith(many), options);
+		expect(markdown).toContain("and 10 more");
+	});
+
+	it("frames findings as introduced when reporting a baseline delta", () => {
+		const result = {
+			...resultWith([code({ line: 1 })]),
+			scope: { mode: "changed" as const, fixed: 2, changedFiles: 1 },
+		};
+		const markdown = buildMarkdownReport(result, {
+			...options,
+			scope: result.scope,
+		});
+		expect(markdown).toContain("introduced by this change");
+		expect(markdown).toContain("resolved 2 existing findings");
+	});
+
+	it("warns when the requested scope could not be honoured", () => {
+		const scope = {
+			mode: "files" as const,
+			degradedFrom: "changed" as const,
+			changedFiles: 3,
+		};
+		const markdown = buildMarkdownReport(
+			{ ...resultWith([]), scope },
+			{ ...options, scope }
+		);
+		expect(markdown).toContain("[!WARNING]");
+		expect(markdown).toContain("fetch-depth: 0");
+	});
+});
+
+describe("GitHub Actions annotations", () => {
+	it("escapes message bodies and property values", () => {
+		expect(escapeCommandData("50% of\nlines")).toBe("50%25 of%0Alines");
+		expect(escapeCommandProperty("a:b,c")).toBe("a%3Ab%2Cc");
+	});
+
+	it("emits file, line, and column for a code finding", () => {
+		const [line] = buildAnnotations(resultWith([code({ line: 8 })]), ROOT);
+		expect(line).toContain("::warning ");
+		expect(line).toContain("file=src/a.service.ts");
+		expect(line).toContain("line=8");
+		expect(line).toContain("col=3");
+	});
+
+	it("omits line and column for a schema finding", () => {
+		const [line] = buildAnnotations(resultWith([schemaDiagnostic]), ROOT);
+		expect(line).toContain("::error ");
+		expect(line).not.toContain("line=");
+	});
+
+	it("caps each level at GitHub's per-step limit of ten", () => {
+		// Beyond ten, GitHub drops annotations silently; the job summary and the
+		// pull request comment carry the complete set instead.
+		const many = Array.from({ length: 25 }, (_, index) =>
+			code({ line: index + 1 })
+		);
+		expect(buildAnnotations(resultWith(many), ROOT)).toHaveLength(10);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/git.test.ts
+++ b/packages/nestjs-doctor/tests/unit/git.test.ts
@@ -1,0 +1,318 @@
+import { execFileSync } from "node:child_process";
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The git helpers normalise to posix on every platform by design, so a link
+// built with `join` has to be normalised before it can be compared to one.
+const BACKSLASH_RE = /\\/g;
+const toPosix = (path: string): string => path.replace(BACKSLASH_RE, "/");
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	checkoutBase,
+	findGitRepo,
+	type GitRepo,
+	getChangedFiles,
+	getChangedLineRanges,
+	getStagedFiles,
+	parseDiffLineRanges,
+	refExists,
+	resolveBaseRef,
+	runGit,
+} from "../../src/engine/git.js";
+
+const git = (cwd: string, ...args: string[]): void => {
+	execFileSync("git", args, { cwd, stdio: "ignore" });
+};
+
+describe("git helpers", () => {
+	let root: string;
+	let repo: GitRepo;
+
+	beforeAll(() => {
+		root = mkdtempSync(join(tmpdir(), "nestjs-doctor-git-test-"));
+		git(root, "init", "-q", ".");
+		git(root, "config", "user.email", "test@example.com");
+		git(root, "config", "user.name", "Test");
+		git(root, "config", "commit.gpgsign", "false");
+
+		mkdirSync(join(root, "src"), { recursive: true });
+		writeFileSync(join(root, "src/a.ts"), "const a = 1;\nconst b = 2;\n");
+		writeFileSync(join(root, "src/keep.ts"), "const keep = 1;\n");
+		git(root, "add", "-A");
+		git(root, "commit", "-qm", "base");
+
+		writeFileSync(
+			join(root, "src/a.ts"),
+			"const a = 1;\nconst inserted = 0;\nconst b = 2;\n"
+		);
+		writeFileSync(join(root, "src/new.ts"), "const c = 3;\n");
+		git(root, "add", "-A");
+		git(root, "commit", "-qm", "head");
+
+		repo = findGitRepo(root) as GitRepo;
+	});
+
+	afterAll(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("finds the repository root", () => {
+		expect(repo).not.toBeNull();
+		expect(findGitRepo(join(root, "src"))?.root).toBe(repo.root);
+	});
+
+	it("returns null outside a repository", () => {
+		const loose = mkdtempSync(join(tmpdir(), "nestjs-doctor-not-git-"));
+		try {
+			// A stray parent repository would make this pass for the wrong reason,
+			// so only assert the shape when the temp dir really is standalone.
+			const found = findGitRepo(loose);
+			if (found) {
+				expect(found.root).not.toBe(loose);
+			} else {
+				expect(found).toBeNull();
+			}
+		} finally {
+			rmSync(loose, { recursive: true, force: true });
+		}
+	});
+
+	it("returns null rather than throwing on a failed command", () => {
+		expect(runGit(root, ["definitely-not-a-git-command"])).toBeNull();
+	});
+
+	it("recognises refs that exist and rejects ones that do not", () => {
+		expect(refExists(repo, "HEAD")).toBe(true);
+		expect(refExists(repo, "refs/heads/does-not-exist")).toBe(false);
+	});
+
+	it("resolves an explicit base only when it is reachable", () => {
+		expect(resolveBaseRef(repo, "HEAD~1")).toBe("HEAD~1");
+		expect(resolveBaseRef(repo, "nope/nope")).toBeNull();
+	});
+
+	it("lists the files a commit added or modified", () => {
+		const changed = getChangedFiles(repo, "HEAD~1");
+		expect(changed).not.toBeNull();
+		const names = (changed ?? []).map((path) => path.split("/").pop());
+		expect(names).toContain("a.ts");
+		expect(names).toContain("new.ts");
+		expect(names).not.toContain("keep.ts");
+	});
+
+	it("restricts the changed set to the scanned subdirectory", () => {
+		const scoped = findGitRepo(join(root, "src")) as GitRepo;
+		const changed = getChangedFiles(scoped, "HEAD~1") ?? [];
+		expect(changed.length).toBeGreaterThan(0);
+		expect(changed.every((path) => path.includes("/src/"))).toBe(true);
+	});
+
+	it("derives the changed line ranges on the new side", () => {
+		const ranges = getChangedLineRanges(repo, "HEAD~1");
+		expect(ranges).not.toBeNull();
+		const forA = [...(ranges ?? new Map())].find(([path]) =>
+			path.endsWith("/src/a.ts")
+		)?.[1];
+		// Only line 2 was inserted; lines 1 and 3 are untouched context.
+		expect(forA).toEqual([{ start: 2, end: 2 }]);
+	});
+
+	it("lists staged files", () => {
+		writeFileSync(join(root, "src/staged.ts"), "const s = 1;\n");
+		git(root, "add", "src/staged.ts");
+		try {
+			const staged = getStagedFiles(repo) ?? [];
+			expect(staged.map((path) => path.split("/").pop())).toEqual([
+				"staged.ts",
+			]);
+		} finally {
+			git(root, "reset", "-q");
+			rmSync(join(root, "src/staged.ts"), { force: true });
+		}
+	});
+
+	it("checks the base revision out into a disposable worktree", () => {
+		const checkout = checkoutBase(repo, "HEAD~1");
+		expect(checkout).not.toBeNull();
+		if (!checkout) {
+			return;
+		}
+		try {
+			const { readFileSync } = require("node:fs") as typeof import("node:fs");
+			// The base content, not HEAD's.
+			expect(
+				readFileSync(join(checkout.targetPath, "src/a.ts"), "utf-8")
+			).not.toContain("inserted");
+		} finally {
+			checkout.cleanup();
+			// Cleanup is idempotent, so a `finally` on an already-cleaned checkout
+			// cannot throw.
+			checkout.cleanup();
+		}
+	});
+
+	it("returns null when the base revision is unreachable", () => {
+		expect(
+			checkoutBase(repo, "0000000000000000000000000000000000000000")
+		).toBeNull();
+	});
+
+	it("resolves a repository reached through a symlink", () => {
+		// macOS hands out `/var/...` and `/tmp/...` paths that are symlinks to
+		// `/private/...`, and git always reports the canonical form. Deciding
+		// containment by comparing those two absolute paths matches nothing, which
+		// empties the changed-file set — a scoped scan then reports zero findings
+		// on a change that has plenty. Reproduced here with an explicit symlink so
+		// it is caught on every platform, not just macOS.
+		const link = join(tmpdir(), `nestjs-doctor-symlink-${process.pid}`);
+		rmSync(link, { force: true });
+		symlinkSync(root, link, "dir");
+
+		try {
+			const viaLink = findGitRepo(link);
+			expect(viaLink).not.toBeNull();
+			if (!viaLink) {
+				return;
+			}
+
+			const changed = getChangedFiles(viaLink, "HEAD~1") ?? [];
+			expect(changed.map((path) => path.split("/").pop())).toContain("a.ts");
+			// Paths come back in the caller's own space, so they still match the
+			// file paths the scanner puts on diagnostics.
+			expect(changed.every((path) => path.startsWith(toPosix(link)))).toBe(
+				true
+			);
+
+			const ranges = getChangedLineRanges(viaLink, "HEAD~1");
+			expect(ranges?.size).toBeGreaterThan(0);
+		} finally {
+			rmSync(link, { force: true });
+		}
+	});
+
+	it("scopes to a subdirectory reached through a symlink", () => {
+		const link = join(tmpdir(), `nestjs-doctor-symlink-sub-${process.pid}`);
+		rmSync(link, { force: true });
+		symlinkSync(root, link, "dir");
+
+		try {
+			const scoped = findGitRepo(join(link, "src"));
+			expect(scoped?.prefix).toBe("src");
+
+			const changed = scoped ? (getChangedFiles(scoped, "HEAD~1") ?? []) : [];
+			expect(changed.length).toBeGreaterThan(0);
+			expect(
+				changed.every((path) => path.startsWith(`${toPosix(link)}/src/`))
+			).toBe(true);
+		} finally {
+			rmSync(link, { force: true });
+		}
+	});
+
+	it("ignores the repository-scoping git variables a hook leaves in the environment", () => {
+		// Git exports GIT_DIR and friends to every hook it runs, and a hook's
+		// children inherit them — so `nestjs-doctor --staged` from a husky
+		// pre-commit would otherwise resolve refs against the hook's repository
+		// instead of the scanned one. The symptom is deceptive: `--show-toplevel`
+		// still honours `-C`, while ref resolution silently targets the wrong repo.
+		const other = mkdtempSync(join(tmpdir(), "nestjs-doctor-hook-env-"));
+		const saved = {
+			GIT_DIR: process.env.GIT_DIR,
+			GIT_INDEX_FILE: process.env.GIT_INDEX_FILE,
+			GIT_WORK_TREE: process.env.GIT_WORK_TREE,
+		};
+
+		try {
+			git(other, "init", "-q", ".");
+			git(other, "config", "user.email", "test@example.com");
+			git(other, "config", "user.name", "Test");
+			git(other, "config", "commit.gpgsign", "false");
+			writeFileSync(join(other, "only.txt"), "single commit\n");
+			git(other, "add", "-A");
+			git(other, "commit", "-qm", "only");
+
+			process.env.GIT_DIR = join(other, ".git");
+			process.env.GIT_INDEX_FILE = join(other, ".git/index");
+			process.env.GIT_WORK_TREE = other;
+
+			// `other` has a single commit, so a leaked GIT_DIR makes HEAD~1
+			// unresolvable and every one of these fails.
+			expect(getChangedFiles(repo, "HEAD~1")).not.toBeNull();
+
+			const checkout = checkoutBase(repo, "HEAD~1");
+			expect(checkout).not.toBeNull();
+			checkout?.cleanup();
+		} finally {
+			for (const [name, value] of Object.entries(saved)) {
+				if (value === undefined) {
+					delete process.env[name];
+				} else {
+					process.env[name] = value;
+				}
+			}
+			rmSync(other, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("parseDiffLineRanges", () => {
+	const repo: GitRepo = { prefix: "", root: "/repo", targetPath: "/repo" };
+
+	it("reads single-line and multi-line hunks", () => {
+		const diff = [
+			"diff --git a/src/a.ts b/src/a.ts",
+			"--- a/src/a.ts",
+			"+++ b/src/a.ts",
+			"@@ -1 +1 @@",
+			"@@ -10,0 +11,3 @@",
+			"",
+		].join("\n");
+		expect(parseDiffLineRanges(repo, diff).get("/repo/src/a.ts")).toEqual([
+			{ start: 1, end: 1 },
+			{ start: 11, end: 13 },
+		]);
+	});
+
+	it("ignores pure deletions, which touch no new-side line", () => {
+		const diff = [
+			"--- a/src/a.ts",
+			"+++ b/src/a.ts",
+			"@@ -4,2 +3,0 @@",
+			"",
+		].join("\n");
+		expect(parseDiffLineRanges(repo, diff).get("/repo/src/a.ts")).toEqual([]);
+	});
+
+	it("skips deleted files and paths outside the scanned directory", () => {
+		const repoScoped: GitRepo = {
+			prefix: "apps/api",
+			root: "/repo",
+			targetPath: "/repo/apps/api",
+		};
+		const diff = [
+			"--- a/src/gone.ts",
+			"+++ /dev/null",
+			"@@ -1,3 +0,0 @@",
+			"--- a/libs/x.ts",
+			"+++ b/libs/x.ts",
+			"@@ -1 +1,2 @@",
+			"--- a/apps/api/src/y.ts",
+			"+++ b/apps/api/src/y.ts",
+			"@@ -1 +5,1 @@",
+			"",
+		].join("\n");
+		const ranges = parseDiffLineRanges(repoScoped, diff);
+		expect([...ranges.keys()]).toEqual(["/repo/apps/api/src/y.ts"]);
+		expect(ranges.get("/repo/apps/api/src/y.ts")).toEqual([
+			{ start: 5, end: 5 },
+		]);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/git.test.ts
+++ b/packages/nestjs-doctor/tests/unit/git.test.ts
@@ -28,8 +28,26 @@ import {
 	runGit,
 } from "../../src/engine/git.js";
 
+// The suite runs from a husky pre-commit hook, and git exports GIT_DIR and
+// friends to every hook. Inherited, they point these fixture repos at the outer
+// repository, so `add` and `commit` land in the wrong index.
+const CLEAN_GIT_ENV = { ...process.env };
+for (const name of [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_NAMESPACE",
+	"GIT_PREFIX",
+	"GIT_CEILING_DIRECTORIES",
+]) {
+	delete CLEAN_GIT_ENV[name];
+}
+
 const git = (cwd: string, ...args: string[]): void => {
-	execFileSync("git", args, { cwd, stdio: "ignore" });
+	execFileSync("git", args, { cwd, env: CLEAN_GIT_ENV, stdio: "ignore" });
 };
 
 describe("git helpers", () => {

--- a/packages/nestjs-doctor/tests/unit/scope.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scope.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type {
+	CodeDiagnostic,
+	Diagnostic,
+	SchemaDiagnostic,
+} from "../../src/common/diagnostic.js";
+import { isScopeMode, SCOPE_MODES } from "../../src/common/scope.js";
+import type { GitRepo } from "../../src/engine/git.js";
+import {
+	applyScope,
+	buildScopeInfo,
+	type ResolvedScope,
+	resolveScope,
+} from "../../src/engine/scope.js";
+
+const repo: GitRepo = { prefix: "", root: "/repo", targetPath: "/repo" };
+
+const code = (filePath: string, line: number): CodeDiagnostic => ({
+	rule: "performance/no-sync-io",
+	category: "performance",
+	severity: "warning",
+	filePath,
+	message: "Synchronous I/O.",
+	help: "Use the async variant.",
+	column: 1,
+	line,
+});
+
+const schemaDiagnostic = (filePath: string): SchemaDiagnostic => ({
+	rule: "schema/require-primary-key",
+	category: "schema",
+	severity: "error",
+	filePath,
+	message: "No primary key.",
+	help: "Add one.",
+	entity: "User",
+});
+
+const scoped = (overrides: Partial<ResolvedScope>): ResolvedScope => ({
+	baseRef: "origin/main",
+	files: null,
+	lineRanges: null,
+	mode: "full",
+	repo,
+	requestedMode: "full",
+	warnings: [],
+	...overrides,
+});
+
+describe("scope modes", () => {
+	it("exposes the four documented modes", () => {
+		expect(SCOPE_MODES).toEqual(["full", "files", "lines", "changed"]);
+	});
+
+	it("recognises valid modes only", () => {
+		expect(isScopeMode("changed")).toBe(true);
+		expect(isScopeMode("diff")).toBe(false);
+	});
+});
+
+describe("applyScope", () => {
+	const a = code("/repo/src/a.ts", 5);
+	const b = code("/repo/src/b.ts", 5);
+	const schemaFinding = schemaDiagnostic("/repo/src/a.ts");
+	const all: Diagnostic[] = [a, b, schemaFinding];
+
+	it("returns everything in full mode", () => {
+		expect(applyScope(all, scoped({ mode: "full" }))).toBe(all);
+	});
+
+	it("keeps only findings in the changed files", () => {
+		const result = applyScope(
+			all,
+			scoped({ mode: "files", files: new Set(["/repo/src/a.ts"]) })
+		);
+		expect(result).toEqual([a, schemaFinding]);
+	});
+
+	it("keeps only findings inside a changed hunk in lines mode", () => {
+		const result = applyScope(
+			[code("/repo/src/a.ts", 3), a, code("/repo/src/a.ts", 20)],
+			scoped({
+				mode: "lines",
+				files: new Set(["/repo/src/a.ts"]),
+				lineRanges: new Map([["/repo/src/a.ts", [{ start: 4, end: 6 }]]]),
+			})
+		);
+		expect(result).toEqual([a]);
+	});
+
+	it("drops schema findings in lines mode, since they carry no line", () => {
+		const result = applyScope(
+			[schemaFinding],
+			scoped({
+				mode: "lines",
+				files: new Set(["/repo/src/a.ts"]),
+				lineRanges: new Map([["/repo/src/a.ts", [{ start: 1, end: 100 }]]]),
+			})
+		);
+		expect(result).toEqual([]);
+	});
+
+	it("falls back to file granularity when line ranges are unavailable", () => {
+		// Reporting a whole changed file beats reporting nothing at all.
+		const result = applyScope(
+			all,
+			scoped({
+				mode: "lines",
+				files: new Set(["/repo/src/b.ts"]),
+				lineRanges: null,
+			})
+		);
+		expect(result).toEqual([b]);
+	});
+
+	it("normalises Windows separators before matching", () => {
+		const windowsDiagnostic = code("C:\\repo\\src\\a.ts", 1);
+		const result = applyScope(
+			[windowsDiagnostic],
+			scoped({ mode: "files", files: new Set(["C:/repo/src/a.ts"]) })
+		);
+		expect(result).toEqual([windowsDiagnostic]);
+	});
+});
+
+describe("buildScopeInfo", () => {
+	it("is absent when nothing was narrowed", () => {
+		expect(buildScopeInfo(scoped({}))).toBeUndefined();
+	});
+
+	it("records the mode, base, and changed-file count", () => {
+		expect(
+			buildScopeInfo(
+				scoped({
+					mode: "files",
+					requestedMode: "files",
+					files: new Set(["/repo/a.ts", "/repo/b.ts"]),
+				})
+			)
+		).toEqual({ mode: "files", baseRef: "origin/main", changedFiles: 2 });
+	});
+
+	it("records the mode it fell back from", () => {
+		const info = buildScopeInfo(
+			scoped({ mode: "files", requestedMode: "changed", files: new Set() })
+		);
+		expect(info?.degradedFrom).toBe("changed");
+	});
+
+	it("carries the baseline outcome through", () => {
+		const info = buildScopeInfo(
+			scoped({ mode: "changed", requestedMode: "changed", files: new Set() }),
+			{ baselineAvailable: true, fixed: 4 }
+		);
+		expect(info).toMatchObject({ baselineAvailable: true, fixed: 4 });
+	});
+});
+
+describe("resolveScope", () => {
+	it("short-circuits in full mode without touching git", () => {
+		const result = resolveScope({ mode: "full", targetPath: "/nowhere" });
+		expect(result.mode).toBe("full");
+		expect(result.files).toBeNull();
+		expect(result.warnings).toEqual([]);
+	});
+
+	it("degrades to full with a warning outside a repository", () => {
+		const result = resolveScope({
+			mode: "files",
+			targetPath: "/definitely/not/a/repo",
+		});
+		expect(result.mode).toBe("full");
+		expect(result.requestedMode).toBe("files");
+		expect(result.warnings.join(" ")).toContain("git repository");
+	});
+});

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -1,6 +1,6 @@
 # NestJS Doctor
 
-> Diagnose and fix your NestJS code in one command. 40 built-in rules across security, performance, correctness, and architecture. Outputs a 0-100 score with actionable diagnostics. Zero config. Monorepo support.
+> Diagnose and fix your NestJS code in one command. 50 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics. Zero config. Monorepo support. Reports only what a change introduced, so it can gate a pull request without drowning it in pre-existing findings.
 
 ## Quick Start
 
@@ -21,17 +21,44 @@ npm install -D nestjs-doctor
 ```
 Usage: nestjs-doctor [directory] [options]
 
-  --verbose       Show file paths, line numbers, and source context per diagnostic
-  --score         Output only the numeric score (for CI)
-  --json          JSON output (for tooling)
-  --report        Generate an interactive HTML report (--graph also works)
-  --min-score <n> Minimum passing score (0-100). Exits with code 1 if below threshold
-  --config <p>    Path to config file
-  --init          Set up the /nestjs-doctor skill for AI coding agents
-  -h, --help      Show help
+  --verbose             Show file paths, line numbers, and source context per diagnostic
+  --score               Output only the numeric score (for CI)
+  --json                JSON output (for tooling)
+  --format <f>          console (default), json, sarif, gitlab, markdown, github
+  --output <path>       Write the formatted output to a file instead of stdout
+  --json-compact        Emit JSON-based formats without indentation
+  --scope <s>           full (default), files, lines, changed
+  --base <ref>          Git ref to compare against (auto-detected)
+  --staged              Scope to the staged files, for pre-commit hooks
+  --changed-files-from  Path to a newline-separated list of changed files
+  --blocking <level>    Severity that fails the run: none, warning, error
+  --min-score <n>       Minimum passing score (0-100). Exits with code 1 if below threshold
+  --report              Generate an interactive HTML report (--graph also works)
+  --config <p>          Path to config file
+  --list-rules          List every built-in rule and exit
+  --init                Set up the /nestjs-doctor skill for AI coding agents
+  -h, --help            Show help
 ```
 
-Exit codes: 0 = pass, 1 = score below threshold, 2 = bad input.
+Exit codes: 0 = pass, 1 = a gate failed (min-score or blocking), 2 = bad input.
+
+## Scoping to a change
+
+The whole project is always analysed — cross-file rules need it — so `--scope`
+only narrows what gets reported.
+
+- `full` — every finding in the project (the default)
+- `files` — findings in files the change touched
+- `lines` — findings on the lines the change touched
+- `changed` — findings the change introduced, measured against the base revision
+
+```bash
+npx nestjs-doctor . --scope changed --base origin/main
+npx nestjs-doctor . --staged --blocking error   # pre-commit hook
+```
+
+The score always reflects the whole project, whatever the scope. `--min-score`
+gates on that score; `--blocking` gates on the reported findings.
 
 ## Configuration
 

--- a/packages/website/src/app/docs/ci/page.mdx
+++ b/packages/website/src/app/docs/ci/page.mdx
@@ -1,0 +1,139 @@
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { docsMetadata } from "@/lib/docs-metadata";
+export const metadata = docsMetadata["/docs/ci"];
+
+<BreadcrumbJsonLd path="/docs/ci" />
+
+# CI & Pull Requests
+
+Running a linter on a codebase that predates it produces a wall of findings
+nobody reads. nestjs-doctor solves that by reporting only what a change
+introduced, and leaving the existing backlog to the score.
+
+## Scope
+
+The whole project is always analysed. Cross-file rules like
+`architecture/no-circular-module-deps` and `performance/no-unused-providers`
+would produce nonsense from a partial view, so `--scope` narrows only what gets
+**reported**.
+
+| Scope | Reports |
+|-------|---------|
+| `full` | Every finding in the project (the CLI default) |
+| `files` | Findings in files the change touched |
+| `lines` | Findings on the lines the change touched |
+| `changed` | Findings the change introduced, measured against the base (the action's default) |
+
+`changed` checks the base revision out into a temporary git worktree, scans it
+with the same rules and config, and subtracts what was already there. Findings
+are matched on rule, file, message, and source text — never on line number — so
+an unrelated edit higher up in a file does not make an old finding look new. The
+comment also reports how many findings the change **resolved**.
+
+`lines` reports only findings whose line falls inside a diff hunk. Schema
+findings describe an entity rather than a line, so they never appear at this
+scope; use `files` or `changed` if you want them.
+
+```bash
+# What did this branch introduce?
+npx nestjs-doctor . --scope changed --base origin/main
+
+# Pre-commit hook: only what you are about to commit
+npx nestjs-doctor . --staged --blocking error
+```
+
+## Gates
+
+Two gates run independently, and either one failing exits `1`.
+
+`--min-score` gates on the **project** score. The score always reflects the
+whole codebase regardless of scope — narrowing a report cannot make a project
+look healthier than it is.
+
+`--blocking` gates on the **reported** findings:
+
+| Level | Fails the run when |
+|-------|--------------------|
+| `none` | Never — advisory only |
+| `warning` | Any error or warning is reported |
+| `error` | Any error is reported |
+
+The default is `error` for the console report and `none` for `--json` and
+`--score`, which reproduces the behaviour that shipped before the flag existed.
+Pass `--blocking` explicitly and both paths behave identically.
+
+Exit codes: `0` pass, `1` a gate failed, `2` bad input.
+
+## Code scanning
+
+SARIF sends findings to a code-scanning backend, where they persist across runs
+as alerts rather than living only in a pull request comment.
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+
+steps:
+  - uses: actions/checkout@v4
+  - run: npx nestjs-doctor@latest . --format sarif --output nestjs-doctor.sarif
+  - uses: github/codeql-action/upload-sarif@v3
+    with:
+      sarif_file: nestjs-doctor.sarif
+```
+
+Every result carries a `partialFingerprints` entry derived from the rule, path,
+message, and source text. Without it GitHub computes its own fingerprint from
+surrounding source, and an edit near a finding closes the old alert and opens an
+identical new one.
+
+## GitLab
+
+The `gitlab` format emits the CodeClimate subset GitLab's Code Quality widget
+reads, so findings appear on the merge request diff.
+
+```yaml
+nestjs-doctor:
+  image: node:22
+  script:
+    - npx nestjs-doctor@latest . --format gitlab --output gl-code-quality-report.json
+  artifacts:
+    reports:
+      codequality: gl-code-quality-report.json
+```
+
+## Other output formats
+
+| Format | Use |
+|--------|-----|
+| `console` | Human-readable report (default) |
+| `json` | The full result object, for tooling |
+| `sarif` | SARIF 2.1.0, for code scanning |
+| `gitlab` | GitLab Code Quality report |
+| `markdown` | A comment body for any pull or merge request |
+| `github` | Workflow annotations plus a job summary, alongside the console report |
+
+`--output <path>` writes the payload to a file instead of stdout, and
+`--json-compact` drops the indentation from the JSON-based formats.
+
+`github` is additive rather than a replacement: it prints annotations and
+appends the markdown report to `$GITHUB_STEP_SUMMARY` while still printing the
+readable console report to the log. GitHub caps annotations at ten errors and
+ten warnings per step and silently drops the rest, so the annotations are a
+convenience — the job summary carries every finding.
+
+## Pre-commit hook
+
+```bash
+# .husky/pre-commit
+npx nestjs-doctor . --staged --blocking error
+```
+
+`--staged` scopes to the files in the git index. The project is still analysed
+in full, so a change that breaks a cross-file rule is caught even when the file
+it is reported against is not part of the commit.
+
+Running from inside a hook is safe: git exports `GIT_DIR`, `GIT_INDEX_FILE`, and
+friends to every hook, and children inherit them, so nestjs-doctor clears those
+before shelling out to git and resolves everything against the directory it was
+pointed at.

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -35,15 +35,27 @@ npm install -D nestjs-doctor
 ```
 Usage: nestjs-doctor [directory] [options]
 
-  --verbose       Show file paths and line numbers per diagnostic
-  --score         Output only the numeric score (for CI)
-  --json          JSON output (for tooling)
-  --report        Generate an interactive HTML report (--graph also works)
-  --min-score <n> Minimum passing score (0-100). Exits with code 1 if below
-  --config <p>    Path to config file
-  --init          Set up the /nestjs-doctor skill for AI coding agents
-  -h, --help      Show help
+  --verbose             Show file paths and line numbers per diagnostic
+  --score               Output only the numeric score (for CI)
+  --json                JSON output (for tooling)
+  --format <f>          console (default), json, sarif, gitlab, markdown, github
+  --output <path>       Write the formatted output to a file instead of stdout
+  --json-compact        Emit JSON-based formats without indentation
+  --scope <s>           full (default), files, lines, changed
+  --base <ref>          Git ref to compare against (auto-detected)
+  --staged              Scope to the staged files, for pre-commit hooks
+  --changed-files-from  Path to a newline-separated list of changed files
+  --blocking <level>    Severity that fails the run: none, warning, error
+  --min-score <n>       Minimum passing score (0-100)
+  --report              Generate an interactive HTML report (--graph also works)
+  --config <p>          Path to config file
+  --list-rules          List every built-in rule and exit
+  --init                Set up the /nestjs-doctor skill for AI coding agents
+  -h, --help            Show help
 ```
+
+See [CI & Pull Requests](/docs/ci) for `--scope`, `--blocking`, and the official
+GitHub Action.
 
 ## CI Integration
 
@@ -65,13 +77,20 @@ Or add it as a script in `package.json`:
 
 ### Exit Codes
 
-| Code | Meaning                                        |
-| ---- | ---------------------------------------------- |
-| `0`  | Score is at or above threshold                 |
-| `1`  | Score is below threshold, or errors were found |
-| `2`  | Invalid input (bad path, invalid flags)        |
+| Code | Meaning                                 |
+| ---- | --------------------------------------- |
+| `0`  | Both gates passed                       |
+| `1`  | A gate failed — see below               |
+| `2`  | Invalid input (bad path, invalid flags) |
 
-All output modes (`--score`, `--json`, default) respect exit codes.
+Two independent gates can fail a run. `--min-score` compares the project's
+health score against a threshold. `--blocking` fails on reported findings at or
+above a severity: `error` (the default for the console report), `warning`, or
+`none`.
+
+`--json` and `--score` default to `--blocking none`, so they fail only on
+`--min-score` — the behaviour they had before `--blocking` existed. Pass
+`--blocking` explicitly to make every output mode behave the same.
 
 ## Report
 

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -21,6 +21,11 @@ export const docsMetadata: Record<string, Metadata> = {
 		description:
 			"Extend nestjs-doctor with project-specific checks. Encode domain conventions, enforce team standards, or flag patterns unique to your codebase.",
 	},
+	"/docs/ci": {
+		title: "CI & Pull Requests",
+		description:
+			"Run nestjs-doctor in CI. Official GitHub Action with sticky pull request comments, inline review comments, and commit statuses; diff-scoped scanning that reports only what a change introduced; SARIF and GitLab Code Quality output.",
+	},
 	"/docs/vscode-extension": {
 		title: "VS Code Extension",
 		description:

--- a/packages/website/src/lib/docs-navigation.ts
+++ b/packages/website/src/lib/docs-navigation.ts
@@ -16,6 +16,7 @@ export const DOCS_NAV: NavSection[] = [
 			{ title: "Setup", href: "/docs/setup" },
 			{ title: "Configuration", href: "/docs/configuration" },
 			{ title: "Custom Rules", href: "/docs/custom-rules" },
+			{ title: "CI & Pull Requests", href: "/docs/ci" },
 			{ title: "VS Code Extension", href: "/docs/vscode-extension" },
 		],
 	},


### PR DESCRIPTION
**2 of 3.** Stacked on #129 — review that first, or read this diff against `claude/nestjs-doctor-1-hygiene`.

## 1. Context

nestjs-doctor scores a whole project. On an established codebase that means a wall of pre-existing findings, which is fine for a health check and useless as a merge gate — nobody reads a hundred warnings to find the one their change caused.

## 2. Problem

There was no way to ask what a *change* did. The CLI had one scope (everything), one machine format (`--json`), and a failure gate that was hardcoded and inconsistent between modes:

| Mode | Exit on error diagnostics | Exit on `--min-score` |
|---|---|---|
| console | 1 | 1 |
| `--json` | **0** | 1 |
| `--score` | **0** | 1 |

So the documented CI recipe, `--json` piped to a tool, never failed on errors.

## 3. Possible flows

Every way a scan can be narrowed, and what each reports:

| Scope | Reports | Needs git | Needs the base tree |
|---|---|---|---|
| `full` | every finding | no | no |
| `files` | findings in changed files | yes | no |
| `lines` | findings on changed lines | yes | no |
| `changed` | findings the change introduced | yes | yes |
| `--staged` | findings in staged files | yes | no |

And every way the base can be unavailable, since that decides whether a report is trustworthy:

| Situation | Behaviour |
|---|---|
| Not a git repository | degrade to `full`, warn |
| Base ref unresolvable | degrade to `full`, warn |
| Shallow clone, base unreachable | degrade to `files`, warn |
| Base reachable | measured delta |

Degrading always reports *more*, never less. A scan that silently reports nothing is indistinguishable from a clean one.

## 4. Solution

`--scope full|files|lines|changed` with `--base`, `--staged`, and `--changed-files-from`. The whole project is still analysed — cross-file rules produce nonsense from a partial view — so scope filters the reported set only.

`changed` scans the base revision in a throwaway git worktree and subtracts what was already there. Findings match on rule, file, message, and source text, never on line number: a baseline that calls a shifted finding "new" fires on exactly the pull requests that touched nothing relevant.

Formats: SARIF, GitLab Code Quality, markdown, GitHub annotations, via `--format` / `--output` / `--json-compact`. `--blocking none|warning|error` makes the gate explicit. `--list-rules` prints the catalogue.

What this deliberately does **not** do: change the existing exit codes. `--blocking` defaults per-mode to the table above, because silently making `--json` start failing would break pipelines that pass today. Passing it explicitly makes every mode agree.

Two bugs fixed here. Git invocations clear `GIT_DIR` and friends, which git exports to every hook and children inherit — so `--staged` from a `pre-commit` resolved refs against the hook's repository. And containment uses `git rev-parse --show-prefix` rather than comparing absolute paths, because git reports canonical paths while the caller's keep their symlinks, and on macOS `/var` is a symlink into `/private`.

## 5. Before vs after

| Behaviour | Before | After |
|---|---|---|
| Reporting only what a change introduced | not possible | `--scope changed` |
| SARIF / GitLab / markdown output | none | supported |
| Gate severity | hardcoded | `--blocking` |
| `--json` exit code on errors | 0 | **0** (unchanged by default) |
| console exit code on errors | 1 | **1** (unchanged) |
| Score under any scope | whole project | **whole project** (unchanged) |
| `--staged` from a git hook | wrong repository | scanned repository |
| Tests | 735 | 821 |

## 6. Example

A branch that pads a file with a pre-existing finding and adds one new file:

```console
$ npx nestjs-doctor . --scope full --json | jq '.summary.total'
4

$ npx nestjs-doctor . --scope changed --base HEAD~1 --json | jq '{total: .summary.total, scope}'
{
  "total": 3,
  "scope": {
    "mode": "changed",
    "baseRef": "HEAD~1",
    "changedFiles": 2,
    "baselineAvailable": true,
    "fixed": 0
  }
}
```

The pre-existing finding moved down twelve lines and is correctly not reported. Deleting it instead:

```console
$ npx nestjs-doctor . --scope changed --base HEAD~1 --json | jq '.scope.fixed'
1
```

## Stack

1. #129 — hygiene *(merge first)*
2. **This PR**
3. #131 — the official GitHub Action

---
_Generated with [Claude Code](https://claude.com/claude-code)_
