### PR TITLE
feat(action): official GitHub Action for pull request review

### DIFF
--- a/.changeset/markdown-scope-caption.md
+++ b/.changeset/markdown-scope-caption.md
@@ -1,0 +1,15 @@
+---
+"nestjs-doctor": patch
+---
+
+Make the markdown report's scope caption self-explanatory.
+
+When the scan was handed fewer files than the change touched, the caption now
+reads "5 of 9 changed files scanned" instead of "5 files in scope" — the old
+wording invited a reader to compare it against the pull request's own file count
+and read the gap as a miscount. It falls back to the previous wording when the
+caller does not know the pre-filter total, and says nothing extra when nothing
+was filtered out.
+
+A base given as a full commit SHA is abbreviated to seven characters. Branch
+names are printed as they were given.

--- a/.github/workflows/action-self-test.yml
+++ b/.github/workflows/action-self-test.yml
@@ -1,0 +1,93 @@
+name: Action Self-Test
+
+# The composite action is published straight from this repository, so nothing
+# else catches a broken step, a renamed output, or a helper script that stopped
+# parsing. This runs it against a fixture using the checkout's own build.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "action.yml"
+      - "scripts/action/**"
+      - "packages/nestjs-doctor/**"
+      - ".github/workflows/action-self-test.yml"
+  # No branch filter: the pull request that introduces or changes the action is
+  # the one that most needs this to run, and it is usually stacked rather than
+  # aimed at `main`. Filtered to `main`, the action's only test silently never
+  # ran on the pull request adding it.
+  pull_request:
+    paths:
+      - "action.yml"
+      - "scripts/action/**"
+      - "packages/nestjs-doctor/**"
+      - ".github/workflows/action-self-test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: action-self-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  self-test:
+    name: Run the action against a fixture
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `--scope changed` checks the base revision out into a worktree, so
+          # the full history has to be present.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter nestjs-doctor build
+
+      # The fixture is deliberately unhealthy, so this asserts the action
+      # reports findings rather than that the fixture is clean. Reporting is
+      # switched off: a self-test must not comment on unrelated pull requests.
+      - id: doctor
+        uses: ./
+        with:
+          directory: packages/nestjs-doctor/tests/fixtures/bad-architecture
+          version: ${{ github.workspace }}/packages/nestjs-doctor
+          scope: full
+          blocking: none
+          comment: "false"
+          review-comments: "false"
+          commit-status: "false"
+          sarif: "true"
+          sarif-file: ${{ runner.temp }}/self-test.sarif
+
+      - name: Assert the action produced a usable result
+        shell: bash
+        env:
+          SCORE: ${{ steps.doctor.outputs.score }}
+          TOTAL: ${{ steps.doctor.outputs.total-issues }}
+          ERRORS: ${{ steps.doctor.outputs.error-count }}
+          SARIF: ${{ steps.doctor.outputs.sarif-file }}
+        run: |
+          set -euo pipefail
+          echo "score=$SCORE total=$TOTAL errors=$ERRORS sarif=$SARIF"
+
+          [ -n "$SCORE" ] || { echo "::error::no score output"; exit 1; }
+          [ "$TOTAL" -gt 0 ] || { echo "::error::expected findings in the fixture"; exit 1; }
+          [ "$ERRORS" -gt 0 ] || { echo "::error::expected error-severity findings in the fixture"; exit 1; }
+          [ -s "$SARIF" ] || { echo "::error::no SARIF written"; exit 1; }
+
+          node -e '
+            const log = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+            if (log.version !== "2.1.0") throw new Error("unexpected SARIF version " + log.version);
+            if (!log.runs?.[0]?.results?.length) throw new Error("SARIF has no results");
+            for (const result of log.runs[0].results) {
+              if (!result.partialFingerprints?.["nestjsDoctor/v1"]) {
+                throw new Error("SARIF result is missing its partial fingerprint");
+              }
+            }
+            console.log("SARIF ok:", log.runs[0].results.length, "results");
+          ' "$SARIF"

--- a/.github/workflows/action-tag.yml
+++ b/.github/workflows/action-tag.yml
@@ -1,0 +1,42 @@
+name: Move Action Major Tag
+
+# Consumers pin `RoloBits/nestjs-doctor@v1`, so that tag has to follow every
+# release. The action's major version tracks its own input/output contract, not
+# the npm package's version — a patch release of the CLI must not move a major.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      major-tag:
+        description: "Major tag to move (e.g. v1)"
+        required: true
+        default: "v1"
+
+permissions:
+  contents: write
+
+jobs:
+  retag:
+    name: Point the major tag at the release commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Move the tag
+        shell: bash
+        env:
+          MAJOR_TAG: ${{ inputs.major-tag || 'v1' }}
+          TARGET_SHA: ${{ github.event.release.target_commitish || github.sha }}
+        run: |
+          set -euo pipefail
+          # A branch name in `target_commitish` resolves through the fetched
+          # history; a SHA passes straight through.
+          SHA="$(git rev-parse "$TARGET_SHA^{commit}")"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --force "$MAJOR_TAG" "$SHA"
+          git push --force origin "refs/tags/$MAJOR_TAG"
+          echo "Moved $MAJOR_TAG to $SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ packages/
   nestjs-doctor-lsp/        # Language server, used by the VS Code extension
   nestjs-doctor-vscode/     # VS Code extension
   website/                  # Documentation site (Next.js + MDX)
+action.yml                  # The official GitHub Action (composite)
+scripts/action/             # Helper scripts the action invokes
 ```
 
 Full pipeline docs: [nestjs.doctor/docs](https://nestjs.doctor/docs)
@@ -200,6 +202,25 @@ pnpm build        # Build succeeds
 ```
 
 If all of those pass, the pre-commit hook will too.
+
+## Working on the GitHub Action
+
+`action.yml` at the repository root is the published composite action, and its
+helper scripts live in `scripts/action/`. Nothing else exercises it, so the
+`Action Self-Test` workflow runs it against a fixture on every change to
+`action.yml`, `scripts/action/**`, or the main package.
+
+Two things to keep in mind when editing it:
+
+- **Pin every nested action by commit SHA**, with the version as a trailing
+  comment. Dependabot keeps those pins current.
+- **The comment renderer is imported from the installed package**
+  (`buildMarkdownReport`), never reimplemented in the action. That is what keeps
+  the pull request comment, the job summary, and `--format markdown` identical.
+
+Consumers pin `RoloBits/nestjs-doctor@v1`, so a change to the action's inputs or
+outputs is a breaking change for them even when the npm package's version does
+not move.
 
 ## Docs
 

--- a/action.yml
+++ b/action.yml
@@ -473,11 +473,18 @@ runs:
           }
 
           const ours = new Map();
+          // Comments from before the key format cannot be matched to a finding,
+          // so this run's keyed set supersedes them.
+          const legacy = [];
           for (const thread of threads) {
             const first = thread.comments.nodes[0];
             if (!first?.body?.startsWith(MARKER)) continue;
             const match = first.body.match(KEY_RE);
-            if (match) ours.set(match[1], { ...thread, commentId: first.databaseId });
+            if (match) {
+              ours.set(match[1], { ...thread, commentId: first.databaseId });
+            } else if (!thread.isResolved) {
+              legacy.push({ ...thread, commentId: first.databaseId });
+            }
           }
 
           // Only genuinely new findings are posted. An unchanged one keeps its
@@ -523,7 +530,26 @@ runs:
             }
           }
 
-          core.info(`inline comments — posted ${fresh.length}, kept ${wanted.size - fresh.length}, resolved ${resolved}`);
+          for (const thread of legacy) {
+            try {
+              await github.rest.pulls.updateReviewComment({
+                ...context.repo,
+                comment_id: thread.commentId,
+                body: `${MARKER}\n_Superseded by an updated comment._`,
+              });
+              await github.graphql(
+                `mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
+                { id: thread.id },
+              );
+            } catch (error) {
+              core.warning(`nestjs-doctor could not retire a superseded comment: ${error.message}`);
+            }
+          }
+
+          core.info(
+            `inline comments — posted ${fresh.length}, kept ${wanted.size - fresh.length}, ` +
+              `resolved ${resolved}, superseded ${legacy.length}`,
+          );
     - name: Publish commit status
       if: ${{ always() && inputs.commit-status == 'true' }}
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,555 @@
+name: "NestJS Doctor"
+description: "Scan a NestJS codebase for security, performance, correctness, architecture, and schema issues"
+branding:
+  icon: "activity"
+  color: "red"
+
+inputs:
+  directory:
+    description: "Project directory to scan"
+    default: "."
+  scope:
+    description: "On pull requests, what to report (same meanings as the CLI --scope): 'changed' (only findings the pull request introduced vs its base — the default), 'files' (every finding in the changed files), 'lines' (only findings on the changed lines), or 'full' (the whole project). Other events always report the full project."
+    default: "changed"
+  blocking:
+    description: "Severity that fails the workflow: none (default; advisory), warning, or error."
+    default: "none"
+  min-score:
+    description: "Fail the workflow when the project's health score drops below this value (0-100). Empty to disable. The score always reflects the whole project, never just the changed files."
+    default: ""
+  config:
+    description: "Path to a nestjs-doctor config file. Empty to auto-detect."
+    default: ""
+  comment:
+    description: "Create or update a sticky pull request summary comment. Requires `pull-requests: write`."
+    default: "true"
+  review-comments:
+    description: "Post inline review comments on the changed lines that triggered findings (pull requests only). Requires `pull-requests: write`."
+    default: "true"
+  commit-status:
+    description: "Publish a commit status with the score and finding counts. Requires `statuses: write` (skipped with a warning otherwise)."
+    default: "true"
+  sarif:
+    description: "Also write a SARIF report to `sarif-file`, for upload to GitHub code scanning."
+    default: "false"
+  sarif-file:
+    description: "Where the SARIF report is written when `sarif` is enabled."
+    default: "nestjs-doctor.sarif"
+  silence-missing-baseline-warning:
+    description: "Hide the warning shown when a compare scope cannot reach the base commit (a shallow checkout) and falls back to reporting every finding in the changed files. Setting `fetch-depth: 0` on actions/checkout is the real remedy."
+    default: "false"
+  node-version:
+    description: "Node.js version to use"
+    default: "22"
+  version:
+    description: "nestjs-doctor npm version or package spec to run"
+    default: "latest"
+
+outputs:
+  score:
+    description: "Health score (0-100) for the whole project. Empty when the scan could not produce one."
+    value: ${{ steps.report.outputs.score }}
+  label:
+    description: "Score label: Excellent, Good, Fair, Poor, or Critical."
+    value: ${{ steps.report.outputs.label }}
+  total-issues:
+    description: "Findings in the reported scope. On a pull request with the default scope, the count the change introduced."
+    value: ${{ steps.report.outputs.total-issues }}
+  fixed-issues:
+    description: "Findings the change resolved. Only meaningful with `scope: changed`; 0 otherwise."
+    value: ${{ steps.report.outputs.fixed-issues }}
+  error-count:
+    description: "Error-severity findings in the reported scope."
+    value: ${{ steps.report.outputs.error-count }}
+  warning-count:
+    description: "Warning-severity findings in the reported scope."
+    value: ${{ steps.report.outputs.warning-count }}
+  affected-files:
+    description: "Number of files carrying at least one reported finding."
+    value: ${{ steps.report.outputs.affected-files }}
+  report-file:
+    description: "Path to the raw JSON report."
+    value: ${{ steps.scan.outputs.report-file }}
+  sarif-file:
+    description: "Path to the SARIF report, when `sarif` is enabled."
+    value: ${{ steps.scan.outputs.sarif-file }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      with:
+        node-version: ${{ inputs.node-version }}
+        package-manager-cache: false
+
+    # Pin `latest` to the version it currently resolves to, so the install cache
+    # key is stable. Keying on the literal string "latest" would freeze whichever
+    # release a repository happened to cache first.
+    - id: resolve-version
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: node "$GITHUB_ACTION_PATH/scripts/action/resolve-package-spec.mjs" "$INPUT_VERSION"
+
+    # The npm install dominates the cost of a small scan. Keyed on the exact
+    # resolved version plus the toolchain identity, with no `restore-keys`
+    # fallback: a partial restore from another version could leave a broken tree.
+    # Restore + explicit save rather than the combined action, because the
+    # combined post-job save is skipped when the job fails — and a blocking scan
+    # with findings fails the job BY DESIGN, which is exactly the run whose
+    # fix-and-push retry wants a warm cache.
+    - id: toolchain-cache
+      if: ${{ steps.resolve-version.outputs.cacheable == 'true' }}
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/nestjs-doctor-toolchain
+        key: nestjs-doctor-${{ steps.resolve-version.outputs.resolved }}-node${{ inputs.node-version }}-${{ runner.os }}-${{ runner.arch }}
+
+    # Resolve the pull request's changed files from git first: no API rate
+    # limit, and it works on forks where `pulls.listFiles` can be denied. The
+    # API step below is the fallback for a checkout too shallow to diff.
+    - id: base
+      if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' }}
+      shell: bash
+      env:
+        INPUT_DIRECTORY: ${{ inputs.directory }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        CHANGED_FILES_FILE: ${{ runner.temp }}/nestjs-doctor-changed-files.txt
+      run: |
+        # Best-effort fetch of the base commit. `--scope changed` needs its full
+        # tree to scan, so ask for enough history to check it out; `|| true`
+        # keeps an already-present base (fetch-depth: 0) from failing the step.
+        if [ -n "$BASE_SHA" ] && git -C "$INPUT_DIRECTORY" rev-parse --git-dir >/dev/null 2>&1; then
+          git -C "$INPUT_DIRECTORY" fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
+        fi
+
+        # The prefix mapping repo-root-relative diff paths onto scan-relative
+        # ones. Taken from git rather than the raw `directory` input so it stays
+        # correct for an absolute path, an actions/checkout `path:` layout, and a
+        # nested repository alike — a wrong prefix drops every changed file and
+        # the scan silently reports nothing.
+        if SCAN_PREFIX="$(git -C "$INPUT_DIRECTORY" rev-parse --show-prefix 2>/dev/null)"; then
+          # `--show-prefix` legitimately returns "" at the repo root; the `.`
+          # sentinel keeps GHA's `||` fallback from reading that as "unresolved".
+          SCAN_PREFIX="${SCAN_PREFIX:-.}"
+        else
+          SCAN_PREFIX="$INPUT_DIRECTORY"
+        fi
+        # A newline in the prefix would smuggle extra entries into
+        # $GITHUB_OUTPUT's line-oriented protocol. No real prefix contains one.
+        case "$SCAN_PREFIX" in
+          *$'\n'*) SCAN_PREFIX="." ;;
+        esac
+        echo "prefix=$SCAN_PREFIX" >> "$GITHUB_OUTPUT"
+
+        # Three-dot (merge-base) + AMR matches both the `pulls.listFiles`
+        # contract and the CLI's own baseline semantics.
+        RAW_CHANGED="${RUNNER_TEMP:-/tmp}/nestjs-doctor-raw-changed.txt"
+        if [ -n "$BASE_SHA" ] && git -C "$INPUT_DIRECTORY" diff --name-only --diff-filter=AMR "$BASE_SHA...HEAD" > "$RAW_CHANGED" 2>/dev/null; then
+          node "$GITHUB_ACTION_PATH/scripts/action/normalize-changed-files.mjs" "$SCAN_PREFIX" "$CHANGED_FILES_FILE" < "$RAW_CHANGED"
+          echo "path=$CHANGED_FILES_FILE" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::nestjs-doctor could not derive the changed files from git — the base commit is not in this checkout. Set \`fetch-depth: 0\` on actions/checkout. Falling back to the GitHub API."
+        fi
+
+    # API fallback, used only when the local diff above could not run.
+    - id: pr-files
+      if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' && steps.base.outputs.path == '' }}
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        NESTJS_DOCTOR_CHANGED_FILES: ${{ runner.temp }}/nestjs-doctor-changed-files.txt
+        INPUT_DIRECTORY: ${{ steps.base.outputs.prefix || inputs.directory }}
+        # `github.action_path` is THIS composite action's directory. Inside a
+        # nested github-script step the ambient GITHUB_ACTION_PATH points at
+        # github-script's own directory, so pass ours explicitly.
+        COMPOSITE_ACTION_PATH: ${{ github.action_path }}
+      with:
+        script: |
+          const fs = require("fs");
+          const { pathToFileURL } = require("url");
+          const { normalizeChangedFiles } = await import(
+            pathToFileURL(`${process.env.COMPOSITE_ACTION_PATH}/scripts/action/normalize-changed-files.mjs`).href,
+          );
+          const outputPath = process.env.NESTJS_DOCTOR_CHANGED_FILES;
+          const pullRequest = context.payload.pull_request;
+          if (!pullRequest || !outputPath) return;
+          let files;
+          try {
+            files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+          } catch (error) {
+            core.warning(
+              `nestjs-doctor could not list pull request files (${error.message}). ` +
+                "Reporting the full project instead. Grant the workflow `pull-requests: read` to scope to the changed files.",
+            );
+            return;
+          }
+          const included = new Set(["added", "modified", "renamed"]);
+          const changed = normalizeChangedFiles(
+            files.filter((file) => included.has(file.status)).map((file) => file.filename),
+            process.env.INPUT_DIRECTORY,
+          );
+          fs.writeFileSync(outputPath, changed.length ? `${changed.join("\n")}\n` : "");
+          core.setOutput("path", outputPath);
+
+    - id: scan
+      shell: bash
+      env:
+        NO_COLOR: "1"
+        INPUT_DIRECTORY: ${{ inputs.directory }}
+        INPUT_SCOPE: ${{ inputs.scope }}
+        INPUT_BLOCKING: ${{ inputs.blocking }}
+        INPUT_MIN_SCORE: ${{ inputs.min-score }}
+        INPUT_CONFIG: ${{ inputs.config }}
+        INPUT_SARIF: ${{ inputs.sarif }}
+        INPUT_SARIF_FILE: ${{ inputs.sarif-file }}
+        PACKAGE_SPEC: ${{ steps.resolve-version.outputs.spec }}
+        CHANGED_FILES_FROM: ${{ steps.base.outputs.path || steps.pr-files.outputs.path }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        EVENT_NAME: ${{ github.event_name }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: |
+        set -o pipefail
+        TOOLCHAIN_DIR="${RUNNER_TEMP:-/tmp}/nestjs-doctor-toolchain"
+        REPORT_FILE="${RUNNER_TEMP:-/tmp}/nestjs-doctor-report.json"
+        echo "report-file=$REPORT_FILE" >> "$GITHUB_OUTPUT"
+
+        # Install into a deterministic prefix (unlike npx's opaque _npx/<hash>
+        # directory) so actions/cache can carry it between runs and the render
+        # step can import the package's API entry by path. The version probe
+        # re-installs when the restore was empty or broken.
+        if ! "$TOOLCHAIN_DIR/node_modules/.bin/nestjs-doctor" --version >/dev/null 2>&1; then
+          mkdir -p "$TOOLCHAIN_DIR"
+          npm install --prefix "$TOOLCHAIN_DIR" --no-save --no-audit --no-fund "$PACKAGE_SPEC"
+        fi
+        DOCTOR_BIN="$TOOLCHAIN_DIR/node_modules/.bin/nestjs-doctor"
+        echo "api-entry=$TOOLCHAIN_DIR/node_modules/nestjs-doctor/dist/api/index.mjs" >> "$GITHUB_OUTPUT"
+        echo "cli-version=$("$DOCTOR_BIN" --version 2>/dev/null || echo unknown)" >> "$GITHUB_OUTPUT"
+
+        FLAGS=("--format" "json" "--output" "$REPORT_FILE" "--blocking" "$INPUT_BLOCKING")
+        if [ -n "$INPUT_MIN_SCORE" ]; then FLAGS+=("--min-score" "$INPUT_MIN_SCORE"); fi
+        if [ -n "$INPUT_CONFIG" ]; then FLAGS+=("--config" "$INPUT_CONFIG"); fi
+
+        # Lowercase so this bash test agrees with the case-insensitive `!= 'full'`
+        # comparisons the changed-file steps use; otherwise `scope: Full` would
+        # skip those steps yet still take the diff path here.
+        SCOPE="$(printf '%s' "$INPUT_SCOPE" | tr '[:upper:]' '[:lower:]')"
+        if [ "$EVENT_NAME" != "pull_request" ] || [ "$SCOPE" = "full" ]; then
+          FLAGS+=("--scope" "full")
+        else
+          case "$SCOPE" in
+            files|lines|changed) FLAGS+=("--scope" "$SCOPE") ;;
+            *) FLAGS+=("--scope" "changed") ;;
+          esac
+          if [ -n "$CHANGED_FILES_FROM" ]; then
+            FLAGS+=("--changed-files-from" "$CHANGED_FILES_FROM")
+          fi
+          # A branch name rarely resolves in a shallow pull request checkout, so
+          # hand the CLI the fetched SHA directly.
+          if [ -n "$BASE_SHA" ]; then FLAGS+=("--base" "$BASE_SHA"); fi
+        fi
+
+        set +e
+        "$DOCTOR_BIN" "$INPUT_DIRECTORY" "${FLAGS[@]}"
+        SCAN_STATUS=$?
+        set -e
+        echo "exit-code=$SCAN_STATUS" >> "$GITHUB_OUTPUT"
+
+        # A second render of the same scan would double the cost, so SARIF is
+        # produced from the JSON report rather than by scanning again.
+        if [ "$INPUT_SARIF" = "true" ]; then
+          SARIF_PATH="$INPUT_SARIF_FILE"
+          if node "$GITHUB_ACTION_PATH/scripts/action/render-sarif.mjs" \
+               "$TOOLCHAIN_DIR/node_modules/nestjs-doctor/dist/api/index.mjs" \
+               "$REPORT_FILE" "$SARIF_PATH" "$INPUT_DIRECTORY"; then
+            echo "sarif-file=$SARIF_PATH" >> "$GITHUB_OUTPUT"
+          fi
+        fi
+
+    - name: Save toolchain cache
+      if: ${{ always() && steps.resolve-version.outputs.cacheable == 'true' && steps.toolchain-cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/nestjs-doctor-toolchain
+        key: nestjs-doctor-${{ steps.resolve-version.outputs.resolved }}-node${{ inputs.node-version }}-${{ runner.os }}-${{ runner.arch }}
+
+    - id: report
+      if: always()
+      shell: bash
+      env:
+        REPORT_FILE: ${{ steps.scan.outputs.report-file }}
+        COMMENT_FILE: ${{ runner.temp }}/nestjs-doctor-comment.md
+        API_ENTRY: ${{ steps.scan.outputs.api-entry }}
+        NESTJS_DOCTOR_TARGET_PATH: ${{ inputs.directory }}
+        NESTJS_DOCTOR_VERSION: ${{ steps.scan.outputs.cli-version }}
+        NESTJS_DOCTOR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        NESTJS_DOCTOR_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        NESTJS_DOCTOR_SILENCE_BASELINE_WARNING: ${{ inputs.silence-missing-baseline-warning }}
+      run: |
+        node "$GITHUB_ACTION_PATH/scripts/action/read-report.mjs" "$REPORT_FILE"
+        node "$GITHUB_ACTION_PATH/scripts/action/render-comment.mjs" "$API_ENTRY" "$REPORT_FILE" "$COMMENT_FILE"
+        echo "comment-file=$COMMENT_FILE" >> "$GITHUB_OUTPUT"
+
+    - name: Update sticky pull request comment
+      if: ${{ always() && github.event_name == 'pull_request' && inputs.comment == 'true' }}
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        NESTJS_DOCTOR_COMMENT_FILE: ${{ steps.report.outputs.comment-file }}
+      with:
+        script: |
+          const fs = require("fs");
+          const commentPath = process.env.NESTJS_DOCTOR_COMMENT_FILE;
+          if (!commentPath || !fs.existsSync(commentPath)) return;
+          const body = fs.readFileSync(commentPath, "utf8").trim();
+          if (!body) return;
+
+          const marker = "<!-- nestjs-doctor:summary -->";
+          try {
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const previous = comments.find((comment) => comment.body?.startsWith(marker));
+            if (previous) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+          } catch (error) {
+            core.warning(
+              `nestjs-doctor could not update the sticky pull request comment (${error.message}). ` +
+                "Grant the workflow `pull-requests: write` to enable it.",
+            );
+          }
+
+    - name: Post inline review comments
+      if: ${{ always() && github.event_name == 'pull_request' && inputs.review-comments == 'true' }}
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        NESTJS_DOCTOR_REPORT_FILE: ${{ steps.scan.outputs.report-file }}
+        INPUT_DIRECTORY: ${{ steps.base.outputs.prefix || inputs.directory }}
+      with:
+        script: |
+          const fs = require("fs");
+          const path = require("path");
+          const reportPath = process.env.NESTJS_DOCTOR_REPORT_FILE;
+          const pullRequest = context.payload.pull_request;
+          if (!pullRequest || !reportPath || !fs.existsSync(reportPath)) return;
+
+          let report;
+          try {
+            report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+          } catch {
+            // A crashed scan leaves a truncated report; leave existing feedback
+            // in place rather than wiping it on a transient failure.
+            return;
+          }
+          const diagnostics = Array.isArray(report.diagnostics) ? report.diagnostics : [];
+
+          const marker = "<!-- nestjs-doctor:review -->";
+          const directoryPrefix = (process.env.INPUT_DIRECTORY || ".")
+            .replace(/^\.\/?/, "")
+            .replace(/\/$/, "");
+
+          let files;
+          try {
+            files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+          } catch (error) {
+            core.warning(`nestjs-doctor could not list pull request files for review comments (${error.message}).`);
+            return;
+          }
+
+          // The Reviews API accepts RIGHT-side comments on any line inside a
+          // hunk — added (`+`) and unchanged context (` `) alike, since a
+          // finding can land on a context line when the change that caused it
+          // is elsewhere in the hunk. Removed lines are not RIGHT-side lines.
+          const commentableByFile = new Map();
+          for (const file of files) {
+            if (!file.patch) continue;
+            const commentable = new Set();
+            let newLine = 0;
+            for (const patchLine of file.patch.split("\n")) {
+              const hunk = patchLine.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+              if (hunk) {
+                newLine = Number(hunk[1]);
+                continue;
+              }
+              if (patchLine.startsWith("+") || patchLine.startsWith(" ")) {
+                commentable.add(newLine);
+                newLine += 1;
+              }
+            }
+            commentableByFile.set(file.filename, commentable);
+          }
+
+          // Report paths are absolute; map them back onto repo-relative ones.
+          const workspace = (process.env.GITHUB_WORKSPACE || process.cwd()).replace(/\\/g, "/");
+          const toRepoPath = (filePath) => {
+            let normalized = String(filePath || "").replace(/\\/g, "/").replace(/^\.\//, "");
+            if (normalized.startsWith(`${workspace}/`)) {
+              normalized = normalized.slice(workspace.length + 1);
+            }
+            if (commentableByFile.has(normalized)) return normalized;
+            const prefixed = directoryPrefix ? `${directoryPrefix}/${normalized}` : normalized;
+            if (commentableByFile.has(prefixed)) return prefixed;
+            const suffixMatches = [...commentableByFile.keys()].filter((name) =>
+              name.endsWith(`/${normalized}`),
+            );
+            return suffixMatches.length === 1 ? suffixMatches[0] : null;
+          };
+
+          const seen = new Set();
+          const comments = [];
+          for (const diagnostic of diagnostics) {
+            if (!diagnostic || typeof diagnostic.line !== "number" || diagnostic.line <= 0) continue;
+            const repoPath = toRepoPath(diagnostic.filePath);
+            if (!repoPath) continue;
+            const commentable = commentableByFile.get(repoPath);
+            if (!commentable || !commentable.has(diagnostic.line)) continue;
+            const dedupeKey = `${repoPath}:${diagnostic.line}:${diagnostic.rule}`;
+            if (seen.has(dedupeKey)) continue;
+            seen.add(dedupeKey);
+            const fix = diagnostic.help ? `\n\n**Fix** → ${diagnostic.help}` : "";
+            comments.push({
+              path: repoPath,
+              line: diagnostic.line,
+              side: "RIGHT",
+              body: `${marker}\n**nestjs-doctor** · \`${diagnostic.rule}\` _(${diagnostic.severity})_\n\n${diagnostic.message}${fix}`,
+            });
+          }
+
+          // Findings that mapped onto no changed line must not wipe existing
+          // inline feedback — that would read as "all clear" when it isn't.
+          if (comments.length === 0 && diagnostics.length > 0) return;
+
+          // Capture the prior review comments up front, and delete them only
+          // after the new review posts, so a failed post leaves the last run's
+          // feedback rather than nothing at all.
+          let priorIds = [];
+          try {
+            const existing = await github.paginate(github.rest.pulls.listReviewComments, {
+              ...context.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+            priorIds = existing
+              .filter((comment) => comment.body?.startsWith(marker))
+              .map((comment) => comment.id);
+          } catch (error) {
+            core.warning(`nestjs-doctor could not list prior review comments: ${error.message}`);
+          }
+
+          // Capped to stay inside GitHub's per-review size limits and to keep a
+          // large pull request readable; the sticky comment holds every finding.
+          const MAX_COMMENTS = 40;
+          if (comments.length > 0) {
+            try {
+              await github.rest.pulls.createReview({
+                ...context.repo,
+                pull_number: pullRequest.number,
+                event: "COMMENT",
+                comments: comments.slice(0, MAX_COMMENTS),
+              });
+            } catch (error) {
+              core.warning(
+                `nestjs-doctor could not post inline review comments (${error.message}). ` +
+                  "Grant the workflow `pull-requests: write` to enable them.",
+              );
+              return;
+            }
+          }
+
+          for (const commentId of priorIds) {
+            try {
+              await github.rest.pulls.deleteReviewComment({ ...context.repo, comment_id: commentId });
+            } catch (error) {
+              core.warning(`nestjs-doctor could not clear a prior review comment: ${error.message}`);
+            }
+          }
+
+    - name: Publish commit status
+      if: ${{ always() && inputs.commit-status == 'true' }}
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        NESTJS_DOCTOR_SCORE: ${{ steps.report.outputs.score }}
+        NESTJS_DOCTOR_LABEL: ${{ steps.report.outputs.label }}
+        NESTJS_DOCTOR_ERROR_COUNT: ${{ steps.report.outputs.error-count }}
+        NESTJS_DOCTOR_WARNING_COUNT: ${{ steps.report.outputs.warning-count }}
+        NESTJS_DOCTOR_SCAN_EXIT: ${{ steps.scan.outputs.exit-code }}
+        NESTJS_DOCTOR_STATUS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        NESTJS_DOCTOR_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      with:
+        script: |
+          const sha = process.env.NESTJS_DOCTOR_STATUS_SHA;
+          if (!sha) return;
+
+          const score = process.env.NESTJS_DOCTOR_SCORE;
+          const label = process.env.NESTJS_DOCTOR_LABEL;
+          const errors = Number(process.env.NESTJS_DOCTOR_ERROR_COUNT || "0");
+          const warnings = Number(process.env.NESTJS_DOCTOR_WARNING_COUNT || "0");
+          const scanExit = process.env.NESTJS_DOCTOR_SCAN_EXIT;
+          const isPullRequest = context.eventName === "pull_request";
+
+          const plural = (count, noun) => `${count} ${noun}${count === 1 ? "" : "s"}`;
+          const counts = `${plural(errors, "error")} · ${plural(warnings, "warning")}`;
+          // An empty exit code means the scan step never finished; treat that as
+          // a failure so this status cannot read green while the gate fails.
+          const scanFailed = scanExit !== "0";
+          const description = score
+            ? `Score: ${score}/100 (${label}) · ${counts}`
+            : scanFailed
+              ? "Scan could not complete"
+              : counts;
+
+          // Advisory on pushes — a default-branch health signal that must never
+          // turn the branch red. On a pull request it mirrors the gate.
+          const state = isPullRequest && scanFailed ? "failure" : "success";
+
+          try {
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha,
+              state,
+              context: "NestJS Doctor",
+              description: description.slice(0, 140),
+              target_url: process.env.NESTJS_DOCTOR_RUN_URL,
+            });
+          } catch (error) {
+            core.warning(
+              `nestjs-doctor could not publish the commit status (${error.message}). ` +
+                "Grant the workflow `statuses: write` to enable it.",
+            );
+          }
+
+    - name: Fail if nestjs-doctor found blocking issues
+      if: always()
+      shell: bash
+      env:
+        SCAN_STATUS: ${{ steps.scan.outputs.exit-code }}
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        # Non-pull-request events run a whole-project health snapshot rather than
+        # a gate: the result is visible in the job summary and commit status, but
+        # the run never fails on pre-existing findings, so the default branch
+        # does not go red. Pull requests propagate the CLI's exit code, which
+        # already reflects `blocking` and `min-score`.
+        if [ "$EVENT_NAME" != "pull_request" ]; then
+          exit 0
+        fi
+        exit "${SCAN_STATUS:-1}"

--- a/action.yml
+++ b/action.yml
@@ -367,6 +367,7 @@ runs:
 
           const MARKER = "<!-- nestjs-doctor:review -->";
           const KEY_RE = /<!-- nestjs-doctor:key ([A-Za-z0-9+/=]+) -->/;
+          const RETIRED = "<!-- nestjs-doctor:retired -->";
           const headSha = process.env.NESTJS_DOCTOR_HEAD_SHA || "";
           const shortSha = headSha.slice(0, 7);
           const directoryPrefix = (process.env.INPUT_DIRECTORY || ".")
@@ -466,7 +467,7 @@ runs:
                        nodes{
                          id
                          isResolved
-                         comments(first:1){ nodes{ databaseId body } }
+                         comments(first:1){ nodes{ id databaseId body isMinimized } }
                        }
                      }
                    }
@@ -486,11 +487,19 @@ runs:
           for (const thread of threads) {
             const first = thread.comments.nodes[0];
             if (!first?.body?.startsWith(MARKER)) continue;
+            const entry = {
+              threadId: thread.id,
+              commentId: first.databaseId,
+              commentNodeId: first.id,
+              isResolved: thread.isResolved,
+              isMinimized: first.isMinimized,
+              retired: first.body.includes(RETIRED),
+            };
             const match = first.body.match(KEY_RE);
             if (match) {
-              ours.set(match[1], { ...thread, commentId: first.databaseId });
-            } else if (!thread.isResolved) {
-              legacy.push({ ...thread, commentId: first.databaseId });
+              ours.set(match[1], entry);
+            } else if (!entry.retired) {
+              legacy.push(entry);
             }
           }
 
@@ -515,47 +524,113 @@ runs:
             }
           }
 
-          // A finding that stopped being reported is resolved, not deleted, and
-          // not called fixed: the scan cannot tell a fix from a suppression, a
-          // deletion, or a disabled rule, so it states only what it observed.
-          let resolved = 0;
-          for (const [key, thread] of ours) {
-            if (wanted.has(key) || thread.isResolved) continue;
+          // GitHub refuses resolveReviewThread to the default token, so a
+          // collapsed comment stands in when resolving is not permitted.
+          let collapseDenied = false;
+          const isDenied = (error) => /not accessible by integration/i.test(error.message);
+
+          const mutate = async (query, variables) => {
             try {
-              await github.rest.pulls.updateReviewComment({
-                ...context.repo,
-                comment_id: thread.commentId,
-                body: `${MARKER}\n<!-- nestjs-doctor:key ${key} -->\n_No longer reported as of \`${shortSha}\`._`,
-              });
-              await github.graphql(
-                `mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
-                { id: thread.id },
-              );
-              resolved += 1;
+              await github.graphql(query, variables);
+              return true;
             } catch (error) {
-              core.warning(`nestjs-doctor could not resolve a review thread: ${error.message}`);
+              if (!isDenied(error)) throw error;
+              return false;
+            }
+          };
+
+          const setBody = (entry, body) =>
+            github.rest.pulls.updateReviewComment({
+              ...context.repo,
+              comment_id: entry.commentId,
+              body,
+            });
+
+          const collapse = async (entry) => {
+            const resolvedNow =
+              entry.isResolved ||
+              (await mutate(
+                `mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
+                { id: entry.threadId },
+              ));
+            if (resolvedNow || entry.isMinimized) return;
+            const minimized = await mutate(
+              `mutation($id:ID!){ minimizeComment(input:{subjectId:$id,classifier:OUTDATED}){ clientMutationId } }`,
+              { id: entry.commentNodeId },
+            );
+            collapseDenied = collapseDenied || !minimized;
+          };
+
+          const reopen = async (entry) => {
+            if (entry.isResolved) {
+              const unresolved = await mutate(
+                `mutation($id:ID!){ unresolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
+                { id: entry.threadId },
+              );
+              collapseDenied = collapseDenied || !unresolved;
+            }
+            if (entry.isMinimized) {
+              const unminimized = await mutate(
+                `mutation($id:ID!){ unminimizeComment(input:{subjectId:$id}){ clientMutationId } }`,
+                { id: entry.commentNodeId },
+              );
+              collapseDenied = collapseDenied || !unminimized;
+            }
+          };
+
+          // A finding that comes back reuses its original thread, so the
+          // discussion under it survives the round trip.
+          let reopened = 0;
+          for (const [key, comment] of wanted) {
+            const entry = ours.get(key);
+            if (!entry?.retired) continue;
+            try {
+              await setBody(entry, comment.body);
+              await reopen(entry);
+              reopened += 1;
+            } catch (error) {
+              core.warning(`nestjs-doctor could not reopen a review thread: ${error.message}`);
             }
           }
 
-          for (const thread of legacy) {
+          // A finding that stopped being reported is retired, not deleted, and
+          // not called fixed: the scan cannot tell a fix from a suppression, a
+          // deletion, or a disabled rule, so it states only what it observed.
+          let retired = 0;
+          for (const [key, entry] of ours) {
+            if (wanted.has(key) || entry.retired) continue;
             try {
-              await github.rest.pulls.updateReviewComment({
-                ...context.repo,
-                comment_id: thread.commentId,
-                body: `${MARKER}\n_Superseded by an updated comment._`,
-              });
-              await github.graphql(
-                `mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
-                { id: thread.id },
+              await setBody(
+                entry,
+                `${MARKER}\n<!-- nestjs-doctor:key ${key} -->\n${RETIRED}\n_No longer reported as of \`${shortSha}\`._`,
               );
+              await collapse(entry);
+              retired += 1;
+            } catch (error) {
+              core.warning(`nestjs-doctor could not retire a review thread: ${error.message}`);
+            }
+          }
+
+          for (const entry of legacy) {
+            try {
+              await setBody(entry, `${MARKER}\n${RETIRED}\n_Superseded by an updated comment._`);
+              await collapse(entry);
             } catch (error) {
               core.warning(`nestjs-doctor could not retire a superseded comment: ${error.message}`);
             }
           }
 
+          if (collapseDenied) {
+            core.warning(
+              "nestjs-doctor marked stale comments but could not collapse them: GitHub refuses " +
+                "resolveReviewThread and minimizeComment to the default GITHUB_TOKEN. Pass a " +
+                "GitHub App installation token or a machine account's PAT as `github-token`.",
+            );
+          }
+
           core.info(
             `inline comments — posted ${fresh.length}, kept ${wanted.size - fresh.length}, ` +
-              `resolved ${resolved}, superseded ${legacy.length}`,
+              `reopened ${reopened}, retired ${retired}, superseded ${legacy.length}`,
           );
     - name: Publish commit status
       if: ${{ always() && inputs.commit-status == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -448,8 +448,15 @@ runs:
               pull_number: pullRequest.number,
               per_page: 100,
             });
+            // A comment someone replied to is a conversation, not just output.
+            // Deleting its parent would leave the reply answering nothing, so
+            // those are kept even once the finding is resolved.
+            const repliedTo = new Set(
+              existing.map((comment) => comment.in_reply_to_id).filter(Boolean),
+            );
             priorIds = existing
               .filter((comment) => comment.body?.startsWith(marker))
+              .filter((comment) => !repliedTo.has(comment.id))
               .map((comment) => comment.id);
           } catch (error) {
             core.warning(`nestjs-doctor could not list prior review comments: ${error.message}`);

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   silence-missing-baseline-warning:
     description: "Hide the warning shown when a compare scope cannot reach the base commit (a shallow checkout) and falls back to reporting every finding in the changed files. Setting `fetch-depth: 0` on actions/checkout is the real remedy."
     default: "false"
+  github-token:
+    description: "Token used to comment and set the commit status. The default posts as github-actions[bot], with GitHub's own avatar; a GitHub App installation token or a bot account's PAT posts under that identity's name and picture instead."
+    default: ${{ github.token }}
   node-version:
     description: "Node.js version to use"
     default: "22"
@@ -164,6 +167,7 @@ runs:
         # github-script's own directory, so pass ours explicitly.
         COMPOSITE_ACTION_PATH: ${{ github.action_path }}
       with:
+        github-token: ${{ inputs.github-token }}
         script: |
           const fs = require("fs");
           const { pathToFileURL } = require("url");
@@ -288,6 +292,7 @@ runs:
         NESTJS_DOCTOR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         NESTJS_DOCTOR_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         NESTJS_DOCTOR_SILENCE_BASELINE_WARNING: ${{ inputs.silence-missing-baseline-warning }}
+        NESTJS_DOCTOR_CHANGED_TOTAL: ${{ steps.base.outputs.changed-total || steps.pr-files.outputs.changed-total }}
       run: |
         node "$GITHUB_ACTION_PATH/scripts/action/read-report.mjs" "$REPORT_FILE"
         node "$GITHUB_ACTION_PATH/scripts/action/render-comment.mjs" "$API_ENTRY" "$REPORT_FILE" "$COMMENT_FILE"
@@ -299,6 +304,7 @@ runs:
       env:
         NESTJS_DOCTOR_COMMENT_FILE: ${{ steps.report.outputs.comment-file }}
       with:
+        github-token: ${{ inputs.github-token }}
         script: |
           const fs = require("fs");
           const commentPath = process.env.NESTJS_DOCTOR_COMMENT_FILE;
@@ -342,6 +348,7 @@ runs:
         INPUT_DIRECTORY: ${{ steps.base.outputs.prefix || inputs.directory }}
         NESTJS_DOCTOR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       with:
+        github-token: ${{ inputs.github-token }}
         script: |
           const fs = require("fs");
           const reportPath = process.env.NESTJS_DOCTOR_REPORT_FILE;
@@ -562,6 +569,7 @@ runs:
         NESTJS_DOCTOR_STATUS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         NESTJS_DOCTOR_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       with:
+        github-token: ${{ inputs.github-token }}
         script: |
           const sha = process.env.NESTJS_DOCTOR_STATUS_SHA;
           if (!sha) return;

--- a/action.yml
+++ b/action.yml
@@ -368,6 +368,7 @@ runs:
           const MARKER = "<!-- nestjs-doctor:review -->";
           const KEY_RE = /<!-- nestjs-doctor:key ([A-Za-z0-9+/=]+) -->/;
           const RETIRED = "<!-- nestjs-doctor:retired -->";
+          const REVIVED = "<!-- nestjs-doctor:revived -->";
           const headSha = process.env.NESTJS_DOCTOR_HEAD_SHA || "";
           const shortSha = headSha.slice(0, 7);
           const directoryPrefix = (process.env.INPUT_DIRECTORY || ".")
@@ -456,7 +457,8 @@ runs:
           if (wanted.size === 0 && diagnostics.length > 0) return;
 
           // Threads, not bare comments: resolving needs the thread id, and only
-          // GraphQL exposes it.
+          // GraphQL exposes it. `viewerCanResolve` answers up front whether the
+          // token behind this run is allowed to resolve at all.
           let threads = [];
           try {
             const result = await github.graphql(
@@ -467,7 +469,9 @@ runs:
                        nodes{
                          id
                          isResolved
-                         comments(first:1){ nodes{ id databaseId body isMinimized } }
+                         viewerCanResolve
+                         root: comments(first:1){ nodes{ databaseId body } }
+                         recent: comments(last:20){ nodes{ body } }
                        }
                      }
                    }
@@ -480,27 +484,29 @@ runs:
             core.warning(`nestjs-doctor could not read review threads (${error.message}).`);
           }
 
-          const ours = new Map();
-          // Comments from before the key format cannot be matched to a finding,
-          // so this run's keyed set supersedes them.
-          const legacy = [];
-          for (const thread of threads) {
-            const first = thread.comments.nodes[0];
-            if (!first?.body?.startsWith(MARKER)) continue;
-            const entry = {
-              threadId: thread.id,
-              commentId: first.databaseId,
-              commentNodeId: first.id,
-              isResolved: thread.isResolved,
-              isMinimized: first.isMinimized,
-              retired: first.body.includes(RETIRED),
-            };
-            const match = first.body.match(KEY_RE);
-            if (match) {
-              ours.set(match[1], entry);
-            } else if (!entry.retired) {
-              legacy.push(entry);
+          // The newest status reply decides the thread's state, so a human
+          // replying afterwards does not change it.
+          const stateOf = (bodies) => {
+            for (let index = bodies.length - 1; index >= 0; index -= 1) {
+              if (bodies[index].includes(RETIRED)) return "retired";
+              if (bodies[index].includes(REVIVED)) return "live";
             }
+            return "live";
+          };
+
+          const ours = new Map();
+          for (const thread of threads) {
+            const root = thread.root.nodes[0];
+            if (!root?.body?.startsWith(MARKER)) continue;
+            const match = root.body.match(KEY_RE);
+            if (!match) continue;
+            ours.set(match[1], {
+              threadId: thread.id,
+              rootId: root.databaseId,
+              isResolved: thread.isResolved,
+              canResolve: thread.viewerCanResolve,
+              state: stateOf(thread.recent.nodes.map((node) => node.body ?? "")),
+            });
           }
 
           // Only genuinely new findings are posted. An unchanged one keeps its
@@ -524,113 +530,88 @@ runs:
             }
           }
 
-          // GitHub refuses resolveReviewThread to the default token, so a
-          // collapsed comment stands in when resolving is not permitted.
-          let collapseDenied = false;
-          const isDenied = (error) => /not accessible by integration/i.test(error.message);
+          core.info(
+            `review threads — ${ours.size} known, ` +
+              `${[...ours.values()].filter((entry) => entry.canResolve).length} resolvable by this token`,
+          );
 
-          const mutate = async (query, variables) => {
-            try {
-              await github.graphql(query, variables);
-              return true;
-            } catch (error) {
-              if (!isDenied(error)) throw error;
-              return false;
-            }
-          };
+          let resolveDenied = false;
 
-          const setBody = (entry, body) =>
-            github.rest.pulls.updateReviewComment({
+          // The finding itself is never rewritten. A reply records what changed,
+          // so the original text and the discussion under it both survive.
+          const reply = (entry, body) =>
+            github.rest.pulls.createReplyForReviewComment({
               ...context.repo,
-              comment_id: entry.commentId,
+              pull_number: pullRequest.number,
+              comment_id: entry.rootId,
               body,
             });
 
-          const collapse = async (entry) => {
-            const resolvedNow =
-              entry.isResolved ||
-              (await mutate(
-                `mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
-                { id: entry.threadId },
-              ));
-            if (resolvedNow || entry.isMinimized) return;
-            const minimized = await mutate(
-              `mutation($id:ID!){ minimizeComment(input:{subjectId:$id,classifier:OUTDATED}){ clientMutationId } }`,
-              { id: entry.commentNodeId },
-            );
-            collapseDenied = collapseDenied || !minimized;
-          };
-
-          const reopen = async (entry) => {
-            if (entry.isResolved) {
-              const unresolved = await mutate(
-                `mutation($id:ID!){ unresolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
-                { id: entry.threadId },
-              );
-              collapseDenied = collapseDenied || !unresolved;
+          const setResolved = async (entry, resolved) => {
+            if (entry.isResolved === resolved) return;
+            if (!entry.canResolve) {
+              resolveDenied = true;
+              return;
             }
-            if (entry.isMinimized) {
-              const unminimized = await mutate(
-                `mutation($id:ID!){ unminimizeComment(input:{subjectId:$id}){ clientMutationId } }`,
-                { id: entry.commentNodeId },
-              );
-              collapseDenied = collapseDenied || !unminimized;
-            }
-          };
-
-          // A finding that comes back reuses its original thread, so the
-          // discussion under it survives the round trip.
-          let reopened = 0;
-          for (const [key, comment] of wanted) {
-            const entry = ours.get(key);
-            if (!entry?.retired) continue;
             try {
-              await setBody(entry, comment.body);
-              await reopen(entry);
-              reopened += 1;
+              await github.graphql(
+                resolved
+                  ? `mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }`
+                  : `mutation($id:ID!){ unresolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
+                { id: entry.threadId },
+              );
             } catch (error) {
-              core.warning(`nestjs-doctor could not reopen a review thread: ${error.message}`);
+              if (!/not accessible by integration/i.test(error.message)) throw error;
+              resolveDenied = true;
             }
-          }
+          };
 
-          // A finding that stopped being reported is retired, not deleted, and
-          // not called fixed: the scan cannot tell a fix from a suppression, a
-          // deletion, or a disabled rule, so it states only what it observed.
+          // "No longer reported" rather than "fixed": the scan cannot tell a fix
+          // from a suppression, a deletion, or a disabled rule.
           let retired = 0;
           for (const [key, entry] of ours) {
-            if (wanted.has(key) || entry.retired) continue;
+            if (wanted.has(key) || entry.state === "retired") continue;
             try {
-              await setBody(
+              await reply(
                 entry,
-                `${MARKER}\n<!-- nestjs-doctor:key ${key} -->\n${RETIRED}\n_No longer reported as of \`${shortSha}\`._`,
+                `${MARKER}\n${RETIRED}\n✅ **No longer reported** as of \`${shortSha}\`.`,
               );
-              await collapse(entry);
+              await setResolved(entry, true);
               retired += 1;
             } catch (error) {
               core.warning(`nestjs-doctor could not retire a review thread: ${error.message}`);
             }
           }
 
-          for (const entry of legacy) {
+          // A finding that comes back reuses its thread rather than opening a
+          // second one somebody has to read alongside the first.
+          let reopened = 0;
+          for (const key of wanted.keys()) {
+            const entry = ours.get(key);
+            if (!entry || entry.state !== "retired") continue;
             try {
-              await setBody(entry, `${MARKER}\n${RETIRED}\n_Superseded by an updated comment._`);
-              await collapse(entry);
+              await reply(
+                entry,
+                `${MARKER}\n${REVIVED}\n⚠️ **Reported again** as of \`${shortSha}\`.`,
+              );
+              await setResolved(entry, false);
+              reopened += 1;
             } catch (error) {
-              core.warning(`nestjs-doctor could not retire a superseded comment: ${error.message}`);
+              core.warning(`nestjs-doctor could not reopen a review thread: ${error.message}`);
             }
           }
 
-          if (collapseDenied) {
+          if (resolveDenied) {
             core.warning(
-              "nestjs-doctor marked stale comments but could not collapse them: GitHub refuses " +
-                "resolveReviewThread and minimizeComment to the default GITHUB_TOKEN. Pass a " +
-                "GitHub App installation token or a machine account's PAT as `github-token`.",
+              "nestjs-doctor replied to stale comments but left their threads open: GitHub does " +
+                "not let this token resolve a review thread. Pass a GitHub App installation " +
+                "token or a machine account's PAT as `github-token` to have them resolved.",
             );
           }
 
           core.info(
             `inline comments — posted ${fresh.length}, kept ${wanted.size - fresh.length}, ` +
-              `reopened ${reopened}, retired ${retired}, superseded ${legacy.length}`,
+              `retired ${retired}, reopened ${reopened}`,
           );
     - name: Publish commit status
       if: ${{ always() && inputs.commit-status == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -340,10 +340,10 @@ runs:
       env:
         NESTJS_DOCTOR_REPORT_FILE: ${{ steps.scan.outputs.report-file }}
         INPUT_DIRECTORY: ${{ steps.base.outputs.prefix || inputs.directory }}
+        NESTJS_DOCTOR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       with:
         script: |
           const fs = require("fs");
-          const path = require("path");
           const reportPath = process.env.NESTJS_DOCTOR_REPORT_FILE;
           const pullRequest = context.payload.pull_request;
           if (!pullRequest || !reportPath || !fs.existsSync(reportPath)) return;
@@ -352,13 +352,16 @@ runs:
           try {
             report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
           } catch {
-            // A crashed scan leaves a truncated report; leave existing feedback
-            // in place rather than wiping it on a transient failure.
+            // A crashed scan leaves a truncated report. Leave existing feedback
+            // alone rather than acting on nothing.
             return;
           }
           const diagnostics = Array.isArray(report.diagnostics) ? report.diagnostics : [];
 
-          const marker = "<!-- nestjs-doctor:review -->";
+          const MARKER = "<!-- nestjs-doctor:review -->";
+          const KEY_RE = /<!-- nestjs-doctor:key ([A-Za-z0-9+/=]+) -->/;
+          const headSha = process.env.NESTJS_DOCTOR_HEAD_SHA || "";
+          const shortSha = headSha.slice(0, 7);
           const directoryPrefix = (process.env.INPUT_DIRECTORY || ".")
             .replace(/^\.\/?/, "")
             .replace(/\/$/, "");
@@ -375,10 +378,8 @@ runs:
             return;
           }
 
-          // The Reviews API accepts RIGHT-side comments on any line inside a
-          // hunk — added (`+`) and unchanged context (` `) alike, since a
-          // finding can land on a context line when the change that caused it
-          // is elsewhere in the hunk. Removed lines are not RIGHT-side lines.
+          // RIGHT-side comments are accepted on added (`+`) and context (` `)
+          // lines. Removed lines and the no-newline marker are not.
           const commentableByFile = new Map();
           for (const file of files) {
             if (!file.patch) continue;
@@ -398,7 +399,6 @@ runs:
             commentableByFile.set(file.filename, commentable);
           }
 
-          // Report paths are absolute; map them back onto repo-relative ones.
           const workspace = (process.env.GITHUB_WORKSPACE || process.cwd()).replace(/\\/g, "/");
           const toRepoPath = (filePath) => {
             let normalized = String(filePath || "").replace(/\\/g, "/").replace(/^\.\//, "");
@@ -414,64 +414,83 @@ runs:
             return suffixMatches.length === 1 ? suffixMatches[0] : null;
           };
 
-          const seen = new Set();
-          const comments = [];
+          // Identity excludes the line number, so a finding that merely shifted
+          // keeps its comment instead of being reposted. The occurrence index
+          // separates two findings that are otherwise identical.
+          const occurrences = new Map();
+          const keyFor = (repoPath, diagnostic) => {
+            const base = `${diagnostic.rule}|${repoPath}|${diagnostic.message}`;
+            const seen = occurrences.get(base) ?? 0;
+            occurrences.set(base, seen + 1);
+            return Buffer.from(`${base}|${seen}`).toString("base64");
+          };
+
+          const wanted = new Map();
           for (const diagnostic of diagnostics) {
             if (!diagnostic || typeof diagnostic.line !== "number" || diagnostic.line <= 0) continue;
             const repoPath = toRepoPath(diagnostic.filePath);
             if (!repoPath) continue;
             const commentable = commentableByFile.get(repoPath);
             if (!commentable || !commentable.has(diagnostic.line)) continue;
-            const dedupeKey = `${repoPath}:${diagnostic.line}:${diagnostic.rule}`;
-            if (seen.has(dedupeKey)) continue;
-            seen.add(dedupeKey);
+            const key = keyFor(repoPath, diagnostic);
+            if (wanted.has(key)) continue;
             const fix = diagnostic.help ? `\n\n**Fix** → ${diagnostic.help}` : "";
-            comments.push({
+            wanted.set(key, {
               path: repoPath,
               line: diagnostic.line,
               side: "RIGHT",
-              body: `${marker}\n**nestjs-doctor** · \`${diagnostic.rule}\` _(${diagnostic.severity})_\n\n${diagnostic.message}${fix}`,
+              body: `${MARKER}\n<!-- nestjs-doctor:key ${key} -->\n**nestjs-doctor** · \`${diagnostic.rule}\` _(${diagnostic.severity})_\n\n${diagnostic.message}${fix}`,
             });
           }
 
-          // Findings that mapped onto no changed line must not wipe existing
-          // inline feedback — that would read as "all clear" when it isn't.
-          if (comments.length === 0 && diagnostics.length > 0) return;
+          // Findings that mapped onto no changed line must not clear existing
+          // feedback — that would read as "all clear" when it is not.
+          if (wanted.size === 0 && diagnostics.length > 0) return;
 
-          // Capture the prior review comments up front, and delete them only
-          // after the new review posts, so a failed post leaves the last run's
-          // feedback rather than nothing at all.
-          let priorIds = [];
+          // Threads, not bare comments: resolving needs the thread id, and only
+          // GraphQL exposes it.
+          let threads = [];
           try {
-            const existing = await github.paginate(github.rest.pulls.listReviewComments, {
-              ...context.repo,
-              pull_number: pullRequest.number,
-              per_page: 100,
-            });
-            // A comment someone replied to is a conversation, not just output.
-            // Deleting its parent would leave the reply answering nothing, so
-            // those are kept even once the finding is resolved.
-            const repliedTo = new Set(
-              existing.map((comment) => comment.in_reply_to_id).filter(Boolean),
+            const result = await github.graphql(
+              `query($owner:String!,$repo:String!,$number:Int!){
+                 repository(owner:$owner,name:$repo){
+                   pullRequest(number:$number){
+                     reviewThreads(first:100){
+                       nodes{
+                         id
+                         isResolved
+                         comments(first:1){ nodes{ databaseId body } }
+                       }
+                     }
+                   }
+                 }
+               }`,
+              { owner: context.repo.owner, repo: context.repo.repo, number: pullRequest.number },
             );
-            priorIds = existing
-              .filter((comment) => comment.body?.startsWith(marker))
-              .filter((comment) => !repliedTo.has(comment.id))
-              .map((comment) => comment.id);
+            threads = result.repository.pullRequest.reviewThreads.nodes ?? [];
           } catch (error) {
-            core.warning(`nestjs-doctor could not list prior review comments: ${error.message}`);
+            core.warning(`nestjs-doctor could not read review threads (${error.message}).`);
           }
 
-          // Capped to stay inside GitHub's per-review size limits and to keep a
-          // large pull request readable; the sticky comment holds every finding.
+          const ours = new Map();
+          for (const thread of threads) {
+            const first = thread.comments.nodes[0];
+            if (!first?.body?.startsWith(MARKER)) continue;
+            const match = first.body.match(KEY_RE);
+            if (match) ours.set(match[1], { ...thread, commentId: first.databaseId });
+          }
+
+          // Only genuinely new findings are posted. An unchanged one keeps its
+          // comment, so re-pushing does not re-notify or break permalinks.
+          const fresh = [...wanted.entries()].filter(([key]) => !ours.has(key)).map(([, c]) => c);
           const MAX_COMMENTS = 40;
-          if (comments.length > 0) {
+          if (fresh.length > 0) {
             try {
               await github.rest.pulls.createReview({
                 ...context.repo,
                 pull_number: pullRequest.number,
                 event: "COMMENT",
-                comments: comments.slice(0, MAX_COMMENTS),
+                comments: fresh.slice(0, MAX_COMMENTS),
               });
             } catch (error) {
               core.warning(
@@ -482,14 +501,29 @@ runs:
             }
           }
 
-          for (const commentId of priorIds) {
+          // A finding that stopped being reported is resolved, not deleted, and
+          // not called fixed: the scan cannot tell a fix from a suppression, a
+          // deletion, or a disabled rule, so it states only what it observed.
+          let resolved = 0;
+          for (const [key, thread] of ours) {
+            if (wanted.has(key) || thread.isResolved) continue;
             try {
-              await github.rest.pulls.deleteReviewComment({ ...context.repo, comment_id: commentId });
+              await github.rest.pulls.updateReviewComment({
+                ...context.repo,
+                comment_id: thread.commentId,
+                body: `${MARKER}\n<!-- nestjs-doctor:key ${key} -->\n_No longer reported as of \`${shortSha}\`._`,
+              });
+              await github.graphql(
+                `mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }`,
+                { id: thread.id },
+              );
+              resolved += 1;
             } catch (error) {
-              core.warning(`nestjs-doctor could not clear a prior review comment: ${error.message}`);
+              core.warning(`nestjs-doctor could not resolve a review thread: ${error.message}`);
             }
           }
 
+          core.info(`inline comments — posted ${fresh.length}, kept ${wanted.size - fresh.length}, resolved ${resolved}`);
     - name: Publish commit status
       if: ${{ always() && inputs.commit-status == 'true' }}
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -9,7 +9,8 @@ const config: KnipConfig = {
 	],
 	workspaces: {
 		".": {
-			ignore: ["packages/website/**"],
+			// GitHub Action entry points: invoked by action.yml, not imported.
+			ignore: ["packages/website/**", "scripts/action/**"],
 		},
 		"packages/nestjs-doctor": {
 			project: ["src/**/*.ts"],

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -116,8 +116,33 @@ comment.
 | `commit-status` | `true` | Commit status with the score |
 | `sarif` | `false` | Also write a SARIF report |
 | `sarif-file` | `nestjs-doctor.sarif` | Where the SARIF report goes |
+| `silence-missing-baseline-warning` | `false` | Hide the degraded-scope warning |
+| `github-token` | `${{ github.token }}` | Token used to comment and set the status |
 | `node-version` | `22` | Node.js version |
 | `version` | `latest` | nestjs-doctor version to run |
+
+### Failing the build
+
+Out of the box the action **never fails** — it comments and sets a status, and
+you decide what to do about it. Enforcement is opt-in through two independent
+gates, and either one failing fails the run.
+
+```yaml
+      - uses: RoloBits/nestjs-doctor@v1
+        with:
+          blocking: error # any error the change introduced fails the run
+          min-score: 80 # …and so does a project score below 80
+```
+
+`blocking` gates on the findings **actually reported**, so with the default
+`scope: changed` it fires only on what the pull request introduced — your
+existing backlog cannot fail somebody else's pull request. `none` (the default)
+never fails, `warning` fails on any error or warning, `error` on errors only.
+
+`min-score` gates on the **whole project**, always, whatever the scope. That is
+deliberate — narrowing a report must not make a codebase look healthier than it
+is — but it does mean a high enough threshold can fail a pull request for debt
+it did not create. Use `blocking` on its own to gate purely on the change.
 
 ### Outputs
 

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -66,6 +66,88 @@ Use `NestJS Doctor: Scan Project` from the command palette to trigger a full sca
 
 ---
 
+## GitHub Action
+
+Reviews every pull request and reports **only what the change introduced**, not
+your existing backlog. Posts a sticky summary comment, inline review comments on
+the changed lines, and a commit status with the score.
+
+```yaml
+# .github/workflows/nestjs-doctor.yml
+name: NestJS Doctor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for `scope: changed`
+      - uses: RoloBits/nestjs-doctor@v1
+```
+
+`fetch-depth: 0` matters. `scope: changed` compares against the **merge base**
+of your branch and its target, which a shallow checkout can't resolve — the
+action falls back to the base branch tip, or, if it can't reach that either, to
+reporting every finding in the changed files. It says which happened in the
+comment.
+
+### Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `directory` | `.` | Project directory to scan |
+| `scope` | `changed` | `changed` (only what the pull request introduced), `files` (everything in the changed files), `lines` (only the changed lines), `full` (the whole project) |
+| `blocking` | `none` | Severity that fails the workflow: `none`, `warning`, `error` |
+| `min-score` | — | Fail when the project's score drops below this |
+| `config` | — | Path to a config file |
+| `comment` | `true` | Sticky pull request summary comment |
+| `review-comments` | `true` | Inline review comments on changed lines |
+| `commit-status` | `true` | Commit status with the score |
+| `sarif` | `false` | Also write a SARIF report |
+| `sarif-file` | `nestjs-doctor.sarif` | Where the SARIF report goes |
+| `node-version` | `22` | Node.js version |
+| `version` | `latest` | nestjs-doctor version to run |
+
+### Outputs
+
+`score`, `label`, `total-issues`, `fixed-issues`, `error-count`,
+`warning-count`, `affected-files`, `report-file`, `sarif-file`.
+
+Pushes to the default branch always scan the whole project and never fail the
+run — they are a health snapshot, surfaced through the job summary and the
+commit status, so `main` doesn't go red on pre-existing findings.
+
+### Code scanning
+
+Turn on `sarif` to send findings to the repository's Security tab:
+
+```yaml
+      - uses: RoloBits/nestjs-doctor@v1
+        id: doctor
+        with:
+          scope: full
+          sarif: "true"
+      - uses: github/codeql-action/upload-sarif@v3
+        if: always() && steps.doctor.outputs.sarif-file != ''
+        with:
+          sarif_file: ${{ steps.doctor.outputs.sarif-file }}
+```
+
+Add `security-events: write` to the job's `permissions`.
+
+---
+
 ## CI
 
 Pin it as a devDependency:

--- a/packages/nestjs-doctor/src/common/scope.ts
+++ b/packages/nestjs-doctor/src/common/scope.ts
@@ -17,6 +17,8 @@ export interface ScopeInfo {
 	baseRef?: string;
 	/** Files the scope narrowed to, not the change's total file count. */
 	changedFiles?: number;
+	/** Files the change touched before filtering, when the caller knows it. */
+	changedFilesTotal?: number;
 	/** Set when the requested mode could not be honoured. */
 	degradedFrom?: ScopeMode;
 	/** Present in `changed` mode: findings the change resolved. */

--- a/packages/nestjs-doctor/src/formatters/markdown-report.ts
+++ b/packages/nestjs-doctor/src/formatters/markdown-report.ts
@@ -4,11 +4,14 @@ import type { DiagnoseResult, MonorepoResult } from "../common/result.js";
 import type { ScopeInfo } from "../common/scope.js";
 import { toRelativePath } from "../engine/fingerprint.js";
 
+/** Square logo, sized to sit on the heading's baseline. */
+const LOGO =
+	'<img src="https://nestjs.doctor/logo.png" width="20" height="20" align="top" alt="">';
+
 /** Lets a CI job find and rewrite its own comment instead of stacking new ones. */
 export const MARKDOWN_COMMENT_MARKER = "<!-- nestjs-doctor:summary -->";
 
 const MAX_TABLE_ROWS = 50;
-const SEVERITY_ICON = { error: "🔴", warning: "🟡", info: "🔵" } as const;
 const SEVERITY_ORDER = { error: 0, warning: 1, info: 2 } as const;
 const PIPE_RE = /\|/g;
 const NEWLINE_RE = /\r?\n/g;
@@ -25,16 +28,6 @@ export interface MarkdownReportOptions {
 
 const escapeCell = (text: string): string =>
 	text.replace(PIPE_RE, "\\|").replace(NEWLINE_RE, " ");
-
-const scoreEmoji = (score: number): string => {
-	if (score >= 75) {
-		return "🟢";
-	}
-	if (score >= 50) {
-		return "🟡";
-	}
-	return "🔴";
-};
 
 const pluralize = (count: number, noun: string): string =>
 	`${count} ${noun}${count === 1 ? "" : "s"}`;
@@ -73,9 +66,9 @@ function renderHeadline(
 		scope?.mode === "changed" ? "introduced by this change" : "reported";
 	const findings = summary.total
 		? `**${pluralize(summary.total, "finding")}** ${scopeNoun} (${counts}).`
-		: `No findings ${scopeNoun}. ✨`;
+		: `No findings ${scopeNoun}.`;
 
-	return `${scoreEmoji(score.value)} **Score ${score.value}/100 — ${score.label}** · ${findings}`;
+	return `**Score ${score.value}/100 — ${score.label}** · ${findings}`;
 }
 
 function renderScopeNote(scope: ScopeInfo | undefined): string[] {
@@ -93,7 +86,7 @@ function renderScopeNote(scope: ScopeInfo | undefined): string[] {
 	}
 	if (scope.mode === "changed" && scope.fixed) {
 		lines.push(
-			`> ✅ This change also resolved ${pluralize(scope.fixed, "existing finding")}.`,
+			`> This change also resolved ${pluralize(scope.fixed, "existing finding")}.`,
 			""
 		);
 	}
@@ -134,7 +127,7 @@ function renderFindingsTable(
 	const shown = sorted.slice(0, MAX_TABLE_ROWS);
 	const rows = shown.map(
 		(diagnostic) =>
-			`| ${SEVERITY_ICON[diagnostic.severity]} | \`${diagnostic.rule}\` | ${locationOf(diagnostic, targetPath)} | ${escapeCell(diagnostic.message)} |`
+			`| ${diagnostic.severity} | \`${diagnostic.rule}\` | ${locationOf(diagnostic, targetPath)} | ${escapeCell(diagnostic.message)} |`
 	);
 
 	const overflow =
@@ -149,8 +142,8 @@ function renderFindingsTable(
 		"",
 		`<details open><summary><b>Findings (${sorted.length})</b></summary>`,
 		"",
-		"| | Rule | Location | Message |",
-		"| :-: | --- | --- | --- |",
+		"| Severity | Rule | Location | Message |",
+		"| --- | --- | --- | --- |",
 		...rows,
 		...overflow,
 		"",
@@ -201,7 +194,7 @@ export function buildMarkdownReport(
 
 	return [
 		MARKDOWN_COMMENT_MARKER,
-		"## 🩺 nestjs-doctor",
+		`## ${LOGO} nestjs-doctor`,
 		"",
 		renderHeadline(result, options.scope),
 		...renderScopeNote(options.scope),

--- a/packages/nestjs-doctor/src/formatters/markdown-report.ts
+++ b/packages/nestjs-doctor/src/formatters/markdown-report.ts
@@ -91,8 +91,15 @@ function renderScopeNote(scope: ScopeInfo | undefined): string[] {
 		);
 	}
 	if (scope.changedFiles !== undefined) {
+		// Showing only the narrowed count invites the reader to compare it with
+		// the pull request's own file count and read the gap as a miscount.
+		const total = scope.changedFilesTotal;
+		const counted =
+			total !== undefined && total !== scope.changedFiles
+				? `${scope.changedFiles} of ${pluralize(total, "changed file")} scanned`
+				: `${pluralize(scope.changedFiles, "file")} in scope`;
 		lines.push(
-			`<sub>Scope \`${scope.mode}\` · ${pluralize(scope.changedFiles, "file")} in scope${scope.baseRef ? ` vs \`${scope.baseRef}\`` : ""}.</sub>`
+			`<sub>Scope \`${scope.mode}\` · ${counted}${scope.baseRef ? ` vs \`${scope.baseRef}\`` : ""}.</sub>`
 		);
 	}
 	return lines.length ? ["", ...lines] : [];

--- a/packages/nestjs-doctor/src/formatters/markdown-report.ts
+++ b/packages/nestjs-doctor/src/formatters/markdown-report.ts
@@ -15,6 +15,11 @@ const MAX_TABLE_ROWS = 50;
 const SEVERITY_ORDER = { error: 0, warning: 1, info: 2 } as const;
 const PIPE_RE = /\|/g;
 const NEWLINE_RE = /\r?\n/g;
+const FULL_SHA_RE = /^[0-9a-f]{40}$/i;
+
+/** Abbreviates a base given as a full SHA; leaves branch names alone. */
+const shortenRef = (ref: string): string =>
+	FULL_SHA_RE.test(ref) ? ref.slice(0, 7) : ref;
 
 export interface MarkdownReportOptions {
 	commitSha?: string;
@@ -99,7 +104,7 @@ function renderScopeNote(scope: ScopeInfo | undefined): string[] {
 				? `${scope.changedFiles} of ${pluralize(total, "changed file")} scanned`
 				: `${pluralize(scope.changedFiles, "file")} in scope`;
 		lines.push(
-			`<sub>Scope \`${scope.mode}\` · ${counted}${scope.baseRef ? ` vs \`${scope.baseRef}\`` : ""}.</sub>`
+			`<sub>Scope \`${scope.mode}\` · ${counted}${scope.baseRef ? ` vs \`${shortenRef(scope.baseRef)}\`` : ""}.</sub>`
 		);
 	}
 	return lines.length ? ["", ...lines] : [];

--- a/packages/nestjs-doctor/tests/unit/formatters.test.ts
+++ b/packages/nestjs-doctor/tests/unit/formatters.test.ts
@@ -24,6 +24,7 @@ import { buildSarifLog } from "../../src/formatters/sarif-report.js";
 
 const ROOT = "/repo";
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+const EMOJI_RE = /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u;
 
 const code = (
 	overrides: Partial<CodeDiagnostic> & { line: number }
@@ -231,6 +232,25 @@ describe("buildMarkdownReport", () => {
 		});
 		expect(markdown).toContain("introduced by this change");
 		expect(markdown).toContain("resolved 2 existing findings");
+	});
+
+	it("brands the heading with the logo rather than an emoji", () => {
+		const markdown = buildMarkdownReport(resultWith([]), options);
+		expect(markdown).toContain("nestjs.doctor/logo.png");
+		expect(markdown).not.toMatch(EMOJI_RE);
+	});
+
+	it("names the severity instead of colouring it", () => {
+		// A screen reader announces a coloured circle as "red circle", not
+		// "error", so the word carries the meaning the colour used to.
+		const markdown = buildMarkdownReport(
+			resultWith([code({ line: 8 }), schemaDiagnostic]),
+			options
+		);
+		expect(markdown).toContain("| Severity |");
+		expect(markdown).toContain("| warning |");
+		expect(markdown).toContain("| error |");
+		expect(markdown).not.toMatch(EMOJI_RE);
 	});
 
 	it("counts files in scope, not files in the change", () => {

--- a/packages/nestjs-doctor/tests/unit/formatters.test.ts
+++ b/packages/nestjs-doctor/tests/unit/formatters.test.ts
@@ -234,6 +234,35 @@ describe("buildMarkdownReport", () => {
 		expect(markdown).toContain("resolved 2 existing findings");
 	});
 
+	it("shows both counts when the change had files it did not scan", () => {
+		const scope = {
+			mode: "changed" as const,
+			changedFiles: 5,
+			changedFilesTotal: 9,
+			baseRef: "main",
+		};
+		const markdown = buildMarkdownReport(
+			{ ...resultWith([]), scope },
+			{ ...options, scope }
+		);
+		expect(markdown).toContain("5 of 9 changed files scanned");
+	});
+
+	it("does not say 'of' when nothing was filtered out", () => {
+		const scope = {
+			mode: "files" as const,
+			changedFiles: 5,
+			changedFilesTotal: 5,
+			baseRef: "main",
+		};
+		const markdown = buildMarkdownReport(
+			{ ...resultWith([]), scope },
+			{ ...options, scope }
+		);
+		expect(markdown).toContain("5 files in scope");
+		expect(markdown).not.toContain(" of ");
+	});
+
 	it("brands the heading with the logo rather than an emoji", () => {
 		const markdown = buildMarkdownReport(resultWith([]), options);
 		expect(markdown).toContain("nestjs.doctor/logo.png");

--- a/packages/nestjs-doctor/tests/unit/formatters.test.ts
+++ b/packages/nestjs-doctor/tests/unit/formatters.test.ts
@@ -248,6 +248,32 @@ describe("buildMarkdownReport", () => {
 		expect(markdown).toContain("5 of 9 changed files scanned");
 	});
 
+	it("abbreviates a base given as a full sha but not a branch name", () => {
+		const sha = "13bb31aa5bf4b88f1da75375c0d1cfec6d022dd2";
+		const shaScope = {
+			mode: "changed" as const,
+			changedFiles: 5,
+			baseRef: sha,
+		};
+		const shaMarkdown = buildMarkdownReport(
+			{ ...resultWith([]), scope: shaScope },
+			{ ...options, scope: shaScope }
+		);
+		expect(shaMarkdown).toContain("vs `13bb31a`");
+		expect(shaMarkdown).not.toContain(sha);
+
+		const branchScope = {
+			mode: "changed" as const,
+			changedFiles: 5,
+			baseRef: "origin/release-1.2.3",
+		};
+		const branchMarkdown = buildMarkdownReport(
+			{ ...resultWith([]), scope: branchScope },
+			{ ...options, scope: branchScope }
+		);
+		expect(branchMarkdown).toContain("vs `origin/release-1.2.3`");
+	});
+
 	it("does not say 'of' when nothing was filtered out", () => {
 		const scope = {
 			mode: "files" as const,

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -1,6 +1,6 @@
 # NestJS Doctor
 
-> Diagnose and fix your NestJS code in one command. 50 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics. Zero config. Monorepo support. Reports only what a change introduced, so it can gate a pull request without drowning it in pre-existing findings.
+> Diagnose and fix your NestJS code in one command. 50 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics. Zero config. Monorepo support. Ships an official GitHub Action that reports only what a pull request introduced.
 
 ## Quick Start
 
@@ -59,6 +59,22 @@ npx nestjs-doctor . --staged --blocking error   # pre-commit hook
 
 The score always reflects the whole project, whatever the scope. `--min-score`
 gates on that score; `--blocking` gates on the reported findings.
+
+## GitHub Action
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0        # required for scope: changed
+- uses: RoloBits/nestjs-doctor@v1
+```
+
+Reports only what the pull request introduced, posts a sticky summary comment,
+inline review comments on the changed lines, and a commit status. Inputs:
+`directory`, `scope`, `blocking`, `min-score`, `config`, `comment`,
+`review-comments`, `commit-status`, `sarif`, `sarif-file`, `node-version`,
+`version`. Outputs: `score`, `label`, `total-issues`, `fixed-issues`,
+`error-count`, `warning-count`, `affected-files`, `report-file`, `sarif-file`.
 
 ## Configuration
 

--- a/packages/website/src/app/docs/ci/page.mdx
+++ b/packages/website/src/app/docs/ci/page.mdx
@@ -10,6 +10,91 @@ Running a linter on a codebase that predates it produces a wall of findings
 nobody reads. nestjs-doctor solves that by reporting only what a change
 introduced, and leaving the existing backlog to the score.
 
+## GitHub Action
+
+```yaml
+# .github/workflows/nestjs-doctor.yml
+name: NestJS Doctor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for `scope: changed`
+      - uses: RoloBits/nestjs-doctor@v1
+```
+
+On a pull request the action reports in three places: a sticky summary comment
+that is rewritten in place on every push, inline review comments on the changed
+lines, and a commit status carrying the score. The full report is also mirrored
+into the run's job summary.
+
+`fetch-depth: 0` matters for the default scope. The action compares against the
+**merge base** of your branch and its target; a shallow checkout cannot resolve
+one, so it falls back to the base branch tip — and if it cannot reach that
+either, to reporting every finding in the changed files. The comment says which
+of those happened, and `silence-missing-baseline-warning` hides the notice if
+you would rather live with the fallback.
+
+### Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `directory` | `.` | Project directory to scan |
+| `scope` | `changed` | What a pull request reports — see below |
+| `blocking` | `none` | Severity that fails the workflow: `none`, `warning`, `error` |
+| `min-score` | — | Fail when the project's health score drops below this |
+| `config` | — | Path to a config file |
+| `comment` | `true` | Sticky pull request summary comment |
+| `review-comments` | `true` | Inline review comments on changed lines |
+| `commit-status` | `true` | Commit status with the score |
+| `sarif` | `false` | Also write a SARIF report |
+| `sarif-file` | `nestjs-doctor.sarif` | Where the SARIF report is written |
+| `silence-missing-baseline-warning` | `false` | Hide the degraded-scope warning |
+| `node-version` | `22` | Node.js version |
+| `version` | `latest` | nestjs-doctor version to run |
+
+### Outputs
+
+`score`, `label`, `total-issues`, `fixed-issues`, `error-count`,
+`warning-count`, `affected-files`, `report-file`, `sarif-file`.
+
+```yaml
+      - uses: RoloBits/nestjs-doctor@v1
+        id: doctor
+      - run: echo "Health is ${{ steps.doctor.outputs.score }}/100"
+```
+
+### Permissions
+
+The action degrades rather than failing when a permission is missing, and logs a
+warning naming the one it needs.
+
+| Feature | Permission |
+|---------|-----------|
+| Sticky comment, inline review comments | `pull-requests: write` |
+| Commit status | `statuses: write` |
+| Changed-file API fallback | `pull-requests: read` |
+| SARIF upload (via `github/codeql-action/upload-sarif`) | `security-events: write` |
+
+### Pushes to the default branch
+
+A push run always scans the whole project and never fails, whatever `blocking`
+says. It is a health snapshot — surfaced through the job summary and the commit
+status — so `main` does not go red on findings that were already there.
+
 ## Scope
 
 The whole project is always analysed. Cross-file rules like
@@ -66,8 +151,8 @@ Exit codes: `0` pass, `1` a gate failed, `2` bad input.
 
 ## Code scanning
 
-SARIF sends findings to a code-scanning backend, where they persist across runs
-as alerts rather than living only in a pull request comment.
+SARIF sends findings to the repository's Security tab, where they persist across
+runs as alerts rather than living only in a pull request comment.
 
 ```yaml
 permissions:
@@ -76,10 +161,17 @@ permissions:
 
 steps:
   - uses: actions/checkout@v4
-  - run: npx nestjs-doctor@latest . --format sarif --output nestjs-doctor.sarif
-  - uses: github/codeql-action/upload-sarif@v3
     with:
-      sarif_file: nestjs-doctor.sarif
+      fetch-depth: 0
+  - uses: RoloBits/nestjs-doctor@v1
+    id: doctor
+    with:
+      scope: full
+      sarif: "true"
+  - uses: github/codeql-action/upload-sarif@v3
+    if: always() && steps.doctor.outputs.sarif-file != ''
+    with:
+      sarif_file: ${{ steps.doctor.outputs.sarif-file }}
 ```
 
 Every result carries a `partialFingerprints` entry derived from the rule, path,

--- a/packages/website/src/app/docs/ci/page.mdx
+++ b/packages/website/src/app/docs/ci/page.mdx
@@ -63,8 +63,107 @@ you would rather live with the fallback.
 | `sarif` | `false` | Also write a SARIF report |
 | `sarif-file` | `nestjs-doctor.sarif` | Where the SARIF report is written |
 | `silence-missing-baseline-warning` | `false` | Hide the degraded-scope warning |
+| `github-token` | `${{ github.token }}` | Token used to comment and set the commit status |
 | `node-version` | `22` | Node.js version |
 | `version` | `latest` | nestjs-doctor version to run |
+
+### Failing the build
+
+The action is **advisory by default**. `blocking` is `none` and `min-score` is
+unset, so a fresh install comments, annotates, and sets a status without ever
+turning a pull request red. Enforcement is something you turn on when you are
+ready for it.
+
+Two gates decide the outcome, they are independent, and either one failing fails
+the run.
+
+```yaml
+      - uses: RoloBits/nestjs-doctor@v1
+        with:
+          blocking: error
+          min-score: 80
+```
+
+That configuration fails a pull request when it introduces any error-severity
+finding, **and separately** when the project's health score is below 80. Drop
+either input to use only the other gate.
+
+#### `blocking` — gate on findings
+
+Gates on the findings the run actually **reported**, which the `scope` input
+decides. With the default `scope: changed`, that is only what the pull request
+introduced.
+
+| Level | Fails when |
+|-------|-----------|
+| `none` | Never. The default — report only |
+| `warning` | Any error or warning is reported |
+| `error` | Any error is reported |
+
+This is the gate to reach for first. Because it follows the scope, a repository
+with a thousand pre-existing findings can adopt `blocking: error` on day one:
+the gate only ever sees what each pull request adds, so nobody inherits somebody
+else's backlog.
+
+> The CLI's `--blocking` default varies by output mode — `error` for the console
+> report, `none` for `--json` and `--score` — because those exit codes predate the
+> flag. The action sidesteps that by always passing `--blocking` explicitly, so
+> the action's default is `none` whichever way you look at it.
+
+#### `min-score` — gate on the score
+
+Gates on the 0–100 project health score. Unset by default; set it to a number
+and the run fails whenever the score falls below it.
+
+The score **always reflects the whole project**, whatever `scope` says. That is
+a deliberate invariant: narrowing a report must never make a codebase look
+healthier than it is. The practical consequence is that `min-score` is a gate on
+the repository's overall health, not on the change — a pull request touching one
+file can fail it because of debt somewhere else entirely.
+
+So the two gates answer different questions:
+
+| Gate | Question | Sees |
+|------|----------|------|
+| `blocking` | Did this change make things worse? | The reported scope |
+| `min-score` | Is the project healthy enough? | The whole project |
+
+Pick `blocking` alone to hold the line on new code. Add `min-score` when you
+also want a floor under the codebase as a whole, and expect to raise it over
+time rather than setting it at today's number and forgetting it.
+
+#### Setting the threshold in config instead
+
+`minScore` is also a config-file key, so a repository can carry its floor in
+`nestjs-doctor.config.js` and have local runs, the pre-commit hook, and CI all
+agree on it:
+
+```js
+export default {
+  minScore: 75,
+};
+```
+
+The action's `min-score` input **overrides** that when set, which is the hook for
+holding CI to a higher bar than a local run. Leave the input empty and the config
+value applies.
+
+#### Which findings count
+
+Both gates count whatever the run reports, so the config file is the third lever.
+Disable a rule or a whole category and it stops counting toward either gate — see
+[Configuration](/docs/configuration). Inline `nestjs-doctor-ignore` comments work
+the same way: a suppressed finding is not reported, so it cannot fail a gate.
+
+Point the action at a CI-specific file with the `config` input when you want CI
+stricter than what contributors run locally.
+
+#### Exit codes
+
+`0` pass · `1` a gate failed · `2` bad input.
+
+A push to the default branch always exits `0`, whatever the gates say — see
+below.
 
 ### Outputs
 
@@ -127,25 +226,26 @@ npx nestjs-doctor . --scope changed --base origin/main
 npx nestjs-doctor . --staged --blocking error
 ```
 
-## Gates
+## Gates on the command line
 
-Two gates run independently, and either one failing exits `1`.
+The same two gates the action exposes, as flags. Everything under
+[Failing the build](#failing-the-build) applies here too — what each gate sees,
+and why `--min-score` is a whole-project measure whatever the scope.
 
-`--min-score` gates on the **project** score. The score always reflects the
-whole codebase regardless of scope — narrowing a report cannot make a project
-look healthier than it is.
+```bash
+# Fail on anything this branch introduced, and on a project score under 80
+npx nestjs-doctor . --scope changed --base origin/main --blocking error --min-score 80
+```
 
-`--blocking` gates on the **reported** findings:
+| Flag | Gates on | Default |
+|------|----------|---------|
+| `--blocking none\|warning\|error` | The reported findings | `error` for the console report, `none` for `--json` and `--score` |
+| `--min-score <0-100>` | The whole-project score | Off |
 
-| Level | Fails the run when |
-|-------|--------------------|
-| `none` | Never — advisory only |
-| `warning` | Any error or warning is reported |
-| `error` | Any error is reported |
-
-The default is `error` for the console report and `none` for `--json` and
-`--score`, which reproduces the behaviour that shipped before the flag existed.
-Pass `--blocking` explicitly and both paths behave identically.
+The split default for `--blocking` reproduces the exit codes that shipped before
+the flag existed: the console report already failed on errors, while `--json`
+and `--score` failed only on `--min-score`. Pass `--blocking` explicitly and
+every output mode behaves the same.
 
 Exit codes: `0` pass, `1` a gate failed, `2` bad input.
 

--- a/scripts/action/normalize-changed-files.mjs
+++ b/scripts/action/normalize-changed-files.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Rewrites repository-relative changed-file paths into scan-relative ones.
+ *
+ * Both the local `git diff` fast path and the `pulls.listFiles` API fallback
+ * feed through here, so the CLI receives an identical set either way — a
+ * mismatched prefix silently drops every file and the scan reads as "nothing
+ * changed" while quietly reporting nothing at all.
+ *
+ * Usage: normalize-changed-files.mjs <scanPrefix> <outputPath> < paths
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+
+// Only source the scanner can actually parse; everything else is noise on a
+// pull request and would widen the changed set for no benefit.
+const SCANNABLE = /\.(?:ts|mts|cts|prisma)$/;
+const BACKSLASH_RE = /\\/g;
+const LEADING_DOT_SLASH_RE = /^\.\/?/;
+const LEADING_DOT_SLASH_STRICT_RE = /^\.\//;
+const TRAILING_SLASHES_RE = /\/+$/;
+
+/**
+ * @param {string[]} files repository-relative paths
+ * @param {string} scanPrefix the scanned directory, relative to the repo root
+ *   (`"."` or `""` when the scan root is the repo root)
+ */
+export function normalizeChangedFiles(files, scanPrefix) {
+	const prefix = String(scanPrefix ?? "")
+		.replace(BACKSLASH_RE, "/")
+		.replace(LEADING_DOT_SLASH_RE, "")
+		.replace(TRAILING_SLASHES_RE, "");
+
+	const normalized = [];
+	for (const file of files) {
+		const path = String(file ?? "")
+			.replace(BACKSLASH_RE, "/")
+			.replace(LEADING_DOT_SLASH_STRICT_RE, "");
+		if (!(path && SCANNABLE.test(path))) {
+			continue;
+		}
+		if (!prefix) {
+			normalized.push(path);
+			continue;
+		}
+		if (path === prefix) {
+			continue;
+		}
+		if (path.startsWith(`${prefix}/`)) {
+			normalized.push(path.slice(prefix.length + 1));
+		}
+	}
+
+	return [...new Set(normalized)].sort();
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+	const [, , scanPrefix, outputPath] = process.argv;
+	const raw = readFileSync(0, "utf-8");
+	const files = normalizeChangedFiles(raw.split("\n"), scanPrefix);
+	writeFileSync(
+		outputPath,
+		files.length ? `${files.join("\n")}\n` : "",
+		"utf-8"
+	);
+	console.log(`nestjs-doctor: ${files.length} changed file(s) in scope`);
+}

--- a/scripts/action/normalize-changed-files.mjs
+++ b/scripts/action/normalize-changed-files.mjs
@@ -9,7 +9,7 @@
  *
  * Usage: normalize-changed-files.mjs <scanPrefix> <outputPath> < paths
  */
-import { readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 
 // Only source the scanner can actually parse; everything else is noise on a
 // pull request and would widen the changed set for no benefit.
@@ -57,11 +57,23 @@ const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
 	const [, , scanPrefix, outputPath] = process.argv;
 	const raw = readFileSync(0, "utf-8");
-	const files = normalizeChangedFiles(raw.split("\n"), scanPrefix);
+	const incoming = raw.split("\n").filter((line) => line.trim());
+	const files = normalizeChangedFiles(incoming, scanPrefix);
 	writeFileSync(
 		outputPath,
 		files.length ? `${files.join("\n")}\n` : "",
 		"utf-8"
 	);
-	console.log(`nestjs-doctor: ${files.length} changed file(s) in scope`);
+
+	// The pre-filter total lets the report say "5 of 9 scanned" rather than a
+	// bare 5, which reads as a miscount beside the pull request's own count.
+	if (process.env.GITHUB_OUTPUT) {
+		appendFileSync(
+			process.env.GITHUB_OUTPUT,
+			`changed-total=${incoming.length}\n`
+		);
+	}
+	console.log(
+		`nestjs-doctor: ${files.length} of ${incoming.length} changed file(s) in scope`
+	);
 }

--- a/scripts/action/read-report.mjs
+++ b/scripts/action/read-report.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Reads the scan's JSON report and exposes its headline numbers as step outputs.
+ *
+ * A crashed or aborted scan leaves a truncated (or empty) file, so every field
+ * is treated as optional: the action still renders, comments, and gates rather
+ * than failing on a parse error and losing the reason the scan died.
+ *
+ * Usage: read-report.mjs <reportPath>
+ */
+import { appendFileSync, readFileSync } from "node:fs";
+
+const setOutput = (name, value) => {
+	const file = process.env.GITHUB_OUTPUT;
+	const line = `${name}=${value}\n`;
+	if (file) {
+		appendFileSync(file, line);
+	} else {
+		process.stdout.write(line);
+	}
+};
+
+const reportPath = process.argv[2];
+
+let report = null;
+try {
+	report = JSON.parse(readFileSync(reportPath, "utf-8"));
+} catch {
+	report = null;
+}
+
+const summary = report?.summary ?? {};
+const diagnostics = Array.isArray(report?.diagnostics)
+	? report.diagnostics
+	: [];
+const affectedFiles = new Set(
+	diagnostics.map((diagnostic) => diagnostic?.filePath).filter(Boolean)
+);
+
+setOutput("score", report?.score?.value ?? "");
+setOutput("label", report?.score?.label ?? "");
+setOutput("total-issues", summary.total ?? 0);
+setOutput("error-count", summary.errors ?? 0);
+setOutput("warning-count", summary.warnings ?? 0);
+setOutput("info-count", summary.info ?? 0);
+setOutput("affected-files", affectedFiles.size);
+setOutput("fixed-issues", report?.scope?.fixed ?? 0);
+setOutput("scope", report?.scope?.mode ?? "full");
+setOutput("degraded-from", report?.scope?.degradedFrom ?? "");
+setOutput("ok", report ? "true" : "false");

--- a/scripts/action/render-comment.mjs
+++ b/scripts/action/render-comment.mjs
@@ -48,6 +48,13 @@ async function render() {
 		report.scope.degradedFrom = undefined;
 	}
 
+	// The scan only ever saw the filtered list, so the pre-filter total has to
+	// come from the step that did the filtering.
+	const total = Number(process.env.NESTJS_DOCTOR_CHANGED_TOTAL);
+	if (report.scope && Number.isFinite(total) && total > 0) {
+		report.scope.changedFilesTotal = total;
+	}
+
 	try {
 		const api = await import(pathToFileURL(apiEntry).href);
 		return api.buildMarkdownReport(report, {

--- a/scripts/action/render-comment.mjs
+++ b/scripts/action/render-comment.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Renders the scan's JSON report into the markdown the action posts.
+ *
+ * The renderer is imported from the installed `nestjs-doctor` package rather
+ * than reimplemented here, so the pull request comment, the job summary, and
+ * `nestjs-doctor --format markdown` can never drift apart. If the import fails
+ * (a broken install, a version predating the export) a plain fallback is
+ * written instead — a run must still report something.
+ *
+ * Usage: render-comment.mjs <apiEntry> <reportPath> <outputPath>
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const FALLBACK_MARKER = "<!-- nestjs-doctor:summary -->";
+
+const [, , apiEntry, reportPath, outputPath] = process.argv;
+
+let report = null;
+try {
+	report = JSON.parse(readFileSync(reportPath, "utf-8"));
+} catch {
+	report = null;
+}
+
+const fallback = (reason) =>
+	[
+		FALLBACK_MARKER,
+		"## 🩺 nestjs-doctor",
+		"",
+		`The scan did not produce a readable report (${reason}). See the workflow logs for details.`,
+		"",
+	].join("\n");
+
+async function render() {
+	if (!report) {
+		return fallback("no JSON output");
+	}
+
+	// Opting out of the degraded-scope warning drops the flag the renderer keys
+	// on; the reported scope itself is untouched, so the comment still says which
+	// scope produced it.
+	if (
+		process.env.NESTJS_DOCTOR_SILENCE_BASELINE_WARNING === "true" &&
+		report.scope?.degradedFrom
+	) {
+		report.scope.degradedFrom = undefined;
+	}
+
+	try {
+		const api = await import(pathToFileURL(apiEntry).href);
+		return api.buildMarkdownReport(report, {
+			targetPath: process.env.NESTJS_DOCTOR_TARGET_PATH || ".",
+			version: process.env.NESTJS_DOCTOR_VERSION || "",
+			commitSha: process.env.NESTJS_DOCTOR_HEAD_SHA || undefined,
+			runUrl: process.env.NESTJS_DOCTOR_RUN_URL || undefined,
+			scope: report.scope,
+		});
+	} catch (error) {
+		return fallback(error instanceof Error ? error.message : String(error));
+	}
+}
+
+const markdown = await render();
+writeFileSync(outputPath, markdown, "utf-8");
+
+// Mirror it into the job summary so every event — including pushes to the
+// default branch, where no pull request comment exists — has a visible result.
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (summaryPath) {
+	try {
+		writeFileSync(summaryPath, `${markdown}\n`, { flag: "a" });
+	} catch {
+		// A read-only summary file is not worth failing the run over.
+	}
+}

--- a/scripts/action/render-sarif.mjs
+++ b/scripts/action/render-sarif.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Converts the scan's JSON report into SARIF, reusing the installed package's
+ * own builder rather than scanning a second time.
+ *
+ * Exits non-zero without writing anything when the report is unreadable, so the
+ * caller skips the upload rather than publishing an empty result set — an empty
+ * SARIF upload closes every existing code-scanning alert.
+ *
+ * Usage: render-sarif.mjs <apiEntry> <reportPath> <outputPath> <targetPath>
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [, , apiEntry, reportPath, outputPath, targetPath] = process.argv;
+
+let report;
+try {
+	report = JSON.parse(readFileSync(reportPath, "utf-8"));
+} catch (error) {
+	console.log(
+		`::warning::nestjs-doctor could not read the JSON report for SARIF conversion (${error.message}). Skipping the SARIF output.`
+	);
+	process.exit(1);
+}
+
+try {
+	const { buildSarifLog } = await import(pathToFileURL(apiEntry).href);
+	const log = buildSarifLog(
+		report,
+		resolve(targetPath || "."),
+		process.env.NESTJS_DOCTOR_VERSION || "0.0.0"
+	);
+	writeFileSync(outputPath, JSON.stringify(log), "utf-8");
+} catch (error) {
+	console.log(
+		`::warning::nestjs-doctor could not build the SARIF report (${error.message}). Skipping the SARIF output.`
+	);
+	process.exit(1);
+}

--- a/scripts/action/resolve-package-spec.mjs
+++ b/scripts/action/resolve-package-spec.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Turns the action's `version` input into a concrete install spec.
+ *
+ * `latest` is resolved to the published version number so the toolchain cache
+ * key is stable — keying on the literal string "latest" would either freeze the
+ * first version a repository ever cached or never hit at all. A local path spec
+ * (used by the action's own self-test) is reported non-cacheable so the caller
+ * falls through to `npm exec` instead.
+ *
+ * Writes `spec`, `resolved`, and `cacheable` to $GITHUB_OUTPUT.
+ */
+import { execFileSync } from "node:child_process";
+import { appendFileSync, existsSync } from "node:fs";
+
+const PACKAGE_NAME = "nestjs-doctor";
+
+const setOutput = (name, value) => {
+	const file = process.env.GITHUB_OUTPUT;
+	if (file) {
+		appendFileSync(file, `${name}=${value}\n`);
+	} else {
+		console.log(`${name}=${value}`);
+	}
+};
+
+const isLocalSpec = (value) =>
+	value.startsWith(".") ||
+	value.startsWith("/") ||
+	value.startsWith("file:") ||
+	existsSync(value);
+
+const requested = (process.argv[2] || "latest").trim() || "latest";
+
+if (isLocalSpec(requested)) {
+	setOutput("spec", requested);
+	setOutput("resolved", "local");
+	setOutput("cacheable", "false");
+	process.exit(0);
+}
+
+// A spec that already names the package (`nestjs-doctor@0.5.1`, or a tarball
+// URL) is passed through; a bare version or dist-tag gets the package prefix.
+const namesPackage =
+	requested.includes("/") || requested.startsWith(`${PACKAGE_NAME}@`);
+const spec = namesPackage ? requested : `${PACKAGE_NAME}@${requested}`;
+
+let resolved = requested.replace(`${PACKAGE_NAME}@`, "");
+
+try {
+	resolved = execFileSync("npm", ["view", spec, "version"], {
+		encoding: "utf-8",
+		stdio: ["ignore", "pipe", "ignore"],
+		timeout: 60_000,
+	}).trim();
+} catch {
+	// Offline or a private registry hiccup: fall back to the raw input. The cache
+	// key is then less precise, but the install still works.
+	console.log(
+		`::warning::Could not resolve "${spec}" against the registry; using the raw version for the cache key.`
+	);
+}
+
+setOutput("spec", spec);
+setOutput("resolved", resolved || requested);
+setOutput("cacheable", "true");


### PR DESCRIPTION
**3 of 3.** #129 and #130 are merged; this now targets `main` directly.

## 1. Context

#130 gave the CLI `--scope changed`, so it can report what a pull request introduced rather than the project&#39;s backlog. Nothing wires that into GitHub. Getting it onto a PR meant hand-writing a workflow: derive the changed files, run the scan, parse the JSON, post something.

## 2. Problem

Every repository that wants this writes the same fragile workflow, and the fragile parts are not obvious until they bite:

| Step | The trap |
|---|---|
| Changed files | `pulls.listFiles` is denied on forks, so the diff path silently falls back to a full scan |
| Path prefix | Derived from the input rather than git, so a `path:` checkout drops every changed file and the scan reports nothing |
| Comment rendering | Reimplemented in the workflow, so it drifts from `--format markdown` |
| Failed scan | Wipes existing inline comments, which reads as &#34;all clear&#34; |
| SARIF | An empty upload closes every existing alert |
| Push to `main` | Fails the branch on pre-existing findings |

## 3. Possible flows

Every event and permission combination the action has to survive:

| Situation | Behaviour |
|---|---|
| Pull request, base reachable | measured delta, comment + inline + status |
| Pull request, shallow checkout | falls back to base tip, then to `files`, and says which |
| Pull request from a fork | git diff succeeds where the API would be denied |
| Push to default branch | full scan, never fails the run |
| No `pull-requests: write` | warns naming the permission, scan still reports |
| No `statuses: write` | warns, everything else proceeds |
| Scan crashes | existing inline comments left in place, no SARIF written |
| Findings map to no changed line | prior comments left alone rather than cleared |
| Reviewer replied to an inline comment | that thread is kept, not cleared on the next run |

## 4. Solution

A composite action at the repository root, published as `RoloBits/nestjs-doctor@v1`.

Changed files come from `git diff` first, with the API only as a fallback — no rate limit, and it works on forks. The scan prefix comes from `git rev-parse --show-prefix`, not the raw input, so it stays correct for an absolute path, a checkout `path:` layout, and a nested repository alike.

The comment renderer is **imported from the installed package** (`buildMarkdownReport`), never reimplemented, so the PR comment, the job summary, and `--format markdown` cannot drift apart.

Failures degrade rather than mislead: prior review comments are deleted only *after* the new review posts, an unreadable report skips the SARIF write entirely, and pushes to the default branch never fail whatever `blocking` says.

Nested actions are pinned by commit SHA, with Dependabot from #129 keeping them current. Nothing else exercises this file, so a self-test workflow runs it against a fixture on every change.

## 5. Before vs after

| | Before | After |
|---|---|---|
| PR feedback | none | sticky comment, inline comments, commit status |
| What a PR run reports | — | only what the change introduced |
| Default branch pushes | — | health snapshot, never red |
| Comment vs `--format markdown` | — | same code path |
| CLI behaviour | — | **unchanged** |
| Tests | 821 | **821** |

## 6. Example

```yaml
- uses: actions/checkout@v4
  with:
    fetch-depth: 0
- uses: RoloBits/nestjs-doctor@v1
```

The self-test run against the `bad-architecture` fixture:

```console
score=64 total=13 errors=5 sarif=/Users/runner/work/_temp/self-test.sarif
SARIF ok: 13 results
```

Every SARIF result carries a fingerprint, so an edit near a finding does not close and reopen the alert:

```json
{
  &#34;ruleId&#34;: &#34;architecture/no-circular-module-deps&#34;,
  &#34;level&#34;: &#34;error&#34;,
  &#34;partialFingerprints&#34;: { &#34;nestjsDoctor/v1&#34;: &#34;d0bd9f12…&#34; }
}
```

## Needs your call after merge

**The `v1` tag does not exist yet.** `action-tag.yml` moves it on each release, but the first one has to be created by hand or via that workflow&#39;s `workflow_dispatch`. Until then the `@v1` above is unresolvable — this is the one follow-up that cannot wait, since the README already points users at it.

---
_Generated with [Claude Code](https://claude.com/claude-code)_
