### PR TITLE
demo: verify the action on a live pull request

### DIFF
--- a/.github/workflows/action-demo.yml
+++ b/.github/workflows/action-demo.yml
@@ -1,0 +1,55 @@
+name: Action Live Demo
+
+# Temporary. Runs the action with commenting switched on so a human can see what
+# it posts on a real pull request. Delete with the demo branch.
+#
+# `version` points at the local build, not npm: the published package predates
+# every flag this action passes, so `version: latest` would test the wrong code.
+on:
+  pull_request:
+    paths:
+      - "demo/**"
+      - ".github/workflows/action-demo.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  demo:
+    name: Scan the demo app and comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `scope: changed` resolves the merge base, which a shallow clone cannot.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter nestjs-doctor build
+
+      - id: doctor
+        uses: ./
+        with:
+          directory: demo/sample-api
+          version: ${{ github.workspace }}/packages/nestjs-doctor
+          scope: changed
+          blocking: none
+          comment: "true"
+          review-comments: "true"
+          commit-status: "true"
+
+      - name: Show the outputs
+        run: |
+          echo "score          = ${{ steps.doctor.outputs.score }}"
+          echo "label          = ${{ steps.doctor.outputs.label }}"
+          echo "total-issues   = ${{ steps.doctor.outputs.total-issues }}"
+          echo "fixed-issues   = ${{ steps.doctor.outputs.fixed-issues }}"
+          echo "error-count    = ${{ steps.doctor.outputs.error-count }}"
+          echo "warning-count  = ${{ steps.doctor.outputs.warning-count }}"
+          echo "affected-files = ${{ steps.doctor.outputs.affected-files }}"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -27,6 +27,6 @@
     }
   },
   "files": {
-    "includes": ["!!**/tests/fixtures", "!!**/.changeset"]
+    "includes": ["!!**/tests/fixtures", "!!**/.changeset", "!!demo"]
   }
 }

--- a/demo/sample-api/package.json
+++ b/demo/sample-api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "demo-sample-api",
+  "private": true,
+  "description": "Throwaway NestJS app used to demo the GitHub Action on a live PR. Delete with the demo.",
+  "dependencies": {
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "typeorm": "^0.3.0"
+  }
+}

--- a/demo/sample-api/src/app.module.ts
+++ b/demo/sample-api/src/app.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { AuthGuard } from "./auth.guard";
+import { OrdersController } from "./orders/orders.controller";
+import { UsersController } from "./users/users.controller";
+import { UsersService } from "./users/users.service";
+
+@Module({
+  providers: [AuthGuard, UsersService],
+  controllers: [OrdersController, UsersController],
+})
+export class AppModule {}

--- a/demo/sample-api/src/auth.guard.ts
+++ b/demo/sample-api/src/auth.guard.ts
@@ -1,0 +1,8 @@
+import { CanActivate, Injectable } from "@nestjs/common";
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate() {
+    return true;
+  }
+}

--- a/demo/sample-api/src/orders/orders.controller.ts
+++ b/demo/sample-api/src/orders/orders.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get, Param } from "@nestjs/common";
+import { Controller, Get, Param, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "../auth.guard";
 import { DataSource } from "typeorm";
 
+@UseGuards(AuthGuard)
 @Controller("orders")
 export class OrdersController {
   constructor(private readonly ds: DataSource) {}

--- a/demo/sample-api/src/orders/orders.controller.ts
+++ b/demo/sample-api/src/orders/orders.controller.ts
@@ -5,7 +5,6 @@ import { DataSource } from "typeorm";
 @UseGuards(AuthGuard)
 @Controller("orders")
 export class OrdersController {
-  // nestjs-doctor-ignore-next-line architecture/no-orm-in-controllers
   constructor(private readonly ds: DataSource) {}
 
   @Get(":id")

--- a/demo/sample-api/src/orders/orders.controller.ts
+++ b/demo/sample-api/src/orders/orders.controller.ts
@@ -5,6 +5,7 @@ import { DataSource } from "typeorm";
 @UseGuards(AuthGuard)
 @Controller("orders")
 export class OrdersController {
+  // nestjs-doctor-ignore-next-line architecture/no-orm-in-controllers
   constructor(private readonly ds: DataSource) {}
 
   @Get(":id")

--- a/demo/sample-api/src/orders/orders.controller.ts
+++ b/demo/sample-api/src/orders/orders.controller.ts
@@ -7,7 +7,7 @@ export class OrdersController {
 
   @Get(":id")
   async findOne(@Param("orderId") orderId: string) {
-    const rows = await this.ds.query("SELECT * FROM orders");
+    const rows = await this.ds.query("SELECT * FROM orders WHERE tenant_id = 1");
     const visible = [];
     for (const row of rows) {
       if (row.deletedAt === null) {

--- a/demo/sample-api/src/orders/orders.controller.ts
+++ b/demo/sample-api/src/orders/orders.controller.ts
@@ -3,10 +3,10 @@ import { DataSource } from "typeorm";
 
 @Controller("orders")
 export class OrdersController {
-  constructor(private ds: DataSource) {}
+  constructor(private readonly ds: DataSource) {}
 
   @Get(":id")
-  async findOne(@Param("orderId") orderId: string) {
+  async findOne(@Param("id") id: string) {
     const rows = await this.ds.query("SELECT * FROM orders WHERE tenant_id = 1");
     const visible = [];
     for (const row of rows) {

--- a/demo/sample-api/src/orders/orders.controller.ts
+++ b/demo/sample-api/src/orders/orders.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Param } from "@nestjs/common";
+import { DataSource } from "typeorm";
+
+@Controller("orders")
+export class OrdersController {
+  constructor(private ds: DataSource) {}
+
+  @Get(":id")
+  async findOne(@Param("orderId") orderId: string) {
+    const rows = await this.ds.query("SELECT * FROM orders");
+    const visible = [];
+    for (const row of rows) {
+      if (row.deletedAt === null) {
+        visible.push(row);
+      }
+    }
+    return visible;
+  }
+}

--- a/demo/sample-api/src/users/users.controller.ts
+++ b/demo/sample-api/src/users/users.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "../auth.guard";
+import { UsersService } from "./users.service";
+
+@UseGuards(AuthGuard)
+@Controller("users")
+export class UsersController {
+  constructor(private readonly users: UsersService) {}
+
+  @Get()
+  findAll() {
+    return this.users.findAll();
+  }
+}

--- a/demo/sample-api/src/users/users.service.ts
+++ b/demo/sample-api/src/users/users.service.ts
@@ -6,3 +6,4 @@ export class UsersService {
     return [{ id: 1, name: "Ada" }];
   }
 }
+

--- a/demo/sample-api/src/users/users.service.ts
+++ b/demo/sample-api/src/users/users.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class UsersService {
+  findAll() {
+    return [{ id: 1, name: "Ada" }];
+  }
+}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -10,7 +10,7 @@ const config: KnipConfig = {
 	workspaces: {
 		".": {
 			// GitHub Action entry points: invoked by action.yml, not imported.
-			ignore: ["packages/website/**", "scripts/action/**"],
+			ignore: ["packages/website/**", "scripts/action/**", "demo/**"],
 		},
 		"packages/nestjs-doctor": {
 			project: ["src/**/*.ts"],


### PR DESCRIPTION
**Throwaway.** Delete before #131 merges. Replaces #140, which had accumulated three runs of state.

Fresh run against the current #131, which now carries the reply guard.

`demo/sample-api` is a small NestJS app with one deliberately bad controller. Expect:

- one sticky summary comment
- 5 inline review comments on `orders.controller.ts`
- a `NestJS Doctor` commit status reading `Score: 72/100 (Fair) · 3 errors · 2 warnings`

`users/` is clean on purpose, so a passing file stays quiet.

To watch the sticky behaviour, push any change to `demo/**` — the summary is edited in place rather than duplicated, and resolved inline comments are removed *unless someone replied to them*.