### PR TITLE
demo: walk the action through a real pull request

### DIFF
--- a/.github/workflows/action-demo.yml
+++ b/.github/workflows/action-demo.yml
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/action-demo.yml"
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   statuses: write
 

--- a/.github/workflows/action-demo.yml
+++ b/.github/workflows/action-demo.yml
@@ -1,0 +1,54 @@
+name: Action Live Demo
+
+# Temporary. Runs the action with commenting switched on so a human can see what
+# it posts on a real pull request. Delete with the demo branch.
+#
+# `version` points at the local build, not npm: the published package predates
+# every flag this action passes, so `version: latest` would test the wrong code.
+on:
+  pull_request:
+    paths:
+      - "demo/**"
+      - ".github/workflows/action-demo.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  demo:
+    name: Scan the demo app and comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `scope: changed` resolves the merge base, which a shallow clone cannot.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter nestjs-doctor build
+
+      - id: doctor
+        uses: ./
+        with:
+          directory: demo/billing-api
+          version: ${{ github.workspace }}/packages/nestjs-doctor
+          scope: changed
+          comment: "true"
+          review-comments: "true"
+          commit-status: "true"
+
+      - name: Show the outputs
+        run: |
+          echo "score          = ${{ steps.doctor.outputs.score }}"
+          echo "label          = ${{ steps.doctor.outputs.label }}"
+          echo "total-issues   = ${{ steps.doctor.outputs.total-issues }}"
+          echo "fixed-issues   = ${{ steps.doctor.outputs.fixed-issues }}"
+          echo "error-count    = ${{ steps.doctor.outputs.error-count }}"
+          echo "warning-count  = ${{ steps.doctor.outputs.warning-count }}"
+          echo "affected-files = ${{ steps.doctor.outputs.affected-files }}"

--- a/.github/workflows/action-demo.yml
+++ b/.github/workflows/action-demo.yml
@@ -11,10 +11,7 @@ on:
       - "demo/**"
       - ".github/workflows/action-demo.yml"
 
-permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
+permissions: write-all
 
 jobs:
   demo:

--- a/action.yml
+++ b/action.yml
@@ -369,6 +369,8 @@ runs:
           const KEY_RE = /<!-- nestjs-doctor:key ([A-Za-z0-9+/=]+) -->/;
           const RETIRED = "<!-- nestjs-doctor:retired -->";
           const REVIVED = "<!-- nestjs-doctor:revived -->";
+          // Sized to sit on the text baseline rather than tower over it.
+          const LOGO = '<img src="https://nestjs.doctor/logo.png" width="16" height="16" align="top" alt="">';
           const headSha = process.env.NESTJS_DOCTOR_HEAD_SHA || "";
           const shortSha = headSha.slice(0, 7);
           const directoryPrefix = (process.env.INPUT_DIRECTORY || ".")
@@ -448,7 +450,7 @@ runs:
               path: repoPath,
               line: diagnostic.line,
               side: "RIGHT",
-              body: `${MARKER}\n<!-- nestjs-doctor:key ${key} -->\n**nestjs-doctor** · \`${diagnostic.rule}\` _(${diagnostic.severity})_\n\n${diagnostic.message}${fix}`,
+              body: `${MARKER}\n<!-- nestjs-doctor:key ${key} -->\n${LOGO} **nestjs-doctor** · \`${diagnostic.rule}\` _(${diagnostic.severity})_\n\n${diagnostic.message}${fix}`,
             });
           }
 
@@ -485,13 +487,14 @@ runs:
           }
 
           // The newest status reply decides the thread's state, so a human
-          // replying afterwards does not change it.
+          // replying afterwards does not change it. "none" means this action has
+          // never said anything about the thread beyond the finding itself.
           const stateOf = (bodies) => {
             for (let index = bodies.length - 1; index >= 0; index -= 1) {
               if (bodies[index].includes(RETIRED)) return "retired";
-              if (bodies[index].includes(REVIVED)) return "live";
+              if (bodies[index].includes(REVIVED)) return "revived";
             }
-            return "live";
+            return "none";
           };
 
           const ours = new Map();
@@ -576,7 +579,7 @@ runs:
                 entry,
                 `${MARKER}\n${RETIRED}\n✅ **No longer reported** as of \`${shortSha}\`.`,
               );
-              await setResolved(entry, true);
+              entry.state = "retired";
               retired += 1;
             } catch (error) {
               core.warning(`nestjs-doctor could not retire a review thread: ${error.message}`);
@@ -594,11 +597,19 @@ runs:
                 entry,
                 `${MARKER}\n${REVIVED}\n⚠️ **Reported again** as of \`${shortSha}\`.`,
               );
-              await setResolved(entry, false);
+              entry.state = "revived";
               reopened += 1;
             } catch (error) {
               core.warning(`nestjs-doctor could not reopen a review thread: ${error.message}`);
             }
+          }
+
+          // Resolution is reconciled against what this action last said, so a
+          // resolve refused on an earlier run is retried rather than stranded.
+          // A thread it never spoke about is left exactly as a human left it.
+          for (const entry of ours.values()) {
+            if (entry.state === "retired") await setResolved(entry, true);
+            else if (entry.state === "revived") await setResolved(entry, false);
           }
 
           if (resolveDenied) {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -27,6 +27,6 @@
     }
   },
   "files": {
-    "includes": ["!!**/tests/fixtures", "!!**/.changeset"]
+    "includes": ["!!**/tests/fixtures", "!!**/.changeset", "!!demo"]
   }
 }

--- a/demo/billing-api/.gitignore
+++ b/demo/billing-api/.gitignore
@@ -1,0 +1,2 @@
+templates/
+*.log

--- a/demo/billing-api/README.md
+++ b/demo/billing-api/README.md
@@ -1,0 +1,6 @@
+# billing-api
+
+A deliberately flawed NestJS service, used to show what the nestjs-doctor
+GitHub Action posts on a real pull request.
+
+Every finding here is intentional. Do not copy this code.

--- a/demo/billing-api/package.json
+++ b/demo/billing-api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "billing-api",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "typeorm": "^0.3.20"
+  }
+}

--- a/demo/billing-api/src/app.module.ts
+++ b/demo/billing-api/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { CustomersController } from "./customers/customers.controller";
+import { InvoicesController } from "./invoices/invoices.controller";
+import { InvoicesService } from "./invoices/invoices.service";
+
+@Module({
+  controllers: [InvoicesController, CustomersController],
+  providers: [InvoicesService],
+})
+export class AppModule {}

--- a/demo/billing-api/src/app.module.ts
+++ b/demo/billing-api/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from "@nestjs/common";
 import { CustomersController } from "./customers/customers.controller";
 import { InvoicesController } from "./invoices/invoices.controller";
 import { InvoicesService } from "./invoices/invoices.service";
+import { RefundsController } from "./invoices/refunds.controller";
 
 @Module({
-  controllers: [InvoicesController, CustomersController],
+  controllers: [InvoicesController, CustomersController, RefundsController],
   providers: [InvoicesService],
 })
 export class AppModule {}

--- a/demo/billing-api/src/config/billing.config.ts
+++ b/demo/billing-api/src/config/billing.config.ts
@@ -1,0 +1,5 @@
+export const billingConfig = {
+  apiVersion: "2024-06-20",
+  secretKey: "PLACEHOLDER-not-a-real-key-0123456789",
+  webhookSecret: "PLACEHOLDER-not-a-real-secret-abcdef",
+};

--- a/demo/billing-api/src/config/billing.config.ts
+++ b/demo/billing-api/src/config/billing.config.ts
@@ -1,5 +1,5 @@
 export const billingConfig = {
   apiVersion: "2024-06-20",
-  secretKey: "PLACEHOLDER-not-a-real-key-0123456789",
-  webhookSecret: "PLACEHOLDER-not-a-real-secret-abcdef",
+  secretKey: process.env.BILLING_SECRET_KEY,
+  webhookSecret: process.env.BILLING_WEBHOOK_SECRET,
 };

--- a/demo/billing-api/src/customers/customer.entity.ts
+++ b/demo/billing-api/src/customers/customer.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class Customer {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column()
+  email: string;
+
+  @Column()
+  taxId: string;
+}

--- a/demo/billing-api/src/customers/customers.controller.ts
+++ b/demo/billing-api/src/customers/customers.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Param } from "@nestjs/common";
+import { Repository } from "typeorm";
+import { Customer } from "./customer.entity";
+
+@Controller("customers")
+export class CustomersController {
+  constructor(private customers: Repository<Customer>) {}
+
+  @Get(":id")
+  async findOne(@Param("id") id: string): Promise<Customer> {
+    return await this.customers.findOneByOrFail({ id });
+  }
+}

--- a/demo/billing-api/src/invoices/invoices.controller.ts
+++ b/demo/billing-api/src/invoices/invoices.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Get, Param, Post } from "@nestjs/common";
+import { DataSource } from "typeorm";
+import { InvoicesService } from "./invoices.service";
+
+@Controller("invoices")
+export class InvoicesController {
+  constructor(
+    private ds: DataSource,
+    private invoices: InvoicesService
+  ) {}
+
+  @Get(":id/total")
+  async total(@Param("id") id: string) {
+    const rows = await this.ds.query(
+      `SELECT amount, currency, status FROM invoice_lines WHERE invoice_id = '${id}'`
+    );
+
+    let total = 0;
+    for (const row of rows) {
+      if (row.status === "void") {
+        continue;
+      }
+      total += row.currency === "usd" ? row.amount : row.amount * 1.08;
+    }
+
+    return { id, total };
+  }
+
+  @Post()
+  create(@Body() body: unknown) {
+    this.invoices.sendReceiptEmail(body);
+    return { accepted: true };
+  }
+}

--- a/demo/billing-api/src/invoices/invoices.service.ts
+++ b/demo/billing-api/src/invoices/invoices.service.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class InvoicesService {
+  loadTemplate(name: string): string {
+    return readFileSync(`./templates/${name}.html`, "utf-8");
+  }
+
+  async sendReceiptEmail(payload: unknown): Promise<void> {
+    await Promise.resolve(payload);
+  }
+}

--- a/demo/billing-api/src/invoices/invoices.service.ts
+++ b/demo/billing-api/src/invoices/invoices.service.ts
@@ -1,10 +1,10 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { Injectable } from "@nestjs/common";
 
 @Injectable()
 export class InvoicesService {
-  loadTemplate(name: string): string {
-    return readFileSync(`./templates/${name}.html`, "utf-8");
+  loadTemplate(name: string): Promise<string> {
+    return readFile(`./templates/${name}.html`, "utf-8");
   }
 
   async sendReceiptEmail(payload: unknown): Promise<void> {

--- a/demo/billing-api/src/invoices/refunds.controller.ts
+++ b/demo/billing-api/src/invoices/refunds.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param } from "@nestjs/common";
+import { DataSource } from "typeorm";
+
+@Controller("refunds")
+export class RefundsController {
+  constructor(private ds: DataSource) {}
+
+  @Get(":id")
+  async findOne(@Param("id") id: string) {
+    return await this.ds.query("SELECT * FROM refunds WHERE id = $1", [id]);
+  }
+}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -10,7 +10,7 @@ const config: KnipConfig = {
 	workspaces: {
 		".": {
 			// GitHub Action entry points: invoked by action.yml, not imported.
-			ignore: ["packages/website/**", "scripts/action/**"],
+			ignore: ["packages/website/**", "scripts/action/**", "demo/**"],
 		},
 		"packages/nestjs-doctor": {
 			project: ["src/**/*.ts"],


### PR DESCRIPTION
Temporary. Opened so the nestjs-doctor GitHub Action can be watched doing its
whole job on a real pull request, from an empty thread to a steady state.

`demo/billing-api` is a deliberately flawed NestJS service — hardcoded secrets,
a controller holding a raw `DataSource` and its own business logic, a
`readFileSync` on the request path, unguarded endpoints, an entity with no
timestamps. Twelve findings across all five categories.

A second commit fixes three of them, so the retirement path is visible too.

The workflow runs the action against the local build rather than the published
package, because the published one predates every flag the action passes.

Delete this branch and the `Action Live Demo` workflow before merging #131.
