### PR TITLE
fix(ci): keep an action release from publishing the VS Code extension

### DIFF
--- a/.github/workflows/action-tag.yml
+++ b/.github/workflows/action-tag.yml
@@ -1,24 +1,24 @@
 name: Move Action Major Tag
 
 # Consumers pin `RoloBits/nestjs-doctor@v1`, so that tag has to follow every
-# release. The action's major version tracks its own input/output contract, not
-# the npm package's version — a patch release of the CLI must not move a major.
+# release of the action. The action's major version tracks its own input and
+# output contract, not the npm package's — only its own `vX.Y.Z` releases move a
+# major. A changesets release tagged `nestjs-doctor@0.5.2` leaves `v1` alone.
 on:
   release:
     types: [published]
   workflow_dispatch:
     inputs:
-      major-tag:
-        description: "Major tag to move (e.g. v1)"
+      release-tag:
+        description: "Action release tag to point the major at (e.g. v1.0.0)"
         required: true
-        default: "v1"
 
 permissions:
   contents: write
 
 jobs:
   retag:
-    name: Point the major tag at the release commit
+    name: Point the major tag at the release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,15 +28,27 @@ jobs:
       - name: Move the tag
         shell: bash
         env:
-          MAJOR_TAG: ${{ inputs.major-tag || 'v1' }}
-          TARGET_SHA: ${{ github.event.release.target_commitish || github.sha }}
+          RELEASE_TAG: ${{ inputs.release-tag || github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          # A branch name in `target_commitish` resolves through the fetched
-          # history; a SHA passes straight through.
-          SHA="$(git rev-parse "$TARGET_SHA^{commit}")"
+
+          # Anything not shaped like the action's own release tag belongs to a
+          # package. Every other release in this repository is a changesets one.
+          case "$RELEASE_TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "::notice::$RELEASE_TAG is not an action release; leaving major tags alone."
+              exit 0
+              ;;
+          esac
+
+          MAJOR_TAG="${RELEASE_TAG%%.*}"
+          # The release's own commit, never a branch tip: `v1` has to name code
+          # that was actually released, not whatever main drifted to since.
+          SHA="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag --force "$MAJOR_TAG" "$SHA"
           git push --force origin "refs/tags/$MAJOR_TAG"
-          echo "Moved $MAJOR_TAG to $SHA"
+          echo "Moved $MAJOR_TAG to $SHA ($RELEASE_TAG)"

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,8 +1,12 @@
 name: Publish VS Code Extension
 
+# Manual only. A changesets release already publishes the extension through the
+# `publish-vscode` job in release.yml, which knows whether anything was actually
+# released. This ran on every published release, including ones that have
+# nothing to do with the extension — and since it is in changesets' `ignore`
+# list its version is bumped by hand, so an unrelated release would push
+# whatever `packages/nestjs-doctor-vscode/package.json` happened to carry.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Context

`action.yml` is on `main` and the Marketplace slug `nestjs-doctor` is free, so the action is ready to list. Listing it means drafting a release on a `v1.0.0` tag and ticking the Marketplace box in that dialog.

## Problem

Two workflows listen for `release: published` and neither checks which release fired them, so cutting `v1.0.0` would have run both.

`publish-vscode.yml` builds and pushes the VS Code extension. The extension sits in changesets' `ignore` list, so its version is bumped by hand — an action release would publish whatever `packages/nestjs-doctor-vscode/package.json` carried at that moment. It is safe today only because that version (`0.1.2`) is already live and `skipDuplicate` swallows it.

`action-tag.yml` moves `v1`, on every release, to `target_commitish` — which is a branch name. So `nestjs-doctor@0.5.2` would move `v1`, and it would move it to whatever `main` had drifted to rather than to released code.

## Possible flows

| Release | Before | After |
|---|---|---|
| `nestjs-doctor@0.5.2` (changesets) | extension published again; `v1` → `main` tip | extension published once by `release.yml`; `v1` untouched |
| `nestjs-doctor-lsp@1.1.0` (changesets) | extension published again; `v1` → `main` tip | extension published once by `release.yml`; `v1` untouched |
| `v1.0.0` (action) | extension published from a hand-bumped version | `v1` → the `v1.0.0` commit |
| `v2.0.0` (action, future) | `v1` dragged onto v2 code | `v2` → the `v2.0.0` commit; `v1` stays |
| Manual dispatch | extension published | unchanged |

## Solution

`publish-vscode.yml` keeps only `workflow_dispatch`. `release.yml` already has a `publish-vscode` job gated on `needs.release.outputs.published == 'true'`, so this deletes a duplicate job, not a capability.

`action-tag.yml` filters to tags shaped `vX.Y.Z`, derives the major from the tag rather than hardcoding `v1`, and resolves `refs/tags/<tag>^{commit}`.

Deliberately unchanged: changesets config, npm publishing and provenance, the website deploy, CI, and the action self-test.

## Before vs after

| Event | Fires `publish-vscode.yml` | Moves a major tag |
|---|---|---|
| `nestjs-doctor@0.5.2` | ~~yes~~ → no | ~~`v1`~~ → none |
| `v1.0.0` | ~~yes~~ → no | none → `v1` |
| `v2.0.0` | ~~yes~~ → no | ~~`v1`~~ → `v2` |
| `workflow_dispatch` | yes | yes |

## Example

The tag filter, run against every tag shape this repository produces:

```
v1.0.0                     -> MOVE v1
v1.2.3                     -> MOVE v1
v2.0.0                     -> MOVE v2
nestjs-doctor@0.5.2        -> SKIP
nestjs-doctor-lsp@1.0.0    -> SKIP
v1                         -> SKIP
latest                     -> SKIP
```

`v1` skipping itself matters: it stops the workflow force-pushing a tag onto its own commit if someone dispatches it with a major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)