### PR TITLE
fix(rules): recognise global and composed guards

### DIFF
--- a/.changeset/guards-rule-false-positives.md
+++ b/.changeset/guards-rule-false-positives.md
@@ -1,0 +1,31 @@
+---
+"nestjs-doctor": patch
+---
+
+Stop `security/require-guards-on-endpoints` reporting guarded endpoints.
+
+The rule looked for a literal `@UseGuards()` on the controller class or the
+route method, so two mainstream NestJS auth patterns read as no guard at all:
+
+- **Global guards.** `{ provide: APP_GUARD, useClass: JwtAuthGuard }` in a
+  module's `providers` binds a guard application-wide. Every endpoint in the
+  application was still reported.
+- **Composed decorators.** A custom `@Auth()` built from
+  `applyDecorators(UseGuards(...))` was invisible, so a codebase that wraps its
+  guards — and therefore never writes `@UseGuards` directly — was reported in
+  full.
+
+Measured against three public repositories: `buqiyuan/nest-admin` drops from 72
+findings to 0, `NarHakobyan/awesome-nest-boilerplate` from 12 to the 5 endpoints
+that genuinely carry no guard, and `brocoders/nestjs-boilerplate` stays at 11,
+which are real.
+
+The rule only stays quiet on a positive sighting. If no module is visible — a
+scan pointed at a subdirectory, or a config that excludes the root module — it
+reports exactly as before rather than assuming a guard it cannot see. An
+`APP_GUARD` reached through an aliased import is still not recognised, since
+detection matches on the name as written.
+
+Module nodes now carry `providerRegistrations`, the object-literal entries of
+`providers` parsed into `{ token, useClass, useExisting }`. `providers` is
+unchanged.

--- a/.changeset/guards-rule-false-positives.md
+++ b/.changeset/guards-rule-false-positives.md
@@ -22,10 +22,14 @@ which are real.
 
 The rule only stays quiet on a positive sighting. If no module is visible — a
 scan pointed at a subdirectory, or a config that excludes the root module — it
-reports exactly as before rather than assuming a guard it cannot see. An
-`APP_GUARD` reached through an aliased import is still not recognised, since
-detection matches on the name as written.
+reports exactly as before rather than assuming a guard it cannot see.
 
-Module nodes now carry `providerRegistrations`, the object-literal entries of
-`providers` parsed into `{ token, useClass, useExisting }`. `providers` is
-unchanged.
+Two things it still cannot tell apart. An `APP_GUARD` reached through an aliased
+import is not recognised, because detection matches the token as written. And a
+module declaring `APP_GUARD` counts even when nothing imports it, so a dead
+module left in the tree suppresses the rule project-wide; separating that from a
+real root module needs the application's entry point, which a static scan of an
+arbitrary directory cannot identify.
+
+Module nodes now carry `providerTokens`, the `provide` tokens of object-literal
+providers. `providers` is unchanged.

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -12,7 +12,11 @@ import {
 	buildEndpointGraph,
 	updateEndpointGraphForFile,
 } from "./graph/endpoint-graph.js";
-import { buildGuardDecoratorNames } from "./graph/guard-decorators.js";
+import {
+	buildGuardDecoratorIndex,
+	type GuardDecoratorIndex,
+	updateGuardDecoratorIndexForFile,
+} from "./graph/guard-decorators.js";
 import {
 	buildModuleGraph,
 	type ModuleGraph,
@@ -35,8 +39,7 @@ export interface AnalysisContext {
 	endpointGraph: EndpointGraph;
 	fileRules: Rule[];
 	files: string[];
-	/** Decorator names that compose `UseGuards`, for the guard rule. */
-	guardDecoratorNames: Set<string>;
+	guardDecorators: GuardDecoratorIndex;
 	moduleGraph: ModuleGraph;
 	pathAliases: PathAliasMap;
 	project: ProjectInfo;
@@ -73,7 +76,7 @@ export async function buildAnalysisContext(
 		endpointGraph,
 		fileRules,
 		files,
-		guardDecoratorNames: buildGuardDecoratorNames(astProject, files),
+		guardDecorators: buildGuardDecoratorIndex(astProject, files),
 		moduleGraph,
 		pathAliases,
 		project,
@@ -112,9 +115,10 @@ export function updateFile(context: AnalysisContext, filePath: string): void {
 		filePath,
 		context.pathAliases
 	);
-	context.guardDecoratorNames = buildGuardDecoratorNames(
+	updateGuardDecoratorIndexForFile(
+		context.guardDecorators,
 		context.astProject,
-		context.files
+		filePath
 	);
 	updateProvidersForFile(context.providers, context.astProject, filePath);
 	updateEndpointGraphForFile(
@@ -177,7 +181,7 @@ export async function buildMonorepoContext(
 						endpointGraph,
 						fileRules,
 						files,
-						guardDecoratorNames: buildGuardDecoratorNames(astProject, files),
+						guardDecorators: buildGuardDecoratorIndex(astProject, files),
 						moduleGraph,
 						pathAliases,
 						project,

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -12,6 +12,7 @@ import {
 	buildEndpointGraph,
 	updateEndpointGraphForFile,
 } from "./graph/endpoint-graph.js";
+import { buildGuardDecoratorNames } from "./graph/guard-decorators.js";
 import {
 	buildModuleGraph,
 	type ModuleGraph,
@@ -34,6 +35,8 @@ export interface AnalysisContext {
 	endpointGraph: EndpointGraph;
 	fileRules: Rule[];
 	files: string[];
+	/** Decorator names that compose `UseGuards`, for the guard rule. */
+	guardDecoratorNames: Set<string>;
 	moduleGraph: ModuleGraph;
 	pathAliases: PathAliasMap;
 	project: ProjectInfo;
@@ -70,6 +73,7 @@ export async function buildAnalysisContext(
 		endpointGraph,
 		fileRules,
 		files,
+		guardDecoratorNames: buildGuardDecoratorNames(astProject, files),
 		moduleGraph,
 		pathAliases,
 		project,
@@ -107,6 +111,10 @@ export function updateFile(context: AnalysisContext, filePath: string): void {
 		context.astProject,
 		filePath,
 		context.pathAliases
+	);
+	context.guardDecoratorNames = buildGuardDecoratorNames(
+		context.astProject,
+		context.files
 	);
 	updateProvidersForFile(context.providers, context.astProject, filePath);
 	updateEndpointGraphForFile(
@@ -169,6 +177,7 @@ export async function buildMonorepoContext(
 						endpointGraph,
 						fileRules,
 						files,
+						guardDecoratorNames: buildGuardDecoratorNames(astProject, files),
 						moduleGraph,
 						pathAliases,
 						project,

--- a/packages/nestjs-doctor/src/engine/diagnostician.ts
+++ b/packages/nestjs-doctor/src/engine/diagnostician.ts
@@ -12,6 +12,7 @@ import {
 	runProjectRules,
 	runSchemaRules,
 } from "./rule-runner.js";
+import type { GuardFacts } from "./rules/types.js";
 
 function formatRuleError(error: unknown): string {
 	if (error instanceof Error) {
@@ -112,6 +113,20 @@ function processResults(
 	return { diagnostics, errors: ruleErrors };
 }
 
+/** Guard facts for the file rules, gathered from the whole project. */
+function guardFacts(context: AnalysisContext): GuardFacts {
+	const globallyRegistered = [...context.moduleGraph.modules.values()].some(
+		(module) =>
+			module.providerRegistrations.some(
+				(registration) => registration.token === "APP_GUARD"
+			)
+	);
+	return {
+		composedDecorators: context.guardDecoratorNames,
+		globallyRegistered,
+	};
+}
+
 export function checkFile(
 	context: AnalysisContext,
 	filePath: string
@@ -120,7 +135,8 @@ export function checkFile(
 		context.astProject,
 		[filePath],
 		context.fileRules,
-		context.config
+		context.config,
+		guardFacts(context)
 	);
 	return processResults(result.diagnostics, result.errors, context);
 }
@@ -133,7 +149,8 @@ export function checkAllFiles(context: AnalysisContext): {
 		context.astProject,
 		context.files,
 		context.fileRules,
-		context.config
+		context.config,
+		guardFacts(context)
 	);
 	return processResults(result.diagnostics, result.errors, context);
 }

--- a/packages/nestjs-doctor/src/engine/diagnostician.ts
+++ b/packages/nestjs-doctor/src/engine/diagnostician.ts
@@ -5,6 +5,7 @@ import type { Diagnostic } from "../common/diagnostic.js";
 import type { RuleErrorInfo } from "../common/result.js";
 import type { AnalysisContext } from "./analysis-context.js";
 import { filterIgnoredDiagnostics } from "./filter-diagnostics.js";
+import { guardDecoratorNames } from "./graph/guard-decorators.js";
 import { filterSuppressedDiagnostics } from "./inline-suppressions.js";
 import {
 	type RunRulesOptions,
@@ -116,13 +117,10 @@ function processResults(
 /** Guard facts for the file rules, gathered from the whole project. */
 function guardFacts(context: AnalysisContext): GuardFacts {
 	const globallyRegistered = [...context.moduleGraph.modules.values()].some(
-		(module) =>
-			module.providerRegistrations.some(
-				(registration) => registration.token === "APP_GUARD"
-			)
+		(module) => module.providerTokens.includes("APP_GUARD")
 	);
 	return {
-		composedDecorators: context.guardDecoratorNames,
+		composedDecorators: guardDecoratorNames(context.guardDecorators),
 		globallyRegistered,
 	};
 }

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -1,5 +1,15 @@
-import type { Node, Project } from "ts-morph";
+import type { Node, Project, SourceFile } from "ts-morph";
 import { SyntaxKind } from "ts-morph";
+
+/** Decorator names that compose `UseGuards`, keyed by the file declaring them. */
+export type GuardDecoratorIndex = Map<string, Set<string>>;
+
+const FUNCTION_KINDS = new Set([
+	SyntaxKind.ArrowFunction,
+	SyntaxKind.FunctionDeclaration,
+	SyntaxKind.FunctionExpression,
+	SyntaxKind.MethodDeclaration,
+]);
 
 /** True for `applyDecorators(..., UseGuards(...), ...)`. */
 function appliesGuards(expression: Node | undefined): boolean {
@@ -18,18 +28,28 @@ function appliesGuards(expression: Node | undefined): boolean {
 		);
 }
 
-/** Expressions a function body hands back, whether concise or via `return`. */
-function returnedExpressions(body: Node | undefined): Node[] {
+/**
+ * Expressions `fn` itself hands back. Returns belonging to a nested function
+ * are skipped, since they say nothing about what `fn` returns.
+ */
+function returnedExpressions(fn: Node): Node[] {
+	const body = fn.getChildrenOfKind(SyntaxKind.Block)[0];
 	if (!body) {
-		return [];
+		const arrow = fn.asKind(SyntaxKind.ArrowFunction);
+		const concise = arrow?.getBody();
+		return concise && !concise.isKind(SyntaxKind.Block) ? [concise] : [];
 	}
-	if (!body.isKind(SyntaxKind.Block)) {
-		return [body];
-	}
+
 	const expressions: Node[] = [];
 	for (const statement of body.getDescendantsOfKind(
 		SyntaxKind.ReturnStatement
 	)) {
+		const owner = statement.getFirstAncestor((ancestor) =>
+			FUNCTION_KINDS.has(ancestor.getKind())
+		);
+		if (owner !== fn) {
+			continue;
+		}
 		const expression = statement.getExpression();
 		if (expression) {
 			expressions.push(expression);
@@ -38,38 +58,65 @@ function returnedExpressions(body: Node | undefined): Node[] {
 	return expressions;
 }
 
-/**
- * Names of top-level functions that compose `UseGuards` into a decorator, so a
- * `@Auth()` built from `applyDecorators(UseGuards(...))` counts as a guard.
- */
-export function buildGuardDecoratorNames(
-	project: Project,
-	files: string[]
-): Set<string> {
+/** Names in one file whose implementation composes `UseGuards`. */
+function namesInFile(sourceFile: SourceFile): Set<string> {
 	const names = new Set<string>();
 
-	for (const filePath of files) {
-		const sourceFile = project.getSourceFile(filePath);
-		if (!sourceFile) {
-			continue;
-		}
-
-		for (const fn of sourceFile.getFunctions()) {
-			const name = fn.getName();
-			if (name && returnedExpressions(fn.getBody()).some(appliesGuards)) {
-				names.add(name);
-			}
-		}
-
-		for (const declaration of sourceFile.getVariableDeclarations()) {
-			const arrow = declaration
-				.getInitializer()
-				?.asKind(SyntaxKind.ArrowFunction);
-			if (arrow && returnedExpressions(arrow.getBody()).some(appliesGuards)) {
-				names.add(declaration.getName());
-			}
+	for (const fn of sourceFile.getFunctions()) {
+		const name = fn.getName();
+		if (name && returnedExpressions(fn).some(appliesGuards)) {
+			names.add(name);
 		}
 	}
 
+	for (const declaration of sourceFile.getVariableDeclarations()) {
+		const arrow = declaration
+			.getInitializer()
+			?.asKind(SyntaxKind.ArrowFunction);
+		if (arrow && returnedExpressions(arrow).some(appliesGuards)) {
+			names.add(declaration.getName());
+		}
+	}
+
+	return names;
+}
+
+export function buildGuardDecoratorIndex(
+	project: Project,
+	files: string[]
+): GuardDecoratorIndex {
+	const index: GuardDecoratorIndex = new Map();
+	for (const filePath of files) {
+		const sourceFile = project.getSourceFile(filePath);
+		if (sourceFile) {
+			index.set(filePath, namesInFile(sourceFile));
+		}
+	}
+	return index;
+}
+
+/** Rescans one file, dropping whatever it declared before. */
+export function updateGuardDecoratorIndexForFile(
+	index: GuardDecoratorIndex,
+	project: Project,
+	filePath: string
+): void {
+	const sourceFile = project.getSourceFile(filePath);
+	if (sourceFile) {
+		index.set(filePath, namesInFile(sourceFile));
+		return;
+	}
+	index.delete(filePath);
+}
+
+export function guardDecoratorNames(
+	index: GuardDecoratorIndex
+): ReadonlySet<string> {
+	const names = new Set<string>();
+	for (const fileNames of index.values()) {
+		for (const name of fileNames) {
+			names.add(name);
+		}
+	}
 	return names;
 }

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -1,0 +1,75 @@
+import type { Node, Project } from "ts-morph";
+import { SyntaxKind } from "ts-morph";
+
+/** True for `applyDecorators(..., UseGuards(...), ...)`. */
+function appliesGuards(expression: Node | undefined): boolean {
+	const call = expression?.asKind(SyntaxKind.CallExpression);
+	if (call?.getExpression().getText() !== "applyDecorators") {
+		return false;
+	}
+	return call
+		.getArguments()
+		.some(
+			(argument) =>
+				argument
+					.asKind(SyntaxKind.CallExpression)
+					?.getExpression()
+					.getText() === "UseGuards"
+		);
+}
+
+/** Expressions a function body hands back, whether concise or via `return`. */
+function returnedExpressions(body: Node | undefined): Node[] {
+	if (!body) {
+		return [];
+	}
+	if (!body.isKind(SyntaxKind.Block)) {
+		return [body];
+	}
+	const expressions: Node[] = [];
+	for (const statement of body.getDescendantsOfKind(
+		SyntaxKind.ReturnStatement
+	)) {
+		const expression = statement.getExpression();
+		if (expression) {
+			expressions.push(expression);
+		}
+	}
+	return expressions;
+}
+
+/**
+ * Names of top-level functions that compose `UseGuards` into a decorator, so a
+ * `@Auth()` built from `applyDecorators(UseGuards(...))` counts as a guard.
+ */
+export function buildGuardDecoratorNames(
+	project: Project,
+	files: string[]
+): Set<string> {
+	const names = new Set<string>();
+
+	for (const filePath of files) {
+		const sourceFile = project.getSourceFile(filePath);
+		if (!sourceFile) {
+			continue;
+		}
+
+		for (const fn of sourceFile.getFunctions()) {
+			const name = fn.getName();
+			if (name && returnedExpressions(fn.getBody()).some(appliesGuards)) {
+				names.add(name);
+			}
+		}
+
+		for (const declaration of sourceFile.getVariableDeclarations()) {
+			const arrow = declaration
+				.getInitializer()
+				?.asKind(SyntaxKind.ArrowFunction);
+			if (arrow && returnedExpressions(arrow.getBody()).some(appliesGuards)) {
+				names.add(declaration.getName());
+			}
+		}
+	}
+
+	return names;
+}

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -59,13 +59,6 @@ function resolvePosix(fromDirectory: string, specifier: string): string {
 
 const JS_EXT_REGEX = /\.js$/;
 
-/** An object-literal provider: `{ provide: TOKEN, useClass: X }`. */
-interface ProviderRegistration {
-	token: string;
-	useClass?: string;
-	useExisting?: string;
-}
-
 export interface ModuleNode {
 	classDeclaration: ClassDeclaration;
 	controllers: string[];
@@ -74,9 +67,9 @@ export interface ModuleNode {
 	forwardRefImports: Set<string>;
 	imports: string[];
 	name: string;
-	/** Object-literal entries of `providers`, which `providers` keeps as raw text. */
-	providerRegistrations: ProviderRegistration[];
 	providers: string[];
+	/** `provide` tokens of object-literal providers, which `providers` keeps as raw text. */
+	providerTokens: string[];
 }
 
 export interface ModuleGraph {
@@ -108,7 +101,7 @@ function extractModulesFromFile(
 			forwardRefImports: new Set<string>(),
 			exports: [],
 			providers: [],
-			providerRegistrations: [],
+			providerTokens: [],
 			controllers: [],
 		};
 
@@ -136,7 +129,7 @@ function extractModulesFromFile(
 					"providers",
 					pathAliases
 				).map((t) => t.name);
-				node.providerRegistrations = extractProviderRegistrations(obj);
+				node.providerTokens = extractProviderTokens(obj);
 				node.controllers = extractArrayPropertyNames(
 					obj,
 					"controllers",
@@ -218,45 +211,35 @@ function plain(name: string): ExtractedName {
 	return { name, viaForwardRef: false };
 }
 
-/** Text of a property's initializer, reduced to its last dotted segment. */
-function bareInitializerText(
+/** The initializer of `obj.propertyName`, if it is a plain assignment. */
+function propertyInitializer(
 	obj: ObjectLiteralExpression,
 	propertyName: string
-): string | undefined {
-	const assignment = obj
+): Node | undefined {
+	return obj
 		.getProperty(propertyName)
-		?.asKind(SyntaxKind.PropertyAssignment);
-	const text = assignment?.getInitializer()?.getText();
-	return text ? text.split(".").pop() : undefined;
+		?.asKind(SyntaxKind.PropertyAssignment)
+		?.getInitializer();
 }
 
-/** Object-literal entries of a module's `providers` array. */
-function extractProviderRegistrations(
-	obj: ObjectLiteralExpression
-): ProviderRegistration[] {
-	const initializer = obj
-		.getProperty("providers")
-		?.asKind(SyntaxKind.PropertyAssignment)
-		?.getInitializer()
-		?.asKind(SyntaxKind.ArrayLiteralExpression);
+/** `provide` tokens of the object-literal entries in a module's `providers`. */
+function extractProviderTokens(obj: ObjectLiteralExpression): string[] {
+	const initializer = propertyInitializer(obj, "providers")?.asKind(
+		SyntaxKind.ArrayLiteralExpression
+	);
 	if (!initializer) {
 		return [];
 	}
 
-	const registrations: ProviderRegistration[] = [];
+	const tokens: string[] = [];
 	for (const element of initializer.getElements()) {
 		const literal = element.asKind(SyntaxKind.ObjectLiteralExpression);
-		const token = literal && bareInitializerText(literal, "provide");
-		if (!(literal && token)) {
-			continue;
+		const token = literal && propertyInitializer(literal, "provide")?.getText();
+		if (token) {
+			tokens.push(token.split(".").pop() as string);
 		}
-		registrations.push({
-			token,
-			useClass: bareInitializerText(literal, "useClass"),
-			useExisting: bareInitializerText(literal, "useExisting"),
-		});
 	}
-	return registrations;
+	return tokens;
 }
 
 function extractArrayPropertyNames(
@@ -264,17 +247,7 @@ function extractArrayPropertyNames(
 	propertyName: string,
 	pathAliases: PathAliasMap
 ): ExtractedName[] {
-	const prop = obj.getProperty(propertyName);
-	if (!prop) {
-		return [];
-	}
-
-	const assignment = prop.asKind(SyntaxKind.PropertyAssignment);
-	if (!assignment) {
-		return [];
-	}
-
-	const initializer = assignment.getInitializer();
+	const initializer = propertyInitializer(obj, propertyName);
 	if (!initializer) {
 		return [];
 	}

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -59,6 +59,13 @@ function resolvePosix(fromDirectory: string, specifier: string): string {
 
 const JS_EXT_REGEX = /\.js$/;
 
+/** An object-literal provider: `{ provide: TOKEN, useClass: X }`. */
+interface ProviderRegistration {
+	token: string;
+	useClass?: string;
+	useExisting?: string;
+}
+
 export interface ModuleNode {
 	classDeclaration: ClassDeclaration;
 	controllers: string[];
@@ -67,6 +74,8 @@ export interface ModuleNode {
 	forwardRefImports: Set<string>;
 	imports: string[];
 	name: string;
+	/** Object-literal entries of `providers`, which `providers` keeps as raw text. */
+	providerRegistrations: ProviderRegistration[];
 	providers: string[];
 }
 
@@ -99,6 +108,7 @@ function extractModulesFromFile(
 			forwardRefImports: new Set<string>(),
 			exports: [],
 			providers: [],
+			providerRegistrations: [],
 			controllers: [],
 		};
 
@@ -126,6 +136,7 @@ function extractModulesFromFile(
 					"providers",
 					pathAliases
 				).map((t) => t.name);
+				node.providerRegistrations = extractProviderRegistrations(obj);
 				node.controllers = extractArrayPropertyNames(
 					obj,
 					"controllers",
@@ -205,6 +216,47 @@ interface ExtractedName {
 
 function plain(name: string): ExtractedName {
 	return { name, viaForwardRef: false };
+}
+
+/** Text of a property's initializer, reduced to its last dotted segment. */
+function bareInitializerText(
+	obj: ObjectLiteralExpression,
+	propertyName: string
+): string | undefined {
+	const assignment = obj
+		.getProperty(propertyName)
+		?.asKind(SyntaxKind.PropertyAssignment);
+	const text = assignment?.getInitializer()?.getText();
+	return text ? text.split(".").pop() : undefined;
+}
+
+/** Object-literal entries of a module's `providers` array. */
+function extractProviderRegistrations(
+	obj: ObjectLiteralExpression
+): ProviderRegistration[] {
+	const initializer = obj
+		.getProperty("providers")
+		?.asKind(SyntaxKind.PropertyAssignment)
+		?.getInitializer()
+		?.asKind(SyntaxKind.ArrayLiteralExpression);
+	if (!initializer) {
+		return [];
+	}
+
+	const registrations: ProviderRegistration[] = [];
+	for (const element of initializer.getElements()) {
+		const literal = element.asKind(SyntaxKind.ObjectLiteralExpression);
+		const token = literal && bareInitializerText(literal, "provide");
+		if (!(literal && token)) {
+			continue;
+		}
+		registrations.push({
+			token,
+			useClass: bareInitializerText(literal, "useClass"),
+			useExisting: bareInitializerText(literal, "useExisting"),
+		});
+	}
+	return registrations;
 }
 
 function extractArrayPropertyNames(

--- a/packages/nestjs-doctor/src/engine/rule-runner.ts
+++ b/packages/nestjs-doctor/src/engine/rule-runner.ts
@@ -11,6 +11,7 @@ import type { ModuleGraph } from "./graph/module-graph.js";
 import type { ProviderInfo } from "./graph/type-resolver.js";
 import type {
 	CodeRuleContext,
+	GuardFacts,
 	ProjectRule,
 	ProjectRuleContext,
 	Rule,
@@ -38,7 +39,8 @@ function runFileRulesOnFile(
 	project: Project,
 	filePath: string,
 	rules: Rule[],
-	config?: NestjsDoctorConfig
+	config?: NestjsDoctorConfig,
+	guards?: GuardFacts
 ): RunRulesResult {
 	const diagnostics: CodeDiagnostic[] = [];
 	const errors: RuleError[] = [];
@@ -54,6 +56,7 @@ function runFileRulesOnFile(
 	for (const rule of rules) {
 		const context: CodeRuleContext = {
 			config,
+			guards,
 			sourceFile,
 			filePath,
 			report(partial) {
@@ -88,13 +91,14 @@ export function runFileRules(
 	project: Project,
 	files: string[],
 	rules: Rule[],
-	config?: NestjsDoctorConfig
+	config?: NestjsDoctorConfig,
+	guards?: GuardFacts
 ): RunRulesResult {
 	const diagnostics: Diagnostic[] = [];
 	const errors: RuleError[] = [];
 
 	for (const filePath of files) {
-		const result = runFileRulesOnFile(project, filePath, rules, config);
+		const result = runFileRulesOnFile(project, filePath, rules, config, guards);
 		diagnostics.push(...result.diagnostics);
 		errors.push(...result.errors);
 	}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -1,5 +1,6 @@
+import type { ClassDeclaration, MethodDeclaration } from "ts-morph";
 import { isController, isHttpHandler } from "../../../nest-class-inspector.js";
-import type { Rule } from "../../types.js";
+import type { GuardFacts, Rule } from "../../types.js";
 
 const PUBLIC_DECORATORS = new Set([
 	"Public",
@@ -7,6 +8,20 @@ const PUBLIC_DECORATORS = new Set([
 	"SkipAuth",
 	"IsPublic",
 ]);
+
+/** True for `@UseGuards()` or a decorator known to compose it. */
+function hasGuard(
+	node: ClassDeclaration | MethodDeclaration,
+	guards: GuardFacts | undefined
+): boolean {
+	return node
+		.getDecorators()
+		.some(
+			(decorator) =>
+				decorator.getName() === "UseGuards" ||
+				guards?.composedDecorators.has(decorator.getName())
+		);
+}
 
 export const requireGuardsOnEndpoints: Rule = {
 	meta: {
@@ -19,14 +34,17 @@ export const requireGuardsOnEndpoints: Rule = {
 	},
 
 	check(context) {
+		// Only a positive sighting suppresses. Not knowing still reports.
+		if (context.guards?.globallyRegistered) {
+			return;
+		}
+
 		for (const cls of context.sourceFile.getClasses()) {
 			if (!isController(cls)) {
 				continue;
 			}
 
-			// Check for class-level @UseGuards()
-			const hasClassGuard = cls.getDecorator("UseGuards") !== undefined;
-			if (hasClassGuard) {
+			if (hasGuard(cls, context.guards)) {
 				continue;
 			}
 
@@ -43,9 +61,7 @@ export const requireGuardsOnEndpoints: Rule = {
 					continue;
 				}
 
-				// Check for method-level @UseGuards()
-				const hasMethodGuard = method.getDecorator("UseGuards") !== undefined;
-				if (hasMethodGuard) {
+				if (hasGuard(method, context.guards)) {
 					continue;
 				}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -30,11 +30,10 @@ export const requireGuardsOnEndpoints: Rule = {
 		severity: "warning",
 		description:
 			"Controller endpoints should be protected by @UseGuards() at class or method level",
-		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). If you use a global guard via APP_GUARD, you can disable this rule.",
+		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.",
 	},
 
 	check(context) {
-		// Only a positive sighting suppresses. Not knowing still reports.
 		if (context.guards?.globallyRegistered) {
 			return;
 		}

--- a/packages/nestjs-doctor/src/engine/rules/types.ts
+++ b/packages/nestjs-doctor/src/engine/rules/types.ts
@@ -25,9 +25,18 @@ export interface RuleMeta {
 
 // ── Contexts ──
 
+/** Guard facts a single file cannot see. Absent means "not determined". */
+export interface GuardFacts {
+	/** Decorator names whose implementation composes `UseGuards`. */
+	composedDecorators: ReadonlySet<string>;
+	/** Some module registers a guard through `APP_GUARD`. */
+	globallyRegistered: boolean;
+}
+
 export interface CodeRuleContext {
 	config?: NestjsDoctorConfig;
 	filePath: string;
+	guards?: GuardFacts;
 	report(
 		diagnostic: Omit<CodeDiagnostic, "rule" | "category" | "severity" | "scope">
 	): void;

--- a/packages/nestjs-doctor/tests/fixtures/global-guard-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/global-guard-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "global-guard-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/global-guard-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/global-guard-app/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { OrdersController } from './orders.controller';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+@Module({
+  controllers: [OrdersController],
+  providers: [{ provide: APP_GUARD, useClass: JwtAuthGuard }],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/global-guard-app/src/jwt-auth.guard.ts
+++ b/packages/nestjs-doctor/tests/fixtures/global-guard-app/src/jwt-auth.guard.ts
@@ -1,0 +1,8 @@
+import { CanActivate, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  canActivate(): boolean {
+    return true;
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/global-guard-app/src/orders.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/global-guard-app/src/orders.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('orders')
+export class OrdersController {
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/integration/global-guards.test.ts
+++ b/packages/nestjs-doctor/tests/integration/global-guards.test.ts
@@ -17,8 +17,6 @@ async function scan(fixture: string) {
 }
 
 describe("global guard detection", () => {
-	// Exercises the whole wiring, not the rule alone: the facts are optional all
-	// the way down, so a missed hand-off degrades silently to over-reporting.
 	it("reports no unguarded endpoint when a module registers APP_GUARD", async () => {
 		const { output } = await scan("global-guard-app/src");
 		const guardFindings = output.diagnostics.filter(
@@ -27,16 +25,12 @@ describe("global guard detection", () => {
 		expect(guardFindings).toEqual([]);
 	});
 
-	it("records the APP_GUARD provider structurally on the module graph", async () => {
+	it("records the APP_GUARD token on the module graph", async () => {
 		const { context } = await scan("global-guard-app/src");
-		const registrations = [...context.moduleGraph.modules.values()].flatMap(
-			(module) => module.providerRegistrations
+		const tokens = [...context.moduleGraph.modules.values()].flatMap(
+			(module) => module.providerTokens
 		);
-		expect(registrations).toContainEqual({
-			token: "APP_GUARD",
-			useClass: "JwtAuthGuard",
-			useExisting: undefined,
-		});
+		expect(tokens).toContain("APP_GUARD");
 	});
 
 	it("still reports an unguarded endpoint in a project with no global guard", async () => {

--- a/packages/nestjs-doctor/tests/integration/global-guards.test.ts
+++ b/packages/nestjs-doctor/tests/integration/global-guards.test.ts
@@ -1,0 +1,49 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	buildAnalysisContext,
+	diagnose,
+	resolveScanConfig,
+} from "../../src/engine/scanner.js";
+
+const FIXTURES = resolve(import.meta.dirname, "../fixtures");
+const GUARD_RULE = "security/require-guards-on-endpoints";
+
+async function scan(fixture: string) {
+	const targetPath = resolve(FIXTURES, fixture);
+	const scanConfig = await resolveScanConfig(targetPath);
+	const context = await buildAnalysisContext(targetPath, scanConfig);
+	return { context, output: diagnose(context) };
+}
+
+describe("global guard detection", () => {
+	// Exercises the whole wiring, not the rule alone: the facts are optional all
+	// the way down, so a missed hand-off degrades silently to over-reporting.
+	it("reports no unguarded endpoint when a module registers APP_GUARD", async () => {
+		const { output } = await scan("global-guard-app/src");
+		const guardFindings = output.diagnostics.filter(
+			(diagnostic) => diagnostic.rule === GUARD_RULE
+		);
+		expect(guardFindings).toEqual([]);
+	});
+
+	it("records the APP_GUARD provider structurally on the module graph", async () => {
+		const { context } = await scan("global-guard-app/src");
+		const registrations = [...context.moduleGraph.modules.values()].flatMap(
+			(module) => module.providerRegistrations
+		);
+		expect(registrations).toContainEqual({
+			token: "APP_GUARD",
+			useClass: "JwtAuthGuard",
+			useExisting: undefined,
+		});
+	});
+
+	it("still reports an unguarded endpoint in a project with no global guard", async () => {
+		const { output } = await scan("bad-security/src");
+		const guardFindings = output.diagnostics.filter(
+			(diagnostic) => diagnostic.rule === GUARD_RULE
+		);
+		expect(guardFindings.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
+++ b/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
@@ -1,14 +1,19 @@
 import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
-import { buildGuardDecoratorNames } from "../../src/engine/graph/guard-decorators.js";
+import {
+	buildGuardDecoratorIndex,
+	guardDecoratorNames,
+} from "../../src/engine/graph/guard-decorators.js";
 
 function index(code: string): Set<string> {
 	const project = new Project({ useInMemoryFileSystem: true });
 	project.createSourceFile("/decorators.ts", code);
-	return buildGuardDecoratorNames(project, ["/decorators.ts"]);
+	return new Set(
+		guardDecoratorNames(buildGuardDecoratorIndex(project, ["/decorators.ts"]))
+	);
 }
 
-describe("buildGuardDecoratorNames", () => {
+describe("buildGuardDecoratorIndex", () => {
 	it("indexes a function returning applyDecorators(UseGuards(...))", () => {
 		const names = index(`
       import { applyDecorators, UseGuards } from '@nestjs/common';
@@ -58,12 +63,37 @@ describe("buildGuardDecoratorNames", () => {
 		expect(names.size).toBe(0);
 	});
 
+	it("does not credit a function for a guard its nested function applies", () => {
+		const names = index(`
+      import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+      export function Auth() {
+        function withRoles() {
+          return applyDecorators(UseGuards(RolesGuard));
+        }
+        return SetMetadata('auth', true);
+      }
+    `);
+		expect(names.size).toBe(0);
+	});
+
+	it("still credits the outer function when it returns the composition itself", () => {
+		const names = index(`
+      import { applyDecorators, UseGuards } from '@nestjs/common';
+      export function Auth() {
+        const extra = () => SetMetadata('x', 1);
+        return applyDecorators(extra(), UseGuards(AuthGuard));
+      }
+    `);
+		expect([...names]).toEqual(["Auth"]);
+	});
+
 	it("returns an empty set for a file it was not given", () => {
 		const project = new Project({ useInMemoryFileSystem: true });
 		project.createSourceFile(
 			"/other.ts",
 			"export function Auth() { return applyDecorators(UseGuards(G)); }"
 		);
-		expect(buildGuardDecoratorNames(project, ["/missing.ts"]).size).toBe(0);
+		const empty = buildGuardDecoratorIndex(project, ["/missing.ts"]);
+		expect(guardDecoratorNames(empty).size).toBe(0);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
+++ b/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
@@ -1,0 +1,69 @@
+import { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import { buildGuardDecoratorNames } from "../../src/engine/graph/guard-decorators.js";
+
+function index(code: string): Set<string> {
+	const project = new Project({ useInMemoryFileSystem: true });
+	project.createSourceFile("/decorators.ts", code);
+	return buildGuardDecoratorNames(project, ["/decorators.ts"]);
+}
+
+describe("buildGuardDecoratorNames", () => {
+	it("indexes a function returning applyDecorators(UseGuards(...))", () => {
+		const names = index(`
+      import { applyDecorators, UseGuards } from '@nestjs/common';
+      export function Auth(roles = []) {
+        return applyDecorators(Roles(roles), UseGuards(AuthGuard, RolesGuard));
+      }
+    `);
+		expect([...names]).toEqual(["Auth"]);
+	});
+
+	it("indexes an arrow function with a concise body", () => {
+		const names = index(`
+      import { applyDecorators, UseGuards } from '@nestjs/common';
+      export const Protected = () => applyDecorators(UseGuards(AuthGuard));
+    `);
+		expect([...names]).toEqual(["Protected"]);
+	});
+
+	it("indexes an arrow function with a block body", () => {
+		const names = index(`
+      import { applyDecorators, UseGuards } from '@nestjs/common';
+      export const Protected = () => {
+        return applyDecorators(UseGuards(AuthGuard));
+      };
+    `);
+		expect([...names]).toEqual(["Protected"]);
+	});
+
+	it("ignores a composition that applies no guard", () => {
+		const names = index(`
+      import { applyDecorators } from '@nestjs/common';
+      export function Documented() {
+        return applyDecorators(ApiOperation(), ApiOkResponse());
+      }
+    `);
+		expect(names.size).toBe(0);
+	});
+
+	it("ignores a function that calls UseGuards without composing a decorator", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export function notADecorator() {
+        const x = UseGuards(AuthGuard);
+        return x;
+      }
+    `);
+		expect(names.size).toBe(0);
+	});
+
+	it("returns an empty set for a file it was not given", () => {
+		const project = new Project({ useInMemoryFileSystem: true });
+		project.createSourceFile(
+			"/other.ts",
+			"export function Auth() { return applyDecorators(UseGuards(G)); }"
+		);
+		expect(buildGuardDecoratorNames(project, ["/missing.ts"]).size).toBe(0);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/module-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/module-graph.test.ts
@@ -19,6 +19,42 @@ function createProject(files: Record<string, string>) {
 }
 
 describe("module-graph", () => {
+	it("records object-literal providers structurally", () => {
+		const { project, paths } = createProject({
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { APP_GUARD } from '@nestjs/core';
+        @Module({
+          providers: [
+            AppService,
+            { provide: APP_GUARD, useClass: JwtAuthGuard },
+            { provide: 'TOKEN', useExisting: RealService },
+          ],
+        })
+        export class AppModule {}
+      `,
+		});
+		const graph = buildModuleGraph(project, paths);
+		const registrations = graph.modules.get("AppModule")?.providerRegistrations;
+
+		expect(registrations).toEqual([
+			{ token: "APP_GUARD", useClass: "JwtAuthGuard", useExisting: undefined },
+			{ token: "'TOKEN'", useClass: undefined, useExisting: "RealService" },
+		]);
+	});
+
+	it("leaves providerRegistrations empty when there are no object literals", () => {
+		const { project, paths } = createProject({
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [AppService] })
+        export class AppModule {}
+      `,
+		});
+		const graph = buildModuleGraph(project, paths);
+		expect(graph.modules.get("AppModule")?.providerRegistrations).toEqual([]);
+	});
+
 	// @Module() decorator metadata should populate imports, exports, providers, and controllers
 	it("builds a graph from @Module decorators", () => {
 		const { project, paths } = createProject({

--- a/packages/nestjs-doctor/tests/unit/module-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/module-graph.test.ts
@@ -19,7 +19,7 @@ function createProject(files: Record<string, string>) {
 }
 
 describe("module-graph", () => {
-	it("records object-literal providers structurally", () => {
+	it("records the tokens of object-literal providers", () => {
 		const { project, paths } = createProject({
 			"app.module.ts": `
         import { Module } from '@nestjs/common';
@@ -35,15 +35,13 @@ describe("module-graph", () => {
       `,
 		});
 		const graph = buildModuleGraph(project, paths);
-		const registrations = graph.modules.get("AppModule")?.providerRegistrations;
-
-		expect(registrations).toEqual([
-			{ token: "APP_GUARD", useClass: "JwtAuthGuard", useExisting: undefined },
-			{ token: "'TOKEN'", useClass: undefined, useExisting: "RealService" },
+		expect(graph.modules.get("AppModule")?.providerTokens).toEqual([
+			"APP_GUARD",
+			"'TOKEN'",
 		]);
 	});
 
-	it("leaves providerRegistrations empty when there are no object literals", () => {
+	it("leaves providerTokens empty when there are no object literals", () => {
 		const { project, paths } = createProject({
 			"app.module.ts": `
         import { Module } from '@nestjs/common';
@@ -52,7 +50,7 @@ describe("module-graph", () => {
       `,
 		});
 		const graph = buildModuleGraph(project, paths);
-		expect(graph.modules.get("AppModule")?.providerRegistrations).toEqual([]);
+		expect(graph.modules.get("AppModule")?.providerTokens).toEqual([]);
 	});
 
 	// @Module() decorator metadata should populate imports, exports, providers, and controllers

--- a/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
@@ -557,7 +557,6 @@ describe("require-guards-on-endpoints", () => {
 	});
 
 	it("still reports when the decorator is not a known guard", () => {
-		// Only a positive sighting suppresses; an unrecognised decorator is not one.
 		const diags = runRule(
 			requireGuardsOnEndpoints,
 			`

--- a/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
@@ -10,9 +10,14 @@ import { noRawEntityInResponse } from "../../../src/engine/rules/definitions/sec
 import { noSynchronizeInProduction } from "../../../src/engine/rules/definitions/security/no-synchronize-in-production.js";
 import { noWeakCrypto } from "../../../src/engine/rules/definitions/security/no-weak-crypto.js";
 import { requireGuardsOnEndpoints } from "../../../src/engine/rules/definitions/security/require-guards-on-endpoints.js";
-import type { Rule } from "../../../src/engine/rules/types.js";
+import type { GuardFacts, Rule } from "../../../src/engine/rules/types.js";
 
-function runRule(rule: Rule, code: string, filePath = "test.ts"): Diagnostic[] {
+function runRule(
+	rule: Rule,
+	code: string,
+	filePath = "test.ts",
+	guards?: GuardFacts
+): Diagnostic[] {
 	const project = new Project({ useInMemoryFileSystem: true });
 	const sourceFile = project.createSourceFile(filePath, code);
 	const diagnostics: Diagnostic[] = [];
@@ -20,6 +25,7 @@ function runRule(rule: Rule, code: string, filePath = "test.ts"): Diagnostic[] {
 	rule.check({
 		sourceFile,
 		filePath,
+		guards,
 		report(partial) {
 			diagnostics.push({
 				...partial,
@@ -495,6 +501,93 @@ describe("require-guards-on-endpoints", () => {
     `
 		);
 		expect(diags).toHaveLength(0);
+	});
+
+	it("stays quiet when a module registers a guard through APP_GUARD", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        findAll() { return []; }
+      }
+    `,
+			"test.ts",
+			{ composedDecorators: new Set(), globallyRegistered: true }
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("accepts a decorator that composes UseGuards, on the method", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        @Auth()
+        findAll() { return []; }
+      }
+    `,
+			"test.ts",
+			{ composedDecorators: new Set(["Auth"]), globallyRegistered: false }
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("accepts a decorator that composes UseGuards, on the class", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Auth()
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        findAll() { return []; }
+      }
+    `,
+			"test.ts",
+			{ composedDecorators: new Set(["Auth"]), globallyRegistered: false }
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still reports when the decorator is not a known guard", () => {
+		// Only a positive sighting suppresses; an unrecognised decorator is not one.
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        @ApiOperation()
+        findAll() { return []; }
+      }
+    `,
+			"test.ts",
+			{ composedDecorators: new Set(["Auth"]), globallyRegistered: false }
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("reports when no guard facts were determined at all", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        findAll() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
 	});
 
 	it("does not flag non-handler methods", () => {


### PR DESCRIPTION
## 1. Context

`security/require-guards-on-endpoints` decides an endpoint is unprotected by looking for a literal `@UseGuards()` on the controller class or the route method. NestJS has two other ways to apply a guard that never write that decorator at the call site: binding one application-wide through the `APP_GUARD` token, and wrapping it in a custom decorator built with `applyDecorators`.

## 2. Problem

Both are invisible to the rule, so it reports guarded code as unguarded. Measured with 0.6.0 against three public repositories:

| Repo | Findings | Real |
|---|---:|---|
| `buqiyuan/nest-admin` | 72 | 0 — `app.module.ts` binds `JwtAuthGuard`, `RbacGuard` and `ThrottlerGuard` through `APP_GUARD` |
| `NarHakobyan/awesome-nest-boilerplate` | 12 | 5 — `@Auth()` wraps `UseGuards`; the repo has no direct `@UseGuards` at all |
| `brocoders/nestjs-boilerplate` | 11 | 11 — auth login routes, genuinely unguarded |

84 of 95 findings across those repositories were wrong. The rule's own `help` conceded the first case: *"If you use a global guard via APP_GUARD, you can disable this rule."* Turning off a security rule is not a workaround.

## 3. Possible flows

| How the guard is applied | Before | After |
|---|---|---|
| `@UseGuards()` on the method | quiet | quiet |
| `@UseGuards()` on the class | quiet | quiet |
| `@Public()` / `@AllowAnonymous()` and friends | quiet | quiet |
| `{ provide: APP_GUARD, useClass: X }` in any module | **reports every endpoint** | quiet |
| `@Auth()` from `applyDecorators(UseGuards(...))` | **reports every endpoint** | quiet |
| No guard by any mechanism | reports | reports |
| Decorator the index does not know | reports | reports |
| No module visible at all | reports | reports |

## 4. Solution

Module nodes carry `providerTokens`, the `provide` tokens of object-literal providers, and a per-file index records decorator names whose body composes `UseGuards`. Both reach the rule through an optional field on its context.

The rule stays file-scoped. Project scope would drop `sourceLines` from its diagnostics, and that text feeds `diagnosticIdentity`, so every existing baseline would report all of this rule's findings as newly introduced.

Suppression needs a positive sighting. Seeing no modules — a scan pointed at a subdirectory, a config excluding the root module — still reports, because a scan that silently finds nothing looks exactly like a clean one.

Deliberately not done: `correctness/injectable-must-be-provided` hand-parses the same provider shape and could read `providerTokens` instead, but it matches on the fully qualified initializer text where this reduces to the last segment. Folding it in would change an unrelated rule's behaviour inside a bugfix.

Two cases it still cannot see, both documented in the rule's `help`: an `APP_GUARD` reached through an aliased import, and a module declaring `APP_GUARD` that nothing imports. Separating that second one from a real root module needs the application's entry point, which a static scan of an arbitrary directory cannot identify.

## 5. Before vs after

| Scenario | Before | After |
|---|---:|---:|
| `nest-admin` guard findings | 72 | 0 |
| `awesome-nest-boilerplate` guard findings | 12 | 5 |
| `nestjs-boilerplate` guard findings | 11 | 11 |
| `nest-admin` score | 71 | 78 |
| `nestjs-boilerplate` score | 93 | 93 |
| Fingerprints of this rule's diagnostics | — | unchanged |
| LSP cost of a single-file edit | full project rescan | one file |

## 6. Example

```
$ npx nestjs-doctor . --format json | jq '[.diagnostics[] | select(.rule=="security/require-guards-on-endpoints")] | length'
```

Against `buqiyuan/nest-admin`, whose `app.module.ts` contains:

```ts
providers: [
  { provide: APP_GUARD, useClass: JwtAuthGuard },
  { provide: APP_GUARD, useClass: RbacGuard },
  { provide: APP_GUARD, useClass: ThrottlerGuard },
],
```

Before:

```
72
  modules/health/health.controller.ts:31 | Endpoint 'checkNetwork' has no @UseGuards() at class or method level.
  modules/health/health.controller.ts:38 | Endpoint 'checkDatabase' has no @UseGuards() at class or method level.
  ...
```

After:

```
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)