### PR TITLE
fix(rules): only flag imports that leave their module

### DIFF
--- a/.changeset/module-boundaries-same-module.md
+++ b/.changeset/module-boundaries-same-module.md
@@ -2,19 +2,27 @@
 "nestjs-doctor": patch
 ---
 
-Stop `architecture/require-module-boundaries` flagging a module's own internals.
+Stop `architecture/require-module-boundaries` flagging imports that never leave
+their module.
 
 The rule matched any relative import containing `../` plus an internal directory
-name, without checking whether the import leaves the current module. A mapper
-importing its own module's entity through a sibling directory —
-`mappers/file.mapper.ts` reading `../entities/file.schema`, with the module file
-right beside both — was reported as reaching into another module. On
-`brocoders/nestjs-boilerplate` 13 of 49 findings were of this kind, and shared
-utilities under an application's root module accounted for 15 of 16 on
-`buqiyuan/nest-admin`.
+name, without checking whether the import leaves the current module. Two kinds
+of false positive followed:
+
+- A module reading its **own** internals through a sibling directory —
+  `mappers/file.mapper.ts` importing `../entities/file.schema`, with the module
+  file right beside both. 13 of 49 findings on `brocoders/nestjs-boilerplate`.
+- Shared utilities under an application's **root** module — `common/pipes`
+  importing `../dto`, `decorators` importing `../guards`. 15 of 16 findings on
+  `buqiyuan/nest-admin` and 5 of 21 on `NarHakobyan/awesome-nest-boilerplate`.
 
 The rule now resolves the import and compares the nearest module directory of
 source and target — module directories being those holding a `*.module.ts` file
 or a `@Module()` class. Only an import whose two sides positively resolve to the
 same module is skipped; a cross-module import, an unknown side, or a project
 with no visible modules reports exactly as before.
+
+One consequence to know about: a project that registers everything in a single
+root module has no internal module boundaries, so folder-to-folder deep imports
+there are no longer reported. The rule reads NestJS's module structure, not the
+directory layout.

--- a/.changeset/module-boundaries-same-module.md
+++ b/.changeset/module-boundaries-same-module.md
@@ -1,0 +1,20 @@
+---
+"nestjs-doctor": patch
+---
+
+Stop `architecture/require-module-boundaries` flagging a module's own internals.
+
+The rule matched any relative import containing `../` plus an internal directory
+name, without checking whether the import leaves the current module. A mapper
+importing its own module's entity through a sibling directory —
+`mappers/file.mapper.ts` reading `../entities/file.schema`, with the module file
+right beside both — was reported as reaching into another module. On
+`brocoders/nestjs-boilerplate` 13 of 49 findings were of this kind, and shared
+utilities under an application's root module accounted for 15 of 16 on
+`buqiyuan/nest-admin`.
+
+The rule now resolves the import and compares the nearest module directory of
+source and target — module directories being those holding a `*.module.ts` file
+or a `@Module()` class. Only an import whose two sides positively resolve to the
+same module is skipped; a cross-module import, an unknown side, or a project
+with no visible modules reports exactly as before.

--- a/packages/nestjs-doctor/src/engine/diagnostician.ts
+++ b/packages/nestjs-doctor/src/engine/diagnostician.ts
@@ -6,14 +6,15 @@ import type { RuleErrorInfo } from "../common/result.js";
 import type { AnalysisContext } from "./analysis-context.js";
 import { filterIgnoredDiagnostics } from "./filter-diagnostics.js";
 import { guardDecoratorNames } from "./graph/guard-decorators.js";
+import { posixDirname } from "./graph/module-graph.js";
 import { filterSuppressedDiagnostics } from "./inline-suppressions.js";
+import type { FileRuleFacts } from "./rule-runner.js";
 import {
 	type RunRulesOptions,
 	runFileRules,
 	runProjectRules,
 	runSchemaRules,
 } from "./rule-runner.js";
-import type { GuardFacts } from "./rules/types.js";
 
 function formatRuleError(error: unknown): string {
 	if (error instanceof Error) {
@@ -114,14 +115,30 @@ function processResults(
 	return { diagnostics, errors: ruleErrors };
 }
 
-/** Guard facts for the file rules, gathered from the whole project. */
-function guardFacts(context: AnalysisContext): GuardFacts {
-	const globallyRegistered = [...context.moduleGraph.modules.values()].some(
-		(module) => module.providerTokens.includes("APP_GUARD")
-	);
+const MODULE_FILE_RE = /\.module\.[mc]?ts$/;
+
+/** Project-wide facts for the file rules, gathered once per run. */
+function fileRuleFacts(context: AnalysisContext): FileRuleFacts {
+	const modules = [...context.moduleGraph.modules.values()];
+
+	const moduleDirectories = new Set<string>();
+	for (const filePath of context.files) {
+		if (MODULE_FILE_RE.test(filePath)) {
+			moduleDirectories.add(posixDirname(filePath));
+		}
+	}
+	for (const module of modules) {
+		moduleDirectories.add(posixDirname(module.filePath));
+	}
+
 	return {
-		composedDecorators: guardDecoratorNames(context.guardDecorators),
-		globallyRegistered,
+		guards: {
+			composedDecorators: guardDecoratorNames(context.guardDecorators),
+			globallyRegistered: modules.some((module) =>
+				module.providerTokens.includes("APP_GUARD")
+			),
+		},
+		moduleDirectories,
 	};
 }
 
@@ -134,7 +151,7 @@ export function checkFile(
 		[filePath],
 		context.fileRules,
 		context.config,
-		guardFacts(context)
+		fileRuleFacts(context)
 	);
 	return processResults(result.diagnostics, result.errors, context);
 }
@@ -148,7 +165,7 @@ export function checkAllFiles(context: AnalysisContext): {
 		context.files,
 		context.fileRules,
 		context.config,
-		guardFacts(context)
+		fileRuleFacts(context)
 	);
 	return processResults(result.diagnostics, result.errors, context);
 }

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -18,7 +18,7 @@ const toPosix = (path: string): string =>
 	path.replace(NATIVE_SEPARATOR_RE, "/");
 
 /** The directory part of a posix path, without consulting the platform. */
-const posixDirname = (path: string): string => {
+export const posixDirname = (path: string): string => {
 	const trimmed = toPosix(path);
 	const cut = trimmed.replace(TRAILING_SEGMENT_RE, "");
 	return cut === "" && trimmed.startsWith("/") ? "/" : cut;
@@ -28,7 +28,7 @@ const posixDirname = (path: string): string => {
  * Resolves a relative import using posix rules only, keeping the base's own
  * prefix so a posix root, a Windows drive root, and an in-memory `/` all work.
  */
-function resolvePosix(fromDirectory: string, specifier: string): string {
+export function resolvePosix(fromDirectory: string, specifier: string): string {
 	const base = toPosix(fromDirectory);
 	const segments = `${base}/${toPosix(specifier)}`.split("/");
 	const resolved: string[] = [];

--- a/packages/nestjs-doctor/src/engine/rule-runner.ts
+++ b/packages/nestjs-doctor/src/engine/rule-runner.ts
@@ -35,12 +35,18 @@ export interface RunRulesOptions {
 	providers: Map<string, ProviderInfo>;
 }
 
+/** Project-wide facts handed to file rules that need more than one file. */
+export interface FileRuleFacts {
+	guards?: GuardFacts;
+	moduleDirectories?: ReadonlySet<string>;
+}
+
 function runFileRulesOnFile(
 	project: Project,
 	filePath: string,
 	rules: Rule[],
 	config?: NestjsDoctorConfig,
-	guards?: GuardFacts
+	facts?: FileRuleFacts
 ): RunRulesResult {
 	const diagnostics: CodeDiagnostic[] = [];
 	const errors: RuleError[] = [];
@@ -56,7 +62,8 @@ function runFileRulesOnFile(
 	for (const rule of rules) {
 		const context: CodeRuleContext = {
 			config,
-			guards,
+			guards: facts?.guards,
+			moduleDirectories: facts?.moduleDirectories,
 			sourceFile,
 			filePath,
 			report(partial) {
@@ -92,13 +99,13 @@ export function runFileRules(
 	files: string[],
 	rules: Rule[],
 	config?: NestjsDoctorConfig,
-	guards?: GuardFacts
+	facts?: FileRuleFacts
 ): RunRulesResult {
 	const diagnostics: Diagnostic[] = [];
 	const errors: RuleError[] = [];
 
 	for (const filePath of files) {
-		const result = runFileRulesOnFile(project, filePath, rules, config, guards);
+		const result = runFileRulesOnFile(project, filePath, rules, config, facts);
 		diagnostics.push(...result.diagnostics);
 		errors.push(...result.errors);
 	}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/require-module-boundaries.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/require-module-boundaries.ts
@@ -1,3 +1,4 @@
+import { posixDirname, resolvePosix } from "../../../graph/module-graph.js";
 import type { Rule } from "../../types.js";
 
 // Detect deep imports into other feature modules' internals
@@ -11,6 +12,24 @@ const INTERNAL_PATHS = [
 	"/pipes/",
 	"/strategies/",
 ];
+
+/** The deepest module directory containing `path`, if any is known. */
+function nearestModuleDirectory(
+	path: string,
+	directories: ReadonlySet<string>
+): string | undefined {
+	let nearest: string | undefined;
+	for (const directory of directories) {
+		const prefix = directory === "/" ? "/" : `${directory}/`;
+		if (
+			path.startsWith(prefix) &&
+			(nearest === undefined || directory.length > nearest.length)
+		) {
+			nearest = directory;
+		}
+	}
+	return nearest;
+}
 
 export const requireModuleBoundaries: Rule = {
 	meta: {
@@ -39,16 +58,33 @@ export const requireModuleBoundaries: Rule = {
 			const crossesModuleBoundary = INTERNAL_PATHS.some((p) =>
 				moduleSpecifier.includes(p)
 			);
-
-			if (crossesModuleBoundary) {
-				context.report({
-					filePath: context.filePath,
-					message: `Import '${moduleSpecifier}' reaches into another module's internals.`,
-					help: this.meta.help,
-					line: imp.getStartLineNumber(),
-					column: 1,
-				});
+			if (!crossesModuleBoundary) {
+				continue;
 			}
+
+			// An import that stays inside its own module crosses nothing.
+			const directories = context.moduleDirectories;
+			if (directories) {
+				const target = resolvePosix(
+					posixDirname(context.filePath),
+					moduleSpecifier
+				);
+				const sourceModule = nearestModuleDirectory(
+					context.filePath,
+					directories
+				);
+				const targetModule = nearestModuleDirectory(target, directories);
+				if (sourceModule !== undefined && sourceModule === targetModule) {
+					continue;
+				}
+			}
+			context.report({
+				filePath: context.filePath,
+				message: `Import '${moduleSpecifier}' reaches into another module's internals.`,
+				help: this.meta.help,
+				line: imp.getStartLineNumber(),
+				column: 1,
+			});
 		}
 	},
 };

--- a/packages/nestjs-doctor/src/engine/rules/types.ts
+++ b/packages/nestjs-doctor/src/engine/rules/types.ts
@@ -37,6 +37,8 @@ export interface CodeRuleContext {
 	config?: NestjsDoctorConfig;
 	filePath: string;
 	guards?: GuardFacts;
+	/** Directories that hold a module file, for boundary checks. */
+	moduleDirectories?: ReadonlySet<string>;
 	report(
 		diagnostic: Omit<CodeDiagnostic, "rule" | "category" | "severity" | "scope">
 	): void;

--- a/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "module-boundaries-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { OrdersModule } from './orders/orders.module';
+
+@Module({
+  imports: [OrdersModule],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/billing/billing.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/billing/billing.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { OrderEntity } from '../orders/entities/order.entity';
+
+@Injectable()
+export class BillingService {
+  describe(order: OrderEntity): string {
+    return order.id;
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/orders/entities/order.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/orders/entities/order.entity.ts
@@ -1,0 +1,3 @@
+export class OrderEntity {
+  id: string;
+}

--- a/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/orders/mappers/order.mapper.ts
+++ b/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/orders/mappers/order.mapper.ts
@@ -1,0 +1,3 @@
+import { OrderEntity } from '../entities/order.entity';
+
+export const toId = (order: OrderEntity): string => order.id;

--- a/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/orders/orders.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/module-boundaries-app/src/orders/orders.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class OrdersModule {}

--- a/packages/nestjs-doctor/tests/integration/module-boundaries.test.ts
+++ b/packages/nestjs-doctor/tests/integration/module-boundaries.test.ts
@@ -1,0 +1,28 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	buildAnalysisContext,
+	diagnose,
+	resolveScanConfig,
+} from "../../src/engine/scanner.js";
+
+const FIXTURES = resolve(import.meta.dirname, "../fixtures");
+const BOUNDARY_RULE = "architecture/require-module-boundaries";
+
+async function boundaryFindings(fixture: string) {
+	const targetPath = resolve(FIXTURES, fixture);
+	const scanConfig = await resolveScanConfig(targetPath);
+	const context = await buildAnalysisContext(targetPath, scanConfig);
+	return diagnose(context).diagnostics.filter(
+		(diagnostic) => diagnostic.rule === BOUNDARY_RULE
+	);
+}
+
+describe("module boundary detection", () => {
+	it("reports the cross-module import and not the same-module one", async () => {
+		const findings = await boundaryFindings("module-boundaries-app/src");
+		expect(findings).toHaveLength(1);
+		expect(findings[0].filePath).toContain("billing.service.ts");
+		expect(findings[0].message).toContain("../orders/entities/order.entity");
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -16,7 +16,8 @@ function runRule(
 	rule: Rule,
 	code: string,
 	filePath = "test.ts",
-	config: NestjsDoctorConfig = {}
+	config: NestjsDoctorConfig = {},
+	moduleDirectories?: ReadonlySet<string>
 ): Diagnostic[] {
 	const project = new Project({ useInMemoryFileSystem: true });
 	const sourceFile = project.createSourceFile(filePath, code);
@@ -24,6 +25,7 @@ function runRule(
 
 	rule.check({
 		config,
+		moduleDirectories,
 		sourceFile,
 		filePath,
 		report(partial) {
@@ -721,6 +723,61 @@ describe("require-module-boundaries", () => {
     `
 		);
 		expect(diags).toHaveLength(0);
+	});
+	it("does not flag an import that stays inside its own module", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { FileEntity } from '../entities/file.entity';
+    `,
+			"/src/files/mappers/file.mapper.ts",
+			{},
+			new Set(["/src/files", "/src"])
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags a cross-module import when directories are known", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { OrderEntity } from '../orders/entities/order.entity';
+    `,
+			"/src/billing/billing.service.ts",
+			{},
+			new Set(["/src/billing", "/src/orders", "/src"])
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("flags an import crossing between nested sibling modules", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { FileEntity } from '../../relational/entities/file.entity';
+    `,
+			"/src/files/persistence/document/mappers/file.mapper.ts",
+			{},
+			new Set([
+				"/src/files",
+				"/src/files/persistence/document",
+				"/src/files/persistence/relational",
+			])
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("still flags when no module directory contains the source file", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { UsersRepository } from '../users/repositories/users.repository';
+    `,
+			"/elsewhere/tool.ts",
+			{},
+			new Set(["/src/users"])
+		);
+		expect(diags).toHaveLength(1);
 	});
 });
 

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -767,6 +767,19 @@ describe("require-module-boundaries", () => {
 		expect(diags).toHaveLength(1);
 	});
 
+	it("does not flag folders that share their only module", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { OrderEntity } from '../orders/entities/order.entity';
+    `,
+			"/src/billing/billing.service.ts",
+			{},
+			new Set(["/src"])
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("still flags when no module directory contains the source file", () => {
 		const diags = runRule(
 			requireModuleBoundaries,


### PR DESCRIPTION
> Stacked on #149 — merge that first, then this. Only the last two commits are this PR's.

## 1. Context

`architecture/require-module-boundaries` discourages deep imports into another feature module's internals (`/dto/`, `/entities/`, `/repositories/`, …). Its detection is textual: any relative import containing `../` plus one of those directory names.

## 2. Problem

The rule never asks whether the import actually leaves the current module, so a module reading its **own** internals through a sibling directory is reported as crossing into another one. Measured with the #149 build against three public repositories:

| Repo | Findings | Wrong |
|---|---:|---:|
| `brocoders/nestjs-boilerplate` | 49 | 13 — hexagonal layout: `mappers/file.mapper.ts` importing `../entities/file.schema`, with `document-persistence.module.ts` beside both |
| `buqiyuan/nest-admin` | 16 | 15 — shared utilities under the root module: `common/pipes` importing `../dto` |
| `NarHakobyan/awesome-nest-boilerplate` | 21 | 5 — same root-module pattern: `decorators` importing `../guards` |

33 of 86 findings (38%) never leave a module. The message — "reaches into another module's internals" — is factually false for every one of them.

## 3. Possible flows

| Import | Before | After |
|---|---|---|
| `./sibling` or a package import | quiet | quiet |
| `../entities/x` inside the same module | **reports** | quiet |
| `../other-module/dto/x` across modules | reports | reports |
| Across nested sibling sub-modules of one feature | reports | reports |
| Source file under no known module directory | reports | reports |
| No module visible anywhere | reports | reports |
| Folder-to-folder in a single-root-module project | reports | quiet — one module means no internal boundary; pinned by a test |

## 4. Solution

The rule resolves the import and compares the **nearest module directory** of source and target. Module directories are those holding a `*.module.ts` file or a `@Module()` class — the filename convention survives the module graph's same-name collision (#119: brocoders alone has three `files.module.ts`), and the graph covers an unconventional filename. Only two sides positively resolving to the same module skip the report.

The optional guards parameter file rules gained in #149 becomes a `FileRuleFacts` bag, so this second project-wide fact rides the same threading instead of a sixth positional parameter.

Not done: resolving path-alias imports (the rule already skips non-relative specifiers), and a pre-existing `resolvePosix` edge where enough `../` can pop a `D:` drive prefix — its effect here is over-reporting, the safe direction, and it predates this change.

## 5. Before vs after

| Scenario | Before | After |
|---|---:|---:|
| `nestjs-boilerplate` findings | 49 | 36 |
| `nest-admin` findings | 16 | 1 |
| `awesome-nest-boilerplate` findings | 21 | 16 |
| Guard findings on all three (from #149) | 0 / 5 / 11 | 0 / 5 / 11 |
| Behaviour with no module directories supplied | — | byte-identical |

Every removed finding was re-verified by an independent implementation: all 33 share their nearest module directory.

## 6. Example

```
$ npx nestjs-doctor . --format json | jq '[.diagnostics[] | select(.rule=="architecture/require-module-boundaries")] | length'
```

Against `brocoders/nestjs-boilerplate`, where `files/infrastructure/persistence/document/` contains `document-persistence.module.ts`, `mappers/`, and `entities/`:

Before:

```
49
  files/infrastructure/persistence/document/mappers/file.mapper.ts:2
    Import '../entities/file.schema' reaches into another module's internals.
```

After:

```
36
```

The 36 that remain genuinely cross modules — `auth-apple/auth-apple.controller.ts` importing `../auth/dto/login-response.dto` is still reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)