### PR TITLE
chore: republish the editor surfaces on the current engine

### DIFF
--- a/.changeset/lsp-rebundle.md
+++ b/.changeset/lsp-rebundle.md
@@ -1,0 +1,6 @@
+---
+"nestjs-doctor-lsp": patch
+---
+
+Rebuild against nestjs-doctor 0.6.1, picking up the guard and module-boundary
+detection fixes so editor diagnostics match the CLI's.

--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nestjs-doctor-vscode",
   "displayName": "NestJS Doctor",
-  "description": "Static analysis for NestJS — inline diagnostics and health score",
-  "version": "0.1.2",
+  "description": "Static analysis for NestJS \u2014 inline diagnostics and health score",
+  "version": "0.1.3",
   "publisher": "rolobits",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## 1. Context

The VS Code extension copies the LSP's `server.cjs` into its own dist at build time, and the LSP bundles the engine. Both therefore freeze the engine at whatever it was when they were last built and published — unlike the CLI and the GitHub Action, which resolve `latest` from npm.

## 2. Problem

The marketplace extension is `0.1.2`, built April 7. npm's `nestjs-doctor-lsp@2.0.0` was published two hours before #149/#150 merged. Editor users still see the 84 guard and 33 module-boundary false positives the CLI and Action no longer report — the editor disagrees with CI on the same code. The release pipeline cannot fix this alone: the extension sits in changesets' `ignore` list, so its version never moves, and `skipDuplicate` makes every publish a no-op at `0.1.2`.

## 3. Possible flows

| Surface | Gets the engine via | Current state |
|---|---|---|
| CLI (`npx nestjs-doctor`) | npm `latest` | 0.6.1, current |
| GitHub Action `@v1` | resolves npm at run time | 0.6.1, current |
| npm LSP | bundled at its build | stale by two fixes |
| VS Code extension | bundles the LSP's build | stale since April |

## 4. Solution

A changeset for `nestjs-doctor-lsp` (patch) and a hand bump of the extension to `0.1.3` — the ignore list means the hand bump is the designed process. Nothing else: no workflow changes, no engine changes.

## 5. Before vs after

| | Before | After next release |
|---|---|---|
| npm `nestjs-doctor-lsp` | 2.0.0, pre-fix engine | 2.0.1, rebuilt on 0.6.1 |
| Marketplace extension | 0.1.2, April build | 0.1.3, rebuilt on 0.6.1 |
| CLI / Action | 0.6.1 | unchanged |

## 6. Example

After merging this and the Version Packages PR, the `Publish VS Code Extension` job publishes instead of logging a duplicate skip, and the marketplace listing's version reads `0.1.3` with a current date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)