### PR TITLE
fix(rules): stop three rules reporting working code

### DIFF
--- a/.changeset/rule-false-positives.md
+++ b/.changeset/rule-false-positives.md
@@ -1,0 +1,32 @@
+---
+"nestjs-doctor": patch
+---
+
+Stop three rules reporting working NestJS code, all found by scanning public
+repositories.
+
+`correctness/no-missing-injectable` flagged CQRS handlers and queue processors.
+The rule modelled a list of decorators that "imply @Injectable", which is not
+how NestJS works: the injector reads `design:paramtypes`, and TypeScript emits
+that for a class carrying any class-level decorator. The rule now asks that
+question instead of consulting a list, so `@CommandHandler`, `@Processor` and
+every third-party or project decorator work without being enumerated. A
+provider with constructor parameters and no class decorator — the shape that
+actually fails at boot — still reports, and so does one whose only decorator is
+on a method.
+
+`architecture/no-manual-instantiation` flagged `new HeaderResolver(['x-lang'])`
+inside `I18nModule.forRootAsync(...)`. A `new` inside a decorator argument is
+configuration; `useValue: new X()` is documented NestJS. The skip that already
+covered guards and interceptors now covers every suffix.
+
+`security/no-hardcoded-secrets` flagged message keys and permission constants:
+`throw new UnprocessableEntityException({ errors: { password: 'incorrectPassword' } })`,
+`PASSWORD_UPDATE: 'password:update'`, and `SYS_USER_INITPASSWORD = 'sys_user_initPassword'`.
+Three narrow skips on the name-based path: a string handed to `throw`, a
+lowercase colon-separated scope, and a value that only restates its own name. A
+credential never matches any of the three; `correct-horse-battery-staple` and
+`super-secret-key` under a `password` property still report, and the
+pattern-based detection is untouched.
+
+Twelve false errors removed across the three repositories.

--- a/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
+++ b/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
@@ -56,8 +56,7 @@ export function isService(cls: ClassDeclaration): boolean {
 	return hasDecorator(cls, "Injectable");
 }
 
-// NestJS treats @Resolver and @WebSocketGateway as implicit @Injectable —
-// they participate in dependency injection without requiring an explicit @Injectable() decorator.
+// Classes NestJS treats as DI participants, controllers included.
 export function isInjectable(cls: ClassDeclaration): boolean {
 	return (
 		hasDecorator(cls, "Injectable") ||
@@ -65,6 +64,14 @@ export function isInjectable(cls: ClassDeclaration): boolean {
 		hasDecorator(cls, "Resolver") ||
 		hasDecorator(cls, "WebSocketGateway")
 	);
+}
+
+/**
+ * True when TypeScript emits `design:paramtypes` for the class, which is what
+ * the injector reads. Any class-level decorator triggers the emit.
+ */
+export function emitsConstructorMetadata(cls: ClassDeclaration): boolean {
+	return cls.getDecorators().length > 0;
 }
 
 export function isModule(cls: ClassDeclaration): boolean {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
@@ -73,12 +73,13 @@ export const noManualInstantiation: Rule = {
 				continue;
 			}
 
-			if (isContextAware) {
-				// Skip if inside a decorator argument (e.g. @UseGuards(new AuthGuard()))
-				if (expr.getFirstAncestorByKind(SyntaxKind.Decorator)) {
-					continue;
-				}
+			// A decorator argument is configuration, not construction:
+			// @UseGuards(new AuthGuard()), useValue: new X(), Module.forRoot({...}).
+			if (expr.getFirstAncestorByKind(SyntaxKind.Decorator)) {
+				continue;
+			}
 
+			if (isContextAware) {
 				// Only flag if inside a method body or constructor body
 				const inMethod = expr.getFirstAncestorByKind(
 					SyntaxKind.MethodDeclaration

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-missing-injectable.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-missing-injectable.ts
@@ -1,4 +1,5 @@
 import type { ClassDeclaration } from "ts-morph";
+import { emitsConstructorMetadata } from "../../../nest-class-inspector.js";
 import type { ProjectRule } from "../../types.js";
 
 export const noMissingInjectable: ProjectRule = {
@@ -55,13 +56,7 @@ export const noMissingInjectable: ProjectRule = {
 					const hasConstructorDependencies =
 						(ctorDecl?.getParameters().length ?? 0) > 0;
 
-					// @Resolver and @WebSocketGateway implicitly apply @Injectable() metadata in NestJS,
-					// so classes with these decorators don't need an explicit @Injectable() decorator.
-					const hasImplicitInjectable =
-						cls.getDecorator("Injectable") ||
-						cls.getDecorator("Resolver") ||
-						cls.getDecorator("WebSocketGateway");
-					if (!hasImplicitInjectable && hasConstructorDependencies) {
+					if (!emitsConstructorMetadata(cls) && hasConstructorDependencies) {
 						context.report({
 							filePath,
 							message: `Class '${providerName}' is listed in '${mod.name}' providers but is missing @Injectable() decorator.`,

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
@@ -158,6 +158,24 @@ function isLikelyCodeIdentifier(value: string): boolean {
 	return false;
 }
 
+// A permission scope, not a credential: `password:update`, `user:read`.
+const SCOPE_VALUE = /^[a-z][a-z0-9]*(:[a-z][a-z0-9]*)+$/;
+
+const NON_ALNUM = /[^a-z0-9]/g;
+
+// True when the value only restates the name, as a config key does.
+function echoesName(name: string, value: string): boolean {
+	return (
+		name.toLowerCase().replace(NON_ALNUM, "") ===
+		value.toLowerCase().replace(NON_ALNUM, "")
+	);
+}
+
+// A string handed to `throw` is a message or a field name.
+function isThrownMessage(node: Node): boolean {
+	return node.getFirstAncestorByKind(SyntaxKind.ThrowStatement) !== undefined;
+}
+
 function isPaginationContext(literal: Node): boolean {
 	const parent = literal.getParent();
 	if (!parent) {
@@ -242,6 +260,13 @@ export const noHardcodedSecrets: Rule = {
 			}
 
 			const value = initializer.getText().slice(1, -1);
+			if (
+				SCOPE_VALUE.test(value) ||
+				echoesName(name, value) ||
+				isThrownMessage(decl)
+			) {
+				continue;
+			}
 			if (isSuspiciousValue(value)) {
 				context.report({
 					filePath: context.filePath,
@@ -269,6 +294,13 @@ export const noHardcodedSecrets: Rule = {
 			}
 
 			const value = initializer.getText().slice(1, -1);
+			if (
+				SCOPE_VALUE.test(value) ||
+				echoesName(name, value) ||
+				isThrownMessage(prop)
+			) {
+				continue;
+			}
 			if (isSuspiciousValue(value)) {
 				context.report({
 					filePath: context.filePath,

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { BillingModule } from './billing/billing.module';
+
+@Module({
+  imports: [BillingModule],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/auth.guard.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/auth.guard.ts
@@ -1,0 +1,8 @@
+import { CanActivate, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate(): boolean {
+    return true;
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/billing.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/billing.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AuthGuard } from './auth.guard';
+import { BillingService } from './billing.service';
+
+@Controller('billing')
+@UseGuards(AuthGuard)
+export class BillingController {
+  constructor(private readonly billing: BillingService) {}
+
+  @Get()
+  list(): string[] {
+    return this.billing.list();
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/billing.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/billing.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { HeaderResolver, I18nModule } from 'nestjs-i18n';
+import { AuthGuard } from './auth.guard';
+import { BillingController } from './billing.controller';
+import { BillingService } from './billing.service';
+import { CreateInvoiceHandler } from './create-invoice.handler';
+import { InvoiceRepository } from './invoice.repository';
+
+@Module({
+  imports: [
+    I18nModule.forRootAsync({
+      resolvers: [new HeaderResolver(['x-lang'])],
+    }),
+  ],
+  controllers: [BillingController],
+  providers: [AuthGuard, BillingService, CreateInvoiceHandler, InvoiceRepository],
+})
+export class BillingModule {}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/billing.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/billing.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { InvoiceRepository } from './invoice.repository';
+
+@Injectable()
+export class BillingService {
+  constructor(private readonly invoices: InvoiceRepository) {}
+
+  verify(password: string): void {
+    if (!password) {
+      throw new UnprocessableEntityException({
+        errors: { password: 'incorrectPassword' },
+      });
+    }
+  }
+
+  list(): string[] {
+    return this.invoices.all();
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/create-invoice.handler.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/create-invoice.handler.ts
@@ -1,0 +1,13 @@
+import { CommandHandler } from '@nestjs/cqrs';
+import { BillingService } from './billing.service';
+
+export class CreateInvoiceCommand {}
+
+@CommandHandler(CreateInvoiceCommand)
+export class CreateInvoiceHandler {
+  constructor(private readonly billing: BillingService) {}
+
+  execute(): string[] {
+    return this.billing.list();
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/invoice.repository.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/invoice.repository.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class InvoiceRepository {
+  all(): string[] {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/permissions.ts
+++ b/packages/nestjs-doctor/tests/fixtures/false-positives/src/billing/permissions.ts
@@ -1,0 +1,6 @@
+export const permissions = {
+  PASSWORD_UPDATE: 'password:update',
+  PASSWORD_RESET: 'pass:reset',
+} as const;
+
+export const SYS_USER_INITPASSWORD = 'sys_user_initPassword';

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -307,7 +307,7 @@ describe("scanner integration", () => {
 		expect(secretDiags).toHaveLength(0);
 	});
 
-	it("produces a clean result for graphql-app (resolvers are implicit injectables)", async () => {
+	it("produces a clean result for graphql-app (decorated classes emit constructor metadata)", async () => {
 		const targetPath = resolve(FIXTURES, "graphql-app/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
@@ -901,7 +901,7 @@ describe("scanner integration", () => {
 		).toHaveLength(1);
 	});
 
-	it("does not flag migration identifiers as secrets in false-positives fixture", async () => {
+	it("reports nothing on the false-positives fixture", async () => {
 		const targetPath = resolve(FIXTURES, "false-positives/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -659,6 +659,41 @@ describe("no-manual-instantiation", () => {
 		expect(diags).toHaveLength(1);
 		expect(diags[0].message).toContain("UserService");
 	});
+
+	it("does not flag construction inside a dynamic module's options", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+	      import { Module } from '@nestjs/common';
+	      import { HeaderResolver, I18nModule } from 'nestjs-i18n';
+
+	      @Module({
+	        imports: [
+	          I18nModule.forRootAsync({
+	            resolvers: [new HeaderResolver(['x-lang'])],
+	          }),
+	        ],
+	      })
+	      export class AppModule {}
+	    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag a useValue provider instance", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+	      import { Module } from '@nestjs/common';
+
+	      @Module({
+	        providers: [{ provide: 'TOKEN', useValue: new MailerService() }],
+	      })
+	      export class AppModule {}
+	    `
+		);
+		expect(diags).toHaveLength(0);
+	});
 });
 
 describe("prefer-constructor-injection", () => {

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -179,6 +179,62 @@ describe("no-missing-injectable", () => {
 		expect(diags[0].message).toContain("MyService");
 	});
 
+	it("does not flag a CQRS handler, whose decorator emits the metadata", () => {
+		const diags = runProjectRule(noMissingInjectable, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [CreatePostHandler] })
+        export class AppModule {}
+      `,
+			"create-post.handler.ts": `
+        import { CommandHandler } from '@nestjs/cqrs';
+        @CommandHandler(CreatePostCommand)
+        export class CreatePostHandler {
+          constructor(private readonly repo: PostRepository) {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag a queue processor", () => {
+		const diags = runProjectRule(noMissingInjectable, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [TaskConsumer] })
+        export class AppModule {}
+      `,
+			"task.processor.ts": `
+        import { Processor } from '@nestjs/bull';
+        @Processor('tasks')
+        export class TaskConsumer {
+          constructor(private readonly tasks: TaskService) {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags a provider whose only decorator is on a method", () => {
+		const diags = runProjectRule(noMissingInjectable, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [CronRunner] })
+        export class AppModule {}
+      `,
+			"cron.runner.ts": `
+        import { Cron } from '@nestjs/schedule';
+        export class CronRunner {
+          constructor(private readonly dep: OtherService) {}
+
+          @Cron('0 * * * *')
+          run() {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(1);
+	});
+
 	it("does not flag provider without constructor dependencies", () => {
 		const diags = runProjectRule(noMissingInjectable, {
 			"app.module.ts": `

--- a/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
@@ -196,4 +196,53 @@ describe("no-hardcoded-secrets", () => {
     `);
 		expect(diags.length).toBeGreaterThan(0);
 	});
+
+	it("does not flag a message key inside a thrown exception", () => {
+		const diags = runRule(`
+      function check() {
+        throw new UnprocessableEntityException({
+          errors: { password: 'incorrectPassword' },
+        });
+      }
+    `);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag a permission scope value", () => {
+		const diags = runRule(`
+      export const permissions = {
+        PASSWORD_UPDATE: 'password:update',
+        PASSWORD_RESET: 'pass:reset',
+      };
+    `);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag a value that only restates its own name", () => {
+		const diags = runRule(
+			"export const SYS_USER_INITPASSWORD = 'sys_user_initPassword';"
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags a word-shaped credential outside a throw", () => {
+		const diags = runRule(`
+      const config = { password: 'correct-horse-battery-staple' };
+    `);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("still flags a credential pair and a hyphenated secret", () => {
+		expect(runRule("const password = 'admin/administrator';")).toHaveLength(1);
+		expect(runRule("const apiKey = 'super-secret-key-value';")).toHaveLength(1);
+	});
+
+	it("still flags a real secret assigned inside a throw", () => {
+		const diags = runRule(`
+      function boom() {
+        throw new Error('AKIA1234567890ABCDEF');
+      }
+    `);
+		expect(diags.length).toBeGreaterThan(0);
+	});
 });


### PR DESCRIPTION
## 1. Context

Three rules decide whether NestJS code is wrong by matching decorator names, suffixes, and string shapes. Each was scanned against three public repositories before opening pull requests there.

## 2. Problem

All three report working, documented code, and all three are error severity.

| Issue | Rule | False errors | What it actually was |
|---|---|---:|---|
| #156 | `correctness/no-missing-injectable` | 4 | CQRS handlers and a queue processor |
| #155 | `security/no-hardcoded-secrets` | 7 | message keys and permission constants |
| #157 | `architecture/no-manual-instantiation` | 1 | `new HeaderResolver([...])` in `I18nModule.forRootAsync` |

## 3. Possible flows

| Case | Before | After |
|---|---|---|
| Provider with ctor params, no class decorator | reports | reports |
| Provider whose only decorator is on a method (`@Cron`) | reports | reports |
| `@CommandHandler` / `@QueryHandler` / `@Processor` provider | **reports** | quiet |
| Any third-party or project class decorator | **reports** | quiet |
| `new UserService()` in a method body | reports | reports |
| `new X()` in a decorator argument (`useValue`, module options) | **reports** | quiet |
| `password: 'incorrectPassword'` inside a `throw` | **reports** | quiet |
| `PASSWORD_UPDATE: 'password:update'` | **reports** | quiet |
| `SYS_USER_INITPASSWORD = 'sys_user_initPassword'` | **reports** | quiet |
| `password: 'correct-horse-battery-staple'` | reports | reports |
| `apiKey: 'super-secret-key-value'`, `password: 'admin/administrator'` | reports | reports |
| `AKIA…`, `ghp_…`, JWT, base64 — the pattern path | reports | reports |

## 4. Solution

**#156 is a model fix, not a list fix.** The rule kept a set of decorators that "imply `@Injectable`". NestJS has no such concept: the injector reads `design:paramtypes`, and TypeScript emits that for a class carrying any class-level decorator. Confirmed by compiling a probe — an arbitrary non-Nest decorator emits it, no decorator does not, a method-only `@Cron` does not emit it on the class. The rule now asks that question, so nothing has to be enumerated again. Lands as `emitsConstructorMetadata` in `nest-class-inspector.ts`, separate from `isInjectable`, which means something else and has two callers.

**#157** moves the existing decorator-argument skip so it covers every suffix, not just guards and interceptors. `useValue: new X()` is documented NestJS.

**#155** adds three narrow skips to the name-based path only: a string handed to `throw`, a lowercase colon-separated scope, and a value that only restates its own name. The pattern-based path is untouched.

Not done, filed separately: `isLikelyCodeIdentifier` suppresses about 32% of random base64 keys (measured over 5,000), and `^sk[-_][a-zA-Z0-9]{20,}$` never matches a real Stripe key because `sk_live_…` carries a second underscore. Both are pre-existing misses on the pattern path.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| awesome-nest `no-missing-injectable` | 3 | 0 |
| awesome-nest `no-manual-instantiation` | 1 | 0 |
| nest-admin `no-missing-injectable` | 1 | 0 |
| nest-admin `no-hardcoded-secrets` | 4 | 1 |
| brocoders `no-hardcoded-secrets` | 5 | 0 |
| Every other rule, all three repos | — | unchanged |

The one remaining on nest-admin is `secret: 'cookie-secret'`, a real hardcoded secret.

## 6. Example

The shared regression fixture, `tests/fixtures/false-positives/src`, asserts `toHaveLength(0)` across every rule:

```
$ node dist/cli/index.mjs tests/fixtures/false-positives/src --format json
```

With the rules as they were:

```
6
  architecture/no-manual-instantiation   billing/billing.module.ts:12
  security/no-hardcoded-secrets          billing/billing.service.ts:11
  security/no-hardcoded-secrets          billing/permissions.ts:2
  security/no-hardcoded-secrets          billing/permissions.ts:3
  security/no-hardcoded-secrets          billing/permissions.ts:6
  correctness/no-missing-injectable      billing/create-invoice.handler.ts:6
```

After:

```
0
```

Closes #155.
Closes #156.
Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)