### PR TITLE
fix(rules): close three false negatives left by #160

### DIFF
--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
@@ -73,10 +73,17 @@ export const noManualInstantiation: Rule = {
 				continue;
 			}
 
-			// A decorator argument is configuration, not construction:
-			// @UseGuards(new AuthGuard()), useValue: new X(), Module.forRoot({...}).
-			if (expr.getFirstAncestorByKind(SyntaxKind.Decorator)) {
-				continue;
+			const decorator = expr.getFirstAncestorByKind(SyntaxKind.Decorator);
+			if (decorator) {
+				// Handing a pipe or guard to a decorator is the documented API.
+				if (isContextAware) {
+					continue;
+				}
+				// Configuration sits on a class or method; a parameter token
+				// like @Inject(new UserService()) is still a bypass.
+				if (decorator.getParent()?.getKind() !== SyntaxKind.Parameter) {
+					continue;
+				}
 			}
 
 			if (isContextAware) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
@@ -159,7 +159,20 @@ function isLikelyCodeIdentifier(value: string): boolean {
 }
 
 // A permission scope, not a credential: `password:update`, `user:read`.
-const SCOPE_VALUE = /^[a-z][a-z0-9]*(:[a-z][a-z0-9]*)+$/;
+// Digits are excluded so `admin:secretpass123` stays a credential.
+const SCOPE_VALUE = /^[a-z]+(:[a-z]+)+$/;
+
+const WORD_SEGMENT = /^[a-z]{3,}$/;
+const SEGMENT_SPLIT = /[-_:/.]|(?<=[a-z])(?=[A-Z])/;
+
+// True when every part is a plain word, the shape of a message key.
+function isWordSequence(value: string): boolean {
+	const parts = value.split(SEGMENT_SPLIT);
+	return (
+		parts.length >= 2 &&
+		parts.every((part) => WORD_SEGMENT.test(part.toLowerCase()))
+	);
+}
 
 const NON_ALNUM = /[^a-z0-9]/g;
 
@@ -263,7 +276,7 @@ export const noHardcodedSecrets: Rule = {
 			if (
 				SCOPE_VALUE.test(value) ||
 				echoesName(name, value) ||
-				isThrownMessage(decl)
+				(isThrownMessage(decl) && isWordSequence(value))
 			) {
 				continue;
 			}
@@ -297,7 +310,7 @@ export const noHardcodedSecrets: Rule = {
 			if (
 				SCOPE_VALUE.test(value) ||
 				echoesName(name, value) ||
-				isThrownMessage(prop)
+				(isThrownMessage(prop) && isWordSequence(value))
 			) {
 				continue;
 			}

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -680,6 +680,21 @@ describe("no-manual-instantiation", () => {
 		expect(diags).toHaveLength(0);
 	});
 
+	it("still flags construction inside a parameter decorator", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      import { Inject, Injectable } from '@nestjs/common';
+
+      @Injectable()
+      export class ReportService {
+        constructor(@Inject(new ConfigService()) private readonly config: unknown) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
 	it("does not flag a useValue provider instance", () => {
 		const diags = runRule(
 			noManualInstantiation,

--- a/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
@@ -245,4 +245,20 @@ describe("no-hardcoded-secrets", () => {
     `);
 		expect(diags.length).toBeGreaterThan(0);
 	});
+
+	it("still flags a credential nested inside a thrown payload", () => {
+		const diags = runRule(`
+      function boom() {
+        throw new InternalServerErrorException({
+          message: 'Upstream call failed',
+          debug: { apiKey: 'AKIAIOSFODNN7EXAMPLE1234567890AB' },
+        });
+      }
+    `);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("still flags a colon-separated credential pair", () => {
+		expect(runRule("const authToken = 'admin:secretpass123';")).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## 1. Context

#160 loosened three rules to stop them reporting working code. A review of that diff ran after it merged, and found that two of the new skips were wider than intended.

## 2. Problem

Three ways to hide a real problem, live on `main` right now.

| Shape | What happens today |
|---|---|
| `throw new X({ debug: { apiKey: 'AKIA…' } })` | skipped — the throw check walks any number of ancestors |
| `const authToken = 'admin:secretpass123'` | skipped — the scope pattern accepts digits, so a Basic Auth pair reads as a permission |
| `@Inject(new ConfigService())` | skipped — the decorator check covered parameter decorators |

Two are in `security/no-hardcoded-secrets`, the highest-weighted category.

## 3. Possible flows

| Case | On main | After |
|---|---|---|
| `password: 'incorrectPassword'` in a throw | quiet | quiet |
| Credential nested in a thrown payload | **quiet** | reports |
| `PASSWORD_UPDATE: 'password:update'` | quiet | quiet |
| `authToken: 'admin:secretpass123'` | **quiet** | reports |
| `@Module({ providers: [{ useValue: new X() }] })` | quiet | quiet |
| `@UsePipes(new ValidationPipe())`, `@Query(new QueryParamsPipe())` | quiet | quiet |
| `@Inject(new ConfigService())` | **quiet** | reports |
| `new UserService()` in a method body | reports | reports |

## 4. Solution

The throw skip now also requires the value to read as a sequence of plain words. A message key is one; `AKIAIOSFODNN7EXAMPLE1234567890AB` is not.

The scope pattern drops digits: `password:update` still passes, `admin:secretpass123` does not.

The decorator skip splits on what is being built, not on where the decorator sits. Handing a pipe or guard to any decorator is the documented API, parameter decorators included. A service passed as a token is not, so `@Inject(new UserService())` reports again.

That last distinction came from an existing test: narrowing on "parameter decorators are always a bypass" broke `@Query(new QueryParamsPipe())`, which is legitimate.

## 5. Before vs after

| | On main | After |
|---|---:|---:|
| awesome-nest, all rules | 54 | 54 |
| nest-admin, all rules | 259 | 259 |
| brocoders, all rules | 93 | 93 |
| `tests/fixtures/false-positives` | 0 | 0 |
| New regression tests | — | 3 |

The narrowing costs nothing: every repository and the shared fixture are unchanged, so #160's twelve cleared false positives all stay cleared.

## 6. Example

```
$ npx nestjs-doctor . --format json | jq '[.diagnostics[] | select(.rule=="security/no-hardcoded-secrets")] | length'
```

On a file containing:

```ts
const authToken = 'admin:secretpass123';
```

On main: `0`

After: `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)