### PR TITLE
feat(rules)!: drop the base64 shape detector

### DIFF
--- a/.changeset/drop-base64-shape-detector.md
+++ b/.changeset/drop-base64-shape-detector.md
@@ -1,0 +1,25 @@
+---
+"nestjs-doctor": minor
+---
+
+Remove the base64 shape detector from `security/no-hardcoded-secrets`.
+
+Every other pattern in that rule recognises a format someone issues: a GitHub
+token, an AWS access key, a Slack token, a JWT. This one recognised a shape —
+any forty characters of the base64 alphabet containing a digit — so everything
+base64-ish matched, and three guards had to be bolted on to make it usable:
+decode-to-JSON, a pagination-property allowlist, and an identifier heuristic.
+
+Those guards were the rule's two worst failures. The identifier heuristic
+cleared about a third of genuinely random keys, measured over 20,000 samples,
+and its entropy check was dead code that could not change the outcome. In the
+other direction, nine of the twelve tests covering the pattern existed only to
+suppress something it wrongly reported: migration class names, camelCase
+identifiers, pagination cursors, encoded JSON.
+
+Across three public repositories it found nothing at all. Every secret those
+codebases do contain is reported either by a real format pattern or by the
+property-name path, both untouched.
+
+What you lose: a base64 secret stored under a name that does not look like a
+secret. Under `secret`, `password` or `apiKey` the name path still catches it.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
@@ -2,7 +2,6 @@ import { type Node, SyntaxKind } from "ts-morph";
 import type { Rule } from "../../types.js";
 
 const SECRET_PATTERNS = [
-	{ pattern: /^(?=.*\d)[A-Za-z0-9+/]{40,}={0,2}$/, name: "Base64 key" },
 	{ pattern: /^sk[-_][a-zA-Z0-9]{20,}$/, name: "Secret key" },
 	// Issued keys carry an environment segment the plain form misses:
 	// sk_live_…, pk_test_…, sk-proj-…, sk-ant-api03-….
@@ -53,22 +52,6 @@ const PLACEHOLDER_VALUES = new Set([
 const DOT_SEPARATED_CONSTANT =
 	/^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+$/;
 
-const PAGINATION_PROPERTY_NAMES = new Set([
-	"cursor",
-	"nextCursor",
-	"prevCursor",
-	"previousCursor",
-	"startCursor",
-	"endCursor",
-	"pageToken",
-	"nextPageToken",
-	"continuationToken",
-	"continuation",
-	"nextPage",
-	"afterCursor",
-	"beforeCursor",
-]);
-
 function isSuspiciousValue(value: string): boolean {
 	if (value.length < 8) {
 		return false;
@@ -93,76 +76,6 @@ function isSuspiciousValue(value: string): boolean {
 
 function hasSuspiciousName(name: string): boolean {
 	return VARIABLE_NAME_PATTERNS.some((p) => p.test(name));
-}
-
-function isStructuredBase64(value: string): boolean {
-	try {
-		const decoded = Buffer.from(value, "base64").toString("utf-8");
-		JSON.parse(decoded);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-function shannonEntropy(value: string): number {
-	const freq = new Map<string, number>();
-	for (const ch of value) {
-		freq.set(ch, (freq.get(ch) ?? 0) + 1);
-	}
-	let entropy = 0;
-	for (const count of freq.values()) {
-		const p = count / value.length;
-		entropy -= p * Math.log2(p);
-	}
-	return entropy;
-}
-
-const VOWELS = new Set([..."aeiouyAEIOUY"]);
-const DB_PREFIX = /^[A-Z]{2,4}_/;
-const CAMEL_BOUNDARY =
-	/(?<=[a-z])(?=[A-Z])|(?<=[A-Za-z])(?=\d)|(?<=\d)(?=[A-Za-z])|_/;
-const HAS_LETTER = /[a-zA-Z]/;
-
-function isLikelyCodeIdentifier(value: string): boolean {
-	const hasUnderscores = value.includes("_");
-
-	// Split on camelCase boundaries (lower→upper), digit↔letter, and underscores
-	const segments = value.split(CAMEL_BOUNDARY).filter((s) => s.length > 0);
-
-	const letterSegments = segments.filter((s) => HAS_LETTER.test(s));
-	const wordLike = letterSegments.filter(
-		(s) => s.length >= 4 && [...s].some((ch) => VOWELS.has(ch))
-	);
-
-	// If ≥2 word-like segments among the first 6 letter-segments → code identifier
-	const first6 = letterSegments.slice(0, 6);
-	const wordLikeInFirst6 = first6.filter(
-		(s) => s.length >= 4 && [...s].some((ch) => VOWELS.has(ch))
-	);
-	if (wordLikeInFirst6.length >= 2) {
-		return true;
-	}
-
-	// snake_case: underscores with ≥2 segments of 3+ chars
-	if (hasUnderscores) {
-		const underscoreSegments = value.split("_").filter((s) => s.length >= 3);
-		if (underscoreSegments.length >= 2) {
-			return true;
-		}
-	}
-
-	// DB prefix pattern (PK_, IDX_, FK_, etc.)
-	if (DB_PREFIX.test(value)) {
-		return true;
-	}
-
-	// High entropy with no word-like segments and no underscores → random data
-	if (shannonEntropy(value) > 4.9 && !hasUnderscores && wordLike.length === 0) {
-		return false;
-	}
-
-	return false;
 }
 
 // A permission scope, not a credential: `password:update`, `user:read`.
@@ -196,22 +109,6 @@ function isThrownMessage(node: Node): boolean {
 	return node.getFirstAncestorByKind(SyntaxKind.ThrowStatement) !== undefined;
 }
 
-function isPaginationContext(literal: Node): boolean {
-	const parent = literal.getParent();
-	if (!parent) {
-		return false;
-	}
-	const pa = parent.asKind(SyntaxKind.PropertyAssignment);
-	if (pa) {
-		return PAGINATION_PROPERTY_NAMES.has(pa.getName());
-	}
-	const vd = parent.asKind(SyntaxKind.VariableDeclaration);
-	if (vd) {
-		return PAGINATION_PROPERTY_NAMES.has(vd.getName());
-	}
-	return false;
-}
-
 export const noHardcodedSecrets: Rule = {
 	meta: {
 		id: "security/no-hardcoded-secrets",
@@ -241,16 +138,6 @@ export const noHardcodedSecrets: Rule = {
 
 			for (const { pattern, name } of SECRET_PATTERNS) {
 				if (pattern.test(value)) {
-					// Skip Base64 strings that decode to structured data, pagination cursors, or code identifiers
-					if (
-						name === "Base64 key" &&
-						(isStructuredBase64(value) ||
-							isPaginationContext(literal) ||
-							isLikelyCodeIdentifier(value))
-					) {
-						break;
-					}
-
 					context.report({
 						filePath: context.filePath,
 						message: `Possible hardcoded ${name} detected.`,

--- a/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
@@ -77,22 +77,6 @@ describe("no-hardcoded-secrets", () => {
 		expect(diags.length).toBeGreaterThan(0);
 	});
 
-	it("flags real base64 strings containing digits", () => {
-		const diags = runRule(`
-      const data = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnop1234';
-    `);
-		expect(diags.length).toBeGreaterThan(0);
-	});
-
-	it("does not flag long camelCase identifier strings as base64", () => {
-		const diags = runRule(`
-      const config = {
-        id: 'rentalRestrictionAgreementCoapplicantDoc',
-      };
-    `);
-		expect(diags).toHaveLength(0);
-	});
-
 	it("does not flag human-readable text with suspicious property names", () => {
 		const diags = runRule(`
       export const ActivityLogEvents = {
@@ -113,46 +97,6 @@ describe("no-hardcoded-secrets", () => {
 		expect(diags).toHaveLength(0);
 	});
 
-	it("does not flag Base64-encoded JSON pagination cursors", () => {
-		const diags = runRule(`
-      const page = {
-        cursor: 'eyJpZCI6IjQ2MDJCNjI5LTg3N0QtNEVCNC1CQzhELTREM0NGNzkzQkM2NSJ9',
-        size: 10,
-      };
-    `);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag Base64 strings in pagination property names", () => {
-		const diags = runRule(`
-      const nextPageToken = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnop1234';
-    `);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag Base64-encoded JSON in non-pagination property", () => {
-		const diags = runRule(`
-      const config = {
-        payload: 'eyJpZCI6IjQ2MDJCNjI5LTg3N0QtNEVCNC1CQzhELTREM0NGNzkzQkM2NSJ9',
-      };
-    `);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag migration class names with timestamps", () => {
-		const diags = runRule(`
-      const name = 'CreateUsersTable1700000000000abcdef1234567890ab';
-    `);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag migration identifiers with word-like segments", () => {
-		const diags = runRule(`
-      const name = 'AddEmailMigration1700000000000abcdef1234567890ab';
-    `);
-		expect(diags).toHaveLength(0);
-	});
-
 	it("still flags real secrets regardless of file path", () => {
 		const diags = runRule(`
       const token = 'sk-abcdefghijklmnopqrstuvwxyz1234567890';
@@ -160,41 +104,11 @@ describe("no-hardcoded-secrets", () => {
 		expect(diags.length).toBeGreaterThan(0);
 	});
 
-	it("still flags real Base64 secrets not in pagination context", () => {
-		const diags = runRule(`
-      const config = {
-        apiCredential: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnop1234',
-      };
-    `);
-		expect(diags.length).toBeGreaterThan(0);
-	});
-
-	it("does not flag PascalCase identifiers with timestamps", () => {
-		const diags = runRule(`
-      const name = 'CreateUsersTable1700000000000abcdef1234567890ab';
-    `);
-		expect(diags).toHaveLength(0);
-	});
-
 	it("does not flag snake_case DB constraint names", () => {
 		const diags = runRule(`
       const idx = 'IDX_user_email_constraint_abc123def456ghi789jkl';
     `);
 		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag camelCase identifiers with digits", () => {
-		const diags = runRule(`
-      const handler = 'handleUserAuthenticationSessionTimeout12345678ab';
-    `);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("still flags actual Base64 encoded data", () => {
-		const diags = runRule(`
-      const data = 'aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3Qga2V5MTIz';
-    `);
-		expect(diags.length).toBeGreaterThan(0);
 	});
 
 	it("does not flag a message key inside a thrown exception", () => {


### PR DESCRIPTION
> Stacked on #164 — merge that first.

## 1. Context

`security/no-hardcoded-secrets` recognises credentials two ways: a list of patterns, and a check on the property name. Every pattern in that list matches a format someone issues — a GitHub token, an AWS access key, a Slack token, a JWT. Except one.

## 2. Problem

```ts
{ pattern: /^(?=.*\d)[A-Za-z0-9+/]{40,}={0,2}$/, name: "Base64 key" }
```

That is not a format, it is a shape: forty characters of the base64 alphabet with a digit somewhere. Everything base64-ish matches, so three guards were bolted on to make it usable — decode-to-JSON, a pagination-property allowlist, and an identifier heuristic.

The guards became the rule's two worst failures.

| | Evidence |
|---|---|
| Misses real keys | The identifier heuristic clears **32%** of genuinely random keys, measured over 20,000 samples. Its entropy check is dead code: the branch returns `false` and so does the line after it. |
| Reports fake ones | **9 of the 12** tests covering the pattern exist only to suppress something it wrongly reported — migration class names, camelCase identifiers, pagination cursors, encoded JSON. |
| Finds nothing | **0 findings** across `brocoders/nestjs-boilerplate`, `NarHakobyan/awesome-nest-boilerplate` and `buqiyuan/nest-admin`. |

Two designs were measured against the existing test corpus before choosing removal. Entropy alone cannot separate the populations: `handleUserAuthenticationSessionTimeout12345678ab` scores 4.46, above the 4.25 minimum of random keys. A three-feature predicate did reach 99.9%, but only with three constants tuned against the seven values in this repository's own tests — a heuristic fitted to its test set.

## 3. Possible flows

| Value | Before | After |
|---|---|---|
| `ghp_…`, `AKIA…`, `xox…`, JWT, `sk_live_…` | reported | reported |
| `secret: '<base64 blob>'` | reported | reported, by the name path |
| `const data = '<base64 blob>'` | reported ~68% of the time | **not reported** |
| Migration class name, camelCase identifier | ignored, via a guard | ignored, nothing to guard |
| Pagination cursor, encoded JSON | ignored, via a guard | ignored, nothing to guard |

The one real loss is row three: a base64 secret under a name that does not look like a secret. Under `secret`, `password` or `apiKey`, the name path still catches it.

## 4. Solution

Delete the pattern, its branch in the scan loop, and the machinery that existed only to serve it: `isStructuredBase64`, `isPaginationContext`, `isLikelyCodeIdentifier`, `shannonEntropy`, and five constants. 107 lines.

Not done: replacing it with a better classifier. Distinguishing a random key from a long identifier is a real classification problem and deserves a validation corpus, not three constants picked to pass twelve tests. Nothing stops that landing later against the same measurements.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| Patterns that match an issued format | 9 of 10 | 10 of 10 |
| Rule source lines | 335 | 228 |
| Tests for the rule | 32 | 21 |
| Findings, three public repositories | 1 | 1 |
| `tests/fixtures/false-positives` | 0 | 0 |

## 6. Example

```
$ node dist/cli/index.mjs <repo> --format json \
    | jq '[.diagnostics[] | select(.rule=="security/no-hardcoded-secrets")] | length'
```

| Repository | Before | After |
|---|---:|---:|
| `buqiyuan/nest-admin` | 1 | 1 |
| `brocoders/nestjs-boilerplate` | 0 | 0 |
| `NarHakobyan/awesome-nest-boilerplate` | 0 | 0 |

The one finding on nest-admin is `secret: 'cookie-secret'`, from the name path, and it is real.

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)