### PR TITLE
fix(rules): stop two rules reporting working code

### DIFF
--- a/.changeset/corpus-false-positives.md
+++ b/.changeset/corpus-false-positives.md
@@ -1,0 +1,38 @@
+---
+"nestjs-doctor": patch
+---
+
+Two rules were reporting working code, found by scanning ten public NestJS
+projects — ghostfolio, vendure, novu, twenty, immich, amplication and four
+starters.
+
+`correctness/no-duplicate-decorators` flagged stacked interceptors:
+
+```ts
+@UseInterceptors(RedactValuesInResponseInterceptor)
+@UseInterceptors(TransformDataSourceInRequestInterceptor)
+@UseInterceptors(TransformDataSourceInResponseInterceptor)
+```
+
+Three different interceptors. `@UseInterceptors` accumulates, so stacking is the
+same as passing them in one call. The rule compared decorator names and kept an
+allowlist of things it knew repeat, which could never be complete. It now
+compares the whole decorator, so a repeat means the identical text — which is
+what a copy-paste mistake looks like. The allowlist is replaced by the opposite
+and much smaller list: the decorators a target can only carry once, like
+`@Controller` and `@Module`, where a second is wrong whatever its arguments.
+
+`correctness/validated-non-primitive-needs-type` asked for `@Type()` on any
+property whose type was not a primitive, including string unions:
+
+```ts
+export type Granularity = 'day' | 'month';
+granularity: Granularity;   // reported
+```
+
+`@Type()` constructs a class, so a union or alias has nothing to build. The rule
+now requires the type to resolve to a class declaration, unwrapping arrays and
+unions so `AddressDto | undefined` and `Tag[]` still report.
+
+Across the ten projects this removes 550 findings and leaves the real ones: 44
+properties genuinely typed as a nested class with no `@Type()`.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-decorators.ts
@@ -1,16 +1,18 @@
 import type { Rule } from "../../types.js";
 
-// Decorators that are intentionally used multiple times with different arguments
-const STACKABLE_DECORATORS = new Set([
-	"ApiResponse",
-	"ApiQuery",
-	"ApiParam",
-	"ApiHeader",
-	"ApiSecurity",
-	"SetMetadata",
-	"Roles",
-	"Header",
-	"Throttle",
+const WHITESPACE = /\s+/g;
+
+// A target can carry only one of these, so a second is an error whatever its
+// arguments. Everything else repeats legitimately unless written verbatim twice.
+const SINGLE_USE_DECORATORS = new Set([
+	"Catch",
+	"Controller",
+	"Entity",
+	"Global",
+	"Injectable",
+	"Module",
+	"Resolver",
+	"WebSocketGateway",
 ]);
 
 export const noDuplicateDecorators: Rule = {
@@ -48,7 +50,11 @@ export const noDuplicateDecorators: Rule = {
 };
 
 function checkDecorators(
-	decorators: { getName(): string; getStartLineNumber(): number }[],
+	decorators: {
+		getName(): string;
+		getStartLineNumber(): number;
+		getText(): string;
+	}[],
 	context: {
 		filePath: string;
 		report(diagnostic: {
@@ -64,13 +70,14 @@ function checkDecorators(
 	const seen = new Set<string>();
 
 	for (const decorator of decorators) {
+		// The whole decorator, so @UseInterceptors(A) and @UseInterceptors(B)
+		// are two interceptors rather than a repeat.
 		const name = decorator.getName();
+		const key = SINGLE_USE_DECORATORS.has(name)
+			? name
+			: decorator.getText().replace(WHITESPACE, " ");
 
-		if (STACKABLE_DECORATORS.has(name)) {
-			continue;
-		}
-
-		if (seen.has(name)) {
+		if (seen.has(key)) {
 			context.report({
 				filePath: context.filePath,
 				message: `Duplicate @${name}() decorator on the same target.`,
@@ -79,7 +86,7 @@ function checkDecorators(
 				column: 1,
 			});
 		} else {
-			seen.add(name);
+			seen.add(key);
 		}
 	}
 }

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/validated-non-primitive-needs-type.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/validated-non-primitive-needs-type.ts
@@ -1,3 +1,5 @@
+import type { PropertyDeclaration, Type } from "ts-morph";
+import { SyntaxKind } from "ts-morph";
 import type { Rule } from "../../types.js";
 
 const CLASS_VALIDATOR_DECORATORS = new Set([
@@ -106,6 +108,29 @@ function isPrimitiveType(typeText: string): boolean {
 	return false;
 }
 
+/** True when the type, unwrapping arrays and unions, names a class. */
+function isClassType(type: Type | undefined): boolean {
+	if (!type) {
+		return false;
+	}
+	if (type.isArray()) {
+		return isClassType(type.getArrayElementType());
+	}
+	if (type.isUnion()) {
+		return type.getUnionTypes().some(isClassType);
+	}
+	return Boolean(
+		type
+			.getSymbol()
+			?.getDeclarations()
+			.some((declaration) => declaration.isKind(SyntaxKind.ClassDeclaration))
+	);
+}
+
+function resolvesToClass(prop: PropertyDeclaration): boolean {
+	return isClassType(prop.getType());
+}
+
 export const validatedNonPrimitiveNeedsType: Rule = {
 	meta: {
 		id: "correctness/validated-non-primitive-needs-type",
@@ -153,6 +178,11 @@ export const validatedNonPrimitiveNeedsType: Rule = {
 
 				const typeText = typeNode.getText();
 				if (isPrimitiveType(typeText)) {
+					continue;
+				}
+
+				// @Type() constructs a class. A union or alias has nothing to build.
+				if (!resolvesToClass(prop)) {
 					continue;
 				}
 

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1303,6 +1303,52 @@ describe("factory-inject-matches-params", () => {
 });
 
 describe("validated-non-primitive-needs-type", () => {
+	it("does not flag a union type alias", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsIn, IsOptional } from 'class-validator';
+      type Granularity = 'day' | 'month';
+      export class Dto {
+        @IsIn(['day', 'month'])
+        @IsOptional()
+        granularity: Granularity;
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("flags a property typed as a class", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsDefined } from 'class-validator';
+      export class Branding { color: string; }
+      export class Dto {
+        @IsDefined()
+        branding: Branding;
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("flags an array of a class", () => {
+		const diags = runRule(
+			validatedNonPrimitiveNeedsType,
+			`
+      import { IsArray } from 'class-validator';
+      export class Tag { id: string; }
+      export class Dto {
+        @IsArray()
+        tags: Tag[];
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
 	it("flags non-primitive property with validator but no @Type()", () => {
 		const diags = runRule(
 			validatedNonPrimitiveNeedsType,
@@ -1472,6 +1518,52 @@ describe("validated-non-primitive-needs-type", () => {
 });
 
 describe("no-duplicate-decorators", () => {
+	it("does not flag stacked interceptors with different arguments", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      import { Controller, Get, UseInterceptors } from '@nestjs/common';
+      @Controller('a')
+      export class AController {
+        @Get()
+        @UseInterceptors(RedactInterceptor)
+        @UseInterceptors(TransformRequestInterceptor)
+        @UseInterceptors(TransformResponseInterceptor)
+        list() { return []; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag the same decorator with different arguments", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      export class A {
+        @ApiResponse({ status: 200 })
+        @ApiResponse({ status: 404 })
+        find() {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("flags a decorator repeated verbatim", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      export class A {
+        @UseInterceptors(LoggingInterceptor)
+        @UseInterceptors(LoggingInterceptor)
+        find() {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
 	it("flags duplicate decorator on a method", () => {
 		const diags = runRule(
 			noDuplicateDecorators,


### PR DESCRIPTION
## 1. Context

Ten public NestJS projects were scanned with 0.7.0 to look for bugs: ghostfolio, vendure, novu, twenty, immich, amplication, and four starters. Between them, 6,038 files in one repository alone. No rule crashed. Two rules reported working code often enough to stand out.

## 2. Problem

594 findings from two rules, on code that is correct.

| Rule | Findings | What it actually was |
|---|---:|---|
| `correctness/validated-non-primitive-needs-type` | 474 | string union aliases |
| `correctness/no-duplicate-decorators` | 120 | three different interceptors, stacked |

```ts
// ghostfolio — three interceptors, reported as duplicates
@UseInterceptors(RedactValuesInResponseInterceptor)
@UseInterceptors(TransformDataSourceInRequestInterceptor)
@UseInterceptors(TransformDataSourceInResponseInterceptor)

// ghostfolio — Granularity is `'day' | 'month'`, asked for @Type()
@IsIn(['day', 'month'] as Granularity[])
granularity: Granularity;
```

Both rules kept a list where they needed a model. `no-duplicate-decorators` had an allowlist of decorators it knew could repeat — nine entries, missing `@UseInterceptors`, `@UseGuards`, `@UseFilters` and anything a third party ships. `validated-non-primitive-needs-type` treated every non-primitive type name as a class.

## 3. Possible flows

| Case | Before | After |
|---|---|---|
| `@UseInterceptors(A)` `@UseInterceptors(B)` | **reported** | quiet |
| `@ApiResponse({status:200})` `@ApiResponse({status:404})` | quiet, via the allowlist | quiet, no allowlist needed |
| The identical decorator written twice | reported | reported |
| `@Controller('a')` `@Controller('b')` | reported | reported — a class carries one |
| A third-party decorator repeated with different arguments | **reported** | quiet |
| `granularity: 'day' \| 'month'` alias | **reported** | quiet |
| `branding: BrandingDto` | reported | reported |
| `tags: Tag[]` | reported | reported |
| `address: AddressDto \| undefined` | reported | reported |
| Primitive property | quiet | quiet |

## 4. Solution

`no-duplicate-decorators` compares the whole decorator instead of its name, so a duplicate is the identical text — which is what the rule's own help describes, "likely copy-pasted by mistake". That deletes the allowlist. In its place goes the opposite list, which is closed and short: the decorators a target can only carry once, where a second is wrong whatever its arguments.

`validated-non-primitive-needs-type` requires the type to resolve to a class declaration, unwrapping arrays and unions first. `@Type()` constructs a class; an alias has nothing to construct.

Deliberately not fixed here: `detectProject` never searches upward for `package.json`, so scanning `apps/api/src` reports `orm: null` and silently skips every schema rule. All ten projects hit it. That is #168 and a separate change.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| `no-duplicate-decorators`, ten projects | 120 | 0 |
| `validated-non-primitive-needs-type`, ten projects | 474 | 44 |
| Every other rule | — | unchanged |
| Total findings, ten projects | 7,449 | 6,899 |

The 44 that remain are properties genuinely typed as a nested class with no `@Type()`, such as `branding: OrganizationBrandingResponseDto` in novu — where class-transformer will not construct the nested object and its validation silently passes.

## 6. Example

```
$ node dist/cli/index.mjs ghostfolio/apps/api/src --format json \
    | jq '[.diagnostics[] | select(.rule=="correctness/no-duplicate-decorators")] | length'
```

Before: `41`

After: `0`

Closes #166.
Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)