### PR TITLE
fix(engine): find package.json when scanning a subdirectory

### DIFF
--- a/.changeset/detect-project-upward.md
+++ b/.changeset/detect-project-upward.md
@@ -1,0 +1,22 @@
+---
+"nestjs-doctor": patch
+---
+
+Find the project's `package.json` when scanning a subdirectory.
+
+`detectProject` read `package.json` from the scanned directory and nowhere else.
+Point the scanner at `apps/api/src`, which is where the code lives in a
+monorepo, and there is nothing beside it — so the ORM came back null, the Nest
+version came back null, and every schema rule was skipped without a word. All
+ten public projects used to test this hit it.
+
+It now reads the nearest `package.json` at or above the scanned directory,
+stopping at the repository root so a scan never adopts an unrelated parent's
+manifest.
+
+Seven of the ten projects now report their ORM, and five of those gain no
+findings at all — it is metadata that was missing. Two gain schema findings that
+were always there and never ran: three on `twentyhq/twenty`, and 95 on
+`vendurehq/vendure`, of which 64 are `require-primary-key` on entities that
+declare their key through a custom decorator resolved at runtime. Static
+analysis cannot see that one; it is tracked separately.

--- a/packages/nestjs-doctor/src/engine/project-detector.ts
+++ b/packages/nestjs-doctor/src/engine/project-detector.ts
@@ -1,5 +1,6 @@
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { glob } from "tinyglobby";
 import type { ProjectInfo } from "../common/result.js";
 
@@ -375,16 +376,37 @@ export async function looksLikeMonorepo(targetPath: string): Promise<boolean> {
 	return false;
 }
 
-export async function detectProject(targetPath: string): Promise<ProjectInfo> {
-	const pkgPath = join(targetPath, "package.json");
-	let pkg: PackageJson = {};
+/**
+ * Reads the nearest `package.json` at or above `targetPath`, stopping at the
+ * repository root so a scan never adopts an unrelated parent's manifest.
+ */
+async function readNearestPackageJson(
+	targetPath: string
+): Promise<PackageJson> {
+	let current = resolve(targetPath);
 
-	try {
-		const raw = await readFile(pkgPath, "utf-8");
-		pkg = JSON.parse(raw) as PackageJson;
-	} catch {
-		// No package.json found — use defaults
+	for (;;) {
+		try {
+			const raw = await readFile(join(current, "package.json"), "utf-8");
+			return JSON.parse(raw) as PackageJson;
+		} catch {
+			// Keep walking.
+		}
+
+		if (existsSync(join(current, ".git"))) {
+			return {};
+		}
+
+		const parent = dirname(current);
+		if (parent === current) {
+			return {};
+		}
+		current = parent;
 	}
+}
+
+export async function detectProject(targetPath: string): Promise<ProjectInfo> {
+	const pkg = await readNearestPackageJson(targetPath);
 
 	const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
 


### PR DESCRIPTION
## 1. Context

`detectProject` reads `package.json` to learn the project name, the Nest version, the ORM and the HTTP framework. The ORM is what decides whether a schema graph is built, and therefore whether the three schema rules run at all.

## 2. Problem

It only ever looked in the scanned directory:

```ts
const pkgPath = join(targetPath, "package.json");
```

In a monorepo the code lives in `apps/api/src` and the manifest does not. Scanning ten public NestJS projects, **all ten reported `orm: null` and `nestVersion: null`**, and every schema rule was skipped without a word in the output.

```
$ nestjs-doctor ghostfolio/apps/api/src   -> orm=null,   nest=null
$ nestjs-doctor ghostfolio                -> orm=prisma, nest=11.1.27
```

Per CLAUDE.md: a scan that silently reports nothing looks identical to a clean one.

## 3. Possible flows

| Scanned path | Before | After |
|---|---|---|
| Repository root with `package.json` | detected | detected, unchanged |
| `apps/api/src` in a monorepo | **nothing** | nearest ancestor manifest |
| `src` in a single-package project | **nothing** | the project's manifest |
| A directory with no manifest anywhere below the repository root | nothing | nothing — the walk stops at `.git` |
| A directory outside any repository | nothing | walks to the filesystem root, then stops |

The `.git` stop matters: without it, scanning a directory with no manifest would keep climbing and adopt whatever unrelated project sits above it.

## 4. Solution

Read the nearest `package.json` at or above the scanned directory, stopping at the repository root.

Not done: making the report say so when no ORM is found. That is worth doing and is independent of this change.

## 5. Before vs after

Measured on ten public projects:

| | Before | After |
|---|---:|---:|
| Projects reporting their ORM | 0 of 10 | 7 of 10 |
| Projects reporting a Nest version | 0 of 10 | 10 of 10 |
| Projects whose findings changed | — | 2 of 10 |
| Unit and integration tests | 860 pass | 860 pass |

The three still reporting no ORM genuinely declare none: `novu` and `infisical` have no ORM dependency, and `immich` uses Kysely, which is not one of the four supported.

## 6. Example

Two projects gain findings, because schema rules that were silently skipped now run:

| Project | Findings | New | Real? |
|---|---:|---|---|
| `twentyhq/twenty` | 2162 → 2165 | 3 × `require-cascade-rule` | yes |
| `vendurehq/vendure` | 955 → 1050 | 64 × `require-primary-key`, 30 × `require-cascade-rule`, 1 × `require-timestamps` | the 64 are **not** |

Worth being explicit about vendure. Its entities inherit from an abstract base that declares the key through a project-specific decorator:

```ts
@PrimaryGeneratedId()
id: ID;
```

`PrimaryGeneratedId` never calls `PrimaryGeneratedColumn()` in source — it records the property and applies the real decorator at runtime, once the configured ID strategy is known. No static analysis can see that, so those 64 findings are a limitation of `schema/require-primary-key` rather than something this change introduces. They were always going to appear the moment the ORM was detected. Filed separately.

The other five projects that gained ORM detection gained zero findings: it is metadata that was simply missing.

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)