### PR TITLE
fix(rules): a constructor parameter decorator emits the metadata too

### DIFF
--- a/.changeset/param-decorator-emits-metadata.md
+++ b/.changeset/param-decorator-emits-metadata.md
@@ -1,0 +1,24 @@
+---
+"nestjs-doctor": patch
+---
+
+Recognise a provider whose only decorator sits on a constructor parameter.
+
+`correctness/no-missing-injectable` asks whether TypeScript emits
+`design:paramtypes` for the class, which is what Nest's injector reads. It
+checked for a class-level decorator, but a decorator on any constructor
+parameter triggers the same emit:
+
+```ts
+export class NotificationRepository {
+  constructor(@InjectKysely() private db: Kysely<DB>) {}
+}
+```
+
+Compiling that with `emitDecoratorMetadata` produces the metadata, so the class
+resolves its dependencies without `@Injectable()`. It was reported anyway — 12
+times on `immich-app/immich`, which injects its Kysely connection this way
+throughout.
+
+A provider with constructor parameters and no decorator anywhere, the shape that
+actually fails at boot, still reports.

--- a/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
+++ b/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
@@ -68,10 +68,18 @@ export function isInjectable(cls: ClassDeclaration): boolean {
 
 /**
  * True when TypeScript emits `design:paramtypes` for the class, which is what
- * the injector reads. Any class-level decorator triggers the emit.
+ * the injector reads. A class decorator triggers it, and so does a decorator on
+ * any constructor parameter.
  */
 export function emitsConstructorMetadata(cls: ClassDeclaration): boolean {
-	return cls.getDecorators().length > 0;
+	if (cls.getDecorators().length > 0) {
+		return true;
+	}
+	return cls
+		.getConstructors()
+		.some((ctor) =>
+			ctor.getParameters().some((param) => param.getDecorators().length > 0)
+		);
 }
 
 export function isModule(cls: ClassDeclaration): boolean {

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -215,6 +215,23 @@ describe("no-missing-injectable", () => {
 		expect(diags).toHaveLength(0);
 	});
 
+	it("does not flag a provider decorated only on a constructor parameter", () => {
+		const diags = runProjectRule(noMissingInjectable, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [NotificationRepository] })
+        export class AppModule {}
+      `,
+			"notification.repository.ts": `
+        import { InjectKysely } from 'nestjs-kysely';
+        export class NotificationRepository {
+          constructor(@InjectKysely() private db: unknown) {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
 	it("still flags a provider whose only decorator is on a method", () => {
 		const diags = runProjectRule(noMissingInjectable, {
 			"app.module.ts": `


### PR DESCRIPTION
## 1. Context

#160 changed `correctness/no-missing-injectable` from consulting a list of decorators that "imply `@Injectable`" to asking the question Nest's injector actually asks: does TypeScript emit `design:paramtypes` for this class?

## 2. Problem

It asked that question incompletely — only a class-level decorator counted. Compiling with `emitDecoratorMetadata` shows a decorator on a constructor parameter produces the same metadata:

```ts
@Injectable()
export class WithClassDec { constructor(private d: Dep) {} }        // emits

export class WithParamDecOnly { constructor(@Inject() private d: Dep) {} }  // emits

export class NoDec { constructor(private d: Dep) {} }               // does not
```

```
$ tsc --experimentalDecorators --emitDecoratorMetadata …
25: exports.WithClassDec = WithClassDec = __decorate([
27:     __metadata("design:paramtypes", [Dep])
36: exports.WithParamDecOnly = WithParamDecOnly = __decorate([
38:     __metadata("design:paramtypes", [Dep])
```

`NoDec` is absent from that list; the other two are not. So a class whose only decorator sits on a constructor parameter resolves through DI without `@Injectable()`, and was being reported anyway.

Found on `immich-app/immich`, which injects its Kysely connection this way throughout:

```ts
export class NotificationRepository {
  constructor(@InjectKysely() private db: Kysely<DB>) {}
}
```

12 findings, all wrong. This is a hole I left in #160, not a pre-existing bug.

## 3. Possible flows

| Class | Emits metadata | Before | After |
|---|---|---|---|
| `@Injectable()` | yes | quiet | quiet |
| `@CommandHandler()`, `@Processor()`, any class decorator | yes | quiet | quiet |
| Only `@Inject()` / `@InjectKysely()` on a constructor parameter | yes | **reported** | quiet |
| Only a method decorator such as `@Cron()` | no | reported | reported |
| Constructor parameters, no decorator anywhere | no | reported | reported |
| No constructor parameters | — | quiet | quiet |

## 4. Solution

`emitsConstructorMetadata` now also returns true when any constructor parameter carries a decorator.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| `immich-app/immich` | 12 | 0 |
| Every other project of the 76 scanned | 0 | 0 |
| Every other rule | — | unchanged |
| Tests | 869 | 870 |

## 6. Example

```
$ node dist/cli/index.mjs immich/server/src --format json \
    | jq '[.diagnostics[] | select(.rule=="correctness/no-missing-injectable")] | length'
```

Before: `12`

After: `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)