### PR TITLE
fix(engine): stop the endpoint trace re-expanding shared subtrees

### DIFF
--- a/.changeset/endpoint-trace-unbounded.md
+++ b/.changeset/endpoint-trace-unbounded.md
@@ -1,0 +1,24 @@
+---
+"nestjs-doctor": patch
+---
+
+Stop the endpoint dependency trace re-expanding shared subtrees.
+
+`buildMethodDependencyTree` traces one node per call site, which is the point —
+call order and conditionality stay visible. But it re-expanded a callee's whole
+subtree at every path that reached it, so a diamond in the call graph grew
+multiplicatively.
+
+On `bookorbit/bookorbit` a single endpoint's trace held 126,708 nodes covering
+44 distinct classes, `DatabaseService` among them 33,860 times. Whole-project
+`--format json` came to 249 MB and died with an unhandled
+`RangeError: Invalid string length` from `JSON.stringify` — exit 1, no output,
+indistinguishable from a failed scan. 2 of 76 public projects crashed this way.
+
+A class's subtree is now expanded at its first call site in an endpoint; later
+call sites keep their own node and carry `expandedElsewhere: true`. A per-endpoint
+ceiling of 5,000 serialised nodes backs it up, and an endpoint that hits it is
+marked `truncated` and reported on stderr rather than cut silently.
+
+Across the same 76 projects the trace drops from 725,159 nodes to 190,614 and
+the JSON from 555 MB to 158 MB, with every diagnostic unchanged.

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { MAX_DEPENDENCY_NODES } from "../common/endpoint.js";
 import type { DiagnoseResult, MonorepoResult } from "../common/result.js";
 import type { EngineResult, MonorepoEngineResult } from "../engine/scanner.js";
 import { shouldBlock } from "./blocking.js";
@@ -75,6 +76,14 @@ function emit(
 	// makes a report look cleaner than the code actually is.
 	for (const warning of scopeWarnings) {
 		logger.warn(warning);
+	}
+
+	const truncated =
+		result.endpoints?.endpoints.filter((e) => e.truncated).length ?? 0;
+	if (truncated > 0) {
+		logger.warn(
+			`Dependency trace stopped at ${MAX_DEPENDENCY_NODES} nodes for ${truncated} endpoint(s); those traces are incomplete.`
+		);
 	}
 
 	if (options.score) {

--- a/packages/nestjs-doctor/src/common/endpoint.ts
+++ b/packages/nestjs-doctor/src/common/endpoint.ts
@@ -52,6 +52,8 @@ export interface MethodDependencyNode {
 	dependencies: MethodDependencyNode[];
 	/** Last line of the method declaration (for full-function highlighting) */
 	endLine: number;
+	/** Set when this class's subtree was already expanded at an earlier call site */
+	expandedElsewhere?: true;
 	filePath: string;
 	/** Merged guard-throw for call nodes (fetch + null-check + throw pattern) */
 	guardThrow: GuardThrow | null;
@@ -124,6 +126,8 @@ export interface EndpointNode {
 	routePath: string;
 	/** Swagger/OpenAPI metadata, null when no swagger decorators present */
 	swagger: SwaggerMetadata | null;
+	/** Set when the trace hit MAX_DEPENDENCY_NODES, so `dependencies` is incomplete */
+	truncated?: true;
 }
 
 /**
@@ -146,3 +150,6 @@ export interface MethodCallNode {
 export interface EndpointGraph {
 	endpoints: EndpointNode[];
 }
+
+/** Most dependency nodes traced for a single endpoint before the trace is cut short. */
+export const MAX_DEPENDENCY_NODES = 5000;

--- a/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
@@ -20,6 +20,7 @@ import type {
 	StepStatement,
 	SwaggerMetadata,
 } from "../../common/endpoint.js";
+import { MAX_DEPENDENCY_NODES } from "../../common/endpoint.js";
 import {
 	HTTP_DECORATORS,
 	hasDecorator,
@@ -1377,16 +1378,63 @@ function classifyDependency(name: string): DependencyType {
 	return "service";
 }
 
+/**
+ * Node allowance for one endpoint's trace, shared by every recursion below it.
+ * A diamond in the call graph is re-expanded once per path, so the tree can grow
+ * far beyond the number of distinct classes it covers.
+ */
+interface NodeBudget {
+	exhausted: boolean;
+	/** Classes whose subtree has already been expanded somewhere in this endpoint. */
+	expanded: Set<string>;
+	remaining: number;
+}
+
+/** Takes `n` nodes from the budget. False once nothing is left. */
+function claim(budget: NodeBudget, n = 1): boolean {
+	if (budget.remaining < n) {
+		budget.exhausted = true;
+		return false;
+	}
+	budget.remaining -= n;
+	return true;
+}
+
+/**
+ * Nodes a subtree serialises to, stopping once `limit` is passed. Shared child
+ * arrays are one object in memory but a full copy each in the JSON.
+ */
+function serialisedSize(nodes: MethodDependencyNode[], limit: number): number {
+	let total = 0;
+	const stack = [...nodes];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node) {
+			break;
+		}
+		total++;
+		if (total > limit) {
+			return total;
+		}
+		stack.push(...node.dependencies);
+	}
+	return total;
+}
+
 function buildMethodDependencyTree(
 	scanResult: ScanResult,
 	parentClassName: string,
 	providers: Map<string, ProviderInfo>,
 	visited: Set<string>,
+	budget: NodeBudget,
 	cache?: ScanCache
 ): MethodDependencyNode[] {
 	const nodes: MethodDependencyNode[] = [];
 	const firstSeenClass = new Set<string>();
-	const computedChildNodes = new Map<string, MethodDependencyNode[]>();
+	const computedChildNodes = new Map<
+		string,
+		{ nodes: MethodDependencyNode[]; size: number }
+	>();
 	const usedDeps = scanResult.deps;
 
 	// Build a flat list of all individual method calls across all deps
@@ -1418,6 +1466,9 @@ function buildMethodDependencyTree(
 		if (visited.has(dep.className) || firstSeenClass.has(dep.className)) {
 			continue;
 		}
+		if (!claim(budget)) {
+			break;
+		}
 		firstSeenClass.add(dep.className);
 		visited.add(dep.className);
 
@@ -1448,6 +1499,7 @@ function buildMethodDependencyTree(
 				dep.className,
 				providers,
 				new Set(visited),
+				budget,
 				cache
 			),
 			endLine: 0,
@@ -1482,6 +1534,9 @@ function buildMethodDependencyTree(
 		if (visited.has(className)) {
 			continue;
 		}
+		if (!claim(budget)) {
+			break;
+		}
 
 		const provider = providers.get(className);
 		const isFirst = !firstSeenClass.has(className);
@@ -1490,8 +1545,19 @@ function buildMethodDependencyTree(
 		}
 
 		let childNodes: MethodDependencyNode[] = [];
+		let collapsed = false;
 
-		if (isFirst && provider) {
+		if (!isFirst) {
+			const cached = computedChildNodes.get(className);
+			if (cached && claim(budget, cached.size)) {
+				childNodes = cached.nodes;
+			} else {
+				collapsed = true;
+			}
+		} else if (budget.expanded.has(className)) {
+			collapsed = true;
+		} else if (provider) {
+			budget.expanded.add(className);
 			const childVisited = new Set(visited);
 			childVisited.add(className);
 			const injMap = buildInjectionMap(
@@ -1632,11 +1698,13 @@ function buildMethodDependencyTree(
 				className,
 				providers,
 				childVisited,
+				budget,
 				cache
 			);
-			computedChildNodes.set(className, childNodes);
-		} else if (!isFirst) {
-			childNodes = computedChildNodes.get(className) ?? [];
+			computedChildNodes.set(className, {
+				nodes: childNodes,
+				size: serialisedSize(childNodes, budget.remaining),
+			});
 		}
 
 		let line = 0;
@@ -1682,12 +1750,16 @@ function buildMethodDependencyTree(
 			throwMessage: null,
 			totalMethods: provider?.publicMethodCount ?? 0,
 			type: classifyDependency(className),
+			...(collapsed ? { expandedElsewhere: true as const } : {}),
 		});
 	}
 
 	// Process same-class helper calls as intermediate nodes
 	const parentProvider = providers.get(parentClassName);
 	for (const scc of scanResult.sameClassCalls) {
+		if (!claim(budget)) {
+			break;
+		}
 		let line = 0;
 		let endLine = 0;
 		let sccReturnType: string | null = null;
@@ -1712,6 +1784,7 @@ function buildMethodDependencyTree(
 			parentClassName,
 			providers,
 			new Set(visited),
+			budget,
 			cache
 		);
 
@@ -1744,6 +1817,9 @@ function buildMethodDependencyTree(
 
 	// Process throw statements as leaf nodes
 	for (const t of scanResult.throws) {
+		if (!claim(budget)) {
+			break;
+		}
 		nodes.push({
 			assignedTo: null,
 			branchGroupId: t.branchGroupId,
@@ -1773,6 +1849,9 @@ function buildMethodDependencyTree(
 
 	// Process inline logic step nodes
 	for (const s of scanResult.steps) {
+		if (!claim(budget)) {
+			break;
+		}
 		nodes.push({
 			assignedTo: null,
 			branchGroupId: s.branchGroupId,
@@ -1858,11 +1937,17 @@ function extractEndpointsFromFile(
 				undefined,
 				cache
 			);
+			const budget: NodeBudget = {
+				expanded: new Set(),
+				exhausted: false,
+				remaining: MAX_DEPENDENCY_NODES,
+			};
 			const dependencies = buildMethodDependencyTree(
 				scanResult,
 				controllerName,
 				providers,
 				new Set(),
+				budget,
 				cache
 			);
 
@@ -1880,6 +1965,7 @@ function extractEndpointsFromFile(
 				returnType,
 				routePath: fullPath,
 				swagger,
+				...(budget.exhausted ? { truncated: true as const } : {}),
 			});
 		}
 	}

--- a/packages/nestjs-doctor/tests/unit/endpoint-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/endpoint-graph.test.ts
@@ -2245,6 +2245,86 @@ describe("endpoint-graph", () => {
 		expect(throwNode!.branchKind).toBe("catch");
 	});
 
+	it("expands a shared class once per endpoint and marks the later path", () => {
+		const { project, paths } = createProject({
+			"orders.controller.ts": `
+				import { Controller, Get } from '@nestjs/common';
+				@Controller('orders')
+				export class OrdersController {
+					constructor(
+						private readonly billing: BillingService,
+						private readonly shipping: ShippingService,
+					) {}
+
+					@Get()
+					list() {
+						this.billing.charge();
+						return this.shipping.send();
+					}
+				}
+			`,
+			"billing.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class BillingService {
+					constructor(private readonly audit: AuditService) {}
+					charge() { return this.audit.record('charge'); }
+				}
+			`,
+			"shipping.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class ShippingService {
+					constructor(private readonly audit: AuditService) {}
+					send() { return this.audit.record('send'); }
+				}
+			`,
+			"audit.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class AuditService {
+					constructor(private readonly db: DatabaseService) {}
+					record(what: string) { return this.db.write(what); }
+				}
+			`,
+			"database.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class DatabaseService {
+					write(what: string) { return {}; }
+				}
+			`,
+		});
+
+		const graph = buildEndpointGraph(
+			project,
+			paths,
+			resolveProviders(project, paths)
+		);
+		const ep = graph.endpoints[0];
+		const billing = ep.dependencies.find(
+			(d) => d.className === "BillingService"
+		);
+		const shipping = ep.dependencies.find(
+			(d) => d.className === "ShippingService"
+		);
+
+		// Both call sites survive, so the call flow is intact.
+		expect(billing).toBeDefined();
+		expect(shipping).toBeDefined();
+
+		const first = billing?.dependencies[0];
+		const second = shipping?.dependencies[0];
+		expect(first?.className).toBe("AuditService");
+		expect(second?.className).toBe("AuditService");
+
+		// Only the first path carries AuditService's subtree.
+		expect(first?.dependencies.length).toBeGreaterThan(0);
+		expect(first?.expandedElsewhere).toBeUndefined();
+		expect(second?.dependencies).toHaveLength(0);
+		expect(second?.expandedElsewhere).toBe(true);
+	});
+
 	it("repeated method nodes share the same children", () => {
 		const { project, paths } = createProject({
 			"items.controller.ts": `


### PR DESCRIPTION
## 1. Context

Every scan builds a dependency trace per endpoint. It is a call-flow trace, not a dependency list — each call site gets its own node so that order, branches and iteration stay visible, and `endpoint.ts` says so:

> Each method call becomes its own node so that call order and conditionality are visible.

The trace is attached to every result and read by `--format json` and the HTML report.

## 2. Problem

`buildMethodDependencyTree` copies its `visited` set per branch. That is correct cycle detection along a path, but it means a class reached by two paths is expanded twice, and the effect compounds per level.

On `bookorbit/bookorbit`, one endpoint:

| | |
|---|---:|
| nodes in the trace | 126,708 |
| distinct classes covered | 44 |
| times `DatabaseService` appears | 33,860 |
| depth | 22 |

Whole-project `--format json` came to 249 MB and then:

```
RangeError: Invalid string length
    at JSON.stringify (<anonymous>)
```

Unhandled. Exit 1, zero bytes of output. Exit 1 is also what a scan with error diagnostics returns, so in CI this is indistinguishable from a normal failing scan.

**2 of 76 public projects crash. 2 more produce 25-28 MB.** The median project is 0.06 MB.

Nothing bounded this function: `MAX_TRACE_DEPTH` applies only to `traceMethodCalls`, a separate Layer 2 tree that nothing inside the package calls.

## 3. Possible flows

| Path | Before | After |
|---|---|---|
| `--format json` on a large project | **RangeError, exit 1, no output** | scans, bounded output |
| `--format json` on the median project | fine | byte-identical |
| HTML report | asks dagre to lay out every duplicate | lays out one subtree per class |
| sarif / gitlab / markdown / console / github | never read `endpoints` | unchanged |
| Rules and the score | never read `endpoints` | unchanged |
| Two call sites of the same class, same caller | both keep children | both keep children |
| Same class reached down two different paths | expanded twice | expanded once, second marked |

## 4. Solution

Two changes, one for the cause and one as a floor.

**Expand each class once per endpoint.** A class's subtree is built at its first call site; later call sites anywhere in that endpoint keep their own node with empty `dependencies` and `expandedElsewhere: true`. No call-site node is lost, so the call flow is intact — only the repeated copies of the same subtree go.

**A ceiling of 5,000 serialised nodes per endpoint.** Sibling call sites share one child array in memory but serialise to a full copy each, so the budget is charged the reused subtree's size, not one node. An endpoint that hits the ceiling is marked `truncated` and reported on stderr through the existing warning channel, next to the scope warnings:

```
Dependency trace stopped at 5000 nodes for 3 endpoint(s); those traces are incomplete.
```

Not done: sharing one `visited` set per endpoint root. That drops a repeated call site entirely rather than collapsing it, and which path survives depends on call order — it would delete real nodes from all 76 projects to fix 2, invisibly.

## 5. Before vs after

Re-scanning all 76 projects:

| | Before | After |
|---|---:|---:|
| Projects that crash on `--format json` | 2 | 0 |
| Trace nodes, all projects | 725,159 | 190,614 |
| JSON output, all projects | 555 MB | 158 MB |
| Worst single endpoint | 126,708 nodes | 4,704 nodes |
| **Diagnostics** | **9,131** | **9,131** |
| Rules whose count moved | — | **0** |
| Endpoints marked `truncated` | — | 4, in 2 projects |
| Tests | 870 | 871 |

## 6. Example

```
$ node dist/cli/index.mjs <bookorbit>/server/src --format json --json-compact > out.json
```

Before:

```
RangeError: Invalid string length
    at JSON.stringify (<anonymous>)
$ echo $?
1
$ wc -c < out.json
0
```

After:

```
$ echo $?
0
$ wc -c < out.json
45581093
```

with `Dependency trace stopped at 5000 nodes for 3 endpoint(s); those traces are incomplete.` on stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)