### PR TITLE
fix(schema): detect two primary key forms the extractors missed

### DIFF
--- a/.changeset/primary-key-detection-gaps.md
+++ b/.changeset/primary-key-detection-gaps.md
@@ -1,0 +1,30 @@
+---
+"nestjs-doctor": patch
+---
+
+Detect two primary key forms the extractors were missing.
+
+`schema/require-primary-key` fired on entities that have one, because neither
+extractor recognised how it was declared.
+
+**Drizzle composite keys.** A junction table declares its key in the extras
+callback, not on a column:
+
+```ts
+export const userPermissions = pgTable(
+  'user_permissions',
+  { userId: integer('user_id').notNull(), permissionName: varchar('permission_name').notNull() },
+  (t) => [primaryKey({ columns: [t.userId, t.permissionName] })],
+);
+```
+
+The extractor read that third argument only for `.on(...)` index calls. Both the
+object form and the legacy positional `primaryKey(t.a, t.b)` are now read.
+
+**TypeORM on Mongo.** The Mongo driver declares the key as `@ObjectIdColumn()`
+on `_id`. It was not in `COLUMN_DECORATORS`, so the column was not extracted at
+all and the entity looked keyless. Closes #108.
+
+Across 76 public projects this takes `require-primary-key` from 117 findings to
+70 — 30 gone in a Drizzle project, 17 in a TypeORM/Mongo one, with no other rule
+moving.

--- a/packages/nestjs-doctor/src/engine/schema/drizzle-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/drizzle-extractor.ts
@@ -253,6 +253,64 @@ function extractIndexes(
 	return indexes;
 }
 
+/**
+ * Column names of a composite key declared in the extras callback, as
+ * `primaryKey({ columns: [t.a, t.b] })` or the legacy `primaryKey(t.a, t.b)`.
+ */
+function extractCompositePrimaryKey(thirdArg: Node): string[] {
+	for (const call of thirdArg.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+		const expr = call.getExpression();
+		if (
+			expr.getKind() !== SyntaxKind.Identifier ||
+			expr.getText() !== "primaryKey"
+		) {
+			continue;
+		}
+
+		const named: string[] = [];
+		for (const arg of call.getArguments()) {
+			if (arg.getKind() === SyntaxKind.PropertyAccessExpression) {
+				named.push(
+					arg.asKindOrThrow(SyntaxKind.PropertyAccessExpression).getName()
+				);
+				continue;
+			}
+			if (arg.getKind() !== SyntaxKind.ObjectLiteralExpression) {
+				continue;
+			}
+			const obj = arg.asKindOrThrow(SyntaxKind.ObjectLiteralExpression);
+			for (const prop of obj.getProperties()) {
+				if (prop.getKind() !== SyntaxKind.PropertyAssignment) {
+					continue;
+				}
+				const pa = prop.asKindOrThrow(SyntaxKind.PropertyAssignment);
+				if (pa.getName() !== "columns") {
+					continue;
+				}
+				const init = pa.getInitializer();
+				if (!init || init.getKind() !== SyntaxKind.ArrayLiteralExpression) {
+					continue;
+				}
+				for (const el of init
+					.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
+					.getElements()) {
+					if (el.getKind() === SyntaxKind.PropertyAccessExpression) {
+						named.push(
+							el.asKindOrThrow(SyntaxKind.PropertyAccessExpression).getName()
+						);
+					}
+				}
+			}
+		}
+
+		if (named.length > 0) {
+			return named;
+		}
+	}
+
+	return [];
+}
+
 function extractTablesFromFile(sourceFile: SourceFile): SchemaEntity[] {
 	const entities: SchemaEntity[] = [];
 	const filePath = sourceFile.getFilePath();
@@ -302,6 +360,12 @@ function extractTablesFromFile(sourceFile: SourceFile): SchemaEntity[] {
 
 		let indexes: { columns: string[]; isUnique: boolean }[] | undefined;
 		if (args.length >= 3) {
+			for (const colName of extractCompositePrimaryKey(args[2])) {
+				const col = columns.find((c) => c.name === colName);
+				if (col) {
+					col.isPrimary = true;
+				}
+			}
 			indexes = extractIndexes(args[2]);
 			if (indexes) {
 				for (const idx of indexes) {

--- a/packages/nestjs-doctor/src/engine/schema/typeorm-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/typeorm-extractor.ts
@@ -31,6 +31,7 @@ const FORWARD_REF_REGEX = /=>\s*(\w+)/;
 
 const COLUMN_DECORATORS = new Set([
 	"Column",
+	"ObjectIdColumn",
 	"PrimaryColumn",
 	"PrimaryGeneratedColumn",
 	"CreateDateColumn",
@@ -109,7 +110,9 @@ function extractColumn(
 	decorator: Decorator
 ): SchemaColumn {
 	const decoratorName = decorator.getName();
+	// The Mongo driver declares the key as @ObjectIdColumn() on _id.
 	const isPrimary =
+		decoratorName === "ObjectIdColumn" ||
 		decoratorName === "PrimaryColumn" ||
 		decoratorName === "PrimaryGeneratedColumn";
 	const isGenerated =
@@ -151,6 +154,8 @@ function extractColumn(
 	if (type === "unknown") {
 		if (decoratorName === "PrimaryGeneratedColumn") {
 			type = "integer";
+		} else if (decoratorName === "ObjectIdColumn") {
+			type = "objectId";
 		} else if (
 			decoratorName === "CreateDateColumn" ||
 			decoratorName === "UpdateDateColumn" ||

--- a/packages/nestjs-doctor/tests/unit/schema/drizzle-extractor.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/drizzle-extractor.test.ts
@@ -13,6 +13,68 @@ function createProject(files: Record<string, string>) {
 }
 
 describe("Drizzle Extractor", () => {
+	it("marks a composite primary key from the extras callback", () => {
+		const { project, paths } = createProject({
+			"perms.ts": `
+import { pgTable, integer, varchar, primaryKey } from "drizzle-orm/pg-core";
+
+export const userPermissions = pgTable(
+  'user_permissions',
+  {
+    userId: integer('user_id').notNull(),
+    permissionName: varchar('permission_name', { length: 100 }).notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.permissionName] })],
+);`,
+		});
+
+		const graph = extractSchema(project, paths, "drizzle", "/test");
+		const entity = graph.entities.get("userPermissions");
+		const primary = entity?.columns
+			.filter((c) => c.isPrimary)
+			.map((c) => c.name);
+		expect(primary).toEqual(["userId", "permissionName"]);
+	});
+
+	it("marks a composite primary key from the legacy positional form", () => {
+		const { project, paths } = createProject({
+			"joins.ts": `
+import { pgTable, integer, primaryKey } from "drizzle-orm/pg-core";
+
+export const bookTags = pgTable(
+  'book_tags',
+  {
+    bookId: integer('book_id').notNull(),
+    tagId: integer('tag_id').notNull(),
+  },
+  (t) => ({ pk: primaryKey(t.bookId, t.tagId) }),
+);`,
+		});
+
+		const graph = extractSchema(project, paths, "drizzle", "/test");
+		const entity = graph.entities.get("bookTags");
+		const primary = entity?.columns
+			.filter((c) => c.isPrimary)
+			.map((c) => c.name);
+		expect(primary).toEqual(["bookId", "tagId"]);
+	});
+
+	it("leaves a table with no primary key alone", () => {
+		const { project, paths } = createProject({
+			"logs.ts": `
+import { pgTable, integer, varchar } from "drizzle-orm/pg-core";
+
+export const logs = pgTable('logs', {
+  level: varchar('level').notNull(),
+  count: integer('count').notNull(),
+});`,
+		});
+
+		const graph = extractSchema(project, paths, "drizzle", "/test");
+		const entity = graph.entities.get("logs");
+		expect(entity?.columns.some((c) => c.isPrimary)).toBe(false);
+	});
+
 	it("should extract a basic pgTable with columns", () => {
 		const { project, paths } = createProject({
 			"users.ts": `

--- a/packages/nestjs-doctor/tests/unit/schema/typeorm-extractor.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/typeorm-extractor.test.ts
@@ -13,6 +13,29 @@ function createProject(files: Record<string, string>) {
 }
 
 describe("TypeORM Extractor", () => {
+	it("treats @ObjectIdColumn as the primary key", () => {
+		const { project, paths } = createProject({
+			"city.entity.ts": `
+import { Entity, ObjectIdColumn, Column } from 'typeorm';
+
+@Entity({ name: 'cities' })
+export class City {
+  @ObjectIdColumn()
+  _id: string;
+
+  @Column()
+  name: string;
+}`,
+		});
+
+		const graph = extractSchema(project, paths, "typeorm", "/test");
+		const entity = graph.entities.get("City");
+		const primary = entity?.columns
+			.filter((c) => c.isPrimary)
+			.map((c) => c.name);
+		expect(primary).toEqual(["_id"]);
+	});
+
 	it("should extract a basic entity with columns", () => {
 		const { project, paths } = createProject({
 			"user.entity.ts": `


### PR DESCRIPTION
## 1. Context

`schema/require-primary-key` reports an entity whose extracted columns contain no primary. It trusts the extractor completely — if a key is declared in a form the extractor does not read, the entity looks keyless and the rule fires.

## 2. Problem

Two forms were not read. Of the rule's 117 findings across 76 public projects, **47 are entities that do have a primary key**:

| Project | ORM | Findings | Why |
|---|---|---:|---|
| `bookorbit/bookorbit` | Drizzle | 30 | composite key in the extras callback |
| `chnirt/nestjs-graphql-best-practice` | TypeORM + Mongo | 17 | `@ObjectIdColumn()` |

**Drizzle.** A junction table has no column-level `.primaryKey()`; the key is declared in the third argument:

```ts
export const userPermissions = pgTable(
  'user_permissions',
  {
    userId: integer('user_id').notNull().references(() => users.id),
    permissionName: varchar('permission_name', { length: 100 }).notNull(),
  },
  (t) => [primaryKey({ columns: [t.userId, t.permissionName] })],
);
```

`extractIndexes` walks that argument, but only for `.on(...)` calls. `primaryKey(...)` was never looked for.

**TypeORM on Mongo.** The Mongo driver declares the key as `@ObjectIdColumn()` on `_id`:

```ts
@Entity({ name: 'cities' })
export class City {
  @ObjectIdColumn()
  _id: string;
```

`ObjectIdColumn` was not in `COLUMN_DECORATORS`, so `_id` was not extracted as a column at all — not merely as a non-primary one.

## 3. Possible flows

| Declaration | Before | After |
|---|---|---|
| Drizzle `integer().primaryKey()` on a column | primary | primary |
| Drizzle `primaryKey({ columns: [t.a, t.b] })` | **missed** | primary |
| Drizzle `primaryKey(t.a, t.b)` (legacy positional) | **missed** | primary |
| Drizzle table with no key at all | reported | reported |
| TypeORM `@PrimaryColumn` / `@PrimaryGeneratedColumn` | primary | primary |
| TypeORM `@ObjectIdColumn()` | **column not extracted** | primary, type `objectId` |
| TypeORM entity with no key | reported | reported |
| Prisma `@id` / `@@id` | already handled | unchanged |
| MikroORM | untouched | unchanged |

## 4. Solution

Drizzle gets an `extractCompositePrimaryKey` that scans the extras argument for a `primaryKey` call and reads its column names, from the object form and the positional form. Matching columns are marked primary.

TypeORM gets `ObjectIdColumn` in `COLUMN_DECORATORS` and in the primary test, with type `objectId`.

Not done: the remaining 70 findings. 64 are `vendure`, whose `@PrimaryGeneratedId` is applied through a runtime registry and is not statically resolvable — measured and closed as #171. Three are abstract base classes, two are Prisma models that genuinely have only `@@unique` and no key, and one is a `Repository<User>` subclass its author decorated with `@Entity()`.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| `schema/require-primary-key`, 76 projects | 117 | 70 |
| `bookorbit/bookorbit` | 30 | 0 |
| `chnirt/nestjs-graphql-best-practice` | 17 | 0 |
| Every other rule | 8,801 | 8,801 |
| Tests | 877 | 880 |

## 6. Example

```
$ node dist/cli/index.mjs <bookorbit>/server/src --format json --json-compact \
    | jq '[.diagnostics[] | select(.rule=="schema/require-primary-key")] | length'
```

Before: `30`

After: `0`

Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)