### PR TITLE
fix(rules): a handled promise is not fire-and-forget

### DIFF
--- a/.changeset/handled-promises-not-fire-and-forget.md
+++ b/.changeset/handled-promises-not-fire-and-forget.md
@@ -1,0 +1,31 @@
+---
+"nestjs-doctor": patch
+---
+
+Stop `correctness/no-fire-and-forget-async` reporting handled promises and
+synchronous emits.
+
+Two causes, 254 of the rule's 730 findings across 76 public projects.
+
+**A chain with a rejection handler.** The rule's help text offers `void` plus
+explicit error handling as the alternative to `await`. A `.catch()` is that
+handling, and it was reported anyway:
+
+```ts
+this.allPublicArticlesCache.update().catch((error) => this.logger.error(error));
+```
+
+A statement whose chain ends in `.catch(h)`, or in a `.then(ok, fail)` with a
+rejection handler, is now left alone. A `.then(ok)` with no rejection handler
+still reports, and so does a bare `.finally()`.
+
+**`emit`.** It was in the name heuristic used when the return type cannot be
+resolved, but every emitter in the Nest ecosystem returns synchronously —
+`EventEmitter2.emit` gives a boolean, socket.io's gives the socket, and
+`ClientProxy.emit` gives an Observable, none of which can reject. The message
+claimed "unhandled rejections will crash the process" for
+`this.eventEmitter.emit('article.created', payload)` in 15 of the 76 projects.
+Removing it from the heuristic takes `emit` from 184 findings to the 10 whose
+return type genuinely resolves to a Promise.
+
+No message changes, so no fingerprint churn.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
@@ -17,6 +17,8 @@ function returnsPromise(callExpr: CallExpression): boolean | "unknown" {
 	return false;
 }
 
+// Only consulted when the return type is unresolvable. `emit` is absent on
+// purpose: EventEmitter2, socket.io and ClientProxy all return synchronously.
 const ASYNC_PREFIXES = new Set([
 	"save",
 	"create",
@@ -25,7 +27,6 @@ const ASYNC_PREFIXES = new Set([
 	"delete",
 	"remove",
 	"send",
-	"emit",
 	"publish",
 	"dispatch",
 	"execute",
@@ -35,6 +36,35 @@ const ASYNC_PREFIXES = new Set([
 	"download",
 	"process",
 ]);
+
+/**
+ * True when the chain ends in `.catch(h)` or a `.then(ok, err)`, so a rejection
+ * already has somewhere to go.
+ */
+function hasRejectionHandler(callExpr: CallExpression): boolean {
+	let current: CallExpression | undefined = callExpr;
+	while (current) {
+		const expression = current.getExpression();
+		if (expression.getKind() !== SyntaxKind.PropertyAccessExpression) {
+			return false;
+		}
+		const access = expression.asKindOrThrow(
+			SyntaxKind.PropertyAccessExpression
+		);
+		const name = access.getName();
+		if (name === "catch") {
+			return true;
+		}
+		if (name === "then" && current.getArguments().length > 1) {
+			return true;
+		}
+		if (name !== "then" && name !== "finally") {
+			return false;
+		}
+		current = access.getExpression().asKind(SyntaxKind.CallExpression);
+	}
+	return false;
+}
 
 export const noFireAndForgetAsync: Rule = {
 	meta: {
@@ -89,6 +119,10 @@ export const noFireAndForgetAsync: Rule = {
 
 					const callText = callExpr.getExpression().getText();
 					const methodName = callText.split(".").pop() ?? "";
+
+					if (hasRejectionHandler(callExpr)) {
+						continue;
+					}
 
 					const promiseCheck = returnsPromise(callExpr);
 

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -997,6 +997,95 @@ describe("require-inject-decorator", () => {
 });
 
 describe("no-fire-and-forget-async", () => {
+	it("does not flag a chain that ends in .catch()", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().catch((error) => this.record(error));
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag .catch() followed by .finally()", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().catch(handle).finally(cleanup);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("flags a .then() with no rejection handler", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().then((result) => this.record(result));
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("does not flag a .then() that takes a rejection handler", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().then(ok, fail);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags a bare unawaited promise", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh();
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("does not flag eventEmitter.emit(), which is synchronous", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        run(payload) {
+          this.eventEmitter.emit('article.created', payload);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("flags unawaited async-like calls in service methods", () => {
 		const diags = runRule(
 			noFireAndForgetAsync,


### PR DESCRIPTION
## 1. Context

`correctness/no-fire-and-forget-async` reports an unawaited call whose value is a promise. It resolves the return type where it can, and where the type comes back `any` it falls back to a list of method-name prefixes. Its help text names the escape hatch:

> Add await before the async call, or use void with explicit error handling if fire-and-forget is intentional.

## 2. Problem

Two causes account for **254 of the rule's 730 findings** across 76 public projects.

**A chain that already handles rejection.** `.catch()` is the explicit error handling the help text asks for, and it was reported anyway:

```ts
this.allPublicArticlesCache.update().catch((error) => this.logger.error(error));
```

78 findings in 12 projects, plus 4 `.finally()` and 1 `.then()`.

**`emit`.** It sat in the name heuristic, so any unresolvable `x.emit(...)` was reported with the message *"unhandled rejections will crash the process"*. Nothing in the Nest ecosystem emits a promise:

| Call | Returns |
|---|---|
| `EventEmitter2.emit()` — `@nestjs/event-emitter` | `boolean` |
| `EventEmitter2.emitAsync()` | `Promise` |
| socket.io `socket.emit()` | the socket |
| `ClientProxy.emit()` — microservices | `Observable` |

184 findings in 15 projects. The receivers are what you would expect: `eventEmitter` (32), `auditEvents` (19), `achievementEvents` (17), `client` (11), `eventManager` (9), `socket` (9).

## 3. Possible flows

| Statement | Before | After |
|---|---|---|
| `this.refresh()` — promise, unawaited | reported | reported |
| `this.refresh().catch(h)` | **reported** | quiet |
| `this.refresh().catch(h).finally(c)` | **reported** | quiet |
| `this.refresh().then(ok, fail)` | **reported** | quiet |
| `this.refresh().then(ok)` — no rejection handler | reported | reported |
| `this.refresh().finally(c)` — no catch | reported | reported |
| `void this.refresh()` | quiet | quiet |
| `await this.refresh()` | quiet | quiet |
| `this.eventEmitter.emit(...)` — type unresolvable | **reported** | quiet |
| `x.emit(...)` where the type resolves to `Promise` | reported | reported |
| `emitAsync`, `send`, `publish`, `dispatch`, … | reported | reported |
| Inside an HTTP handler | quiet | quiet |

## 4. Solution

`hasRejectionHandler` walks down the property-access chain from the statement's outermost call. It stops at `catch` (handled), at a `then` with two arguments (handled), and at anything that is not `then` or `finally` (not handled). `finally` is walked through but never counts on its own, because it does not consume a rejection.

`emit` comes out of `ASYNC_PREFIXES`, with a comment saying why so it is not added back. The list is only consulted when the type is unresolvable, so the 10 sites whose type really is a promise still report.

Not done: the name heuristic reads the last link of a chain, so `this.mailer.send().then(ok)` is judged on `then` rather than `send`. That is one finding in the corpus and a separate change.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| `no-fire-and-forget-async` | 730 | **476** |
| of which `emit()` | 184 | 10 |
| of which `catch()` | 78 | 0 |
| of which `finally()` | 4 | 2 |
| Every other rule | unchanged | unchanged |
| Tests | 881 | 887 |

No message text changes, so no SARIF or GitLab fingerprint churn.

## 6. Example

`surmon-china/nodepress`:

```
$ node dist/cli/index.mjs <project> --format json --json-compact \
    | jq '[.diagnostics[] | select(.rule=="correctness/no-fire-and-forget-async")] | length'
```

Before: `730` across the corpus, including every `this.eventEmitter.emit(GlobalEventKey.ArticleCreated, populated)`

After: `476`

🤖 Generated with [Claude Code](https://claude.com/claude-code)