### PR TITLE
fix(rules): count a useClass target and a base class as used

### DIFF
--- a/.changeset/unused-providers-misses-useclass.md
+++ b/.changeset/unused-providers-misses-useclass.md
@@ -1,0 +1,29 @@
+---
+"nestjs-doctor": patch
+---
+
+Count a `useClass` target and a base class as used providers.
+
+`performance/no-unused-providers` decided a provider was dead if nothing injected
+it by type. Two ways of using one were invisible:
+
+```ts
+const repositories: Provider[] = [
+  { provide: USER_REPOSITORY, useClass: UserRepository },
+];
+
+@Module({ providers: [...repositories] })
+export class UserModule {}
+```
+
+Nest instantiates `UserRepository`, and a base class runs through every subclass,
+without either being a constructor dependency anywhere.
+
+`correctness/injectable-must-be-provided` already collected `useClass` targets,
+but only from an array literal written inline in the `@Module` decorator, so the
+common pattern of grouping providers into a const and spreading them was missed.
+That collector moves to a shared `collectProviderImplementations`, keyed on an
+object literal carrying `provide` wherever it appears, and both rules use it.
+
+Across 76 public projects: `no-unused-providers` 236 findings to 212, and
+`injectable-must-be-provided` 171 to 168.

--- a/packages/nestjs-doctor/src/engine/graph/custom-providers.ts
+++ b/packages/nestjs-doctor/src/engine/graph/custom-providers.ts
@@ -1,0 +1,66 @@
+import { type Project, SyntaxKind } from "ts-morph";
+
+const IMPLEMENTATION_KEYS = ["useClass", "useExisting"];
+
+/**
+ * Classes named as the implementation of an object-literal provider, as
+ * `{ provide: TOKEN, useClass: Impl }`. Nest instantiates them, so they are in
+ * use even though nothing injects them by type.
+ */
+export function collectProviderImplementations(
+	project: Project,
+	files: string[]
+): Set<string> {
+	const implementations = new Set<string>();
+
+	for (const filePath of files) {
+		const sourceFile = project.getSourceFile(filePath);
+		if (!sourceFile) {
+			continue;
+		}
+
+		// Any object literal carrying `provide` is a provider definition, wherever
+		// it sits — modules commonly group them into consts and spread them in.
+		for (const obj of sourceFile.getDescendantsOfKind(
+			SyntaxKind.ObjectLiteralExpression
+		)) {
+			if (!obj.getProperty("provide")) {
+				continue;
+			}
+			for (const key of IMPLEMENTATION_KEYS) {
+				const initializer = obj
+					.getProperty(key)
+					?.asKind(SyntaxKind.PropertyAssignment)
+					?.getInitializer();
+				if (initializer) {
+					implementations.add(initializer.getText());
+				}
+			}
+		}
+	}
+
+	return implementations;
+}
+
+/** Names appearing in an `extends` clause — a base class is used by its subclasses. */
+export function collectExtendedClasses(
+	project: Project,
+	files: string[]
+): Set<string> {
+	const extended = new Set<string>();
+
+	for (const filePath of files) {
+		const sourceFile = project.getSourceFile(filePath);
+		if (!sourceFile) {
+			continue;
+		}
+		for (const cls of sourceFile.getClasses()) {
+			const base = cls.getExtends()?.getExpression().getText();
+			if (base) {
+				extended.add(base.split("<")[0].split(".").pop() ?? base);
+			}
+		}
+	}
+
+	return extended;
+}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
@@ -1,5 +1,4 @@
-import { SyntaxKind } from "ts-morph";
-import { isModule } from "../../../nest-class-inspector.js";
+import { collectProviderImplementations } from "../../../graph/custom-providers.js";
 import { INFRA_SUFFIXES } from "../../constants.js";
 import type { ProjectRule } from "../../types.js";
 
@@ -26,64 +25,11 @@ export const injectableMustBeProvided: ProjectRule = {
 			}
 		}
 
-		// Also collect useClass/useExisting targets from object-literal providers
-		for (const filePath of context.files) {
-			const sourceFile = context.project.getSourceFile(filePath);
-			if (!sourceFile) {
-				continue;
-			}
-			for (const cls of sourceFile.getClasses()) {
-				if (!isModule(cls)) {
-					continue;
-				}
-				const moduleDecorator = cls.getDecorator("Module");
-				if (!moduleDecorator) {
-					continue;
-				}
-				const args = moduleDecorator.getArguments()[0];
-				if (!args || args.getKind() !== SyntaxKind.ObjectLiteralExpression) {
-					continue;
-				}
-				const obj = args.asKind(SyntaxKind.ObjectLiteralExpression);
-				if (!obj) {
-					continue;
-				}
-				const providersProp = obj.getProperty("providers");
-				if (!providersProp) {
-					continue;
-				}
-				const providersArray = providersProp.getChildrenOfKind(
-					SyntaxKind.ArrayLiteralExpression
-				)[0];
-				if (!providersArray) {
-					continue;
-				}
-				for (const element of providersArray.getElements()) {
-					if (element.getKind() !== SyntaxKind.ObjectLiteralExpression) {
-						continue;
-					}
-					const providerObj = element.asKind(
-						SyntaxKind.ObjectLiteralExpression
-					);
-					if (!providerObj) {
-						continue;
-					}
-					for (const propName of ["useClass", "useExisting"]) {
-						const prop = providerObj.getProperty(propName);
-						if (!prop) {
-							continue;
-						}
-						const assignment = prop.asKind(SyntaxKind.PropertyAssignment);
-						if (!assignment) {
-							continue;
-						}
-						const initializer = assignment.getInitializer();
-						if (initializer) {
-							registeredProviders.add(initializer.getText());
-						}
-					}
-				}
-			}
+		for (const implementation of collectProviderImplementations(
+			context.project,
+			context.files
+		)) {
+			registeredProviders.add(implementation);
 		}
 
 		// Scan all files for @Injectable() classes

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
@@ -1,4 +1,8 @@
 import type { ClassDeclaration } from "ts-morph";
+import {
+	collectExtendedClasses,
+	collectProviderImplementations,
+} from "../../../graph/custom-providers.js";
 import { INFRA_SUFFIXES } from "../../constants.js";
 import type { ProjectRule } from "../../types.js";
 
@@ -92,8 +96,20 @@ export const noUnusedProviders: ProjectRule = {
 			}
 		}
 
+		// Nest instantiates a useClass/useExisting target, and a base class runs
+		// through every subclass, without either being injected by type.
+		const implementations = collectProviderImplementations(
+			context.project,
+			context.files
+		);
+		const extended = collectExtendedClasses(context.project, context.files);
+
 		for (const provider of context.providers.values()) {
 			const name = provider.name;
+
+			if (implementations.has(name) || extended.has(name)) {
+				continue;
+			}
 
 			// Skip common infrastructure patterns
 			if (INFRA_SUFFIXES.some((suffix) => name.endsWith(suffix))) {

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -5,6 +5,7 @@ import type { Diagnostic } from "../../../src/common/diagnostic.js";
 import { buildModuleGraph } from "../../../src/engine/graph/module-graph.js";
 import { resolveProviders } from "../../../src/engine/graph/type-resolver.js";
 import { noCircularModuleDeps } from "../../../src/engine/rules/definitions/architecture/no-circular-module-deps.js";
+import { noUnusedProviders } from "../../../src/engine/rules/definitions/performance/no-unused-providers.js";
 import type { ProjectRule } from "../../../src/engine/rules/types.js";
 
 function createProjectContext(
@@ -317,5 +318,63 @@ describe("no-circular-module-deps", () => {
 			}
 		);
 		expect(diags.length).toBeGreaterThan(0);
+	});
+});
+
+describe("no-unused-providers", () => {
+	it("does not flag a class registered with useClass", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [{ provide: 'USER_REPO', useClass: UserRepository }] })
+        export class AppModule {}
+      `,
+			"user.repository.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class UserRepository {}
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag a base class that a provider extends", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [BaseService, ArticleService] })
+        export class AppModule {}
+      `,
+			"base.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class BaseService {}
+      `,
+			"article.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class ArticleService extends BaseService {}
+      `,
+		});
+		expect(
+			diags.filter((d) => d.message.includes("'BaseService'"))
+		).toHaveLength(0);
+	});
+
+	it("still flags a provider nothing references", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [OrphanService] })
+        export class AppModule {}
+      `,
+			"orphan.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class OrphanService {}
+      `,
+		});
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("OrphanService");
 	});
 });


### PR DESCRIPTION
## 1. Context

`performance/no-unused-providers` builds the set of every constructor dependency across all providers, resolvers, gateways and controllers, then reports any provider whose name is not in it — *"never injected by any other provider or controller"*, help text *"may be dead code"*.

## 2. Problem

Two ways of using a provider never produce a constructor dependency.

**A `useClass` target.** Nest instantiates it under a different token:

```ts
const repositories: Provider[] = [
  { provide: USER_REPOSITORY, useClass: UserRepository },
];

@Module({ providers: [...repositories] })
export class UserModule {}
```

**A base class.** It runs on every request through its subclasses, and nothing injects it by its own name.

Classifying the rule's 236 findings across 76 public projects by where the name actually appears:

| | findings | share |
|---|---:|---:|
| nothing references it — a true finding | 101 | 42.8% |
| `new X(...)` somewhere | 68 | 28.8% |
| `{ provide: …, useClass: X }` | **36** | 15.3% |
| passed to a `.get()` / `.resolve()` | 26 | 11.0% |
| appears in an `extends` clause | **4** | 1.7% |

The last two are unambiguous. `new X(...)` and `.get(X)` are not — a textual match there can hit an unrelated symbol, so they are left alone.

`correctness/injectable-must-be-provided` already collected `useClass` targets, but only from an array literal written inline in the `@Module` decorator. The pattern above groups providers into a const and spreads them, so it saw nothing.

## 3. Possible flows

| How the provider is reached | Before | After |
|---|---|---|
| injected by type into a service | quiet | quiet |
| injected into a controller / resolver / gateway | quiet | quiet |
| `{ provide: T, useClass: X }` inline in `@Module` | **reported** | quiet |
| the same, spread in from a const | **reported** | quiet |
| `{ provide: T, useExisting: X }` | **reported** | quiet |
| extended by another class | **reported** | quiet |
| name ends in `Guard`, `Interceptor`, `Strategy`, … | quiet | quiet |
| carries `@Cron`, `@OnEvent`, `@Process`, … | quiet | quiet |
| listed in a module's `exports` | quiet | quiet |
| nothing at all references it | reported | reported |

## 4. Solution

The `useClass` collector moves out of `injectable-must-be-provided` into a shared `collectProviderImplementations`, and its predicate changes: an object literal carrying a `provide` key is a provider definition wherever it sits, rather than only inside the decorator's array. `provide` is what makes it unambiguous, so no file-location test is needed.

`collectExtendedClasses` reads every `extends` clause. Both feed `no-unused-providers`.

Not done: the 68 `new X(...)` and 26 `.get(X)` matches. Both are name-only matches with no binding resolution behind them, and `skipFileDependencyResolution` means the type is usually unavailable to confirm. Reporting them as used on a textual hit would trade a false positive for a silent false negative.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| `performance/no-unused-providers` | 236 | **212** |
| `correctness/injectable-must-be-provided` | 171 | **168** |
| Every other rule | unchanged | unchanged |
| Lines of duplicated collection logic | 65 | 0 |
| Tests | 881 | 884 |

The three that leave `injectable-must-be-provided` are `UserRepository` and `WalletRepository` in `Sairyss/domain-driven-hexagon` and `MyConfigService` in `eicrud/eicrud` — all registered through a spread const.

## 6. Example

`Sairyss/domain-driven-hexagon`:

```
$ node dist/cli/index.mjs <project>/src --format json --json-compact \
    | jq '[.diagnostics[] | select(.rule=="performance/no-unused-providers") | .message]'
```

Before:

```json
[
  "Provider 'UserRepository' is never injected by any other provider or controller.",
  "Provider 'WalletRepository' is never injected by any other provider or controller."
]
```

After: `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)