### PR TITLE
fix(cli): fail on a target path that does not exist

### DIFF
--- a/.changeset/validate-target-path.md
+++ b/.changeset/validate-target-path.md
@@ -1,0 +1,29 @@
+---
+"nestjs-doctor": patch
+---
+
+Fail on a target path that does not exist, and say when nothing was scanned.
+
+The path was resolved but never checked. Pointing the CLI at a directory that
+does not exist globbed a missing cwd, collected zero files, and printed:
+
+```
+  100 / 100  ★★★★★  Excellent
+  No issues found!  0 files scanned  in 0ms
+```
+
+with exit code 0. A CI job with a typo in its path, a wrong `working-directory`,
+or a checkout that had not produced the sources yet went green on a perfect
+score for a project nobody read.
+
+A missing path, or a path that is a file, now exits 2 with a message. When the
+path is a directory but no TypeScript matched, the scan still runs and a warning
+goes to stderr in every output format, next to the existing scope warnings:
+
+```
+No TypeScript files matched under /repo/apps/api. The score describes nothing.
+```
+
+Left alone: `--min-score` still passes on a zero-file scan. Making a gate fail
+there is a change to exit-code policy, not a bug fix, so it is called out
+separately.

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -34,6 +34,7 @@ const main = defineCommand({
 		const ctx = await new CliSetup(args as CliArgs, version)
 			.resolveTargetPath()
 			.handleListRules()
+			.validateTargetPath()
 			.handleInit()
 			.handleReport()
 			.validateMinScore()

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -78,6 +78,12 @@ function emit(
 		logger.warn(warning);
 	}
 
+	if (result.project.fileCount === 0) {
+		logger.warn(
+			`No TypeScript files matched under ${targetPath}. The score describes nothing.`
+		);
+	}
+
 	const truncated =
 		result.endpoints?.endpoints.filter((e) => e.truncated).length ?? 0;
 	if (truncated > 0) {

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -11,6 +11,7 @@ import {
 	validateFormatArg,
 } from "./formatters/render.js";
 import { validateMinScoreArg } from "./min-score.js";
+import { validateTargetPathArg } from "./target-path.js";
 import { logger } from "./ui/logger.js";
 
 export interface PipelineOptions {
@@ -104,6 +105,17 @@ export class CliSetup {
 	resolveTargetPath(): this {
 		this.steps.push(() => {
 			this.targetPath = resolve(this.args.path ?? ".");
+			return true;
+		});
+		return this;
+	}
+
+	validateTargetPath(): this {
+		this.steps.push(() => {
+			const error = validateTargetPathArg(this.targetPath);
+			if (error) {
+				failWith(error);
+			}
 			return true;
 		});
 		return this;

--- a/packages/nestjs-doctor/src/cli/target-path.ts
+++ b/packages/nestjs-doctor/src/cli/target-path.ts
@@ -1,0 +1,17 @@
+import { existsSync, statSync } from "node:fs";
+
+/**
+ * Error message when the path cannot be scanned, null when it can. A path that
+ * is missing or is not a directory collects no files, which reads as a clean scan.
+ */
+export const validateTargetPathArg = (targetPath: string): string | null => {
+	if (!existsSync(targetPath)) {
+		return `Path does not exist: ${targetPath}`;
+	}
+
+	if (!statSync(targetPath).isDirectory()) {
+		return `Path is not a directory: ${targetPath}`;
+	}
+
+	return null;
+};

--- a/packages/nestjs-doctor/tests/unit/target-path.test.ts
+++ b/packages/nestjs-doctor/tests/unit/target-path.test.ts
@@ -1,0 +1,35 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { validateTargetPathArg } from "../../src/cli/target-path.js";
+
+const TMP = resolve(import.meta.dirname, "../.tmp-target-path");
+
+describe("validateTargetPathArg", () => {
+	beforeAll(() => {
+		mkdirSync(TMP, { recursive: true });
+		writeFileSync(resolve(TMP, "a.ts"), "export const a = 1;\n");
+	});
+
+	afterAll(() => {
+		rmSync(TMP, { recursive: true, force: true });
+	});
+
+	it("accepts an existing directory", () => {
+		expect(validateTargetPathArg(TMP)).toBeNull();
+	});
+
+	it("rejects a path that does not exist", () => {
+		const missing = resolve(TMP, "nope");
+		expect(validateTargetPathArg(missing)).toBe(
+			`Path does not exist: ${missing}`
+		);
+	});
+
+	it("rejects a file", () => {
+		const file = resolve(TMP, "a.ts");
+		expect(validateTargetPathArg(file)).toBe(
+			`Path is not a directory: ${file}`
+		);
+	});
+});


### PR DESCRIPTION
## 1. Context

`resolveTargetPath()` does one thing:

```ts
this.targetPath = resolve(this.args.path ?? ".");
```

`collectFiles` then globs with that as `cwd`. A glob over a directory that is not there returns `[]` rather than throwing, and every stage downstream is happy to analyse nothing.

## 2. Problem

Point the CLI at a path that does not exist:

```
$ nestjs-doctor ./apps/api-typo

  ┌────────────────────────────────────────────────────┐
  │ 100 / 100  ★★★★★  Excellent                        │
  │ No issues found!  0 files scanned  in 0ms          │
  └────────────────────────────────────────────────────┘

$ echo $?
0
```

`--score` prints `100`. `--min-score 90` passes. `--format json` reports `"fileCount": 0` beside `"value": 100`, and SARIF and GitLab emit an empty, successful report.

This is the failure `CLAUDE.md` names directly:

> Degrade wider, never narrower. A scan that silently reports nothing looks identical to a clean one.

The realistic triggers are all CI: a typo in the path, a wrong `working-directory`, a monorepo package that moved, a checkout step that has not produced the sources yet. Every one of them turns into a green build with a perfect score.

Found while scanning `pietrzakadrian/bank`, whose repository contains no TypeScript at all. It scored 100.

## 3. Possible flows

| Invocation | Before | After |
|---|---|---|
| path does not exist | **100 / 100, exit 0** | exit 2, `Path does not exist: …` |
| path is a file, not a directory | **100 / 100, exit 0** | exit 2, `Path is not a directory: …` |
| directory with no TypeScript | 100 / 100, exit 0, silent | 100 / 100, exit 0, **warned on stderr** |
| directory with TypeScript, no NestJS | scans, silent | scans, unchanged |
| a real project | unchanged | unchanged |
| `--list-rules` with any path | works | works |
| `--init` / `--report` on a missing path | proceeded | exit 2 |

## 4. Solution

A pure `validateTargetPathArg(path)` returning an error string or `null`, matching `validateMinScoreArg` and `validateBlockingArg`. The setup chain calls it through the existing `failWith`, which exits 2 — the code already used for a bad argument.

It sits **after** `handleListRules()`, so `nestjs-doctor --list-rules` still works from anywhere, and **before** `handleInit()` and `handleReport()`, which both write relative to the target.

For a directory that exists but matched no files, `emit()` warns on stderr, using the same channel and the same reasoning as the scope warnings a few lines above it:

> Always surfaced, on stderr, whatever the format: a silently degraded scope makes a report look cleaner than the code actually is.

**Deliberately not done:** `--min-score 90` still passes on a zero-file scan. The score is meaningless there, so an argument exists for failing the gate — but that is a change to exit-code policy rather than a bug fix, and it would break any pipeline that currently runs against a package before its sources land. Worth deciding separately.

## 5. Before vs after

| | Before | After |
|---|---|---|
| exit code, missing path | 0 | **2** |
| exit code, path is a file | 0 | **2** |
| exit code, empty directory | 0 | 0 (warned) |
| exit code, real project | 0 | 0 |
| Findings on `immich`, `ghostfolio`, `swetrix` | 388 / 187 / 608 | 388 / 187 / 608 |
| Tests | 894 | 897 |

No diagnostic, score or fingerprint changes for any path that was valid before.

## 6. Example

```
$ node dist/cli/index.mjs ./apps/api-typo --score --min-score 90
```

Before:

```
100
$ echo $?
0
```

After:

```
Path does not exist: /repo/apps/api-typo
$ echo $?
2
```

And for a directory that exists but holds no TypeScript:

```
$ node dist/cli/index.mjs ./docs --format json > out.json
No TypeScript files matched under /repo/docs. The score describes nothing.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
