### PR TITLE
fix(rules): a @Global() module's exports are visible without an import

### DIFF
--- a/.changeset/global-module-exports.md
+++ b/.changeset/global-module-exports.md
@@ -1,0 +1,27 @@
+---
+"nestjs-doctor": patch
+---
+
+Recognise `@Global()` visibility and `@Inject()` tokens in
+`performance/no-unused-module-exports`.
+
+The rule decided who could see an export by walking explicit `imports` arrays.
+A `@Global()` module is visible to every module without an import edge, so the
+walk never found the consumer:
+
+```ts
+@Global()
+@Module({ providers: [{ provide: DRIZZLE, useFactory }], exports: [DRIZZLE] })
+export class DatabaseModule {}
+
+@Injectable()
+export class CustomersRepository {
+  constructor(@Inject(DRIZZLE) private readonly db: DrizzleDB) {}
+}
+```
+
+Two things were missing. A global module's consumers are every module, not its
+importers. And usage was read from constructor parameter *types* only, so an
+`@Inject(TOKEN)` injection of a token-provided export counted for nothing.
+
+Across 76 public projects this takes the rule from 345 findings to 268. Closes #104.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-module-exports.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-module-exports.ts
@@ -1,4 +1,50 @@
-import type { ProjectRule } from "../../types.js";
+import type { ClassDeclaration } from "ts-morph";
+import type { ModuleNode } from "../../../graph/module-graph.js";
+import { hasDecorator } from "../../../nest-class-inspector.js";
+import type { ProjectRule, ProjectRuleContext } from "../../types.js";
+
+const QUOTES = /^['"`]|['"`]$/g;
+
+/** Constructor parameter types plus any `@Inject(TOKEN)` argument. */
+function collectInjectedNames(cls: ClassDeclaration, into: Set<string>): void {
+	const ctor = cls.getConstructors()[0];
+	if (!ctor) {
+		return;
+	}
+
+	for (const param of ctor.getParameters()) {
+		const typeNode = param.getTypeNode();
+		const typeText = typeNode ? typeNode.getText() : param.getType().getText();
+		into.add(typeText.split(".").pop()?.split("<")[0] ?? typeText);
+
+		for (const decorator of param.getDecorators()) {
+			if (decorator.getName() !== "Inject") {
+				continue;
+			}
+			const token = decorator.getArguments()[0]?.getText();
+			if (token) {
+				into.add(token);
+				into.add(token.replace(QUOTES, ""));
+			}
+		}
+	}
+}
+
+/** Modules that can see this one's exports. A `@Global()` module is visible to all. */
+function resolveConsumers(
+	mod: ModuleNode,
+	context: ProjectRuleContext
+): ModuleNode[] {
+	const all = [...context.moduleGraph.modules.values()].filter(
+		(other) => other.name !== mod.name
+	);
+
+	if (hasDecorator(mod.classDeclaration, "Global")) {
+		return all;
+	}
+
+	return all.filter((other) => other.imports.includes(mod.name));
+}
 
 export const noUnusedModuleExports: ProjectRule = {
 	meta: {
@@ -12,79 +58,46 @@ export const noUnusedModuleExports: ProjectRule = {
 	},
 
 	check(context) {
-		// For each module, check if its exports are actually used by importing modules
+		const classesByName = new Map<string, ClassDeclaration>();
+		for (const filePath of context.files) {
+			const sourceFile = context.project.getSourceFile(filePath);
+			if (!sourceFile) {
+				continue;
+			}
+			for (const cls of sourceFile.getClasses()) {
+				const name = cls.getName();
+				if (name && !classesByName.has(name)) {
+					classesByName.set(name, cls);
+				}
+			}
+		}
+
 		for (const mod of context.moduleGraph.modules.values()) {
 			if (mod.exports.length === 0) {
 				continue;
 			}
 
-			// Find modules that import this one
-			const importingModules: string[] = [];
-			for (const otherMod of context.moduleGraph.modules.values()) {
-				if (otherMod.name === mod.name) {
-					continue;
-				}
-				if (otherMod.imports.includes(mod.name)) {
-					importingModules.push(otherMod.name);
-				}
+			const consumers = resolveConsumers(mod, context);
+			if (consumers.length === 0) {
+				// no-orphan-modules handles a module nothing can reach
+				continue;
 			}
 
-			// If no module imports this one, all exports are unused
-			if (importingModules.length === 0) {
-				continue; // no-orphan-modules handles this case
-			}
-
-			// Collect all provider dependencies from importing modules
 			const usedProviders = new Set<string>();
-			for (const importerName of importingModules) {
-				const importer = context.moduleGraph.modules.get(importerName);
-				if (!importer) {
-					continue;
-				}
-
-				// Check which providers in the importing module depend on exported providers
-				for (const providerName of importer.providers) {
-					const provider = context.providers.get(providerName);
-					if (!provider) {
-						continue;
-					}
-					for (const dep of provider.dependencies) {
-						usedProviders.add(dep);
+			for (const consumer of consumers) {
+				for (const name of [...consumer.providers, ...consumer.controllers]) {
+					const cls =
+						context.providers.get(name)?.classDeclaration ??
+						classesByName.get(name);
+					if (cls) {
+						collectInjectedNames(cls, usedProviders);
 					}
 				}
 
-				// If the importing module re-exports this module, all exports are "used"
-				if (importer.exports.includes(mod.name)) {
-					for (const exp of mod.exports) {
-						usedProviders.add(exp);
-					}
-				}
-
-				// Check controllers too
-				for (const controllerName of importer.controllers) {
-					for (const filePath of context.files) {
-						const sourceFile = context.project.getSourceFile(filePath);
-						if (!sourceFile) {
-							continue;
-						}
-						for (const cls of sourceFile.getClasses()) {
-							if (cls.getName() !== controllerName) {
-								continue;
-							}
-							const ctor = cls.getConstructors()[0];
-							if (!ctor) {
-								continue;
-							}
-							for (const param of ctor.getParameters()) {
-								const typeNode = param.getTypeNode();
-								const typeText = typeNode
-									? typeNode.getText()
-									: param.getType().getText();
-								const simpleName =
-									typeText.split(".").pop()?.split("<")[0] ?? typeText;
-								usedProviders.add(simpleName);
-							}
-						}
+				// A re-export makes every export reachable one level further out
+				if (consumer.exports.includes(mod.name)) {
+					for (const exported of mod.exports) {
+						usedProviders.add(exported);
 					}
 				}
 			}

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -5,6 +5,7 @@ import type { Diagnostic } from "../../../src/common/diagnostic.js";
 import { buildModuleGraph } from "../../../src/engine/graph/module-graph.js";
 import { resolveProviders } from "../../../src/engine/graph/type-resolver.js";
 import { noCircularModuleDeps } from "../../../src/engine/rules/definitions/architecture/no-circular-module-deps.js";
+import { noUnusedModuleExports } from "../../../src/engine/rules/definitions/performance/no-unused-module-exports.js";
 import { noUnusedProviders } from "../../../src/engine/rules/definitions/performance/no-unused-providers.js";
 import type { ProjectRule } from "../../../src/engine/rules/types.js";
 
@@ -376,5 +377,111 @@ describe("no-unused-providers", () => {
 		});
 		expect(diags).toHaveLength(1);
 		expect(diags[0].message).toContain("OrphanService");
+	});
+});
+
+describe("no-unused-module-exports", () => {
+	it("does not flag a @Global() module's token injected without an import", () => {
+		const diags = runProjectRule(noUnusedModuleExports, {
+			"database.module.ts": `
+        import { Global, Module } from '@nestjs/common';
+        @Global()
+        @Module({
+          providers: [{ provide: DRIZZLE, useFactory: () => ({}) }],
+          exports: [DRIZZLE],
+        })
+        export class DatabaseModule {}
+      `,
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ imports: [DatabaseModule], providers: [] })
+        export class AppModule {}
+      `,
+			"customers.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [CustomersRepository] })
+        export class CustomersModule {}
+      `,
+			"customers.repository.ts": `
+        import { Inject, Injectable } from '@nestjs/common';
+        @Injectable()
+        export class CustomersRepository {
+          constructor(@Inject(DRIZZLE) private readonly db: DrizzleDB) {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags a @Global() export nothing injects", () => {
+		const diags = runProjectRule(noUnusedModuleExports, {
+			"database.module.ts": `
+        import { Global, Module } from '@nestjs/common';
+        @Global()
+        @Module({ providers: [UnusedService], exports: [UnusedService] })
+        export class DatabaseModule {}
+      `,
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ imports: [DatabaseModule], providers: [OtherService] })
+        export class AppModule {}
+      `,
+			"other.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class OtherService {
+          constructor(private readonly nothing: SomethingElse) {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("UnusedService");
+	});
+
+	it("counts an @Inject() token used by an importing module", () => {
+		const diags = runProjectRule(noUnusedModuleExports, {
+			"config.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [], exports: ['CONFIG_TOKEN'] })
+        export class ConfigModule {}
+      `,
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ imports: [ConfigModule], providers: [AppService] })
+        export class AppModule {}
+      `,
+			"app.service.ts": `
+        import { Inject, Injectable } from '@nestjs/common';
+        @Injectable()
+        export class AppService {
+          constructor(@Inject('CONFIG_TOKEN') private readonly config: Config) {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags a plain export no importer uses", () => {
+		const diags = runProjectRule(noUnusedModuleExports, {
+			"shared.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ providers: [HelperService], exports: [HelperService] })
+        export class SharedModule {}
+      `,
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({ imports: [SharedModule], providers: [AppService] })
+        export class AppModule {}
+      `,
+			"app.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class AppService {
+          constructor(private readonly other: OtherService) {}
+        }
+      `,
+		});
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("HelperService");
 	});
 });


### PR DESCRIPTION
## 1. Context

`performance/no-unused-module-exports` reports an export that no importing module uses. It answers "who can see this?" by walking explicit `imports` arrays:

```ts
if (otherMod.imports.includes(mod.name)) {
  importingModules.push(otherMod.name);
}
```

and answers "who uses it?" from the constructor parameter types of those modules' providers and controllers.

## 2. Problem

Both answers are incomplete, and together they produce the shape filed as #104:

```ts
@Global()
@Module({
  providers: [{ provide: DRIZZLE, useFactory: () => ... }],
  exports: [DRIZZLE],
})
export class DatabaseModule {}

@Injectable()
export class CustomersRepository {
  constructor(@Inject(DRIZZLE) private readonly db: DrizzleDB) {}   // imports nothing
}
```

```
● Module 'DatabaseModule' exports 'DRIZZLE' but no importing module uses it.
```

**Visibility.** A `@Global()` module reaches every module in the application without an import edge. Nothing needs to import it, so the walk finds no consumer.

**Usage.** `ProviderInfo.dependencies` is built from parameter *types*:

```ts
const typeText = typeNode ? typeNode.getText() : p.getType().getText();
return extractSimpleTypeName(typeText);
```

`@Inject(DRIZZLE) private db: DrizzleDB` therefore records `DrizzleDB`. The token the module actually exports is never seen.

Across 76 public projects, **121 of the rule's 345 findings are exports of a `@Global()` module**.

## 3. Possible flows

| Export | Before | After |
|---|---|---|
| `@Global()` module, injected by type anywhere | **reported** | quiet |
| `@Global()` module, injected by `@Inject(TOKEN)` anywhere | **reported** | quiet |
| `@Global()` module, injected nowhere | reported | reported |
| plain module, injected by an importer's provider | quiet | quiet |
| plain module, `@Inject(TOKEN)` in an importer's provider | **reported** | quiet |
| plain module, injected by an importer's controller | quiet | quiet |
| plain module, nothing uses it | reported | reported |
| re-exported by an importing module | quiet | quiet |
| the export is itself a module | skipped | skipped |
| module nothing can reach | skipped (`no-orphan-modules` owns it) | skipped |

## 4. Solution

`resolveConsumers(mod)` returns every module when the declaring class carries `@Global()`, and the importers otherwise. `collectInjectedNames(cls)` reads parameter types **and** `@Inject()` arguments, adding the token both quoted and bare so `exports: ['CONFIG']` and `@Inject('CONFIG')` meet.

The controller lookup also stops re-walking every source file per controller; classes are indexed once up front.

Not done: the 128 findings whose export is injected somewhere in the project but not by anything that can see it. Some are real, and separating them needs a transitive-visibility model — a module re-exporting a *provider* by name rather than re-exporting the module, and imports reached through several hops. That is a change to the module graph, not to this rule.

## 5. Before vs after

Re-scanning all 76 projects, on the main this branch was cut from:

| | Before | After |
|---|---:|---:|
| `performance/no-unused-module-exports` | 345 | **268** |
| Every other rule | 8,110 | 8,110 |

Re-measured after merging current `main` in, over a larger corpus of 189 public projects:

| | Before | After |
|---|---:|---:|
| `performance/no-unused-module-exports` | 478 | **419** |
| Every other rule | 13,119 | 13,119 |
| Tests | 910 | 914 |

Only this rule moves in either run.

## 6. Example

The reproduction from #104, as a test:

```
$ node dist/cli/index.mjs <project> --format json --json-compact \
    | jq '[.diagnostics[] | select(.rule=="performance/no-unused-module-exports")] | length'
```

`andrechristikan/ack-nestjs-boilerplate`, whose `@Global() ActivityLogModule` exports a service and a repository used across the app:

Before: `34`

After: `16`

Closes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

