### PR TITLE
fix(rules): @InjectRepository supplies a token just like @Inject

### DIFF
--- a/.changeset/inject-token-decorators.md
+++ b/.changeset/inject-token-decorators.md
@@ -1,0 +1,29 @@
+---
+"nestjs-doctor": patch
+---
+
+Recognise every `@Inject*` token decorator in
+`correctness/require-inject-decorator`.
+
+The rule reports a constructor parameter with no type annotation and no
+injection token, at error severity, saying NestJS cannot resolve it. It looked
+for exactly one decorator name:
+
+```ts
+const hasInject = param.getDecorators().some((d) => d.getName() === "Inject");
+```
+
+Every other Nest DI decorator supplies a token the same way — `@InjectRepository`
+and `@InjectEntityManager` and `@InjectDataSource` from TypeORM, `@InjectModel`
+from Mongoose, `@InjectQueue` from Bull, and whatever a community package adds.
+So this working code was an error:
+
+```ts
+constructor(@InjectRepository(Company) repo) {}
+```
+
+Across 76 public projects and 16 Nest libraries the rule fires 7 times, and 6 of
+those carry `@InjectRepository`. The check now keys on the `Inject` prefix, which
+is the naming every one of these follows, rather than a list that needs a new
+entry per package. `@Optional()` on its own still reports, because it supplies no
+token.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/require-inject-decorator.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/require-inject-decorator.ts
@@ -1,4 +1,6 @@
 import { isInjectable } from "../../../nest-class-inspector.js";
+// Every Nest DI decorator that supplies a token is named Inject*: @Inject,
+// @InjectRepository, @InjectModel, @InjectQueue, @InjectDataSource, and so on.
 import type { Rule } from "../../types.js";
 
 export const requireInjectDecorator: Rule = {
@@ -26,7 +28,7 @@ export const requireInjectDecorator: Rule = {
 				const typeNode = param.getTypeNode();
 				const hasInject = param
 					.getDecorators()
-					.some((d) => d.getName() === "Inject");
+					.some((d) => d.getName().startsWith("Inject"));
 
 				if (!(typeNode || hasInject)) {
 					context.report({

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -952,6 +952,50 @@ describe("no-missing-module-decorator", () => {
 });
 
 describe("require-inject-decorator", () => {
+	it("accepts a token supplied by @InjectRepository", () => {
+		const diags = runRule(
+			requireInjectDecorator,
+			`
+      import { Injectable } from '@nestjs/common';
+      import { InjectRepository } from '@nestjs/typeorm';
+      @Injectable()
+      export class CompaniesService {
+        constructor(@InjectRepository(Company) repo) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("accepts a token supplied by @InjectQueue", () => {
+		const diags = runRule(
+			requireInjectDecorator,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class MailService {
+        constructor(@InjectQueue('mail') queue) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags a parameter with @Optional() and no type", () => {
+		const diags = runRule(
+			requireInjectDecorator,
+			`
+      import { Injectable, Optional } from '@nestjs/common';
+      @Injectable()
+      export class MailService {
+        constructor(@Optional() options) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("options");
+	});
+
 	it("flags untyped constructor param without @Inject", () => {
 		const diags = runRule(
 			requireInjectDecorator,


### PR DESCRIPTION
## 1. Context

NestJS resolves a constructor parameter from its type, or from an explicit token when there is no usable type. `correctness/require-inject-decorator` reports, at **error** severity, a parameter that has neither:

> Constructor parameter 'repo' in 'CompaniesService' has no type annotation and no @Inject() decorator — NestJS cannot resolve it.

## 2. Problem

The token check is an exact name match:

```ts
const hasInject = param.getDecorators().some((d) => d.getName() === "Inject");
```

Every Nest DI decorator supplies a token through `Inject` under the hood, and none of them are called `Inject`:

| Decorator | From |
|---|---|
| `@InjectRepository` | `@nestjs/typeorm`, `@mikro-orm/nestjs` |
| `@InjectEntityManager`, `@InjectDataSource`, `@InjectConnection` | `@nestjs/typeorm` |
| `@InjectModel` | `@nestjs/mongoose` |
| `@InjectQueue` | `@nestjs/bull`, `@nestjs/bullmq` |
| `@InjectRedis`, `@InjectPinoLogger`, `@InjectMetric` | community |

So working code was reported as broken:

```ts
@Injectable()
export class CompaniesService {
  constructor(@InjectRepository(Company) repo) {}
}
```

`@InjectRepository(Company)` expands to `Inject(getRepositoryToken(Company))`, which Nest reads from `SELF_DECLARED_DEPS_METADATA`. The parameter resolves; the message asserting otherwise is simply untrue, and it is an error rather than a warning.

Across 76 public NestJS projects and 16 Nest libraries the rule fires **7 times, and 6 of them carry `@InjectRepository`** — all in `nestjsx/crud`. The one real finding is a parameter with no decorator at all.

## 3. Possible flows

| Constructor parameter | Before | After |
|---|---|---|
| `private repo: Repository<X>` — typed | quiet | quiet |
| `@Inject(TOKEN) repo` | quiet | quiet |
| `@InjectRepository(Company) repo` | **error** | quiet |
| `@InjectModel(Cat.name) model` | **error** | quiet |
| `@InjectQueue('mail') queue` | **error** | quiet |
| `@Optional() options` — no token | error | error |
| `repo` — nothing at all | error | error |
| class is not a DI participant | not checked | not checked |

## 4. Solution

Key on the `Inject` prefix. That is the naming convention every one of these decorators follows, so a list is never needed again — the next package that ships `@InjectWhatever` is covered on the day it is published.

`@Optional()` still reports, because it changes resolution behaviour without supplying a token, and a parameter with no type and no token genuinely cannot be resolved.

Not done: the rule does not check that the *class* is registered anywhere, only that it is a DI participant by decorator. That is a different question and a different rule.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| `require-inject-decorator`, 76 projects + 16 libraries | 7 | **1** |
| of which false | 6 | 0 |
| Every other rule, 76 projects | 8,455 | 8,455 |
| Tests | 894 | 897 |

The app corpus is unchanged end to end: its single finding is a parameter with no decorator, which still reports.

## 6. Example

`nestjsx/crud`, `companies.service.ts`:

```ts
@Injectable()
export class CompaniesService extends TypeOrmCrudService<Company> {
  constructor(@InjectRepository(Company) repo) {
    super(repo);
  }
}
```

Before:

```
✖ error  correctness/require-inject-decorator
  Constructor parameter 'repo' in 'CompaniesService' has no type annotation and
  no @Inject() decorator — NestJS cannot resolve it.
```

After: nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)