### PR TITLE
fix(rules): check class properties for hardcoded secrets

### DIFF
--- a/.changeset/secrets-on-class-properties.md
+++ b/.changeset/secrets-on-class-properties.md
@@ -1,0 +1,25 @@
+---
+"nestjs-doctor": patch
+---
+
+Check class properties in `security/no-hardcoded-secrets`.
+
+The name-based path walked `VariableDeclaration` and `PropertyAssignment` in two
+near-identical blocks. A class field is a `PropertyDeclaration` and matched
+neither, so the most natural place to park a credential in a NestJS service was
+invisible:
+
+```ts
+export class SocketConstants {
+  // authentication token
+  public static readonly AUTH_TOKEN = 'FutureIsComing';
+}
+```
+
+That one is real, in `apitable/apitable`, in `src/shared/common/constants/`.
+Across 76 public projects it is the only miss the change recovers — a small
+number, but for a security rule a miss is the failure that matters.
+
+The three node kinds now run through one loop with the same name test, value
+test, and the scope-string, echoed-name and thrown-message skips. No existing
+finding changes.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
@@ -150,72 +150,45 @@ export const noHardcodedSecrets: Rule = {
 			}
 		}
 
-		// Check variable declarations and property assignments with suspicious names
-		const variableDeclarations = context.sourceFile.getDescendantsOfKind(
-			SyntaxKind.VariableDeclaration
-		);
+		// A named binding holding a string literal, wherever it is declared.
+		const NAMED_BINDINGS = [
+			{ kind: SyntaxKind.VariableDeclaration, noun: "Variable" },
+			{ kind: SyntaxKind.PropertyAssignment, noun: "Property" },
+			{ kind: SyntaxKind.PropertyDeclaration, noun: "Property" },
+		] as const;
 
-		for (const decl of variableDeclarations) {
-			const name = decl.getName();
-			const initializer = decl.getInitializer();
-			if (!initializer || initializer.getKind() !== SyntaxKind.StringLiteral) {
-				continue;
-			}
+		for (const { kind, noun } of NAMED_BINDINGS) {
+			for (const node of context.sourceFile.getDescendantsOfKind(kind)) {
+				const name = node.getName();
+				const initializer = node.getInitializer();
+				if (
+					!initializer ||
+					initializer.getKind() !== SyntaxKind.StringLiteral
+				) {
+					continue;
+				}
 
-			if (!hasSuspiciousName(name)) {
-				continue;
-			}
+				if (!hasSuspiciousName(name)) {
+					continue;
+				}
 
-			const value = initializer.getText().slice(1, -1);
-			if (
-				SCOPE_VALUE.test(value) ||
-				echoesName(name, value) ||
-				(isThrownMessage(decl) && isWordSequence(value))
-			) {
-				continue;
-			}
-			if (isSuspiciousValue(value)) {
-				context.report({
-					filePath: context.filePath,
-					message: `Variable '${name}' appears to contain a hardcoded secret.`,
-					help: this.meta.help,
-					line: decl.getStartLineNumber(),
-					column: 1,
-				});
-			}
-		}
-
-		const propertyAssignments = context.sourceFile.getDescendantsOfKind(
-			SyntaxKind.PropertyAssignment
-		);
-
-		for (const prop of propertyAssignments) {
-			const name = prop.getName();
-			const initializer = prop.getInitializer();
-			if (!initializer || initializer.getKind() !== SyntaxKind.StringLiteral) {
-				continue;
-			}
-
-			if (!hasSuspiciousName(name)) {
-				continue;
-			}
-
-			const value = initializer.getText().slice(1, -1);
-			if (
-				SCOPE_VALUE.test(value) ||
-				echoesName(name, value) ||
-				(isThrownMessage(prop) && isWordSequence(value))
-			) {
-				continue;
-			}
-			if (isSuspiciousValue(value)) {
-				context.report({
-					filePath: context.filePath,
-					message: `Property '${name}' appears to contain a hardcoded secret.`,
-					help: this.meta.help,
-					line: prop.getStartLineNumber(),
-					column: 1,
-				});
+				const value = initializer.getText().slice(1, -1);
+				if (
+					SCOPE_VALUE.test(value) ||
+					echoesName(name, value) ||
+					(isThrownMessage(node) && isWordSequence(value))
+				) {
+					continue;
+				}
+				if (isSuspiciousValue(value)) {
+					context.report({
+						filePath: context.filePath,
+						message: `${noun} '${name}' appears to contain a hardcoded secret.`,
+						help: this.meta.help,
+						line: node.getStartLineNumber(),
+						column: 1,
+					});
+				}
 			}
 		}
 	},

--- a/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
@@ -25,6 +25,46 @@ function runRule(code: string, filePath = "test.ts"): Diagnostic[] {
 }
 
 describe("no-hardcoded-secrets", () => {
+	it("flags a class property holding a secret", () => {
+		const diags = runRule(`
+      export class SocketConstants {
+        public static readonly AUTH_TOKEN = 'FutureIsComing';
+      }
+    `);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("AUTH_TOKEN");
+	});
+
+	it("flags a private readonly password field", () => {
+		const diags = runRule(`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class MailService {
+        private readonly password = 'hunter2hunter2hunter2';
+      }
+    `);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("password");
+	});
+
+	it("does not flag a class property read from the environment", () => {
+		const diags = runRule(`
+      export class Config {
+        private readonly apiSecret = process.env.API_SECRET;
+      }
+    `);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag a class property whose value echoes its name", () => {
+		const diags = runRule(`
+      export class Fields {
+        readonly passwordField = 'password';
+      }
+    `);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("flags hardcoded secret key patterns", () => {
 		const diags = runRule(`
       const token = 'sk-abcdefghijklmnopqrstuvwxyz1234567890';


### PR DESCRIPTION
## 1. Context

`security/no-hardcoded-secrets` has two paths. The pattern path tests every string literal against known credential shapes — Stripe keys, GitHub tokens, JWTs. The name-based path looks for a suspicious *name* holding a suspicious *value*, which is what catches a credential that has no recognisable format.

## 2. Problem

The name-based path was written as two near-identical blocks:

```ts
const variableDeclarations = context.sourceFile.getDescendantsOfKind(
  SyntaxKind.VariableDeclaration
);
...
const propertyAssignments = context.sourceFile.getDescendantsOfKind(
  SyntaxKind.PropertyAssignment
);
```

A class field is a `PropertyDeclaration` and is neither. So the rule saw all of these:

```ts
const dbPassword = 'hunter2hunter2hunter2';        // VariableDeclaration     ✓
config = { password: 'hunter2hunter2hunter2' };    // PropertyAssignment      ✓
```

and none of these:

```ts
private readonly password = 'hunter2hunter2hunter2';   // PropertyDeclaration ✗
private readonly apiSecret = 'P@ssw0rd!SuperSecret99'; // PropertyDeclaration ✗
```

A field on an `@Injectable()` service is where a credential most naturally ends up in a NestJS codebase, and it was the one shape not checked.

Across 76 public projects this recovers exactly one finding, in `apitable/apitable`:

```ts
// packages/room-server/src/shared/common/constants/socket.module.constants.ts
export class SocketConstants {
  ...
  // authentication token
  public static readonly AUTH_TOKEN = 'FutureIsComing';
}
```

Production source, not a fixture, in a public repository.

## 3. Possible flows

| Declaration | Before | After |
|---|---|---|
| `const dbPassword = '…'` | reported | reported |
| `{ password: '…' }` in an object literal | reported | reported |
| `private readonly password = '…'` | **missed** | reported |
| `public static readonly AUTH_TOKEN = '…'` | **missed** | reported |
| `private readonly apiSecret = process.env.API_SECRET` | quiet | quiet |
| `readonly passwordField = 'password'` — value echoes the name | quiet | quiet |
| `'password:update'` — a permission scope | quiet | quiet |
| a secret inside a `throw` message | quiet | quiet |
| any string matching a credential pattern | reported | reported |

## 4. Solution

The three node kinds run through one loop. Each still goes through `hasSuspiciousName`, `isSuspiciousValue`, and the `SCOPE_VALUE` / `echoesName` / `isThrownMessage` skips that earlier work tuned, so a class field is treated exactly like a variable — no new heuristic, one fewer copy of the old one.

Not done: the rule still requires a string *literal* initializer. A field assigned from a template literal or a concatenation is not checked, in either the old shape or the new one.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| `security/no-hardcoded-secrets`, 76 projects | 51 | **52** |
| False positives added | — | 0 |
| Every other rule | 8,404 | 8,404 |
| Duplicated blocks in the rule | 2 | 0 |
| Tests | 894 | 898 |

One finding is a small number. It is also a live authentication token in a public repository that the tool was built to find and did not.

## 6. Example

```
$ node dist/cli/index.mjs <apitable>/packages/room-server/src --format json --json-compact \
    | jq '[.diagnostics[] | select(.rule=="security/no-hardcoded-secrets") | .message]'
```

Before: the `AUTH_TOKEN` field is absent from the output.

After:

```
Property 'AUTH_TOKEN' appears to contain a hardcoded secret.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)