### PR TITLE
fix(engine): detect Nx projects that have no package.json

### DIFF
--- a/.changeset/nx-projects-without-package-json.md
+++ b/.changeset/nx-projects-without-package-json.md
@@ -1,0 +1,28 @@
+---
+"nestjs-doctor": patch
+---
+
+Detect Nx projects that have no `package.json` of their own.
+
+Nx keeps a single dependency list at the workspace root — that is its
+single-version policy — so most Nx projects have a `project.json` and no
+`package.json`. `detectNxMonorepo` required a sibling `package.json` carrying a
+direct `@nestjs/core` or `@nestjs/common` dependency, and skipped everything
+else without a word.
+
+On `amplication/amplication` that meant 9 of its 21 NestJS projects were
+invisible, `packages/amplication-server` among them — 794 files importing
+`@nestjs`, 59 module files. Pointing the CLI at the repository root scanned 252
+files and reported 66 findings.
+
+A project with no usable `package.json` now qualifies when it contains a
+`*.module.ts` that imports `@nestjs/common`. Nx workspaces routinely hold
+Angular projects, which use the same file name, so the import is what separates
+them.
+
+Across the 15 Nx repositories in a 189-project corpus: 3,354 files scanned
+becomes 3,963, and 1,997 findings become 2,679. Amplication alone goes from 252
+files to 1,655. The repositories that scan *fewer* files now were previously
+running NestJS rules over Angular code — `ZenSoftware/zen` no longer reports on
+`libs/auth`, which has 40 files importing `@angular` and none importing
+`@nestjs`. Non-Nx projects are untouched.

--- a/packages/nestjs-doctor/src/engine/project-detector.ts
+++ b/packages/nestjs-doctor/src/engine/project-detector.ts
@@ -4,6 +4,9 @@ import { dirname, join, relative, resolve } from "node:path";
 import { glob } from "tinyglobby";
 import type { ProjectInfo } from "../common/result.js";
 
+/** Module files read per Nx project when probing for a NestJS import. */
+const NEST_MODULE_PROBE_LIMIT = 20;
+
 interface PackageJson {
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;
@@ -253,6 +256,33 @@ async function detectLernaMonorepo(
 	return resolveWorkspaceProjects(targetPath, patterns);
 }
 
+/**
+ * True when the directory holds a NestJS module file. Nx projects declare their
+ * dependencies in the workspace root, so a package.json is often absent — and
+ * Angular projects in the same workspace also use `*.module.ts`, so the import
+ * is what tells them apart.
+ */
+async function containsNestModule(projectDir: string): Promise<boolean> {
+	const moduleFiles = await glob(["**/*.module.ts"], {
+		cwd: projectDir,
+		absolute: true,
+		ignore: ["**/node_modules/**"],
+	});
+
+	for (const file of moduleFiles.slice(0, NEST_MODULE_PROBE_LIMIT)) {
+		try {
+			const text = await readFile(file, "utf-8");
+			if (text.includes("@nestjs/common")) {
+				return true;
+			}
+		} catch {
+			// Unreadable — try the next one
+		}
+	}
+
+	return false;
+}
+
 async function detectNxMonorepo(
 	targetPath: string
 ): Promise<MonorepoInfo | null> {
@@ -281,17 +311,34 @@ async function detectNxMonorepo(
 			continue;
 		}
 
-		const pkgPath = join(projectDir, "package.json");
+		let pkg: PackageJson | undefined;
 		try {
-			const raw = await readFile(pkgPath, "utf-8");
-			const pkg = JSON.parse(raw) as PackageJson;
-
-			if (hasNestDependency(pkg)) {
-				const name = pkg.name ?? relativePath;
-				projects.set(name, relativePath);
-			}
+			pkg = JSON.parse(
+				await readFile(join(projectDir, "package.json"), "utf-8")
+			) as PackageJson;
 		} catch {
-			// No package.json or unreadable — skip
+			// Nx projects commonly have no package.json of their own
+		}
+
+		if (pkg && hasNestDependency(pkg)) {
+			projects.set(pkg.name ?? relativePath, relativePath);
+			continue;
+		}
+
+		if (await containsNestModule(projectDir)) {
+			// Nx names the project in project.json, which is the only name it has
+			// when there is no package.json.
+			let nxName: string | undefined;
+			try {
+				nxName = (
+					JSON.parse(await readFile(projectJsonPath, "utf-8")) as {
+						name?: string;
+					}
+				).name;
+			} catch {
+				// Unreadable — fall back to the path
+			}
+			projects.set(pkg?.name ?? nxName ?? relativePath, relativePath);
 		}
 	}
 

--- a/packages/nestjs-doctor/tests/fixtures/nx-root-deps/apps/web/project.json
+++ b/packages/nestjs-doctor/tests/fixtures/nx-root-deps/apps/web/project.json
@@ -1,0 +1,1 @@
+{ "name": "web", "sourceRoot": "apps/web/src", "projectType": "application" }

--- a/packages/nestjs-doctor/tests/fixtures/nx-root-deps/apps/web/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nx-root-deps/apps/web/src/app.module.ts
@@ -1,0 +1,4 @@
+import { NgModule } from "@angular/core";
+
+@NgModule({})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/nx-root-deps/apps/worker/project.json
+++ b/packages/nestjs-doctor/tests/fixtures/nx-root-deps/apps/worker/project.json
@@ -1,0 +1,1 @@
+{ "name": "worker", "sourceRoot": "apps/worker/src", "projectType": "application" }

--- a/packages/nestjs-doctor/tests/fixtures/nx-root-deps/apps/worker/src/worker.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nx-root-deps/apps/worker/src/worker.module.ts
@@ -1,0 +1,4 @@
+import { Module } from "@nestjs/common";
+
+@Module({})
+export class WorkerModule {}

--- a/packages/nestjs-doctor/tests/fixtures/nx-root-deps/libs/util/project.json
+++ b/packages/nestjs-doctor/tests/fixtures/nx-root-deps/libs/util/project.json
@@ -1,0 +1,1 @@
+{ "name": "util", "sourceRoot": "libs/util/src", "projectType": "library" }

--- a/packages/nestjs-doctor/tests/fixtures/nx-root-deps/libs/util/src/index.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nx-root-deps/libs/util/src/index.ts
@@ -1,0 +1,1 @@
+export const noop = () => undefined;

--- a/packages/nestjs-doctor/tests/fixtures/nx-root-deps/nx.json
+++ b/packages/nestjs-doctor/tests/fixtures/nx-root-deps/nx.json
@@ -1,0 +1,1 @@
+{ "npmScope": "acme" }

--- a/packages/nestjs-doctor/tests/fixtures/nx-root-deps/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/nx-root-deps/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "acme-workspace",
+  "dependencies": { "@nestjs/core": "^10.0.0", "@nestjs/common": "^10.0.0", "@angular/core": "^17.0.0" }
+}

--- a/packages/nestjs-doctor/tests/unit/project-detector.test.ts
+++ b/packages/nestjs-doctor/tests/unit/project-detector.test.ts
@@ -110,6 +110,25 @@ describe("monorepo-detector", () => {
 		expect(info!.projects.has("@lerna/frontend")).toBe(false);
 	});
 
+	it("includes an Nx project that has no package.json of its own", async () => {
+		const info = await detectMonorepo(resolve(FIXTURES, "nx-root-deps"));
+		expect(info).not.toBeNull();
+		// Nx declares dependencies at the workspace root, so apps/worker has no
+		// package.json — its NestJS module file is what identifies it.
+		expect(info?.projects.get("worker")).toBe("apps/worker");
+	});
+
+	it("leaves out an Nx project whose module file is Angular", async () => {
+		const info = await detectMonorepo(resolve(FIXTURES, "nx-root-deps"));
+		expect(info?.projects.has("web")).toBe(false);
+	});
+
+	it("leaves out an Nx library with no NestJS module", async () => {
+		const info = await detectMonorepo(resolve(FIXTURES, "nx-root-deps"));
+		expect(info?.projects.has("util")).toBe(false);
+		expect(info?.projects.size).toBe(1);
+	});
+
 	it("detects Nx monorepo via nx.json and project.json files", async () => {
 		const info = await detectMonorepo(resolve(FIXTURES, "nx-app"));
 		expect(info).not.toBeNull();


### PR DESCRIPTION
## 1. Context

Monorepo detection runs five strategies, first match wins. The Nx strategy finds every `project.json`, then keeps a project only if a sibling `package.json` declares `@nestjs/core` or `@nestjs/common`:

```ts
const pkgPath = join(projectDir, "package.json");
try {
  const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));
  if (hasNestDependency(pkg)) { projects.set(...); }
} catch {
  // No package.json or unreadable — skip
}
```

## 2. Problem

That is a pnpm/yarn-workspaces assumption. Nx keeps **one** dependency list, at the workspace root — its single-version policy — and a project is defined by `project.json`. Most Nx projects have no `package.json` at all, so the `catch` swallowed them.

`amplication/amplication`:

| | |
|---|---:|
| `project.json` directories | 30 |
| with a `package.json` | 12 |
| **no `package.json`, source imports `@nestjs`** | **9** |
| root `package.json` declares `@nestjs/core` | yes |

`packages/amplication-server` — the main API, **794 files importing `@nestjs`, 59 module files** — has a `project.json` and no `package.json`. It was never scanned.

```
$ nestjs-doctor <amplication-root>

  Sub-project breakdown:
    generator-nodejs-nest: 97/100  |  248 files
    @amplication/util-nestjs-logging: 89/100  |  4 files
```

252 files, 66 findings, score 97, no warning. The repository has 1,655 NestJS files.

## 3. Possible flows

| Nx project | Before | After |
|---|---|---|
| own `package.json` with a Nest dep | scanned | scanned |
| own `package.json` without a Nest dep | skipped | skipped unless it holds a Nest module |
| **no `package.json`, has a NestJS `*.module.ts`** | **skipped** | scanned |
| no `package.json`, Angular `*.module.ts` | skipped | skipped |
| no `package.json`, no module file | skipped | skipped |
| root-level `project.json` | skipped | skipped |
| pnpm / yarn / lerna / turbo workspaces | unchanged | unchanged |
| single-project repositories | unchanged | unchanged |

## 4. Solution

When a project has no usable `package.json`, qualify it if it contains a `*.module.ts` importing `@nestjs/common`, reading at most 20 module files per project. Nx workspaces routinely mix Angular in, and Angular uses the same `*.module.ts` convention — the import is what tells them apart, not the filename. The project name comes from `project.json`, which is the only name such a project has.

## 5. Before vs after

Across the 15 Nx repositories in a 189-project corpus:

| | Before | After |
|---|---:|---:|
| Files scanned | 3,354 | **3,963** |
| Findings | 1,997 | **2,679** |
| Schema findings | 51 | 54 |
| Non-Nx repositories changed (25 sampled) | — | **0** |
| Tests | 894 | 897 |

Per repository, where anything moved:

| Repository | files | findings |
|---|---|---|
| `amplication/amplication` | 252 → **1,655** | 66 → 917 |
| `pezzolabs/pezzo` | 212 → 135 | 85 → 90 |
| `ghostfolio/ghostfolio` | 761 → 255 | 278 → 187 |
| `ZenSoftware/zen` | 229 → 73 | 112 → 37 |
| `DimiMikadze/fest` | 66 → 51 | 43 → 43 |
| `chocolat-chaud-io/stator` | 41 → 13 | 16 → 9 |
| `jiayisheji/jianshu` | 22 → 10 | 2 → 1 |

**The repositories that scan fewer files were previously reporting on frontend code.** Those repositories fell through Nx detection entirely and were scanned as a single project from the root, so NestJS rules ran over Angular sources. In `ZenSoftware/zen`, `libs/auth` has 40 files importing `@angular` and **zero** importing `@nestjs`, and `no-fire-and-forget-async` was firing in it. In `ghostfolio`, the dropped files are `apps/client` and `libs/ui`.

**One real loss, and it is pre-existing.** `ghostfolio` keeps its Prisma schema at the repository root, outside every project. `buildAnalysisContext` locates the schema relative to the directory it is given, so in monorepo mode a root-level schema is invisible to every sub-project — `extractSchema(astProject, files, project.orm, targetPath)` with `targetPath` being the sub-project. That costs ghostfolio 11 schema findings. It is not introduced here: any repository already taking the monorepo path has the same gap. Filed separately.

## 6. Example

```
$ node dist/cli/index.mjs <amplication-root>
```

After:

```
  Sub-project breakdown:

    packages/amplication-build-manager: 92/100  |  24 files  |  9 warnings
    packages/amplication-plugin-api: 93/100  |  105 files  |  1 errors  |  32 warnings  |  13 info
    packages/amplication-server: 90/100  |  860 files  |  21 errors  |  338 warnings  |  261 info
    packages/amplication-storage-gateway: 94/100  |  55 files  |  4 errors  |  9 warnings  |  4 info
    packages/data-service-generator-catalog: 94/100  |  136 files  |  2 errors  |  32 warnings  |  24 info
    generator-nodejs-nest: 97/100  |  248 files  |  30 warnings  |  32 info
    packages/gpt-gateway: 93/100  |  182 files  |  2 errors  |  52 warnings  |  37 info
    packages/notification-service: 96/100  |  15 files  |  3 warnings
    ee/packages/git-sync-manager: 94/100  |  18 files  |  2 errors  |  4 warnings
    libs/util/nestjs/kafka: 100/100  |  8 files  |  1 info
    @amplication/util-nestjs-logging: 89/100  |  4 files  |  2 warnings  |  2 info
```

21 errors in `amplication-server` that the tool could not previously see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)