### PR TITLE
fix(engine): find a workspace-root schema from every sub-project

### DIFF
--- a/.changeset/monorepo-root-schema.md
+++ b/.changeset/monorepo-root-schema.md
@@ -1,0 +1,29 @@
+---
+"nestjs-doctor": patch
+---
+
+Find a workspace-root ORM schema from every sub-project.
+
+In monorepo mode each sub-project extracts its schema relative to its own
+directory:
+
+```ts
+const schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
+```
+
+A monorepo usually keeps one schema for the whole workspace, at the root. It sits
+outside every sub-project, so no sub-project found it, and the three schema rules
+reported nothing — which reads exactly like a schema with no problems.
+
+`ghostfolio/ghostfolio` keeps `prisma/schema.prisma` at the repository root.
+Scanned as a single project it reports 11 schema findings; scanned as the
+monorepo it is, it reported 0, while still naming `prisma` as the detected ORM.
+
+A sub-project that finds no schema of its own now retries from the workspace
+root. A sub-project that owns one is unaffected.
+
+Separately, when an ORM is detected and the schema graph is still empty, a
+warning now goes to stderr in every format, so "found nothing" stops looking like
+"found nothing wrong".
+
+Closes #192.

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -78,6 +78,12 @@ function emit(
 		logger.warn(warning);
 	}
 
+	if (result.project.orm && result.schema?.entities.length === 0) {
+		logger.warn(
+			`Detected ${result.project.orm} but found no schema to analyse. The schema rules reported nothing because they read nothing.`
+		);
+	}
+
 	if (result.project.fileCount === 0) {
 		logger.warn(
 			`No TypeScript files matched under ${targetPath}. The score describes nothing.`

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -164,12 +164,22 @@ export async function buildMonorepoContext(
 				const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 				const providers = resolveProviders(astProject, files);
 				const endpointGraph = buildEndpointGraph(astProject, files, providers);
-				const schemaGraph = extractSchema(
+				// A monorepo usually keeps one schema, at the workspace root, outside
+				// every sub-project. Fall back to it rather than report no schema.
+				let schemaGraph = extractSchema(
 					astProject,
 					files,
 					project.orm,
 					projectPath
 				);
+				if (project.orm && schemaGraph.entities.size === 0) {
+					schemaGraph = extractSchema(
+						astProject,
+						files,
+						project.orm,
+						targetPath
+					);
+				}
 				const rules = filterRules(projectConfig, combinedRules);
 				const { fileRules, projectRules, schemaRules } = separateRules(rules);
 

--- a/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/apps/api/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/apps/api/package.json
@@ -1,0 +1,1 @@
+{ "name": "api", "dependencies": { "@nestjs/core": "^10.0.0", "@nestjs/common": "^10.0.0", "@prisma/client": "^5.0.0" } }

--- a/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/apps/api/src/api.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/apps/api/src/api.module.ts
@@ -1,0 +1,4 @@
+import { Module } from "@nestjs/common";
+
+@Module({})
+export class ApiModule {}

--- a/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/apps/worker/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/apps/worker/package.json
@@ -1,0 +1,1 @@
+{ "name": "worker", "dependencies": { "@nestjs/core": "^10.0.0", "@nestjs/common": "^10.0.0", "@prisma/client": "^5.0.0" } }

--- a/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/apps/worker/src/worker.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/apps/worker/src/worker.module.ts
@@ -1,0 +1,4 @@
+import { Module } from "@nestjs/common";
+
+@Module({})
+export class WorkerModule {}

--- a/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/package.json
@@ -1,0 +1,1 @@
+{ "name": "root-schema-workspace", "private": true, "workspaces": ["apps/*"] }

--- a/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/prisma/schema.prisma
+++ b/packages/nestjs-doctor/tests/fixtures/root-schema-monorepo/prisma/schema.prisma
@@ -1,0 +1,10 @@
+model Account {
+  id    String @id @default(uuid())
+  email String @unique
+}
+
+model Session {
+  id        String  @id @default(uuid())
+  accountId String
+  account   Account @relation(fields: [accountId], references: [id])
+}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -5,6 +5,7 @@ import { diagnoseMonorepo } from "../../src/api/index.js";
 import { detectMonorepo } from "../../src/engine/project-detector.js";
 import {
 	buildAnalysisContext,
+	buildMonorepoContext,
 	buildResult,
 	diagnose,
 	resolveScanConfig,
@@ -549,6 +550,42 @@ describe("scanner integration", () => {
 		expect(result.isMonorepo).toBe(false);
 		expect(result.subProjects.length).toBe(1);
 		expect(result.subProjects[0].name).toBe("default");
+	});
+
+	describe("root-schema-monorepo fixture", () => {
+		it("falls back to the workspace-root schema for every sub-project", async () => {
+			const targetPath = resolve(FIXTURES, "root-schema-monorepo");
+			const monorepo = await detectMonorepo(targetPath);
+			expect(monorepo).not.toBeNull();
+
+			const scanConfig = await resolveScanConfig(targetPath);
+			const context = await buildMonorepoContext(
+				targetPath,
+				scanConfig,
+				monorepo!
+			);
+
+			for (const [name, subProject] of context.subProjects) {
+				const entities = [...(subProject.schemaGraph?.entities.keys() ?? [])];
+				expect(entities, name).toEqual(
+					expect.arrayContaining(["Account", "Session"])
+				);
+			}
+		});
+
+		it("still prefers a schema the sub-project owns", async () => {
+			const targetPath = resolve(FIXTURES, "turborepo-app");
+			const monorepo = await detectMonorepo(targetPath);
+			const scanConfig = await resolveScanConfig(targetPath);
+			const context = await buildMonorepoContext(
+				targetPath,
+				scanConfig,
+				monorepo!
+			);
+
+			const db = context.subProjects.get("@acme/db");
+			expect(db?.schemaGraph?.entities.size).toBeGreaterThan(0);
+		});
 	});
 
 	describe("turborepo-app fixture", () => {


### PR DESCRIPTION
## 1. Context

Every scan extracts an ORM schema and hands it to the three schema rules. In monorepo mode each sub-project builds its own context, and the schema is located relative to that sub-project:

```ts
const schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
```

For Prisma that path is all the extractor uses — it looks for `prisma/schema.prisma`, a root `schema.prisma`, or a custom path from `package.json`, and ignores the TypeScript sources entirely.

## 2. Problem

A monorepo usually has **one** database and keeps **one** schema, at the workspace root. That is outside every sub-project directory, so every sub-project looked and found nothing.

`ghostfolio/ghostfolio` keeps `prisma/schema.prisma` at the repository root:

| Scanned as | `project.orm` | entities | schema findings |
|---|---|---:|---:|
| a single project | `prisma` | 18 | **11** |
| the monorepo it is | `prisma` | 0 | **0** |

The ORM is named in the output, the score is computed, and the schema section is empty. Nothing says the schema was never read — the failure `CLAUDE.md` describes:

> Degrade wider, never narrower. A scan that silently reports nothing looks identical to a clean one.

## 3. Possible flows

| Sub-project | Before | After |
|---|---|---|
| owns `prisma/schema.prisma` | used | used, unchanged |
| owns a TypeORM/MikroORM/Drizzle schema in its sources | used | used, unchanged |
| no schema, workspace root has one | **empty** | root schema used |
| no schema anywhere, ORM detected | empty, silent | empty, **warned** |
| no ORM detected | empty | empty, no warning |
| single-project scan | unchanged | unchanged |

## 4. Solution

When a sub-project's extraction yields no entities and an ORM was detected, retry from the workspace root. A sub-project that owns a schema never reaches the fallback, so `turborepo-app`'s `@acme/db` still resolves its own — covered by a test.

Second, independent of monorepos: when an ORM is detected and the schema graph is still empty, `emit()` warns on stderr through the channel already used for scope warnings:

```
Detected prisma but found no schema to analyse. The schema rules reported nothing because they read nothing.
```

Not done: sharing one extraction across sub-projects. There is normally one database, so extracting the same root schema per sub-project is redundant work — but merging the graphs changes what "per sub-project" means for the schema rules and for the HTML report's ER diagram. The fallback is the fix; deduplicating the work is a separate question.

## 5. Before vs after

Scanning at the repository root, across the 65 projects in a 189-project corpus that carry a workspace marker:

| | Before | After |
|---|---:|---:|
| Schema findings | 423 | **434** |
| Schema entities | 605 | **623** |
| Repositories affected | — | 1 (`ghostfolio`) |
| Every non-schema rule | unchanged | unchanged |
| Tests | 910 | 912 |

One repository in 65, because most monorepos keep the schema inside a package. For that one it is the difference between reading the schema and not.

## 6. Example

```
$ node dist/cli/index.mjs <ghostfolio-root> --format json --json-compact \
    | jq '{orm: .project.orm, entities: (.schema.entities | length),
           schema: [.diagnostics[] | select(.rule | startswith("schema/"))] | length}'
```

Before:

```json
{ "orm": "prisma", "entities": 0, "schema": 0 }
```

After:

```json
{ "orm": "prisma", "entities": 18, "schema": 11 }
```

Closes #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)