### PR TITLE
fix(rules): recognise a controller behind a composed decorator

### DIFF
--- a/.changeset/base-controller-handlers.md
+++ b/.changeset/base-controller-handlers.md
@@ -1,0 +1,31 @@
+---
+"nestjs-doctor": patch
+---
+
+Recognise a controller behind a composed decorator.
+
+Nine rules opened with `if (!isController(cls)) continue;`, and `isController`
+matches the literal name `Controller`. A project that wraps it — which NestJS
+encourages through `applyDecorators` — was invisible to all nine:
+
+```ts
+export const ApiController = (path?: string) => Controller(`/api/v${API_VERSION}/${path}`);
+
+@ApiController('activities')
+export class ActivityController {
+  @Get('/') activities(@Query() pager: ActivityQueryDto) { switch (pager.type) { ... } }
+}
+```
+
+`ApiController` returns `Controller(...)`. The class is a controller in every
+sense NestJS cares about, and no rule looked at it.
+
+Across 189 public projects there are **58 such classes holding 358 route
+handlers**. Examining them adds 86 findings, 72 of them in `mx-space/core`:
+`switch` statements in handlers, raw entities returned, repositories injected
+into controllers.
+
+A class now counts when it carries `@Controller()`, or when it carries some
+class decorator and declares route handlers. A class with **no** decorator at
+all is still skipped: NestJS needs a concrete subclass to register it, and a
+guard or an injection may live there rather than on the base.

--- a/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
+++ b/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
@@ -52,6 +52,21 @@ export function isController(cls: ClassDeclaration): boolean {
 	return hasDecorator(cls, "Controller");
 }
 
+/**
+ * True when the class carries `@Controller()`, or a decorator that composes it.
+ * `applyDecorators(Controller(path), ApiTags(...))` is common, and the composed
+ * name is all that survives in the source, so route handlers identify it.
+ */
+export function declaresRoutes(cls: ClassDeclaration): boolean {
+	if (isController(cls)) {
+		return true;
+	}
+	if (cls.getDecorators().length === 0) {
+		return false;
+	}
+	return cls.getMethods().some(isHttpHandler);
+}
+
 export function isService(cls: ClassDeclaration): boolean {
 	return hasDecorator(cls, "Injectable");
 }

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-business-logic-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-business-logic-in-controllers.ts
@@ -1,7 +1,7 @@
 import { type IfStatement, SyntaxKind } from "ts-morph";
 import {
+	declaresRoutes,
 	HTTP_DECORATORS,
-	isController,
 } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
@@ -36,7 +36,7 @@ export const noBusinessLogicInControllers: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-controllers.ts
@@ -1,5 +1,5 @@
 import { extractSimpleTypeName } from "../../../graph/type-resolver.js";
-import { isController } from "../../../nest-class-inspector.js";
+import { declaresRoutes } from "../../../nest-class-inspector.js";
 import { columnOf } from "../../../source-position.js";
 import type { Rule } from "../../types.js";
 
@@ -31,7 +31,7 @@ export const noOrmInControllers: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-repository-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-repository-in-controllers.ts
@@ -1,5 +1,5 @@
 import { extractSimpleTypeName } from "../../../graph/type-resolver.js";
-import { isController } from "../../../nest-class-inspector.js";
+import { declaresRoutes } from "../../../nest-class-inspector.js";
 import { columnOf } from "../../../source-position.js";
 import type { Rule } from "../../types.js";
 
@@ -17,7 +17,7 @@ export const noRepositoryInControllers: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-routes.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-routes.ts
@@ -1,6 +1,6 @@
 import {
+	declaresRoutes,
 	HTTP_DECORATORS,
-	isController,
 } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
@@ -16,7 +16,7 @@ export const noDuplicateRoutes: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-empty-handlers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-empty-handlers.ts
@@ -1,7 +1,7 @@
 import { SyntaxKind } from "ts-morph";
 import {
+	declaresRoutes,
 	HTTP_DECORATORS,
-	isController,
 } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
@@ -16,7 +16,7 @@ export const noEmptyHandlers: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/param-decorator-matches-route.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/param-decorator-matches-route.ts
@@ -1,7 +1,7 @@
 import { type Node, SyntaxKind } from "ts-morph";
 import {
+	declaresRoutes,
 	HTTP_DECORATORS,
-	isController,
 } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
@@ -27,7 +27,7 @@ export const paramDecoratorMatchesRoute: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-dangerous-redirects.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-dangerous-redirects.ts
@@ -1,5 +1,5 @@
 import { SyntaxKind } from "ts-morph";
-import { isController } from "../../../nest-class-inspector.js";
+import { declaresRoutes } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
 export const noDangerousRedirects: Rule = {
@@ -14,7 +14,7 @@ export const noDangerousRedirects: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-raw-entity-in-response.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-raw-entity-in-response.ts
@@ -1,4 +1,7 @@
-import { isController, isHttpHandler } from "../../../nest-class-inspector.js";
+import {
+	declaresRoutes,
+	isHttpHandler,
+} from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
 const ENTITY_SUFFIXES = ["Entity", "Model"];
@@ -18,7 +21,7 @@ export const noRawEntityInResponse: Rule = {
 
 	check(context) {
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -1,5 +1,8 @@
 import type { ClassDeclaration, MethodDeclaration } from "ts-morph";
-import { isController, isHttpHandler } from "../../../nest-class-inspector.js";
+import {
+	declaresRoutes,
+	isHttpHandler,
+} from "../../../nest-class-inspector.js";
 import type { GuardFacts, Rule } from "../../types.js";
 
 const PUBLIC_DECORATORS = new Set([
@@ -39,7 +42,7 @@ export const requireGuardsOnEndpoints: Rule = {
 		}
 
 		for (const cls of context.sourceFile.getClasses()) {
-			if (!isController(cls)) {
+			if (!declaresRoutes(cls)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -42,6 +42,65 @@ function runRule(
 }
 
 describe("no-business-logic-in-controllers", () => {
+	it("examines a class whose @Controller() is behind a composed decorator", () => {
+		const diags = runRule(
+			noBusinessLogicInControllers,
+			`
+      import { Get } from '@nestjs/common';
+      import { ApiController } from './api-controller.decorator';
+      @ApiController('items')
+      export class ItemsController {
+        @Get()
+        list(type: string) {
+          switch (type) {
+            case 'a': return 1;
+            default: return 2;
+          }
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("leaves an undecorated class alone even when it declares handlers", () => {
+		const diags = runRule(
+			noBusinessLogicInControllers,
+			`
+      import { Get } from '@nestjs/common';
+      export class DomainControllerBase {
+        @Get()
+        list(type: string) {
+          switch (type) {
+            case 'a': return 1;
+            default: return 2;
+          }
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("leaves a decorated class with no route handler alone", () => {
+		const diags = runRule(
+			noBusinessLogicInControllers,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class ItemsService {
+        list(type: string) {
+          switch (type) {
+            case 'a': return 1;
+            default: return 2;
+          }
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("does not count guard clauses that only throw", () => {
 		const diags = runRule(
 			noBusinessLogicInControllers,


### PR DESCRIPTION
## 1. Context

Nine rules decide whether a class is worth looking at with the same line:

```ts
if (!isController(cls)) {
  continue;
}
```

and `isController` is a literal name match:

```ts
export function isController(cls: ClassDeclaration): boolean {
  return hasDecorator(cls, "Controller");
}
```

## 2. Problem

NestJS encourages composing decorators, and a composed decorator keeps its own name in the source. `mx-space/core` defines one:

```ts
export const ApiController: (path?: string | string[] | ControllerOptions) => ReturnType<typeof Controller> =
  (...rest) => { ...; return Controller(transformPath(controller), ...args); };
```

It returns `Controller(...)`. Every class using it is a controller — Nest registers its routes, its guards run, its return values are serialised — and `hasDecorator(cls, "Controller")` is false, so **all nine rules skipped the whole class**.

Across 189 public projects: **58 classes carry a composed controller decorator and declare 358 route handlers.** Not one of them was examined by:

`require-guards-on-endpoints`, `no-raw-entity-in-response`, `no-dangerous-redirects`, `no-business-logic-in-controllers`, `no-orm-in-controllers`, `no-repository-in-controllers`, `no-duplicate-routes`, `no-empty-handlers`, `param-decorator-matches-route`.

This corrects the hypothesis in #179. That issue framed the gap as undecorated **base controllers**; measuring the scanned roots of 189 projects found **0** of those and 58 composed ones. The base-class shape exists — `ablestack/nestjs-bff` has one — but it is rare, and it is the shape that is *not* safe to widen, for the reason below.

## 3. Possible flows

| Class | Before | After |
|---|---|---|
| `@Controller('items')` | examined | examined |
| `@ApiController('items')` composing `Controller` | **skipped** | examined |
| `@LogController()` composing `Controller` | **skipped** | examined |
| decorated class with no route handler (a service) | skipped | skipped |
| **undecorated** class declaring `@Get()` handlers | skipped | **still skipped** |
| a class with neither | skipped | skipped |

## 4. Solution

`declaresRoutes(cls)` is true when the class carries `@Controller()`, or when it carries *some* class decorator and declares at least one route handler. All nine rules key on it.

The decorator requirement is what keeps the undecorated base class out, and that is deliberate. A base controller is not registered by Nest on its own — the concrete subclass carries `@Controller()`, and it may also carry the `@UseGuards` that `require-guards-on-endpoints` would otherwise report as missing, or the constructor that `no-orm-in-controllers` would judge. Widening to those needs a base→subclass edge in the graph, which is #179's remaining half.

## 5. Before vs after

Re-scanning all 189 projects:

| Rule | Before | After |
|---|---:|---:|
| `architecture/no-business-logic-in-controllers` | 158 | **223** |
| `security/no-raw-entity-in-response` | 72 | **86** |
| `architecture/no-repository-in-controllers` | 39 | **44** |
| `correctness/no-empty-handlers` | 15 | **16** |
| `security/require-guards-on-endpoints` | 818 | **819** |
| Every other rule | unchanged | unchanged |
| Tests | 914 | 917 |

86 new findings, 72 in `mx-space/core` and the rest in `CatsMiaow/nestjs-project-structure`. Sampled, they are what the rules say: `switch` blocks inside handlers, four chained array operations in a handler, an entity returned raw, a repository injected into a controller.

`require-guards-on-endpoints` moves by 1 because those controllers already carry `@Auth()`, which the guard-decorator index resolves.

## 6. Example

`mx-space/core`, `activity.controller.ts`:

```ts
@ApiController(['activities', 'activity'])
export class ActivityController {
  @Get('/')
  @Auth()
  activities(@Query() pager: ActivityQueryDto) {
    const { page, size, type } = pager
    switch (type) {
      case Activity.Like: { return this.service.getLikeActivities(page, size) }
      ...
    }
  }
}
```

Before: no rule reports on this file.

After:

```
✖ error  architecture/no-business-logic-in-controllers
  Controller method 'activities' contains business logic (0 if, 0 loops, 1 switch). Move to a service.
```

Refs #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)