### PR TITLE
fix(rules): report manual instantiation only for injectable classes

### DIFF
--- a/.changeset/manual-instantiation-di-participants.md
+++ b/.changeset/manual-instantiation-di-participants.md
@@ -1,0 +1,35 @@
+---
+"nestjs-doctor": patch
+---
+
+Report manual instantiation only for classes NestJS can inject.
+
+`architecture/no-manual-instantiation` matched on a name suffix — `Service`,
+`Repository`, `Gateway`, `Resolver`, `Guard`, `Interceptor`, `Pipe`, `Filter` —
+and never checked whether the class was a provider. Its own description says
+otherwise:
+
+> Do not manually instantiate **@Injectable** classes — use NestJS dependency injection
+
+and its help asks for something impossible when the class is not yours:
+
+> Register the class as a provider in a module and inject it via the constructor
+
+So `new ValidationPipe({ whitelist: true })`, straight out of the NestJS docs,
+was an **error**. So was every plain domain class whose name happened to end in
+`Service`, and every builder called with a runtime argument.
+
+Across 189 public projects the rule fired 97 times: 30 on classes NestJS
+actually instantiates, 58 on plain classes declared in the project, 9 on classes
+from `node_modules`.
+
+The rule now consults the set of classes NestJS treats as DI participants —
+`@Injectable`, `@Controller`, `@Resolver`, `@WebSocketGateway` — gathered once
+per run and handed to file rules alongside the existing guard facts. 97 findings
+become 28, and what remains is hand-built `LoggerService`, `RedisService`,
+`ConfigService`, `ConfigRepository`.
+
+The `bad-architecture` fixture gains an `@Injectable()` on `OrderValidatorService`,
+which is what makes it the violation the fixture means it to be.
+
+Closes #188.

--- a/packages/nestjs-doctor/src/engine/diagnostician.ts
+++ b/packages/nestjs-doctor/src/engine/diagnostician.ts
@@ -8,6 +8,7 @@ import { filterIgnoredDiagnostics } from "./filter-diagnostics.js";
 import { guardDecoratorNames } from "./graph/guard-decorators.js";
 import { posixDirname } from "./graph/module-graph.js";
 import { filterSuppressedDiagnostics } from "./inline-suppressions.js";
+import { isInjectable } from "./nest-class-inspector.js";
 import type { FileRuleFacts } from "./rule-runner.js";
 import {
 	type RunRulesOptions,
@@ -131,7 +132,22 @@ function fileRuleFacts(context: AnalysisContext): FileRuleFacts {
 		moduleDirectories.add(posixDirname(module.filePath));
 	}
 
+	const diProviders = new Set<string>();
+	for (const filePath of context.files) {
+		const sourceFile = context.astProject.getSourceFile(filePath);
+		if (!sourceFile) {
+			continue;
+		}
+		for (const cls of sourceFile.getClasses()) {
+			const name = cls.getName();
+			if (name && isInjectable(cls)) {
+				diProviders.add(name);
+			}
+		}
+	}
+
 	return {
+		diProviders,
 		guards: {
 			composedDecorators: guardDecoratorNames(context.guardDecorators),
 			globallyRegistered: modules.some((module) =>

--- a/packages/nestjs-doctor/src/engine/rule-runner.ts
+++ b/packages/nestjs-doctor/src/engine/rule-runner.ts
@@ -37,6 +37,7 @@ export interface RunRulesOptions {
 
 /** Project-wide facts handed to file rules that need more than one file. */
 export interface FileRuleFacts {
+	diProviders?: ReadonlySet<string>;
 	guards?: GuardFacts;
 	moduleDirectories?: ReadonlySet<string>;
 }
@@ -62,6 +63,7 @@ function runFileRulesOnFile(
 	for (const rule of rules) {
 		const context: CodeRuleContext = {
 			config,
+			diProviders: facts?.diProviders,
 			guards: facts?.guards,
 			moduleDirectories: facts?.moduleDirectories,
 			sourceFile,

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
@@ -64,6 +64,18 @@ export const noManualInstantiation: Rule = {
 				continue;
 			}
 
+			// A name suffix is not a provider. Only a class NestJS instantiates can
+			// be injected instead; a plain class, or one from node_modules, cannot.
+			if (
+				context.diProviders &&
+				!(
+					context.diProviders.has(exprText) ||
+					context.diProviders.has(simpleExprText)
+				)
+			) {
+				continue;
+			}
+
 			const isDiOnly = DI_ONLY_SUFFIXES.some((s) => exprText.endsWith(s));
 			const isContextAware = CONTEXT_AWARE_SUFFIXES.some((s) =>
 				exprText.endsWith(s)

--- a/packages/nestjs-doctor/src/engine/rules/types.ts
+++ b/packages/nestjs-doctor/src/engine/rules/types.ts
@@ -35,6 +35,8 @@ export interface GuardFacts {
 
 export interface CodeRuleContext {
 	config?: NestjsDoctorConfig;
+	/** Classes NestJS instantiates itself, which one file cannot enumerate. */
+	diProviders?: ReadonlySet<string>;
 	filePath: string;
 	guards?: GuardFacts;
 	/** Directories that hold a module file, for boundary checks. */

--- a/packages/nestjs-doctor/tests/fixtures/bad-architecture/src/orders.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/bad-architecture/src/orders.service.ts
@@ -15,6 +15,8 @@ export class OrdersService {
 	}
 }
 
+// Registered as a provider elsewhere; instantiating it by hand bypasses DI.
+@Injectable()
 class OrderValidatorService {
 	validate() {
 		return true;

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -17,7 +17,8 @@ function runRule(
 	code: string,
 	filePath = "test.ts",
 	config: NestjsDoctorConfig = {},
-	moduleDirectories?: ReadonlySet<string>
+	moduleDirectories?: ReadonlySet<string>,
+	diProviders?: ReadonlySet<string>
 ): Diagnostic[] {
 	const project = new Project({ useInMemoryFileSystem: true });
 	const sourceFile = project.createSourceFile(filePath, code);
@@ -25,6 +26,7 @@ function runRule(
 
 	rule.check({
 		config,
+		diProviders,
 		moduleDirectories,
 		sourceFile,
 		filePath,
@@ -508,6 +510,46 @@ describe("no-orm-in-services", () => {
 });
 
 describe("no-manual-instantiation", () => {
+	const CODE = `
+    export class OrdersService {
+      run() {
+        const a = new UsersService();
+        const b = new ValidationPipe({ whitelist: true });
+        return [a, b];
+      }
+    }
+  `;
+
+	it("reports a class NestJS could inject", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			CODE,
+			"test.ts",
+			{},
+			undefined,
+			new Set(["UsersService"])
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("UsersService");
+	});
+
+	it("does not report a class NestJS does not know", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			CODE,
+			"test.ts",
+			{},
+			undefined,
+			new Set(["UsersService"])
+		);
+		expect(diags.some((d) => d.message.includes("ValidationPipe"))).toBe(false);
+	});
+
+	it("reports both when the DI facts are unavailable", () => {
+		const diags = runRule(noManualInstantiation, CODE);
+		expect(diags).toHaveLength(2);
+	});
+
 	it("flags new SomeService()", () => {
 		const diags = runRule(
 			noManualInstantiation,


### PR DESCRIPTION
## 1. Context

`architecture/no-manual-instantiation` reports `new X()` at **error** severity when `X` ends in `Service`, `Repository`, `Gateway`, `Resolver`, `Guard`, `Interceptor`, `Pipe` or `Filter`.

That is the whole test. It never asks whether `X` is something NestJS could have injected — although both halves of the rule's own contract say it should:

> **description:** Do not manually instantiate **@Injectable** classes — use NestJS dependency injection
>
> **help:** Register the class as a provider in a module and inject it via the constructor

## 2. Problem

The help is not actionable for a class you do not own, and the first line of most `main.ts` files is an error:

```ts
app.useGlobalPipes(new ValidationPipe({ whitelist: true }));   // from the NestJS docs
new HeaderResolver(['x-lang'])                                  // nestjs-i18n's documented API
```

Neither can be "registered as a provider and injected".

Across 189 public projects the rule fires 97 times:

| The constructed class is | findings | share |
|---|---:|---:|
| a DI participant in the project | 30 | 31% |
| declared in the project, not a provider | 58 | 60% |
| not declared in the project at all | 9 | 9% |

The 58 are largely shapes dependency injection cannot express:

```ts
export const globalClsService = new ClsService(als);                    // runtime argument, module scope
return new GitClientService().create(...);                              // builder
this.host = new MetricGroupRepository(metricService).configure({...});  // builder with a runtime argument
```

## 3. Possible flows

| Expression | Before | After |
|---|---|---|
| `new UsersService()` — `@Injectable` in the project | error | error |
| `new AppGateway()` — `@WebSocketGateway` | error | error |
| `new PostResolver()` — `@Resolver` | error | error |
| `new ValidationPipe({...})` — from `@nestjs/common` | **error** | quiet |
| `new HeaderResolver([...])` — from `nestjs-i18n` | **error** | quiet |
| `new OrderValidatorService()` — plain class, no decorator | **error** | quiet |
| `new ClsService(als)` — builder with a runtime argument | **error** | quiet |
| `new X()` inside a `@Module()` decorator | quiet | quiet |
| a pipe or guard handed to a decorator | quiet | quiet |
| `excludeClasses` config | honoured | honoured |
| DI facts unavailable (direct API use) | reports | reports, unchanged |

## 4. Solution

The set of classes NestJS treats as DI participants — `@Injectable`, `@Controller`, `@Resolver`, `@WebSocketGateway`, via the existing `isInjectable` — is gathered once per run in `fileRuleFacts` and handed to file rules as `diProviders`, beside the `guards` and `moduleDirectories` facts that are already passed the same way. The rule skips a `new X()` whose class is not in it.

`isInjectable` rather than a bare `@Injectable` check, because the rule's own suffix list includes `Gateway` and `Resolver`, and those classes carry `@WebSocketGateway()` and `@Resolver()` instead.

When the facts are absent — a direct `checkFile` call through the public API — the rule behaves as before rather than going silent.

The `bad-architecture` fixture gains `@Injectable()` on `OrderValidatorService`. The fixture means to assert that hand-wiring a provider is a violation; without the decorator it was asserting that constructing any class named `*Service` is one, which is the reading this PR removes.

## 5. Before vs after

Re-scanning all 189 projects:

| | Before | After |
|---|---:|---:|
| `architecture/no-manual-instantiation` | 97 | **28** |
| Every other rule | 13,441 | 13,441 |
| Tests | 916 | 919 |

What still reports, sampled: `new LoggerService()`, `new RedisService()`, `new ConfigService()`, `new StorageRbacService()`, `new ConfigRepository()`, `new CreateDatasheetPipe()` — every one a provider the project declares and Nest would have injected.

## 6. Example

`andrechristikan/ack-nestjs-boilerplate`, `main.ts`:

```ts
app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
```

Before:

```
✖ error  architecture/no-manual-instantiation
  Manual instantiation of 'ValidationPipe' detected. Use dependency injection instead.
  Register the class as a provider in a module and inject it via the constructor.
```

After: nothing. `ValidationPipe` ships in `@nestjs/common` and constructing it with options is how the framework documents it.

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)