### PR TITLE
fix(rules): examine handlers declared on an undecorated base controller

### DIFF
--- a/.changeset/base-controller-classes.md
+++ b/.changeset/base-controller-classes.md
@@ -1,0 +1,38 @@
+---
+"nestjs-doctor": patch
+---
+
+Examine route handlers declared on an undecorated base controller.
+
+Nest reads route metadata off the prototype chain, so a base class can hold the
+handlers while the concrete subclass carries `@Controller()`:
+
+```ts
+export class DomainControllerBase<T> {          // no decorator at all
+  @Get()
+  async getItems(@Req() req): Promise<T[]> { return this.entityRepo.find(...); }
+}
+
+@Controller('/reminder/:organizationSlug/:userId')
+export class ReminderController extends DomainControllerBase<ReminderEntity> {}
+```
+
+The previous release taught the controller rules to recognise a decorator that
+composes `Controller()`. This one drops the decorator requirement entirely: a
+class declaring route handlers is examined whether or not it carries anything.
+
+Across 211 public repositories there are 10 such classes holding 33 handlers,
+and examining them adds 35 findings — repositories injected into a controller,
+raw entities returned, endpoints with no guard.
+
+Two rules needed care rather than widening:
+
+- **`require-guards-on-endpoints`** now knows which base classes a subclass
+  guards, gathered once per run beside the existing `APP_GUARD` and composed
+  decorator facts. A base whose subclass carries `@UseGuards` is left alone; one
+  nothing guards is reported.
+- **`param-decorator-matches-route`** treats a missing `@Controller()` as an
+  unreadable prefix rather than an empty one, so a `@Param('orgId')` matching a
+  prefix declared on the subclass is not reported as a mismatch.
+
+Closes #179.

--- a/packages/nestjs-doctor/src/engine/diagnostician.ts
+++ b/packages/nestjs-doctor/src/engine/diagnostician.ts
@@ -146,13 +146,38 @@ function fileRuleFacts(context: AnalysisContext): FileRuleFacts {
 		}
 	}
 
+	const composedDecorators = guardDecoratorNames(context.guardDecorators);
+	const guardedBaseClasses = new Set<string>();
+	for (const filePath of context.files) {
+		const sourceFile = context.astProject.getSourceFile(filePath);
+		if (!sourceFile) {
+			continue;
+		}
+		for (const cls of sourceFile.getClasses()) {
+			const base = cls.getExtends()?.getExpression().getText();
+			if (!base) {
+				continue;
+			}
+			const guarded = cls
+				.getDecorators()
+				.some(
+					(d) =>
+						d.getName() === "UseGuards" || composedDecorators.has(d.getName())
+				);
+			if (guarded) {
+				guardedBaseClasses.add(base.split("<")[0].split(".").pop() ?? base);
+			}
+		}
+	}
+
 	return {
 		diProviders,
 		guards: {
-			composedDecorators: guardDecoratorNames(context.guardDecorators),
+			composedDecorators,
 			globallyRegistered: modules.some((module) =>
 				module.providerTokens.includes("APP_GUARD")
 			),
+			guardedBaseClasses,
 		},
 		moduleDirectories,
 	};

--- a/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
+++ b/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
@@ -53,18 +53,13 @@ export function isController(cls: ClassDeclaration): boolean {
 }
 
 /**
- * True when the class carries `@Controller()`, or a decorator that composes it.
- * `applyDecorators(Controller(path), ApiTags(...))` is common, and the composed
- * name is all that survives in the source, so route handlers identify it.
+ * True when the class carries `@Controller()` or declares a route handler. Both
+ * a decorator composing `Controller()` and an undecorated base class whose
+ * concrete subclass carries it end up here, because Nest reads route metadata
+ * off the prototype chain.
  */
 export function declaresRoutes(cls: ClassDeclaration): boolean {
-	if (isController(cls)) {
-		return true;
-	}
-	if (cls.getDecorators().length === 0) {
-		return false;
-	}
-	return cls.getMethods().some(isHttpHandler);
+	return isController(cls) || cls.getMethods().some(isHttpHandler);
 }
 
 export function isService(cls: ClassDeclaration): boolean {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/param-decorator-matches-route.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/param-decorator-matches-route.ts
@@ -34,7 +34,9 @@ export const paramDecoratorMatchesRoute: Rule = {
 			// Extract controller-level prefix params
 			const controllerDecorator = cls.getDecorator("Controller");
 			let controllerPath = "";
-			let controllerPathIsReadable = true;
+			// Without @Controller() on this class the prefix is declared by whatever
+			// subclass or composed decorator supplies it, so its params are unknown.
+			let controllerPathIsReadable = controllerDecorator !== undefined;
 			if (controllerDecorator) {
 				const args = controllerDecorator.getArguments();
 				if (args.length > 0) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -1,6 +1,7 @@
 import type { ClassDeclaration, MethodDeclaration } from "ts-morph";
 import {
 	declaresRoutes,
+	isController,
 	isHttpHandler,
 } from "../../../nest-class-inspector.js";
 import type { GuardFacts, Rule } from "../../types.js";
@@ -47,6 +48,17 @@ export const requireGuardsOnEndpoints: Rule = {
 			}
 
 			if (hasGuard(cls, context.guards)) {
+				continue;
+			}
+
+			// A base class carries handlers but no @Controller(); the subclass that
+			// registers it may be where the guard lives.
+			const name = cls.getName();
+			if (
+				!isController(cls) &&
+				name &&
+				context.guards?.guardedBaseClasses.has(name)
+			) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/types.ts
+++ b/packages/nestjs-doctor/src/engine/rules/types.ts
@@ -31,6 +31,8 @@ export interface GuardFacts {
 	composedDecorators: ReadonlySet<string>;
 	/** Some module registers a guard through `APP_GUARD`. */
 	globallyRegistered: boolean;
+	/** Base classes some subclass guards, so the base's handlers are covered. */
+	guardedBaseClasses: ReadonlySet<string>;
 }
 
 export interface CodeRuleContext {

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -65,7 +65,7 @@ describe("no-business-logic-in-controllers", () => {
 		expect(diags).toHaveLength(1);
 	});
 
-	it("leaves an undecorated class alone even when it declares handlers", () => {
+	it("examines a base class that declares handlers without @Controller()", () => {
 		const diags = runRule(
 			noBusinessLogicInControllers,
 			`
@@ -81,7 +81,7 @@ describe("no-business-logic-in-controllers", () => {
       }
     `
 		);
-		expect(diags).toHaveLength(0);
+		expect(diags).toHaveLength(1);
 	});
 
 	it("leaves a decorated class with no route handler alone", () => {

--- a/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
@@ -447,6 +447,47 @@ describe("no-raw-entity-in-response", () => {
 });
 
 describe("require-guards-on-endpoints", () => {
+	it("reports a base class whose handlers nothing guards", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Get } from '@nestjs/common';
+      export class DomainControllerBase {
+        @Get()
+        getItems() { return []; }
+      }
+    `,
+			"base.ts",
+			{
+				composedDecorators: new Set<string>(),
+				globallyRegistered: false,
+				guardedBaseClasses: new Set<string>(),
+			}
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("getItems");
+	});
+
+	it("does not report a base class a subclass guards", () => {
+		const diags = runRule(
+			requireGuardsOnEndpoints,
+			`
+      import { Get } from '@nestjs/common';
+      export class DomainControllerBase {
+        @Get()
+        getItems() { return []; }
+      }
+    `,
+			"base.ts",
+			{
+				composedDecorators: new Set<string>(),
+				globallyRegistered: false,
+				guardedBaseClasses: new Set(["DomainControllerBase"]),
+			}
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("flags unguarded endpoint", () => {
 		const diags = runRule(
 			requireGuardsOnEndpoints,


### PR DESCRIPTION
## 1. Context

NestJS reads route metadata off the prototype chain, so the class holding the handlers and the class carrying `@Controller()` need not be the same one:

```ts
export class DomainControllerBase<TEntity> {        // no decorator at all
  constructor(private readonly entityRepo: BaseRepo<TEntity>) {}

  @Get()
  public async getItems(@Req() req: BffRequest): Promise<TEntity[]> {
    return this.entityRepo.find(...);
  }
}

@Controller('/reminder/:organizationSlug/:userId')
export class ReminderController extends DomainControllerBase<ReminderEntity> {}
```

#195 taught the controller rules to recognise a decorator that *composes* `Controller()`. This is the other half of #179: a class with no decorator at all.

## 2. Problem

`declaresRoutes` still required a decorator, so nine rules skipped the base class and never saw its handlers. Across 211 public repositories:

| | |
|---|---:|
| undecorated classes declaring HTTP handlers | 10 |
| handlers in them | 33 |
| with a subclass in the same repository | 9 |
| with a subclass carrying `@Controller()` | 9 |

`ablestack/nestjs-bff` injects a repository straight into `DomainControllerBase` and returns `TEntity` raw from six handlers. `amplication` generates `HealthControllerBase` with two. None were examined.

## 3. Possible flows

| Class | Before | After |
|---|---|---|
| `@Controller('items')` | examined | examined |
| `@ApiController('items')` composing `Controller` | examined (#195) | examined |
| **undecorated, declares `@Get()` handlers** | **skipped** | examined |
| a service with no handlers | skipped | skipped |
| base whose subclass carries `@UseGuards` | — | **guard rule stays quiet** |
| base whose subclass carries no guard | — | guard rule reports |
| base handler using a prefix param from the subclass | — | **not called a mismatch** |

## 4. Solution

`declaresRoutes(cls)` becomes `isController(cls) || cls.getMethods().some(isHttpHandler)`.

Seven of the nine rules are already correct under that, because they read the handler's body, its return type, or the base class's own constructor — all of which belong to the base. Two needed work:

**`require-guards-on-endpoints`.** A guard may sit on the concrete subclass, and the base cannot see it. `GuardFacts` gains `guardedBaseClasses`, built once per run by walking every `extends` clause and recording the base whenever the subclass carries `@UseGuards` or a decorator composing it — the same index already used for composed guard decorators. A base in that set is skipped.

**`param-decorator-matches-route`.** It read the controller prefix from `@Controller()` and treated its absence as an empty prefix, which would call `@Param('orgId')` a mismatch when `:orgId` is declared on the subclass. A missing decorator now marks the prefix *unreadable*, reusing the flag added for unresolvable paths, so only method-level route params are matched.

## 5. Before vs after

Across 211 repositories, scanning the four that hold base controllers at their repository roots plus the usual 189 project roots:

| Rule | Before | After |
|---|---:|---:|
| `security/require-guards-on-endpoints` | 852 | **880** |
| `security/no-raw-entity-in-response` | 86 | **92** |
| `architecture/no-repository-in-controllers` | 46 | **47** |
| `correctness/param-decorator-matches-route` | unchanged | unchanged |
| Every other rule | unchanged | unchanged |
| Tests | 919 | 924 |

All 35 are true positives, checked by hand:

- `ablestack/nestjs-bff` has no `@UseGuards` and no `APP_GUARD` anywhere in its backend. Its `@Authorization(...)` is `ReflectMetadata('authorization', ...)` — metadata, not a guard.
- `amplication`'s `HealthController extends HealthControllerBase` carries `@Controller("_health")` and nothing else.
- `DomainControllerBase`'s constructor is `constructor(private readonly entityRepo: BaseRepo<TEntity>)`, and its six handlers return `TEntity` unmapped.

`param-decorator-matches-route` gained one finding in an early experiment and gains none now, which is the prefix fix doing its job.

## 6. Example

`ablestack/nestjs-bff`, `domain-controller-base.ts`:

```ts
export class DomainControllerBase<TEntity extends IEntity> {
  constructor(private readonly entityRepo: BaseRepo<TEntity>) {}

  @Get()
  @Authorization([new ScopedEntityAuthCheck()])
  public async getItems(@Req() req: BffRequest, @Body() body): Promise<TEntity[]> {
    return this.entityRepo.find(body || {}, { accessPermissions: req.accessPermissions });
  }
```

Before: no rule reports on this file.

After:

```
● warning  architecture/no-repository-in-controllers
  Controller injects repository 'BaseRepo' directly. Use a service layer instead.
● warning  security/no-raw-entity-in-response
  Controller method 'getItems' returns a raw entity type.
● warning  security/require-guards-on-endpoints
  Endpoint 'getItems' has no @UseGuards() at class or method level.
```

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)