### PR TITLE
fix(engine): stream monorepo sub-projects and stop forcing type resolution

### DIFF
--- a/.changeset/monorepo-memory.md
+++ b/.changeset/monorepo-memory.md
@@ -32,5 +32,8 @@ recovers 19 findings the checker's expanded form had hidden, among them
 `private readonly optionsModel: MongooseModel<Option>` and a
 `Repository<Account>` injected straight into a controller.
 
+The baseline scan behind `--scope changed` streams the same way, so the path
+that runs two full monorepo scans no longer holds either of them.
+
 A 9,800-file Nx workspace that could not be scanned at 8 GB now completes at
-2.9 GB, and its report at 2.2 GB.
+1.9 GB, and its report at 1.6 GB.

--- a/.changeset/monorepo-memory.md
+++ b/.changeset/monorepo-memory.md
@@ -1,0 +1,36 @@
+---
+"nestjs-doctor": patch
+---
+
+Scan a monorepo one sub-project at a time, and read written type names instead
+of asking the checker.
+
+Scanning a large Nx workspace died with `JavaScript heap out of memory`, on both
+`--report` and a plain scan, and raising `--max-old-space-size` to 8 GB did not
+save it.
+
+Two causes, and both were needed.
+
+**Every sub-project stayed alive.** `buildMonorepoContext` built all of them with
+`Promise.all` and returned them in a Map, so 43 ts-morph projects were live at
+once. Worse, `buildResult` returns the module graph and the provider map, and
+both hold `ClassDeclaration` nodes — one node anchors its source file, and
+through it the whole project and every type the checker ever resolved on it. So
+even releasing the contexts kept the memory. Sub-projects are now built,
+diagnosed and reduced one at a time, and what is kept is detached from ts-morph
+first.
+
+**Three rules forced full type resolution.** `no-orm-in-services`,
+`no-orm-in-controllers` and `no-repository-in-controllers` called
+`param.getType().getText()`, which makes the checker type the whole dependency
+closure — exactly the work `createAstParser` sets `skipFileDependencyResolution`
+to avoid. One 20-file sub-project cost 2.7 s and 679 MB. They now read the
+declared type node, as `no-unused-providers` already did.
+
+Reading the written name is also more accurate: across 194 scan targets this
+recovers 19 findings the checker's expanded form had hidden, among them
+`private readonly optionsModel: MongooseModel<Option>` and a
+`Repository<Account>` injected straight into a controller.
+
+A 9,800-file Nx workspace that could not be scanned at 8 GB now completes at
+2.9 GB, and its report at 2.2 GB.

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -2,19 +2,19 @@ import { performance } from "node:perf_hooks";
 import type { Diagnostic } from "../common/diagnostic.js";
 import type { DiagnoseResult } from "../common/result.js";
 import { computeBaselineDelta } from "../engine/baseline.js";
+import { detachModuleGraph } from "../engine/graph/module-graph.js";
 import type { MonorepoInfo } from "../engine/project-detector.js";
 import { withScopedDiagnostics } from "../engine/result-builder.js";
 import {
 	type AnalysisContext,
 	buildAnalysisContext,
-	buildMonorepoContext,
 	buildMonorepoResult,
 	buildResult,
 	diagnose,
 	type EngineResult,
-	type MonorepoContext,
 	type MonorepoEngineResult,
 	type RawDiagnosticOutput,
+	reduceSubProjects,
 	resolveScanConfig,
 	type ScanConfig,
 } from "../engine/scanner.js";
@@ -172,8 +172,7 @@ const restrictToKept = (
 /** Monorepo scan builder — resolveConfig, buildContext, runRules, buildResult, applyScope, warn, output */
 export class MonorepoPipeline extends ScanPipeline {
 	private readonly monorepo: MonorepoInfo;
-	private monorepoCtx!: MonorepoContext;
-	private readonly rawOutputs = new Map<string, RawDiagnosticOutput>();
+	private scanResults!: Map<string, EngineResult>;
 	private result!: MonorepoEngineResult;
 	private scanStartTime!: number;
 
@@ -187,22 +186,31 @@ export class MonorepoPipeline extends ScanPipeline {
 	}
 
 	buildContext(): this {
-		this.steps.push(async () => {
+		this.steps.push(() => {
 			this.scanStartTime = performance.now();
-			this.monorepoCtx = await buildMonorepoContext(
-				this.targetPath,
-				this.scanConfig,
-				this.monorepo
-			);
 		});
 		return this;
 	}
 
 	runRules(): this {
-		this.steps.push(() => {
-			for (const [name, context] of this.monorepoCtx.subProjects) {
-				this.rawOutputs.set(name, diagnose(context));
-			}
+		this.steps.push(async () => {
+			// Build, diagnose and reduce each sub-project in turn. Holding all of
+			// their ts-morph projects at once is what runs a large workspace out of
+			// memory, because every type a rule asks the checker for stays on them.
+			this.scanResults = await reduceSubProjects(
+				this.targetPath,
+				this.scanConfig,
+				this.monorepo,
+				(_name, context: AnalysisContext) => {
+					const scanResult = buildResult(context, diagnose(context));
+					return {
+						...scanResult,
+						moduleGraph: detachModuleGraph(scanResult.moduleGraph),
+						// ProviderInfo holds a ts-morph node, which anchors the project
+						providers: new Map(),
+					};
+				}
+			);
 		});
 		return this;
 	}
@@ -211,8 +219,7 @@ export class MonorepoPipeline extends ScanPipeline {
 		this.steps.push(() => {
 			const totalElapsedMs = performance.now() - this.scanStartTime;
 			this.result = buildMonorepoResult(
-				this.monorepoCtx,
-				this.rawOutputs,
+				this.scanResults,
 				this.scanConfig.customRuleWarnings,
 				totalElapsedMs
 			);

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -194,9 +194,6 @@ export class MonorepoPipeline extends ScanPipeline {
 
 	runRules(): this {
 		this.steps.push(async () => {
-			// Build, diagnose and reduce each sub-project in turn. Holding all of
-			// their ts-morph projects at once is what runs a large workspace out of
-			// memory, because every type a rule asks the checker for stays on them.
 			this.scanResults = await reduceSubProjects(
 				this.targetPath,
 				this.scanConfig,
@@ -206,7 +203,6 @@ export class MonorepoPipeline extends ScanPipeline {
 					return {
 						...scanResult,
 						moduleGraph: detachModuleGraph(scanResult.moduleGraph),
-						// ProviderInfo holds a ts-morph node, which anchors the project
 						providers: new Map(),
 					};
 				}

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -50,10 +50,6 @@ export interface AnalysisContext {
 	targetPath: string;
 }
 
-interface MonorepoContext {
-	subProjects: Map<string, AnalysisContext>;
-}
-
 export async function buildAnalysisContext(
 	targetPath: string,
 	scanConfig: ScanConfig
@@ -137,11 +133,7 @@ export function updateFile(context: AnalysisContext, filePath: string): void {
 	}
 }
 
-/**
- * One sub-project's context. Kept separate so callers can build, use and drop
- * them one at a time — a ts-morph project holds every type the rules ask the
- * checker for, and 40 of them at once is gigabytes.
- */
+/** Builds the context for a single sub-project. */
 async function buildSubProjectContext(
 	targetPath: string,
 	scanConfig: ScanConfig,
@@ -161,8 +153,7 @@ async function buildSubProjectContext(
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 	const providers = resolveProviders(astProject, files);
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);
-	// A monorepo usually keeps one schema, at the workspace root, outside
-	// every sub-project. Fall back to it rather than report no schema.
+	// Falls back to the workspace root, where a monorepo usually keeps its schema.
 	let schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
 	if (project.orm && schemaGraph.entities.size === 0) {
 		schemaGraph = extractSchema(astProject, files, project.orm, targetPath);
@@ -189,8 +180,8 @@ async function buildSubProjectContext(
 }
 
 /**
- * Builds each sub-project in turn, hands it to `consume`, and lets it go before
- * building the next. Only what `consume` returns is retained.
+ * Builds each sub-project in turn, hands it to `consume`, and drops it before
+ * the next. Only what `consume` returns is retained.
  */
 export async function reduceSubProjects<T>(
 	targetPath: string,
@@ -219,18 +210,4 @@ export async function reduceSubProjects<T>(
 		results.set(name, consume(name, context));
 	}
 	return results;
-}
-
-export async function buildMonorepoContext(
-	targetPath: string,
-	scanConfig: ScanConfig,
-	monorepo: MonorepoInfo
-): Promise<MonorepoContext> {
-	const subProjects = await reduceSubProjects(
-		targetPath,
-		scanConfig,
-		monorepo,
-		(_name, context) => context
-	);
-	return { subProjects };
 }

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -50,7 +50,7 @@ export interface AnalysisContext {
 	targetPath: string;
 }
 
-export interface MonorepoContext {
+interface MonorepoContext {
 	subProjects: Map<string, AnalysisContext>;
 }
 
@@ -137,73 +137,100 @@ export function updateFile(context: AnalysisContext, filePath: string): void {
 	}
 }
 
+/**
+ * One sub-project's context. Kept separate so callers can build, use and drop
+ * them one at a time — a ts-morph project holds every type the rules ask the
+ * checker for, and 40 of them at once is gigabytes.
+ */
+async function buildSubProjectContext(
+	targetPath: string,
+	scanConfig: ScanConfig,
+	monorepo: MonorepoInfo,
+	name: string,
+	files: string[]
+): Promise<AnalysisContext> {
+	const { config: rootConfig, combinedRules } = scanConfig;
+	const projectPath = join(targetPath, monorepo.projects.get(name)!);
+	const [project, projectConfig] = await Promise.all([
+		detectProject(projectPath),
+		loadConfigWithFallback(projectPath, rootConfig),
+	]);
+
+	const pathAliases = loadPathAliases(projectPath);
+	const astProject = createAstParser(files, pathAliases);
+	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
+	const providers = resolveProviders(astProject, files);
+	const endpointGraph = buildEndpointGraph(astProject, files, providers);
+	// A monorepo usually keeps one schema, at the workspace root, outside
+	// every sub-project. Fall back to it rather than report no schema.
+	let schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
+	if (project.orm && schemaGraph.entities.size === 0) {
+		schemaGraph = extractSchema(astProject, files, project.orm, targetPath);
+	}
+	const rules = filterRules(projectConfig, combinedRules);
+	const { fileRules, projectRules, schemaRules } = separateRules(rules);
+
+	return {
+		astProject,
+		config: projectConfig,
+		endpointGraph,
+		fileRules,
+		files,
+		guardDecorators: buildGuardDecoratorIndex(astProject, files),
+		moduleGraph,
+		pathAliases,
+		project,
+		projectRules,
+		providers,
+		schemaGraph,
+		schemaRules,
+		targetPath: projectPath,
+	};
+}
+
+/**
+ * Builds each sub-project in turn, hands it to `consume`, and lets it go before
+ * building the next. Only what `consume` returns is retained.
+ */
+export async function reduceSubProjects<T>(
+	targetPath: string,
+	scanConfig: ScanConfig,
+	monorepo: MonorepoInfo,
+	consume: (name: string, context: AnalysisContext) => T
+): Promise<Map<string, T>> {
+	const filesByProject = await collectMonorepoFiles(
+		targetPath,
+		monorepo,
+		scanConfig.config
+	);
+
+	const results = new Map<string, T>();
+	for (const [name, files] of filesByProject) {
+		if (files.length === 0) {
+			continue;
+		}
+		const context = await buildSubProjectContext(
+			targetPath,
+			scanConfig,
+			monorepo,
+			name,
+			files
+		);
+		results.set(name, consume(name, context));
+	}
+	return results;
+}
+
 export async function buildMonorepoContext(
 	targetPath: string,
 	scanConfig: ScanConfig,
 	monorepo: MonorepoInfo
 ): Promise<MonorepoContext> {
-	const { config: rootConfig, combinedRules } = scanConfig;
-	const filesByProject = await collectMonorepoFiles(
+	const subProjects = await reduceSubProjects(
 		targetPath,
+		scanConfig,
 		monorepo,
-		rootConfig
+		(_name, context) => context
 	);
-
-	const entries = await Promise.all(
-		[...filesByProject.entries()]
-			.filter(([, files]) => files.length > 0)
-			.map(async ([name, files]): Promise<[string, AnalysisContext]> => {
-				const projectPath = join(targetPath, monorepo.projects.get(name)!);
-				const [project, projectConfig] = await Promise.all([
-					detectProject(projectPath),
-					loadConfigWithFallback(projectPath, rootConfig),
-				]);
-
-				const pathAliases = loadPathAliases(projectPath);
-				const astProject = createAstParser(files, pathAliases);
-				const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
-				const providers = resolveProviders(astProject, files);
-				const endpointGraph = buildEndpointGraph(astProject, files, providers);
-				// A monorepo usually keeps one schema, at the workspace root, outside
-				// every sub-project. Fall back to it rather than report no schema.
-				let schemaGraph = extractSchema(
-					astProject,
-					files,
-					project.orm,
-					projectPath
-				);
-				if (project.orm && schemaGraph.entities.size === 0) {
-					schemaGraph = extractSchema(
-						astProject,
-						files,
-						project.orm,
-						targetPath
-					);
-				}
-				const rules = filterRules(projectConfig, combinedRules);
-				const { fileRules, projectRules, schemaRules } = separateRules(rules);
-
-				return [
-					name,
-					{
-						astProject,
-						config: projectConfig,
-						endpointGraph,
-						fileRules,
-						files,
-						guardDecorators: buildGuardDecoratorIndex(astProject, files),
-						moduleGraph,
-						pathAliases,
-						project,
-						projectRules,
-						providers,
-						schemaGraph,
-						schemaRules,
-						targetPath: projectPath,
-					},
-				];
-			})
-	);
-
-	return { subProjects: new Map(entries) };
+	return { subProjects };
 }

--- a/packages/nestjs-doctor/src/engine/baseline.ts
+++ b/packages/nestjs-doctor/src/engine/baseline.ts
@@ -1,8 +1,5 @@
 import type { Diagnostic } from "../common/diagnostic.js";
-import {
-	buildAnalysisContext,
-	buildMonorepoContext,
-} from "./analysis-context.js";
+import { buildAnalysisContext, reduceSubProjects } from "./analysis-context.js";
 import type { ScanConfig } from "./config/scan-config.js";
 import { diagnose } from "./diagnostician.js";
 import { diffDiagnostics } from "./fingerprint.js";
@@ -27,16 +24,13 @@ async function scanBaseline(
 	monorepo: MonorepoInfo | undefined
 ): Promise<Diagnostic[]> {
 	if (monorepo) {
-		const context = await buildMonorepoContext(
+		const perProject = await reduceSubProjects(
 			baseTargetPath,
 			scanConfig,
-			monorepo
+			monorepo,
+			(_name, context) => diagnose(context).diagnostics
 		);
-		const diagnostics: Diagnostic[] = [];
-		for (const subProject of context.subProjects.values()) {
-			diagnostics.push(...diagnose(subProject).diagnostics);
-		}
-		return diagnostics;
+		return [...perProject.values()].flat();
 	}
 
 	const context = await buildAnalysisContext(baseTargetPath, scanConfig);

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -60,7 +60,8 @@ export function resolvePosix(fromDirectory: string, specifier: string): string {
 const JS_EXT_REGEX = /\.js$/;
 
 export interface ModuleNode {
-	classDeclaration: ClassDeclaration;
+	/** Absent once the graph is detached from its ts-morph project. */
+	classDeclaration?: ClassDeclaration;
 	controllers: string[];
 	exports: string[];
 	filePath: string;
@@ -925,4 +926,26 @@ export function traceProviderEdges(
 	}
 
 	return edges;
+}
+
+/**
+ * A copy holding no ts-morph nodes. One node reference anchors its source file,
+ * and through it the whole project and every type the checker resolved, so a
+ * graph kept past its scan keeps the memory too.
+ */
+export function detachModuleGraph(graph: ModuleGraph): ModuleGraph {
+	const modules = new Map<string, ModuleNode>();
+	for (const [name, node] of graph.modules) {
+		modules.set(name, { ...node, classDeclaration: undefined });
+	}
+
+	const providerToModule = new Map<string, ModuleNode>();
+	for (const [provider, node] of graph.providerToModule) {
+		const detached = modules.get(node.name);
+		if (detached) {
+			providerToModule.set(provider, detached);
+		}
+	}
+
+	return { modules, edges: graph.edges, providerToModule };
 }

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -60,7 +60,7 @@ export function resolvePosix(fromDirectory: string, specifier: string): string {
 const JS_EXT_REGEX = /\.js$/;
 
 export interface ModuleNode {
-	/** Absent once the graph is detached from its ts-morph project. */
+	/** Absent once the graph is detached. */
 	classDeclaration?: ClassDeclaration;
 	controllers: string[];
 	exports: string[];
@@ -928,24 +928,27 @@ export function traceProviderEdges(
 	return edges;
 }
 
-/**
- * A copy holding no ts-morph nodes. One node reference anchors its source file,
- * and through it the whole project and every type the checker resolved, so a
- * graph kept past its scan keeps the memory too.
- */
+/** A standalone copy of the graph, holding no ts-morph nodes and no shared state. */
 export function detachModuleGraph(graph: ModuleGraph): ModuleGraph {
 	const modules = new Map<string, ModuleNode>();
-	for (const [name, node] of graph.modules) {
-		modules.set(name, { ...node, classDeclaration: undefined });
+	// Keyed by the original node, so the rebuild below survives any change to
+	// what `modules` is keyed by.
+	const detachedByOriginal = new Map<ModuleNode, ModuleNode>();
+	for (const [key, node] of graph.modules) {
+		const detached: ModuleNode = { ...node, classDeclaration: undefined };
+		modules.set(key, detached);
+		detachedByOriginal.set(node, detached);
 	}
 
 	const providerToModule = new Map<string, ModuleNode>();
 	for (const [provider, node] of graph.providerToModule) {
-		const detached = modules.get(node.name);
-		if (detached) {
-			providerToModule.set(provider, detached);
-		}
+		providerToModule.set(provider, detachedByOriginal.get(node) ?? node);
 	}
 
-	return { modules, edges: graph.edges, providerToModule };
+	const edges = new Map<string, Set<string>>();
+	for (const [name, targets] of graph.edges) {
+		edges.set(name, new Set(targets));
+	}
+
+	return { modules, edges, providerToModule };
 }

--- a/packages/nestjs-doctor/src/engine/result-builder.ts
+++ b/packages/nestjs-doctor/src/engine/result-builder.ts
@@ -13,7 +13,7 @@ import type {
 	SerializedSchemaEntity,
 } from "../common/schema.js";
 import type { ScopeInfo } from "../common/scope.js";
-import type { AnalysisContext, MonorepoContext } from "./analysis-context.js";
+import type { AnalysisContext } from "./analysis-context.js";
 import type { RawDiagnosticOutput } from "./diagnostician.js";
 import type { ModuleGraph } from "./graph/module-graph.js";
 import type { ProviderInfo } from "./graph/type-resolver.js";
@@ -123,8 +123,7 @@ export function buildResult(
 }
 
 export function buildMonorepoResult(
-	monorepoCtx: MonorepoContext,
-	rawOutputs: Map<string, RawDiagnosticOutput>,
+	scanResults: Map<string, ReturnType<typeof buildResult>>,
 	customRuleWarnings: string[],
 	totalElapsedMs: number
 ): MonorepoEngineResult {
@@ -138,9 +137,7 @@ export function buildMonorepoResult(
 	const allSchemaRelations: SchemaRelation[] = [];
 	let detectedOrm = "";
 
-	for (const [name, context] of monorepoCtx.subProjects) {
-		const rawOutput = rawOutputs.get(name)!;
-		const scanResult = buildResult(context, rawOutput);
+	for (const [name, scanResult] of scanResults) {
 		subProjects.push({ name, result: scanResult.result });
 		moduleGraphs.set(name, scanResult.moduleGraph);
 		allDiagnostics.push(...scanResult.result.diagnostics);

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-circular-module-deps.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-circular-module-deps.ts
@@ -160,7 +160,7 @@ export const noCircularModuleDeps: ProjectRule = {
 				filePath: firstModule?.filePath ?? "unknown",
 				message: `Circular module dependency detected: ${cycleStr}`,
 				help,
-				line: firstModule?.classDeclaration.getStartLineNumber() ?? 1,
+				line: firstModule?.classDeclaration?.getStartLineNumber() ?? 1,
 				column: 1,
 			});
 		}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-controllers.ts
@@ -41,7 +41,12 @@ export const noOrmInControllers: Rule = {
 			}
 
 			for (const param of ctor.getParameters()) {
-				const typeText = param.getType().getText();
+				// The syntax node, not the checker: createAstParser skips dependency
+				// resolution, and getType() forces the whole closure to be typed.
+				const typeNode = param.getTypeNode();
+				const typeText = typeNode
+					? typeNode.getText()
+					: param.getType().getText();
 				const typeName = extractSimpleTypeName(typeText);
 
 				if (ORM_TYPES.has(typeName)) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-controllers.ts
@@ -41,8 +41,7 @@ export const noOrmInControllers: Rule = {
 			}
 
 			for (const param of ctor.getParameters()) {
-				// The syntax node, not the checker: createAstParser skips dependency
-				// resolution, and getType() forces the whole closure to be typed.
+				// Reads the written annotation, falling back to the checker.
 				const typeNode = param.getTypeNode();
 				const typeText = typeNode
 					? typeNode.getText()

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
@@ -48,7 +48,12 @@ export const noOrmInServices: Rule = {
 			}
 
 			for (const param of ctor.getParameters()) {
-				const typeText = param.getType().getText();
+				// The syntax node, not the checker: createAstParser skips dependency
+				// resolution, and getType() forces the whole closure to be typed.
+				const typeNode = param.getTypeNode();
+				const typeText = typeNode
+					? typeNode.getText()
+					: param.getType().getText();
 				const typeName = extractSimpleTypeName(typeText);
 
 				if (ORM_TYPES.has(typeName)) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
@@ -48,8 +48,7 @@ export const noOrmInServices: Rule = {
 			}
 
 			for (const param of ctor.getParameters()) {
-				// The syntax node, not the checker: createAstParser skips dependency
-				// resolution, and getType() forces the whole closure to be typed.
+				// Reads the written annotation, falling back to the checker.
 				const typeNode = param.getTypeNode();
 				const typeText = typeNode
 					? typeNode.getText()

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-repository-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-repository-in-controllers.ts
@@ -27,8 +27,7 @@ export const noRepositoryInControllers: Rule = {
 			}
 
 			for (const param of ctor.getParameters()) {
-				// The syntax node, not the checker: createAstParser skips dependency
-				// resolution, and getType() forces the whole closure to be typed.
+				// Reads the written annotation, falling back to the checker.
 				const typeNode = param.getTypeNode();
 				const typeText = typeNode
 					? typeNode.getText()

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-repository-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-repository-in-controllers.ts
@@ -27,7 +27,12 @@ export const noRepositoryInControllers: Rule = {
 			}
 
 			for (const param of ctor.getParameters()) {
-				const typeText = param.getType().getText();
+				// The syntax node, not the checker: createAstParser skips dependency
+				// resolution, and getType() forces the whole closure to be typed.
+				const typeNode = param.getTypeNode();
+				const typeText = typeNode
+					? typeNode.getText()
+					: param.getType().getText();
 				const typeName = extractSimpleTypeName(typeText);
 
 				if (REPOSITORY_PATTERNS.some((p) => p.test(typeName))) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
@@ -38,7 +38,7 @@ export const noOrphanModules: ProjectRule = {
 					filePath: mod.filePath,
 					message: `Module '${mod.name}' is never imported by any other module.`,
 					help: this.meta.help,
-					line: mod.classDeclaration.getStartLineNumber(),
+					line: mod.classDeclaration?.getStartLineNumber() ?? 1,
 					column: 1,
 				});
 			}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-module-exports.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-module-exports.ts
@@ -39,7 +39,7 @@ function resolveConsumers(
 		(other) => other.name !== mod.name
 	);
 
-	if (hasDecorator(mod.classDeclaration, "Global")) {
+	if (mod.classDeclaration && hasDecorator(mod.classDeclaration, "Global")) {
 		return all;
 	}
 
@@ -112,7 +112,7 @@ export const noUnusedModuleExports: ProjectRule = {
 						filePath: mod.filePath,
 						message: `Module '${mod.name}' exports '${exportedName}' but no importing module uses it.`,
 						help: this.meta.help,
-						line: mod.classDeclaration.getStartLineNumber(),
+						line: mod.classDeclaration?.getStartLineNumber() ?? 1,
 						column: 1,
 					});
 				}

--- a/packages/nestjs-doctor/src/engine/scanner.ts
+++ b/packages/nestjs-doctor/src/engine/scanner.ts
@@ -14,7 +14,6 @@ import {
 export {
 	type AnalysisContext,
 	buildAnalysisContext,
-	buildMonorepoContext,
 	prepareAnalysis,
 	reduceSubProjects,
 	updateFile,
@@ -53,8 +52,6 @@ export async function scanMonorepo(
 	monorepo: MonorepoInfo
 ): Promise<MonorepoEngineResult> {
 	const startTime = performance.now();
-	// One sub-project at a time: each carries a ts-morph project holding every
-	// type the rules made the checker resolve, so they must not all stay alive.
 	const scanResults = await reduceSubProjects(
 		targetPath,
 		scanConfig,
@@ -64,7 +61,6 @@ export async function scanMonorepo(
 			return {
 				...scanResult,
 				moduleGraph: detachModuleGraph(scanResult.moduleGraph),
-				// ProviderInfo holds a ts-morph node, which anchors the project
 				providers: new Map(),
 			};
 		}

--- a/packages/nestjs-doctor/src/engine/scanner.ts
+++ b/packages/nestjs-doctor/src/engine/scanner.ts
@@ -1,10 +1,7 @@
 import { performance } from "node:perf_hooks";
-import {
-	buildAnalysisContext,
-	buildMonorepoContext,
-} from "./analysis-context.js";
+import { buildAnalysisContext, reduceSubProjects } from "./analysis-context.js";
 import { resolveScanConfig, type ScanConfig } from "./config/scan-config.js";
-import { diagnose, type RawDiagnosticOutput } from "./diagnostician.js";
+import { diagnose } from "./diagnostician.js";
 import { detectMonorepo, type MonorepoInfo } from "./project-detector.js";
 import {
 	buildMonorepoResult,
@@ -18,8 +15,8 @@ export {
 	type AnalysisContext,
 	buildAnalysisContext,
 	buildMonorepoContext,
-	type MonorepoContext,
 	prepareAnalysis,
+	reduceSubProjects,
 	updateFile,
 } from "./analysis-context.js";
 
@@ -43,6 +40,8 @@ export {
 	withScopedDiagnostics,
 } from "./result-builder.js";
 
+import { detachModuleGraph } from "./graph/module-graph.js";
+
 // Facades that compose both
 export type AutoScanResult =
 	| { isMonorepo: true; monorepo: MonorepoEngineResult }
@@ -54,15 +53,25 @@ export async function scanMonorepo(
 	monorepo: MonorepoInfo
 ): Promise<MonorepoEngineResult> {
 	const startTime = performance.now();
-	const ctx = await buildMonorepoContext(targetPath, scanConfig, monorepo);
-	const rawOutputs = new Map<string, RawDiagnosticOutput>();
-	for (const [name, context] of ctx.subProjects) {
-		rawOutputs.set(name, diagnose(context));
-	}
+	// One sub-project at a time: each carries a ts-morph project holding every
+	// type the rules made the checker resolve, so they must not all stay alive.
+	const scanResults = await reduceSubProjects(
+		targetPath,
+		scanConfig,
+		monorepo,
+		(_name, context) => {
+			const scanResult = buildResult(context, diagnose(context));
+			return {
+				...scanResult,
+				moduleGraph: detachModuleGraph(scanResult.moduleGraph),
+				// ProviderInfo holds a ts-morph node, which anchors the project
+				providers: new Map(),
+			};
+		}
+	);
 	const totalElapsedMs = performance.now() - startTime;
 	return buildMonorepoResult(
-		ctx,
-		rawOutputs,
+		scanResults,
 		scanConfig.customRuleWarnings,
 		totalElapsedMs
 	);

--- a/packages/nestjs-doctor/src/report/formatters/report-data.ts
+++ b/packages/nestjs-doctor/src/report/formatters/report-data.ts
@@ -10,18 +10,21 @@ function safeJsonForScript(json: string): string {
 	return json.replace(/<\/script/gi, "<\\/script").replace(/<!--/g, "<\\!--");
 }
 
-function serializeProviders(providers: Map<string, ProviderInfo>): Array<{
-	name: string;
-	filePath: string;
+/** A provider as the report needs it: no ts-morph node, safe to keep and serialise. */
+export interface ReportProvider {
 	dependencies: string[];
+	filePath: string;
+	name: string;
 	publicMethodCount: number;
-}> {
-	return [...providers.values()].map((p) => ({
-		name: p.name,
-		filePath: p.filePath,
-		dependencies: p.dependencies,
-		publicMethodCount: p.publicMethodCount,
-	}));
+}
+
+export function toReportProvider(provider: ProviderInfo): ReportProvider {
+	return {
+		dependencies: provider.dependencies,
+		filePath: provider.filePath,
+		name: provider.name,
+		publicMethodCount: provider.publicMethodCount,
+	};
 }
 
 function buildFileSources(files: string[]): Record<string, string> {
@@ -42,7 +45,7 @@ export function prepareReportData(
 	options?: {
 		files?: string[];
 		projects?: string[];
-		providers?: Map<string, ProviderInfo>;
+		providers?: ReportProvider[];
 	}
 ): ReportScriptData {
 	const graph = serializeModuleGraph(moduleGraph, result, options?.projects);
@@ -79,9 +82,7 @@ export function prepareReportData(
 	const examplesJson = safeJsonForScript(JSON.stringify(getRuleExamples()));
 	const fileSources = buildFileSources(options?.files ?? []);
 	const fileSourcesJson = safeJsonForScript(JSON.stringify(fileSources));
-	const serializedProviders = serializeProviders(
-		options?.providers ?? new Map()
-	);
+	const serializedProviders = options?.providers ?? [];
 	const providersJson = safeJsonForScript(JSON.stringify(serializedProviders));
 	const schemaJson = safeJsonForScript(
 		JSON.stringify(result.schema ?? { entities: [], relations: [], orm: "" })

--- a/packages/nestjs-doctor/src/report/html-report.ts
+++ b/packages/nestjs-doctor/src/report/html-report.ts
@@ -1,7 +1,9 @@
 import type { DiagnoseResult } from "../common/result.js";
 import type { ModuleGraph } from "../engine/graph/module-graph.js";
-import type { ProviderInfo } from "../engine/graph/type-resolver.js";
-import { prepareReportData } from "./formatters/report-data.js";
+import {
+	prepareReportData,
+	type ReportProvider,
+} from "./formatters/report-data.js";
 import {
 	getCodeMirrorImportMap,
 	getCodeMirrorScript,
@@ -16,7 +18,7 @@ export function buildHtmlReport(
 	options?: {
 		files?: string[];
 		projects?: string[];
-		providers?: Map<string, ProviderInfo>;
+		providers?: ReportProvider[];
 	}
 ): string {
 	const data = prepareReportData(moduleGraph, result, options);

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -4,7 +4,6 @@ import {
 	detachModuleGraph,
 	mergeModuleGraphs,
 } from "../engine/graph/module-graph.js";
-import type { ProviderInfo } from "../engine/graph/type-resolver.js";
 import type { MonorepoInfo } from "../engine/project-detector.js";
 import {
 	type AnalysisContext,
@@ -19,6 +18,10 @@ import {
 	resolveScanConfig,
 	type ScanConfig,
 } from "../engine/scanner.js";
+import {
+	type ReportProvider,
+	toReportProvider,
+} from "./formatters/report-data.js";
 import { buildHtmlReport } from "./html-report.js";
 
 type PipelineStep = () => void | Promise<void>;
@@ -108,7 +111,10 @@ export class SingleProjectReportPipeline extends ReportPipeline {
 	generateHtml(): this {
 		this.steps.push(() => {
 			const { moduleGraph, result, files, providers } = this._scanResult;
-			this._html = buildHtmlReport(moduleGraph, result, { files, providers });
+			this._html = buildHtmlReport(moduleGraph, result, {
+				files,
+				providers: [...providers.values()].map(toReportProvider),
+			});
 		});
 		return this;
 	}
@@ -119,7 +125,7 @@ export class MonorepoReportPipeline extends ReportPipeline {
 	private readonly monorepo: MonorepoInfo;
 	private scanResults!: Map<string, EngineResult>;
 	private readonly allFiles: string[] = [];
-	private readonly allProviders = new Map<string, ProviderInfo>();
+	private readonly allProviders: ReportProvider[] = [];
 	private _monoResult!: MonorepoEngineResult;
 	private scanStartTime!: number;
 
@@ -150,22 +156,14 @@ export class MonorepoReportPipeline extends ReportPipeline {
 				this.scanConfig,
 				this.monorepo,
 				(_name, context: AnalysisContext) => {
-					// Copy out what the report needs before the context is dropped.
-					// ProviderInfo holds a ts-morph node, so keep only plain fields.
 					this.allFiles.push(...context.files);
-					for (const [name, info] of context.providers) {
-						this.allProviders.set(name, {
-							name: info.name,
-							filePath: info.filePath,
-							dependencies: info.dependencies,
-							publicMethodCount: info.publicMethodCount,
-						} as ProviderInfo);
+					for (const provider of context.providers.values()) {
+						this.allProviders.push(toReportProvider(provider));
 					}
 					const scanResult = buildResult(context, diagnose(context));
 					return {
 						...scanResult,
 						moduleGraph: detachModuleGraph(scanResult.moduleGraph),
-						// ProviderInfo holds a ts-morph node, which anchors the project
 						providers: new Map(),
 					};
 				}

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -1,19 +1,21 @@
 import { performance } from "node:perf_hooks";
 import { spinner } from "../cli/ui/spinner.js";
-import { mergeModuleGraphs } from "../engine/graph/module-graph.js";
+import {
+	detachModuleGraph,
+	mergeModuleGraphs,
+} from "../engine/graph/module-graph.js";
 import type { ProviderInfo } from "../engine/graph/type-resolver.js";
 import type { MonorepoInfo } from "../engine/project-detector.js";
 import {
 	type AnalysisContext,
 	buildAnalysisContext,
-	buildMonorepoContext,
 	buildMonorepoResult,
 	buildResult,
 	diagnose,
 	type EngineResult,
-	type MonorepoContext,
 	type MonorepoEngineResult,
 	type RawDiagnosticOutput,
+	reduceSubProjects,
 	resolveScanConfig,
 	type ScanConfig,
 } from "../engine/scanner.js";
@@ -115,8 +117,9 @@ export class SingleProjectReportPipeline extends ReportPipeline {
 /** Monorepo report pipeline */
 export class MonorepoReportPipeline extends ReportPipeline {
 	private readonly monorepo: MonorepoInfo;
-	private monorepoCtx!: MonorepoContext;
-	private readonly rawOutputs = new Map<string, RawDiagnosticOutput>();
+	private scanResults!: Map<string, EngineResult>;
+	private readonly allFiles: string[] = [];
+	private readonly allProviders = new Map<string, ProviderInfo>();
 	private _monoResult!: MonorepoEngineResult;
 	private scanStartTime!: number;
 
@@ -134,22 +137,39 @@ export class MonorepoReportPipeline extends ReportPipeline {
 	}
 
 	buildContext(): this {
-		this.steps.push(async () => {
+		this.steps.push(() => {
 			this.scanStartTime = performance.now();
-			this.monorepoCtx = await buildMonorepoContext(
-				this.targetPath,
-				this.scanConfig,
-				this.monorepo
-			);
 		});
 		return this;
 	}
 
 	runRules(): this {
-		this.steps.push(() => {
-			for (const [name, context] of this.monorepoCtx.subProjects) {
-				this.rawOutputs.set(name, diagnose(context));
-			}
+		this.steps.push(async () => {
+			this.scanResults = await reduceSubProjects(
+				this.targetPath,
+				this.scanConfig,
+				this.monorepo,
+				(_name, context: AnalysisContext) => {
+					// Copy out what the report needs before the context is dropped.
+					// ProviderInfo holds a ts-morph node, so keep only plain fields.
+					this.allFiles.push(...context.files);
+					for (const [name, info] of context.providers) {
+						this.allProviders.set(name, {
+							name: info.name,
+							filePath: info.filePath,
+							dependencies: info.dependencies,
+							publicMethodCount: info.publicMethodCount,
+						} as ProviderInfo);
+					}
+					const scanResult = buildResult(context, diagnose(context));
+					return {
+						...scanResult,
+						moduleGraph: detachModuleGraph(scanResult.moduleGraph),
+						// ProviderInfo holds a ts-morph node, which anchors the project
+						providers: new Map(),
+					};
+				}
+			);
 		});
 		return this;
 	}
@@ -158,8 +178,7 @@ export class MonorepoReportPipeline extends ReportPipeline {
 		this.steps.push(() => {
 			const totalElapsedMs = performance.now() - this.scanStartTime;
 			this._monoResult = buildMonorepoResult(
-				this.monorepoCtx,
-				this.rawOutputs,
+				this.scanResults,
 				this.scanConfig.customRuleWarnings,
 				totalElapsedMs
 			);
@@ -173,19 +192,10 @@ export class MonorepoReportPipeline extends ReportPipeline {
 			const merged = mergeModuleGraphs(moduleGraphs);
 			const projects = [...moduleGraphs.keys()];
 
-			const allFiles: string[] = [];
-			const allProviders = new Map<string, ProviderInfo>();
-			for (const context of this.monorepoCtx.subProjects.values()) {
-				allFiles.push(...context.files);
-				for (const [name, info] of context.providers) {
-					allProviders.set(name, info);
-				}
-			}
-
 			this._html = buildHtmlReport(merged, result.combined, {
 				projects,
-				files: allFiles,
-				providers: allProviders,
+				files: this.allFiles,
+				providers: this.allProviders,
 			});
 		});
 		return this;

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -5,9 +5,9 @@ import { diagnoseMonorepo } from "../../src/api/index.js";
 import { detectMonorepo } from "../../src/engine/project-detector.js";
 import {
 	buildAnalysisContext,
-	buildMonorepoContext,
 	buildResult,
 	diagnose,
+	reduceSubProjects,
 	resolveScanConfig,
 	scanMonorepo,
 } from "../../src/engine/scanner.js";
@@ -559,14 +559,14 @@ describe("scanner integration", () => {
 			expect(monorepo).not.toBeNull();
 
 			const scanConfig = await resolveScanConfig(targetPath);
-			const context = await buildMonorepoContext(
+			const entitiesByProject = await reduceSubProjects(
 				targetPath,
 				scanConfig,
-				monorepo!
+				monorepo!,
+				(_name, context) => [...(context.schemaGraph?.entities.keys() ?? [])]
 			);
 
-			for (const [name, subProject] of context.subProjects) {
-				const entities = [...(subProject.schemaGraph?.entities.keys() ?? [])];
+			for (const [name, entities] of entitiesByProject) {
 				expect(entities, name).toEqual(
 					expect.arrayContaining(["Account", "Session"])
 				);
@@ -577,14 +577,14 @@ describe("scanner integration", () => {
 			const targetPath = resolve(FIXTURES, "turborepo-app");
 			const monorepo = await detectMonorepo(targetPath);
 			const scanConfig = await resolveScanConfig(targetPath);
-			const context = await buildMonorepoContext(
+			const sizes = await reduceSubProjects(
 				targetPath,
 				scanConfig,
-				monorepo!
+				monorepo!,
+				(_name, context) => context.schemaGraph?.entities.size ?? 0
 			);
 
-			const db = context.subProjects.get("@acme/db");
-			expect(db?.schemaGraph?.entities.size).toBeGreaterThan(0);
+			expect(sizes.get("@acme/db")).toBeGreaterThan(0);
 		});
 	});
 

--- a/packages/nestjs-doctor/tests/unit/detach-module-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/detach-module-graph.test.ts
@@ -1,0 +1,67 @@
+import { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import {
+	buildModuleGraph,
+	detachModuleGraph,
+} from "../../src/engine/graph/module-graph.js";
+
+function graphOf(files: Record<string, string>) {
+	const project = new Project({ useInMemoryFileSystem: true });
+	const paths: string[] = [];
+	for (const [name, code] of Object.entries(files)) {
+		project.createSourceFile(name, code);
+		paths.push(name);
+	}
+	return buildModuleGraph(project, paths);
+}
+
+const FILES = {
+	"app.module.ts": `
+    import { Module } from '@nestjs/common';
+    @Module({ imports: [UsersModule], providers: [AppService] })
+    export class AppModule {}
+  `,
+	"users.module.ts": `
+    import { Module } from '@nestjs/common';
+    @Module({ providers: [UsersService], exports: [UsersService] })
+    export class UsersModule {}
+  `,
+};
+
+describe("detachModuleGraph", () => {
+	it("keeps no ts-morph node", () => {
+		const detached = detachModuleGraph(graphOf(FILES));
+		for (const [name, node] of detached.modules) {
+			expect(node.classDeclaration, name).toBeUndefined();
+		}
+	});
+
+	it("keeps the same modules, edges and provider index", () => {
+		const original = graphOf(FILES);
+		const detached = detachModuleGraph(original);
+
+		expect([...detached.modules.keys()].sort()).toEqual(
+			[...original.modules.keys()].sort()
+		);
+		expect([...detached.edges.keys()].sort()).toEqual(
+			[...original.edges.keys()].sort()
+		);
+		expect(detached.providerToModule.size).toBe(original.providerToModule.size);
+	});
+
+	it("points the provider index at the detached nodes", () => {
+		const detached = detachModuleGraph(graphOf(FILES));
+		for (const [provider, node] of detached.providerToModule) {
+			expect(node.classDeclaration, provider).toBeUndefined();
+			expect(detached.modules.get(node.name), provider).toBe(node);
+		}
+	});
+
+	it("does not share edge sets with the original", () => {
+		const original = graphOf(FILES);
+		const detached = detachModuleGraph(original);
+
+		original.edges.get("AppModule")?.add("InjectedLater");
+		expect(detached.edges.get("AppModule")?.has("InjectedLater")).toBe(false);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -445,6 +445,35 @@ describe("no-orm-in-controllers", () => {
 });
 
 describe("no-orm-in-services", () => {
+	it("matches an ORM type through the written annotation", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class OptionsService {
+        constructor(private readonly optionsModel: MongooseModel<Option>) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("MongooseModel");
+	});
+
+	it("still ignores a service wrapping a repository", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class UsersService {
+        constructor(private readonly users: Repository<User>) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("flags PrismaService injection in services", () => {
 		const diags = runRule(
 			noOrmInServices,

--- a/packages/nestjs-doctor/tests/unit/rules/no-repository-in-controllers.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/no-repository-in-controllers.test.ts
@@ -25,6 +25,18 @@ function runRule(code: string): Diagnostic[] {
 }
 
 describe("no-repository-in-controllers", () => {
+	it("matches a generic repository through the written annotation", () => {
+		const diags = runRule(`
+      import { Controller } from '@nestjs/common';
+      @Controller('users')
+      export class UsersController {
+        constructor(private usersRepository: Repository<Account>) {}
+      }
+    `);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("Repository");
+	});
+
 	it("flags Repository injection in controllers", () => {
 		const diags = runRule(`
       import { Controller } from '@nestjs/common';

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -2,7 +2,10 @@ import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
 import type { NestjsDoctorConfig } from "../../../src/common/config.js";
 import type { Diagnostic } from "../../../src/common/diagnostic.js";
-import { buildModuleGraph } from "../../../src/engine/graph/module-graph.js";
+import {
+	buildModuleGraph,
+	detachModuleGraph,
+} from "../../../src/engine/graph/module-graph.js";
 import { resolveProviders } from "../../../src/engine/graph/type-resolver.js";
 import { noCircularModuleDeps } from "../../../src/engine/rules/definitions/architecture/no-circular-module-deps.js";
 import { noOrphanModules } from "../../../src/engine/rules/definitions/performance/no-orphan-modules.js";
@@ -543,5 +546,49 @@ describe("no-unused-module-exports", () => {
 		});
 		expect(diags).toHaveLength(1);
 		expect(diags[0].message).toContain("HelperService");
+	});
+});
+
+describe("project rules on a detached graph", () => {
+	it("reports without a class declaration to read a line from", () => {
+		const project = new Project({ useInMemoryFileSystem: true });
+		const paths: string[] = [];
+		for (const [name, code] of Object.entries({
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AppModule {}
+      `,
+			"forgotten.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class ForgottenModule {}
+      `,
+		})) {
+			project.createSourceFile(name, code);
+			paths.push(name);
+		}
+
+		const moduleGraph = detachModuleGraph(buildModuleGraph(project, paths));
+		const diagnostics: Diagnostic[] = [];
+		noOrphanModules.check({
+			project,
+			files: paths,
+			moduleGraph,
+			providers: resolveProviders(project, paths),
+			config: {},
+			report(partial) {
+				diagnostics.push({
+					...partial,
+					rule: noOrphanModules.meta.id,
+					category: noOrphanModules.meta.category,
+					severity: noOrphanModules.meta.severity,
+				});
+			},
+		});
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].message).toContain("ForgottenModule");
+		expect("line" in diagnostics[0] && diagnostics[0].line).toBe(1);
 	});
 });


### PR DESCRIPTION
## 1. Context

Reported from a private 9,836-file Nx workspace:

```
$ npx nestjs-doctor@latest . --report
⠙ Generating report...
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

A plain `nestjs-doctor .` fails the same way. `--max-old-space-size=8192` does not save it — the GC log shows it reaching 8,178 MB before dying.

## 2. Problem

Two independent causes, both required to reproduce.

**Every sub-project stays alive at once.**

```ts
const entries = await Promise.all(
  [...filesByProject.entries()].map(async ([name, files]) => {
    const astProject = createAstParser(files, pathAliases);
    ...
    return [name, { astProject, ... }];
  })
);
return { subProjects: new Map(entries) };
```

43 ts-morph projects, all retained. And releasing the contexts is not enough: `buildResult` returns `moduleGraph` and `providers`, and both hold `ClassDeclaration` nodes. **One node anchors its source file, and through it the whole project and every type the checker ever resolved on it.**

Measured on the reported workspace, building one sub-project at a time:

| what the loop keeps | outcome |
|---|---|
| only `result` | completes, peak **2,429 MB** |
| the full `EngineResult` (graph + providers) | **OOM** |

**Three rules force full type resolution.**

```ts
const typeText = param.getType().getText();
```

in `no-orm-in-services`, `no-orm-in-controllers` and `no-repository-in-controllers`. `getType()` makes the TypeScript checker resolve and print the parameter's type, which types the whole dependency closure — precisely the work `createAstParser` avoids with `skipFileDependencyResolution: true`.

Profiling one sub-project of **20 files**:

```
architecture/no-orm-in-services      2698ms  +679 MB
correctness/no-fire-and-forget-async 2515ms  +737 MB
```

`no-fire-and-forget-async` genuinely needs the checker — it tells a promise-returning call from a synchronous one — so it keeps it. The three above do not: they compare the type's *name* against a fixed set, and the name is written in the source.

## 3. Possible flows

| Path | Before | After |
|---|---|---|
| monorepo scan | all sub-projects live at once | one at a time |
| monorepo `--report` | same | same, plus files and providers copied out as plain data |
| single-project scan | one project, unchanged | unchanged |
| `--scope changed` baseline | held every sub-project | streams the same way |
| `no-orm-in-*`, `no-repository-in-controllers` | checker | declared type node, checker only when there is no annotation |
| `no-fire-and-forget-async` | checker | checker, unchanged |
| `no-unused-providers`, `no-unused-module-exports` | already used the node | unchanged |

## 4. Solution

`reduceSubProjects(targetPath, scanConfig, monorepo, consume)` builds one sub-project, hands it to `consume`, and lets it go before building the next. Only what `consume` returns is retained. All three pipelines — scan, CLI, report — use it.

What each keeps is detached first: `detachModuleGraph` copies the graph without node references, and the provider map is dropped, since `buildMonorepoResult` never reads it and the report copies the four plain fields it needs during the pass.

`ModuleNode.classDeclaration` becomes optional, and the three rules that read a line number from it fall back to `1`. They all run during diagnosis, while the node is still there.

The three rules read `param.getTypeNode()`, falling back to the checker only when there is no annotation — which for a constructor parameter Nest injects there never is, since the annotation is what emits `design:paramtypes`.

`baseline.ts` streams too. It was the last caller of the eager builder and it runs the heaviest path, two full monorepo scans, so leaving it holding every context would have contradicted the rest of this change. The eager `buildMonorepoContext` is gone and the integration tests exercise the streaming path.

`detachModuleGraph` copies the edge sets rather than sharing them with the live graph, since `updateModuleGraphForFile` mutates those in place, and it rebuilds `providerToModule` by node identity rather than by name so it survives the composite module keying that #119 needs.

The report keeps plain provider data (`ReportProvider`) rather than casting a partial `ProviderInfo`. `ProviderInfo.classDeclaration` is genuinely always present in the engine, so the report gets a type that matches what it serialises instead of the engine's invariant being weakened for everyone.

## 5. Before vs after

The reported workspace, 9,836 files, 43 Nx sub-projects:

| | Before | After |
|---|---|---|
| `nestjs-doctor .` | **OOM at 8 GB** | completes, peak **2,079 MB** |
| `nestjs-doctor . --report` | **OOM at 4 GB** | completes, peak **2,070 MB** |
| `nestjs-doctor . --scope changed` | held every sub-project twice | completes, peak **2,004 MB** |
| result | — | 1,357 files, 64 modules, 462 findings, score 96 |

Across 194 scan targets in a 211-repository corpus:

| | Before | After |
|---|---:|---:|
| Findings | 18,312 | **18,331** |
| `architecture/no-orm-in-services` | 1,551 | 1,568 |
| `architecture/no-repository-in-controllers` | 56 | 57 |
| `architecture/no-orm-in-controllers` | 17 | 18 |
| Every other rule | unchanged | unchanged |
| Tests | 924 | **932** |

**+19, and they are real.** The checker prints an expanded structural form, so the name test missed what the developer actually wrote:

```ts
private readonly optionsModel: MongooseModel<Option>,   // surmon-china/nodepress
private usersRepository: Repository<Account>,           // laudspeaker, in a controller
```

`MongooseModel` is in the rule's `ORM_TYPES`, and a `Repository` injected into a controller is exactly what `no-repository-in-controllers` exists for. Reading the written name is both cheaper and closer to what these rules mean.

### Tests

`detachModuleGraph` holds no node, shares no edge set, and points `providerToModule` at the copy. A project rule still reports when `classDeclaration` is absent. The three rules match `MongooseModel<Option>` and `Repository<Account>` through the written annotation, which is what the corpus numbers above claim.

## 6. Example

```
$ node dist/cli/index.mjs <workspace> --format json --json-compact
```

Before:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
$ echo $?
134
```

After:

```
$ echo $?
0
files=1357 modules=64 findings=462 score=96
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
