### PR TITLE
fix(rules): two defects from auditing this week's controller changes

### DIFF
--- a/.changeset/audit-controller-rules.md
+++ b/.changeset/audit-controller-rules.md
@@ -1,0 +1,33 @@
+---
+"nestjs-doctor": patch
+---
+
+Two defects found auditing the controller rules widened this week.
+
+**`correctness/param-decorator-matches-route` stopped running on the classes it
+was widened for.** When a class carries no literal `@Controller`, the route
+prefix comes from elsewhere, so the rule marks it unreadable. It then skips
+every method, which made the rule a no-op on exactly the composed-decorator
+classes the previous release taught it to see:
+
+```ts
+@ApiController('users/:userId')
+export class UsersController {
+  @Get(':id')
+  find(@Param('nonexistent') x: string) {}   // matched nothing, reported nothing
+}
+```
+
+The prefix now also comes from a composed decorator's string argument. A wrong
+guess only adds known parameter names, so it can widen what matches and never
+invent a mismatch. A class with no decorator at all still skips, since its
+prefix genuinely lives on a subclass.
+
+**`architecture/no-repository-in-controllers` reported a repository import once
+per controller in the file.** The import scan sat inside the per-class loop, so
+one `import { UserRepo } from '../repositories/user.repo'` in a file with three
+controllers produced three identical diagnostics on the same line. Imports
+belong to the file, so they are now scanned once.
+
+Neither shows up across 189 public projects, which is why the earlier
+measurements missed them. Both reproduce in a file with two controllers.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-repository-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-repository-in-controllers.ts
@@ -45,22 +45,23 @@ export const noRepositoryInControllers: Rule = {
 					});
 				}
 			}
+		}
 
-			// Also check import declarations for repository imports
-			for (const imp of context.sourceFile.getImportDeclarations()) {
-				const moduleSpecifier = imp.getModuleSpecifierValue();
-				if (
-					moduleSpecifier.includes("/repositories/") ||
-					moduleSpecifier.includes("/repositories")
-				) {
-					context.report({
-						filePath: context.filePath,
-						message: `Controller imports from repository path '${moduleSpecifier}'.`,
-						help: this.meta.help,
-						line: imp.getStartLineNumber(),
-						column: 1,
-					});
-				}
+		if (!context.sourceFile.getClasses().some(declaresRoutes)) {
+			return;
+		}
+
+		// Imports belong to the file, so they are reported once, not once per class.
+		for (const imp of context.sourceFile.getImportDeclarations()) {
+			const moduleSpecifier = imp.getModuleSpecifierValue();
+			if (moduleSpecifier.includes("/repositories")) {
+				context.report({
+					filePath: context.filePath,
+					message: `Controller imports from repository path '${moduleSpecifier}'.`,
+					help: this.meta.help,
+					line: imp.getStartLineNumber(),
+					column: 1,
+				});
 			}
 		}
 	},

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/param-decorator-matches-route.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/param-decorator-matches-route.ts
@@ -1,4 +1,4 @@
-import { type Node, SyntaxKind } from "ts-morph";
+import { type ClassDeclaration, type Node, SyntaxKind } from "ts-morph";
 import {
 	declaresRoutes,
 	HTTP_DECORATORS,
@@ -13,6 +13,25 @@ const QUOTED = /^['"`][^'"`]*['"`]$/;
 function asStringLiteral(node: Node): string | undefined {
 	const text = node.getText();
 	return QUOTED.test(text) ? text.slice(1, -1) : undefined;
+}
+
+/**
+ * The route prefix a class decorator other than `@Controller` supplies, as with
+ * `@ApiController('users/:userId')`. A wrong guess only adds known parameters,
+ * so it can widen what matches but never invent a mismatch.
+ */
+function composedPrefix(cls: ClassDeclaration): string | undefined {
+	for (const decorator of cls.getDecorators()) {
+		const firstArg = decorator.getArguments()[0];
+		if (!firstArg) {
+			continue;
+		}
+		const literal = asStringLiteral(firstArg);
+		if (literal !== undefined) {
+			return literal;
+		}
+	}
+	return undefined;
 }
 
 export const paramDecoratorMatchesRoute: Rule = {
@@ -33,10 +52,12 @@ export const paramDecoratorMatchesRoute: Rule = {
 
 			// Extract controller-level prefix params
 			const controllerDecorator = cls.getDecorator("Controller");
-			let controllerPath = "";
-			// Without @Controller() on this class the prefix is declared by whatever
-			// subclass or composed decorator supplies it, so its params are unknown.
-			let controllerPathIsReadable = controllerDecorator !== undefined;
+			const composed = controllerDecorator ? undefined : composedPrefix(cls);
+			let controllerPath = composed ?? "";
+			// An undecorated class gets its prefix from whichever subclass carries
+			// @Controller(), so its parameters cannot be read here.
+			let controllerPathIsReadable =
+				controllerDecorator !== undefined || composed !== undefined;
 			if (controllerDecorator) {
 				const args = controllerDecorator.getArguments();
 				if (args.length > 0) {

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1287,6 +1287,50 @@ describe("no-fire-and-forget-async", () => {
 });
 
 describe("param-decorator-matches-route", () => {
+	it("reads the prefix from a composed controller decorator", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Get, Param } from '@nestjs/common';
+      @ApiController('users/:userId')
+      export class UsersController {
+        @Get(':id')
+        find(@Param('nonexistent') x: string) { return x; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("accepts a param declared by the composed prefix", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Get, Param } from '@nestjs/common';
+      @ApiController('users/:userId')
+      export class UsersController {
+        @Get(':id')
+        find(@Param('userId') u: string, @Param('id') i: string) { return u + i; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("stays quiet on a base class whose prefix it cannot read", () => {
+		const diags = runRule(
+			paramDecoratorMatchesRoute,
+			`
+      import { Get, Param } from '@nestjs/common';
+      export class DomainControllerBase {
+        @Get(':id')
+        find(@Param('organizationSlug') s: string) { return s; }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("stays quiet when the method path is a constant", () => {
 		const diags = runRule(
 			paramDecoratorMatchesRoute,

--- a/packages/nestjs-doctor/tests/unit/rules/no-repository-in-controllers.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/no-repository-in-controllers.test.ts
@@ -25,6 +25,38 @@ function runRule(code: string): Diagnostic[] {
 }
 
 describe("no-repository-in-controllers", () => {
+	it("reports a repository import once, not once per controller", () => {
+		const diags = runRule(`
+      import { Controller, Get } from '@nestjs/common';
+      import { UserRepo } from '../repositories/user.repo';
+
+      @Controller('one')
+      export class OneController {
+        constructor(private a: string) {}
+        @Get() one() { return 1; }
+      }
+
+      @Controller('two')
+      export class TwoController {
+        constructor(private b: string) {}
+        @Get() two() { return 2; }
+      }
+    `);
+		const imports = diags.filter((d) => d.message.includes("imports from"));
+		expect(imports).toHaveLength(1);
+	});
+
+	it("does not report a repository import with no controller in the file", () => {
+		const diags = runRule(`
+      import { Injectable } from '@nestjs/common';
+      import { UserRepo } from '../repositories/user.repo';
+
+      @Injectable()
+      export class UsersService {}
+    `);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("matches a generic repository through the written annotation", () => {
 		const diags = runRule(`
       import { Controller } from '@nestjs/common';


### PR DESCRIPTION
## 1. Context

Nine rules gate on `declaresRoutes`, which was widened twice this week: #195 taught it to recognise a decorator composing `Controller()`, and #197 dropped the decorator requirement entirely. Auditing those merged changes turned up two defects, neither of which the corpus measurements would have caught.

## 2. Problem

**`param-decorator-matches-route` became a no-op on the classes #195 added.**

```ts
let controllerPathIsReadable = controllerDecorator !== undefined;
...
if (!(isHttpMethod && pathIsReadable && controllerPathIsReadable)) {
  continue;
}
```

`controllerDecorator` is `cls.getDecorator("Controller")`, the literal name. So for any class whose `@Controller` is behind a composed decorator, `controllerPathIsReadable` is false and every method hits `continue`. The rule runs and reports nothing:

```ts
@ApiController('users/:userId')
export class ComposedController {
  @Get(':id/typo')
  find(@Param('nonexistent') x: string) {}   // matches neither the method path nor the prefix
}

@Controller('users')
export class PlainController {
  @Get(':id')
  find(@Param('nonexistent') x: string) {}   // reported
}
```

Only the second reports. #195's own message counted 58 such classes holding 358 handlers, and #197 silently switched this rule off for all of them.

**`no-repository-in-controllers` multiplies import findings by the number of controllers in the file.** The import scan sits inside the per-class loop:

```ts
for (const cls of context.sourceFile.getClasses()) {
  if (!declaresRoutes(cls)) { continue; }
  ...
  // Also check import declarations for repository imports
  for (const imp of context.sourceFile.getImportDeclarations()) {
```

One import, three controllers in the file, three identical diagnostics on the same line. Widening `declaresRoutes` raises the multiplier.

## 3. Possible flows

| Input | Before | After |
|---|---|---|
| `@Controller('users/:userId')`, bad `@Param` | reported | reported |
| `@ApiController('users/:userId')`, bad `@Param` | **silent** | reported |
| `@ApiController('users/:userId')`, `@Param('userId')` | silent | quiet, prefix matched |
| undecorated base class, any `@Param` | silent | still silent |
| `@Controller({ path: SOME_CONST })` | quiet | quiet |
| repository import, one controller in the file | 1 finding | 1 finding |
| repository import, three controllers in the file | **3 findings** | 1 finding |
| repository import, no controller in the file | none | none |
| repository injected by constructor | reported | reported |

## 4. Solution

`composedPrefix(cls)` returns the first string-literal argument of any class decorator when there is no `@Controller`. That is a guess, and it is a safe one: the prefix is only ever used to *add* names to the set of known route parameters, so a wrong guess makes the rule more permissive, never less. A class with no decorator at all still skips, because its prefix really is declared by whichever subclass carries `@Controller()`.

The repository import scan moves out of the class loop and runs once per file, guarded by whether the file holds any route-declaring class.

Not done: `declaresRoutes` accepts an undecorated class with no subclass anywhere, which is how `amplication`'s codegen template `Mixin` collects four `require-guards-on-endpoints` warnings on a file NestJS never instantiates. Distinguishing it needs an extends index threaded to the file rules, and it is one class across 211 repositories.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| Findings, 189 public projects | 13,574 | 13,574 |
| Tests | 932 | 937 |

**Zero corpus movement, and that is the point.** Neither defect appears in 189 public projects: no scanned file pairs a `/repositories` import with more than one controller, and no composed-decorator class in the corpus has a mismatched `@Param`. Both reproduce immediately in a file with two controllers, which is why they were measured as harmless when the rules were widened.

## 6. Example

```
$ node dist/cli/index.mjs ./fixture --format json --json-compact | jq '[.diagnostics[].rule] | group_by(.) | map({(.[0]): length}) | add'
```

Before:

```json
{ "correctness/param-decorator-matches-route": 1, "architecture/no-repository-in-controllers": 3 }
```

After:

```json
{ "correctness/param-decorator-matches-route": 2, "architecture/no-repository-in-controllers": 1 }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)