### PR TITLE
fix(rules): two false negatives from auditing this week's changes

### DIFF
--- a/.changeset/audit-secret-and-rejection.md
+++ b/.changeset/audit-secret-and-rejection.md
@@ -1,0 +1,34 @@
+---
+"nestjs-doctor": patch
+---
+
+Two false negatives found auditing this week's rule changes.
+
+**A colon-separated value stopped being a credential.** The permission-scope
+skip was written for `password: "password:update"`, and it excluded digits so
+`admin:secretpass123` would survive. Anything else lowercase and colon-separated
+went quiet:
+
+```ts
+export const authToken = "admin:supersecret";
+export const dbPassword = "root:hunter";
+export const basicAuthPassword = "admin:admin";
+```
+
+`user:pass` is how basic-auth and database credentials get pasted into source.
+The skip now applies only when the first segment names the same thing as the
+binding, which is the shape it was written for. `password: "password:update"`
+and `apiKey: "apikey:rotate"` stay quiet.
+
+**`.catch()` with no handler counted as handled.** `correctness/no-fire-and-forget-async`
+accepted any `.catch` in the chain. A bare `.catch()` returns a promise that
+rejects with the same reason, so the rejection still reaches the process:
+
+```ts
+this.repo.save({}).catch();
+```
+
+A `catch` now needs an argument. `.catch(() => {})` still counts, since swallowing
+deliberately is not an unhandled rejection.
+
+Neither moves across 189 public projects. Both reproduce in four lines.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
@@ -52,8 +52,9 @@ function hasRejectionHandler(callExpr: CallExpression): boolean {
 			SyntaxKind.PropertyAccessExpression
 		);
 		const name = access.getName();
+		// `.catch()` with no handler still rejects, so it handles nothing.
 		if (name === "catch") {
-			return true;
+			return current.getArguments().length > 0;
 		}
 		if (name === "then" && current.getArguments().length > 1) {
 			return true;

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-hardcoded-secrets.ts
@@ -78,8 +78,8 @@ function hasSuspiciousName(name: string): boolean {
 	return VARIABLE_NAME_PATTERNS.some((p) => p.test(name));
 }
 
-// A permission scope, not a credential: `password:update`, `user:read`.
-// Digits are excluded so `admin:secretpass123` stays a credential.
+// The shape of a permission scope. Digits are excluded so `admin:secretpass123`
+// stays a credential.
 const SCOPE_VALUE = /^[a-z]+(:[a-z]+)+$/;
 
 const WORD_SEGMENT = /^[a-z]{3,}$/;
@@ -97,6 +97,19 @@ function isWordSequence(value: string): boolean {
 const NON_ALNUM = /[^a-z0-9]/g;
 
 // True when the value only restates the name, as a config key does.
+/**
+ * True for `password: "password:update"`, where the first segment names the same
+ * thing as the binding. A colon value that does not is a credential, not a scope.
+ */
+function isPermissionScope(name: string, value: string): boolean {
+	if (!SCOPE_VALUE.test(value)) {
+		return false;
+	}
+	const flatName = name.toLowerCase().replace(NON_ALNUM, "");
+	const flatResource = value.split(":")[0].toLowerCase().replace(NON_ALNUM, "");
+	return flatName.startsWith(flatResource) || flatResource.startsWith(flatName);
+}
+
 function echoesName(name: string, value: string): boolean {
 	return (
 		name.toLowerCase().replace(NON_ALNUM, "") ===
@@ -174,7 +187,7 @@ export const noHardcodedSecrets: Rule = {
 
 				const value = initializer.getText().slice(1, -1);
 				if (
-					SCOPE_VALUE.test(value) ||
+					isPermissionScope(name, value) ||
 					echoesName(name, value) ||
 					(isThrownMessage(node) && isWordSequence(value))
 				) {

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1041,6 +1041,21 @@ describe("require-inject-decorator", () => {
 });
 
 describe("no-fire-and-forget-async", () => {
+	it("flags a bare .catch() with no handler", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().catch();
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
 	it("does not flag a chain that ends in .catch()", () => {
 		const diags = runRule(
 			noFireAndForgetAsync,

--- a/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/no-hardcoded-secrets.test.ts
@@ -25,6 +25,22 @@ function runRule(code: string, filePath = "test.ts"): Diagnostic[] {
 }
 
 describe("no-hardcoded-secrets", () => {
+	it("flags a colon value that does not name the binding", () => {
+		const diags = runRule(`
+      export const authToken = "admin:supersecret";
+      export const dbPassword = "root:hunter";
+    `);
+		expect(diags).toHaveLength(2);
+	});
+
+	it("still ignores a permission scope that names the binding", () => {
+		const diags = runRule(`
+      export const password = "password:update";
+      export const apiKey = "apikey:rotate";
+    `);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("flags a class property holding a secret", () => {
 		const diags = runRule(`
       export class SocketConstants {


### PR DESCRIPTION
## 1. Context

Two rules gained skips this week to cut false positives. Auditing those merged changes, both skips turn out to cover more than they meant to, and a skip in a security rule fails silently.

## 2. Problem

**`security/no-hardcoded-secrets`.** #163 added a permission-scope skip so a property named `password` holding `"password:update"` would not be called a credential:

```ts
// A permission scope, not a credential: `password:update`, `user:read`.
// Digits are excluded so `admin:secretpass123` stays a credential.
const SCOPE_VALUE = /^[a-z]+(:[a-z]+)+$/;
```

The digit exclusion was the only thing separating a scope from a credential, and credentials do not have to contain digits. All three of these are silent:

```ts
export const authToken = "admin:supersecret";
export const dbPassword = "root:hunter";
export const basicAuthPassword = "admin:admin";
```

`user:pass` is exactly how basic-auth headers and database URLs get pasted into source, so this is a live class, not a corner case.

**`correctness/no-fire-and-forget-async`.** #183 added `hasRejectionHandler`, which accepts any `catch` in the chain regardless of its arguments:

```ts
if (name === "catch") {
  return true;
}
```

`Promise.prototype.catch(undefined)` returns a promise that rejects with the same reason, so `this.repo.save({}).catch();` still reaches the process as an unhandled rejection. The rule went quiet on it.

## 3. Possible flows

| Value or expression | Before | After |
|---|---|---|
| `password: "password:update"` | quiet | quiet |
| `apiKey: "apikey:rotate"` | quiet | quiet |
| `secret: "secret:read"` | quiet | quiet |
| `authToken: "admin:supersecret"` | **silent** | reported |
| `dbPassword: "root:hunter"` | **silent** | reported |
| `basicAuthPassword: "admin:admin"` | **silent** | reported |
| `admin:secretpass123` (digits) | reported | reported |
| `.catch()` no handler | **silent** | reported |
| `.catch(e => log(e))` | quiet | quiet |
| `.catch(() => {})` | quiet | quiet |
| `.then(ok, fail)` | quiet | quiet |
| `.then(ok)` alone | reported | reported |

## 4. Solution

The scope skip now applies only when the value's first segment names the same thing as the binding, which is the shape #163 was written for: `password` holding `password:update`, `apiKey` holding `apikey:rotate`. A colon value whose first segment has nothing to do with the binding is a credential.

`catch` needs at least one argument. `.catch(() => {})` still counts, because swallowing an error on purpose is a different complaint from an unhandled rejection, and this rule is about the latter.

Not done: `.catch(e => { throw e; })` rethrows and still leaves the rejection unhandled, but telling a rethrowing handler from a logging one means reading the body. Also not done: `isLogged` in `no-exposed-stack-trace` matches only the last member segment, so `subscriber.error({ stack })` and `client.log(err.stack)` are read as logging. Both are separate changes.

## 5. Before vs after

| | Before | After |
|---|---:|---:|
| Findings, 189 public projects | 13,574 | 13,574 |
| Tests | 932 | 935 |

No corpus movement, which is why the measurements taken when those skips landed did not catch either. Both reproduce in four lines, and the secrets one is the kind that stays hidden precisely because nothing reports it.

## 6. Example

```ts
export const authToken = "admin:supersecret";
export const dbPassword = "root:hunter";
export class B {
  async save() { return 1; }
  run() { this.save().catch(); }
}
```

Before: no findings.

After:

```
✖ error  security/no-hardcoded-secrets   Variable 'authToken' appears to contain a hardcoded secret.
✖ error  security/no-hardcoded-secrets   Variable 'dbPassword' appears to contain a hardcoded secret.
● warning correctness/no-fire-and-forget-async  Async call 'catch()' is not awaited.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)