### PR TITLE
fix(rules): three rules missing cases they were written to catch

### DIFF
--- a/.changeset/audit-round-three.md
+++ b/.changeset/audit-round-three.md
@@ -46,9 +46,9 @@ logs first:
 .catch((e) => { this.logger.error(e); throw e; });
 ```
 
-A handler that ends by throwing no longer counts as handling it. An empty
-handler still does, because swallowing an error deliberately is a different
-complaint.
+A handler that ends by throwing no longer counts as handling it, on the `catch`
+and on the second argument to `then` alike. An empty handler still does, because
+swallowing an error deliberately is a different complaint.
 
 Across 189 public projects this adds 9 findings, all of them rejections that
 reach the process, and removes none. The stack trace rule comes out level at 8:

--- a/.changeset/audit-round-three.md
+++ b/.changeset/audit-round-three.md
@@ -18,8 +18,10 @@ subscriber.error(err.stack);          // silent
 
 It also looked only at the nearest enclosing call, so wrapping the stack on the
 way to a real logger made it fire: `this.logger.error(redact(err.stack))` was
-reported as a leak. A logging call is now identified by its receiver, and the
-search walks out through every enclosing call rather than stopping at the first.
+reported as a leak. A logging call is now identified by its receiver, matched
+anywhere in the expression so that `this._logger` and `new Logger('Ctx')` both
+count, and the search walks out through every enclosing call rather than
+stopping at the first.
 
 **`correctness/no-duplicate-decorators` stopped seeing repeated route
 decorators.** Non-single-use decorators are keyed by their full text so that
@@ -40,6 +42,10 @@ rethrows.** `promise.catch((e) => { throw e; })` returns a promise that rejects,
 so the rejection is still unhandled. A handler whose every statement throws no
 longer counts as handling it.
 
-Across 189 public projects this adds 3 findings: 2 stack traces reaching a
-client and 1 rethrowing catch. No finding is removed. Duplicate route decorators
-do not occur in the corpus at all.
+Across 189 public projects this adds 1 finding, a rethrowing catch, and removes
+none. The stack trace rule comes out level at 8. A first attempt matched the
+receiver too strictly and fired on `this._logger.error(...)` and on
+`new Logger('Bootstrap').error(...)`, the ordinary shape at the foot of a
+`main.ts`; the corpus caught both. Neither a response helper carrying a stack
+nor a repeated route decorator occurs anywhere in public code, so those two are
+covered by tests rather than by a number.

--- a/.changeset/audit-round-three.md
+++ b/.changeset/audit-round-three.md
@@ -18,10 +18,10 @@ subscriber.error(err.stack);          // silent
 
 It also looked only at the nearest enclosing call, so wrapping the stack on the
 way to a real logger made it fire: `this.logger.error(redact(err.stack))` was
-reported as a leak. A logging call is now identified by its receiver, matched
-anywhere in the expression so that `this._logger` and `new Logger('Ctx')` both
-count, and the search walks out through every enclosing call rather than
-stopping at the first.
+reported as a leak. A logging call is now identified by its receiver, split into
+words so that `this._logger`, `this.logService`, `new Logger('Ctx')` and a bare
+`debug(...)` all count while `this.catalog` does not, and the search walks out
+through every enclosing call rather than stopping at the first.
 
 **`correctness/no-duplicate-decorators` stopped seeing repeated route
 decorators.** Non-single-use decorators are keyed by their full text so that
@@ -37,15 +37,23 @@ handler() {}
 registers `alpha` and silently drops `beta`. HTTP method decorators are now
 single-use.
 
-**`correctness/no-fire-and-forget-async` accepted a `.catch()` that only
-rethrows.** `promise.catch((e) => { throw e; })` returns a promise that rejects,
-so the rejection is still unhandled. A handler whose every statement throws no
-longer counts as handling it.
+**`correctness/no-fire-and-forget-async` accepted a `.catch()` that rethrows.**
+`promise.catch((e) => { throw e; })` returns a promise that rejects, so the
+rejection is still unhandled, and the same is true of the commoner shape that
+logs first:
 
-Across 189 public projects this adds 1 finding, a rethrowing catch, and removes
-none. The stack trace rule comes out level at 8. A first attempt matched the
-receiver too strictly and fired on `this._logger.error(...)` and on
-`new Logger('Bootstrap').error(...)`, the ordinary shape at the foot of a
-`main.ts`; the corpus caught both. Neither a response helper carrying a stack
-nor a repeated route decorator occurs anywhere in public code, so those two are
-covered by tests rather than by a number.
+```ts
+.catch((e) => { this.logger.error(e); throw e; });
+```
+
+A handler that ends by throwing no longer counts as handling it. An empty
+handler still does, because swallowing an error deliberately is a different
+complaint.
+
+Across 189 public projects this adds 9 findings, all of them rejections that
+reach the process, and removes none. The stack trace rule comes out level at 8:
+two earlier attempts at the receiver check fired on `this._logger.error(...)`,
+`new Logger('Bootstrap').error(...)`, `this.logService.error(...)` and a bare
+`debug(...)`, and the corpus caught each round. Neither a response helper
+carrying a stack nor a repeated route decorator occurs anywhere in public code,
+so those two are covered by tests rather than by a number.

--- a/.changeset/audit-round-three.md
+++ b/.changeset/audit-round-three.md
@@ -1,0 +1,45 @@
+---
+"nestjs-doctor": patch
+---
+
+Three rules missed cases they were written to catch. Found by working through
+the audit backlog from this week's changes, each reproduced before it was
+touched.
+
+**`security/no-exposed-stack-trace` treated any `.error()` call as logging.**
+The check took the last segment of the callee name, so `res.error(...)` and
+`subscriber.error(...)` counted as logging and the stack went to the client
+unreported:
+
+```ts
+res.error({ stack: err.stack });      // silent
+subscriber.error(err.stack);          // silent
+```
+
+It also looked only at the nearest enclosing call, so wrapping the stack on the
+way to a real logger made it fire: `this.logger.error(redact(err.stack))` was
+reported as a leak. A logging call is now identified by its receiver, and the
+search walks out through every enclosing call rather than stopping at the first.
+
+**`correctness/no-duplicate-decorators` stopped seeing repeated route
+decorators.** Non-single-use decorators are keyed by their full text so that
+`@UseInterceptors(A)` and `@UseInterceptors(B)` read as two interceptors. Route
+decorators fell into that bucket, but Nest stores one path per handler, so
+
+```ts
+@Get('alpha')
+@Get('beta')
+handler() {}
+```
+
+registers `alpha` and silently drops `beta`. HTTP method decorators are now
+single-use.
+
+**`correctness/no-fire-and-forget-async` accepted a `.catch()` that only
+rethrows.** `promise.catch((e) => { throw e; })` returns a promise that rejects,
+so the rejection is still unhandled. A handler whose every statement throws no
+longer counts as handling it.
+
+Across 189 public projects this adds 3 findings: 2 stack traces reaching a
+client and 1 rethrowing catch. No finding is removed. Duplicate route decorators
+do not occur in the corpus at all.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-decorators.ts
@@ -1,3 +1,4 @@
+import { HTTP_DECORATORS } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
 const WHITESPACE = /\s+/g;
@@ -13,6 +14,8 @@ const SINGLE_USE_DECORATORS = new Set([
 	"Module",
 	"Resolver",
 	"WebSocketGateway",
+	// Nest stores one route path per handler, so a second overwrites the first.
+	...HTTP_DECORATORS,
 ]);
 
 export const noDuplicateDecorators: Rule = {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-duplicate-decorators.ts
@@ -14,7 +14,6 @@ const SINGLE_USE_DECORATORS = new Set([
 	"Module",
 	"Resolver",
 	"WebSocketGateway",
-	// Nest stores one route path per handler, so a second overwrites the first.
 	...HTTP_DECORATORS,
 ]);
 
@@ -24,7 +23,7 @@ export const noDuplicateDecorators: Rule = {
 		category: "correctness",
 		severity: "warning",
 		description: "Same decorator should not appear twice on a single target",
-		help: "Remove the duplicate decorator — it was likely copy-pasted by mistake.",
+		help: "Remove the second decorator. Only one of them takes effect, so the other is dropped without an error.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
@@ -38,16 +38,19 @@ const ASYNC_PREFIXES = new Set([
 ]);
 
 /**
- * A handler whose every statement throws leaves the rejection unhandled. Only
- * an inline function body is read, so a handler passed by name is left alone.
+ * A handler that ends by throwing leaves the rejection unhandled. Only an
+ * inline function body is read, so a handler passed by name is left alone.
  */
 function onlyRethrows(handler: Node | undefined): boolean {
 	if (!handler) {
 		return false;
 	}
+	const inner =
+		handler.asKind(SyntaxKind.ParenthesizedExpression)?.getExpression() ??
+		handler;
 	const fn =
-		handler.asKind(SyntaxKind.ArrowFunction) ??
-		handler.asKind(SyntaxKind.FunctionExpression);
+		inner.asKind(SyntaxKind.ArrowFunction) ??
+		inner.asKind(SyntaxKind.FunctionExpression);
 	if (!fn) {
 		return false;
 	}
@@ -56,15 +59,12 @@ function onlyRethrows(handler: Node | undefined): boolean {
 		return false;
 	}
 	const statements = body.asKindOrThrow(SyntaxKind.Block).getStatements();
-	return (
-		statements.length > 0 &&
-		statements.every((st) => st.getKind() === SyntaxKind.ThrowStatement)
-	);
+	return statements.at(-1)?.getKind() === SyntaxKind.ThrowStatement;
 }
 
 /**
- * True when the chain ends in `.catch(h)` or a `.then(ok, err)`, so a rejection
- * already has somewhere to go.
+ * True when the chain ends in `.catch(h)` or a `.then(ok, err)`, unless the
+ * catch handler only rethrows.
  */
 function hasRejectionHandler(callExpr: CallExpression): boolean {
 	let current: CallExpression | undefined = callExpr;

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
@@ -1,4 +1,4 @@
-import { type CallExpression, SyntaxKind } from "ts-morph";
+import { type CallExpression, type Node, SyntaxKind } from "ts-morph";
 import { isHttpHandler } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
@@ -41,6 +41,28 @@ const ASYNC_PREFIXES = new Set([
  * True when the chain ends in `.catch(h)` or a `.then(ok, err)`, so a rejection
  * already has somewhere to go.
  */
+/** A handler whose every path throws leaves the rejection unhandled. */
+function onlyRethrows(handler: Node | undefined): boolean {
+	if (!handler) {
+		return false;
+	}
+	const fn =
+		handler.asKind(SyntaxKind.ArrowFunction) ??
+		handler.asKind(SyntaxKind.FunctionExpression);
+	if (!fn) {
+		return false;
+	}
+	const body = fn.getBody();
+	if (body.getKind() !== SyntaxKind.Block) {
+		return false;
+	}
+	const statements = body.asKindOrThrow(SyntaxKind.Block).getStatements();
+	return (
+		statements.length > 0 &&
+		statements.every((st) => st.getKind() === SyntaxKind.ThrowStatement)
+	);
+}
+
 function hasRejectionHandler(callExpr: CallExpression): boolean {
 	let current: CallExpression | undefined = callExpr;
 	while (current) {
@@ -54,7 +76,8 @@ function hasRejectionHandler(callExpr: CallExpression): boolean {
 		const name = access.getName();
 		// `.catch()` with no handler still rejects, so it handles nothing.
 		if (name === "catch") {
-			return current.getArguments().length > 0;
+			const handler = current.getArguments()[0];
+			return Boolean(handler) && !onlyRethrows(handler);
 		}
 		if (name === "then" && current.getArguments().length > 1) {
 			return true;

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
@@ -83,7 +83,7 @@ function hasRejectionHandler(callExpr: CallExpression): boolean {
 			return Boolean(handler) && !onlyRethrows(handler);
 		}
 		if (name === "then" && current.getArguments().length > 1) {
-			return true;
+			return !onlyRethrows(current.getArguments()[1]);
 		}
 		if (name !== "then" && name !== "finally") {
 			return false;

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
@@ -38,10 +38,9 @@ const ASYNC_PREFIXES = new Set([
 ]);
 
 /**
- * True when the chain ends in `.catch(h)` or a `.then(ok, err)`, so a rejection
- * already has somewhere to go.
+ * A handler whose every statement throws leaves the rejection unhandled. Only
+ * an inline function body is read, so a handler passed by name is left alone.
  */
-/** A handler whose every path throws leaves the rejection unhandled. */
 function onlyRethrows(handler: Node | undefined): boolean {
 	if (!handler) {
 		return false;
@@ -63,6 +62,10 @@ function onlyRethrows(handler: Node | undefined): boolean {
 	);
 }
 
+/**
+ * True when the chain ends in `.catch(h)` or a `.then(ok, err)`, so a rejection
+ * already has somewhere to go.
+ */
 function hasRejectionHandler(callExpr: CallExpression): boolean {
 	let current: CallExpression | undefined = callExpr;
 	while (current) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-exposed-stack-trace.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-exposed-stack-trace.ts
@@ -16,9 +16,11 @@ const LOG_METHODS = new Set([
 	"warning",
 ]);
 
-// Receivers that own the log methods above. `res.error()` and
-// `subscriber.error()` share the name but send the stack onwards.
-const LOGGER_RECEIVER = /(^|\.)(logger|log|console|winston|pino|bunyan)$/i;
+// Receivers that own the log methods above, matched anywhere in the expression
+// so `this._logger` and `new Logger('Ctx')` both count. `res.error()` and
+// `subscriber.error()` share the method name but send the stack onwards.
+const LOGGER_RECEIVER = /logger|console|winston|pino|bunyan/i;
+const BARE_LOG_RECEIVER = /(^|\.)log$/i;
 
 /** True when the call is a log method on a logger, not a same-named method. */
 function isLoggingCall(call: CallExpression): boolean {
@@ -30,7 +32,8 @@ function isLoggingCall(call: CallExpression): boolean {
 	if (!LOG_METHODS.has(access.getName())) {
 		return false;
 	}
-	return LOGGER_RECEIVER.test(access.getExpression().getText());
+	const receiver = access.getExpression().getText();
+	return LOGGER_RECEIVER.test(receiver) || BARE_LOG_RECEIVER.test(receiver);
 }
 
 /** True when the stack is being handed to a logging call, at any depth. */

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-exposed-stack-trace.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-exposed-stack-trace.ts
@@ -1,4 +1,4 @@
-import { type Node, SyntaxKind } from "ts-morph";
+import { type CallExpression, type Node, SyntaxKind } from "ts-morph";
 import type { Rule } from "../../types.js";
 
 const ERROR_VAR_PATTERN = /^(error|err|e|ex|exception)$/;
@@ -16,14 +16,33 @@ const LOG_METHODS = new Set([
 	"warning",
 ]);
 
-/** True when the stack is being handed to a logging call, at any depth. */
-function isLogged(access: Node): boolean {
-	const call = access.getFirstAncestorByKind(SyntaxKind.CallExpression);
-	if (!call) {
+// Receivers that own the log methods above. `res.error()` and
+// `subscriber.error()` share the name but send the stack onwards.
+const LOGGER_RECEIVER = /(^|\.)(logger|log|console|winston|pino|bunyan)$/i;
+
+/** True when the call is a log method on a logger, not a same-named method. */
+function isLoggingCall(call: CallExpression): boolean {
+	const callee = call.getExpression();
+	if (callee.getKind() !== SyntaxKind.PropertyAccessExpression) {
 		return false;
 	}
-	const callee = call.getExpression().getText().split(".").pop() ?? "";
-	return LOG_METHODS.has(callee);
+	const access = callee.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+	if (!LOG_METHODS.has(access.getName())) {
+		return false;
+	}
+	return LOGGER_RECEIVER.test(access.getExpression().getText());
+}
+
+/** True when the stack is being handed to a logging call, at any depth. */
+function isLogged(access: Node): boolean {
+	let call = access.getFirstAncestorByKind(SyntaxKind.CallExpression);
+	while (call) {
+		if (isLoggingCall(call)) {
+			return true;
+		}
+		call = call.getFirstAncestorByKind(SyntaxKind.CallExpression);
+	}
+	return false;
 }
 
 export const noExposedStackTrace: Rule = {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/no-exposed-stack-trace.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/no-exposed-stack-trace.ts
@@ -3,8 +3,7 @@ import type { Rule } from "../../types.js";
 
 const ERROR_VAR_PATTERN = /^(error|err|e|ex|exception)$/;
 
-// Standard log levels. Sending a stack to one of these is the remedy this rule
-// recommends, not the leak it looks for.
+// Standard log levels. A call also needs a logger receiver to count as logging.
 const LOG_METHODS = new Set([
 	"debug",
 	"error",
@@ -16,24 +15,37 @@ const LOG_METHODS = new Set([
 	"warning",
 ]);
 
-// Receivers that own the log methods above, matched anywhere in the expression
-// so `this._logger` and `new Logger('Ctx')` both count. `res.error()` and
-// `subscriber.error()` share the method name but send the stack onwards.
-const LOGGER_RECEIVER = /logger|console|winston|pino|bunyan/i;
-const BARE_LOG_RECEIVER = /(^|\.)log$/i;
+// Words that name a logger. `catalog` and `dialog` end in "log" without any
+// word being it, so they are not loggers.
+const LOGGER_WORD =
+	/^(log|logs|logger|loggers|logging|console|winston|pino|bunyan)$/;
+const CAMEL_BOUNDARY = /([a-z0-9])([A-Z])/g;
+const NON_ALNUM = /[^a-zA-Z0-9]+/;
+
+/** True when any word of the receiver expression names a logger. */
+function looksLikeLogger(receiver: string): boolean {
+	return receiver
+		.replace(CAMEL_BOUNDARY, "$1 $2")
+		.split(NON_ALNUM)
+		.some((word) => LOGGER_WORD.test(word.toLowerCase()));
+}
 
 /** True when the call is a log method on a logger, not a same-named method. */
 function isLoggingCall(call: CallExpression): boolean {
 	const callee = call.getExpression();
-	if (callee.getKind() !== SyntaxKind.PropertyAccessExpression) {
+	// A standalone logger such as `debug(...)` carries no receiver to check.
+	const identifier = callee.asKind(SyntaxKind.Identifier);
+	if (identifier) {
+		return LOG_METHODS.has(identifier.getText());
+	}
+	const access = callee.asKind(SyntaxKind.PropertyAccessExpression);
+	if (!access) {
 		return false;
 	}
-	const access = callee.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
 	if (!LOG_METHODS.has(access.getName())) {
 		return false;
 	}
-	const receiver = access.getExpression().getText();
-	return LOGGER_RECEIVER.test(receiver) || BARE_LOG_RECEIVER.test(receiver);
+	return looksLikeLogger(access.getExpression().getText());
 }
 
 /** True when the stack is being handed to a logging call, at any depth. */

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1056,6 +1056,36 @@ describe("no-fire-and-forget-async", () => {
 		expect(diags).toHaveLength(1);
 	});
 
+	it("flags a .catch() whose handler only rethrows", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().catch((e) => { throw e; });
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("does not flag a .catch() that logs before rethrowing nothing", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().catch((e) => { console.error(e); });
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("does not flag a chain that ends in .catch()", () => {
 		const diags = runRule(
 			noFireAndForgetAsync,
@@ -1805,6 +1835,37 @@ describe("validated-non-primitive-needs-type", () => {
 });
 
 describe("no-duplicate-decorators", () => {
+	it("flags two route decorators of the same method on one handler", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      @Controller('r')
+      class C {
+        @Get('alpha')
+        @Get('beta')
+        handler() {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("@Get()");
+	});
+
+	it("does not flag different route decorators on one handler", () => {
+		const diags = runRule(
+			noDuplicateDecorators,
+			`
+      @Controller('r')
+      class C {
+        @Get('alpha')
+        @Post('alpha')
+        handler() {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("does not flag stacked interceptors with different arguments", () => {
 		const diags = runRule(
 			noDuplicateDecorators,

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1086,6 +1086,21 @@ describe("no-fire-and-forget-async", () => {
 		expect(diags).toHaveLength(1);
 	});
 
+	it("flags a .then() whose rejection handler rethrows", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().then((v) => v, (e) => { throw e; });
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
 	it("does not flag a .catch() that swallows on purpose", () => {
 		const diags = runRule(
 			noFireAndForgetAsync,

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1071,6 +1071,36 @@ describe("no-fire-and-forget-async", () => {
 		expect(diags).toHaveLength(1);
 	});
 
+	it("flags a .catch() that logs and then rethrows", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().catch((e) => { console.error(e); throw e; });
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("does not flag a .catch() that swallows on purpose", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      export class MyService {
+        async refresh() { return 1; }
+        run() {
+          this.refresh().catch(() => {});
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("does not flag a .catch() that logs before rethrowing nothing", () => {
 		const diags = runRule(
 			noFireAndForgetAsync,

--- a/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
@@ -247,6 +247,48 @@ describe("no-exposed-stack-trace", () => {
 		expect(diags).toHaveLength(1);
 	});
 
+	it("flags a stack sent through a response helper named error", () => {
+		const diags = runRule(
+			noExposedStackTrace,
+			`
+      function handle(res) {
+        try {} catch (error) {
+          res.error({ stack: error.stack });
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("flags a stack pushed into an RxJS error channel", () => {
+		const diags = runRule(
+			noExposedStackTrace,
+			`
+      function handle(subscriber) {
+        try {} catch (error) {
+          subscriber.error(error.stack);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("does not flag a stack wrapped before reaching the logger", () => {
+		const diags = runRule(
+			noExposedStackTrace,
+			`
+      function handle() {
+        try {} catch (error) {
+          this.logger.error(redact(error.stack));
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("does not flag unrelated .stack access", () => {
 		const diags = runRule(
 			noExposedStackTrace,

--- a/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
@@ -289,6 +289,30 @@ describe("no-exposed-stack-trace", () => {
 		expect(diags).toHaveLength(0);
 	});
 
+	it("does not flag loggers whose names carry a prefix or suffix", () => {
+		for (const receiver of [
+			"this._logger",
+			"this.appLogger",
+			"this.loggerService",
+			"winstonLogger",
+			"this.logger.child({})",
+			"new Logger('Ctx')",
+			"this.log",
+		]) {
+			const diags = runRule(
+				noExposedStackTrace,
+				`
+      function handle() {
+        try {} catch (error) {
+          ${receiver}.error('failed', error.stack);
+        }
+      }
+    `
+			);
+			expect(diags, receiver).toHaveLength(0);
+		}
+	});
+
 	it("does not flag unrelated .stack access", () => {
 		const diags = runRule(
 			noExposedStackTrace,

--- a/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/security-rules.test.ts
@@ -294,10 +294,16 @@ describe("no-exposed-stack-trace", () => {
 			"this._logger",
 			"this.appLogger",
 			"this.loggerService",
+			"this.logService",
+			"this.loggingService",
+			"this.appLog",
+			"this.logs",
 			"winstonLogger",
 			"this.logger.child({})",
 			"new Logger('Ctx')",
 			"this.log",
+			"this.$log",
+			"this._log",
 		]) {
 			const diags = runRule(
 				noExposedStackTrace,
@@ -311,6 +317,34 @@ describe("no-exposed-stack-trace", () => {
 			);
 			expect(diags, receiver).toHaveLength(0);
 		}
+	});
+
+	it("does not flag a standalone logger called without a receiver", () => {
+		const diags = runRule(
+			noExposedStackTrace,
+			`
+      function handle() {
+        try {} catch (error) {
+          debug('refresh failed %s', error.stack);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("flags a receiver that merely ends in log", () => {
+		const diags = runRule(
+			noExposedStackTrace,
+			`
+      function handle() {
+        try {} catch (error) {
+          this.catalog.error(error.stack);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
 	});
 
 	it("does not flag unrelated .stack access", () => {


### PR DESCRIPTION
## 1. Context

The audit of this week's rule changes left a backlog of six suspected defects. This PR is the outcome of working through them: each was reproduced on a fixture before anything was touched, and the corpus of 189 public projects was measured before anything was kept. Three were real and are fixed here. One is not a defect. Two are reported below rather than fixed.

## 2. Problem

Three rules stayed quiet on the exact case they exist for.

`security/no-exposed-stack-trace` decides a stack is being logged by taking the last segment of the callee name. Any method called `error`, `warn` or `log` qualifies, whoever owns it:

```ts
res.error({ stack: err.stack });   // straight to the client, silent
subscriber.error(err.stack);       // straight to the client, silent
```

The same function looks only at the nearest enclosing call, so a wrapper on the way to a real logger flips it the other way and it reports a leak that isn't one:

```ts
this.logger.error(redact(err.stack));   // reported
```

`correctness/no-duplicate-decorators` keys non-single-use decorators by full text, which is right for `@UseInterceptors(A)` and `@UseInterceptors(B)`. Route decorators sit in the same bucket, but Nest stores one path per handler, so `@Get('alpha') @Get('beta')` registers `alpha` and drops `beta` with no error at runtime and none from us.

`correctness/no-fire-and-forget-async` accepts any `.catch()` carrying an argument. `promise.catch((e) => { throw e; })` returns a promise that rejects, so nothing is handled, and neither does the commoner shape that logs first and rethrows.

## 3. Possible flows

| Path | Affected | Why |
|---|---|---|
| `logger.error(err.stack)` | no | receiver is a logger, still silent |
| `logger.error({ stack })` | no | still silent, the walk finds the logger |
| `logger.error(wrap(err.stack))` | yes | was reported, now silent |
| `res.error` / `subscriber.error` | yes | was silent, now reported |
| `return { stack }` | no | already reported |
| `@Get` twice on one handler | yes | was silent, now reported |
| `@Get` + `@Post` on one handler | no | different decorators, still silent |
| `@UseInterceptors(A)` + `(B)` | no | not single-use, still silent |
| `.catch(e => { throw e })` | yes | was silent, now reported |
| `.catch(e => { log(e); throw e })` | yes | was silent, now reported |
| `.catch(e => { log(e) })` | no | still silent |
| `.catch(() => {})` | no | deliberate swallow, still silent |
| `.catch()` bare | no | already reported |

## 4. Solution

A logging call is now recognised by its receiver rather than by the method name alone, and the search walks out through every enclosing call instead of stopping at the first. The receiver is split into words at camel case and punctuation, and one of them has to be `log`, `logs`, `logger`, `loggers`, `logging`, `console`, `winston`, `pino` or `bunyan`. A call with no receiver counts when its own name is a log level, which is how `debug(err.stack)` stays quiet.

That took three attempts. Anchoring to the last dot-segment reported `this._logger` and `new Logger('Bootstrap')`; matching a substring anywhere then reported `this.logService` and `this.loggingService`, and dropped the standalone `debug(...)` the first version had handled. Each round was caught by the corpus or by review, and all of them are now regression tests.

HTTP method decorators join the single-use set. A catch handler that ends by throwing no longer counts as handling the rejection; an empty handler still does, because swallowing an error on purpose is a different complaint.

Identifying a logger by name is a heuristic, and #176 warned against exactly this shape of guess when it declined to treat `bag.set("error.stack", …)` as logging. Resolving the receiver's type would settle it properly, but #198 removed a `getType()` call from a rule for costing 679 MB on 20 files, so the checker is not available here. The names are matched loosely on purpose and the corpus is the check on them.

Two things I did not fix, both filed instead:

`architecture/no-business-logic-in-controllers` allows one non-guard `if` per handler, which became a double allowance once #182 stopped counting guard clauses. Tightening it to zero adds **201 error-severity findings** across the corpus, nearly doubling the rule. That is a policy call rather than a defect, so it is #204.

`MethodDependencyNode.expandedElsewhere` is computed and serialised but read nowhere, so the HTML report shows a collapsed subtree with no sign it was expanded elsewhere. That is #205.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| stack via `res.error` | silent | reported |
| stack via `subscriber.error` | silent | reported |
| stack wrapped en route to logger | reported | silent |
| `@Get('a') @Get('b')` | silent | reported |
| `.catch(e => { throw e })` | silent | reported |
| stack to a plain logger *(unchanged)* | silent | silent |
| stack to `this._logger` / `logService` / `debug()` *(unchanged)* | silent | silent |
| stack to `this.catalog.error()` *(unchanged)* | reported | reported |
| `@UseInterceptors(A)(B)` *(unchanged)* | silent | silent |
| 189-project corpus | 13,574 | 13,583 |

## 6. Example

Only one of the three shows up in public code, so here is that one, from `Rebilly/nestjs-transaction` in the corpus:

```
$ nestjs-doctor . --format json | jq -r '.diagnostics[] | select(.rule=="correctness/no-fire-and-forget-async") | "L\(.line)"' | wc -l
```

Before: `637` across the corpus. After: `646`.

Eight of the nine log and then rethrow. From `weicanie/prisma-ai`:

```ts
.catch(error => {
  this.logger.error(`...${task.resultKey}...: ${error}`);
  throw error;
});
```

The ninth, from `laudspeaker/laudspeaker`, rethrows bare and then chains `.finally()`.

The other two are covered by fixtures rather than by a corpus number. On a file holding `res.error({ stack: err.stack })`, `subscriber.error(err.stack)` and a handler carrying `@Get('alpha') @Get('beta')`:

Before:

```
security/no-exposed-stack-trace L18
```

After:

```
security/no-exposed-stack-trace L10
security/no-exposed-stack-trace L18
security/no-exposed-stack-trace L22
correctness/no-duplicate-decorators L7
```

L10 and L22 both put a stack trace in front of a client.
