### PR TITLE
fix(rules): treat a throw-only if/else chain as a guard clause

### DIFF
--- a/.changeset/guard-chains-in-controllers.md
+++ b/.changeset/guard-chains-in-controllers.md
@@ -27,7 +27,9 @@ concern a controller exists for. A chain now counts as a guard when every one of
 its branches only throws. A branch that does anything else still counts, so an
 `else` that assigns or calls is a branch as before.
 
-Across 189 public projects this removes 21 findings in 7 files and adds none.
+Across 189 public projects this removes 21 findings and adds none. All 21 sit in
+one project, across 7 of its controllers, so the count is a weak signal of how
+often this happens; the argument is the shape rather than the frequency.
 
 The threshold is unchanged. One non-guard `if` per handler is still allowed,
 which was measured against two stricter alternatives: counting every remaining

--- a/.changeset/guard-chains-in-controllers.md
+++ b/.changeset/guard-chains-in-controllers.md
@@ -1,0 +1,35 @@
+---
+"nestjs-doctor": patch
+---
+
+`architecture/no-business-logic-in-controllers` no longer reports a controller
+for mapping errors to HTTP exceptions.
+
+#182 taught the rule that a guard clause is not business logic, but it only
+recognised an `if` with no `else`. The commonest way to reject a request in a
+`catch` is a chain, and every branch of it throws:
+
+```ts
+} catch (e) {
+  if (e instanceof GroupIdNotFoundError) {
+    throw new NotFoundException('Group not found');
+  } else if (e instanceof Error) {
+    throw new BadRequestException(`Unexpected error: ${e.message}`);
+  } else {
+    throw new BadRequestException('Server error');
+  }
+}
+```
+
+That counted as three branches and was reported as business logic, which is the
+opposite of true: translating a domain error into a status code is the HTTP
+concern a controller exists for. A chain now counts as a guard when every one of
+its branches only throws. A branch that does anything else still counts, so an
+`else` that assigns or calls is a branch as before.
+
+Across 189 public projects this removes 21 findings in 7 files and adds none.
+
+The threshold is unchanged. One non-guard `if` per handler is still allowed,
+which was measured against two stricter alternatives: counting every remaining
+`if` adds 226 findings, and counting only branches that assign churns 49 out and
+67 in, among them header parsing that belongs in a controller.

--- a/.changeset/guard-chains-in-controllers.md
+++ b/.changeset/guard-chains-in-controllers.md
@@ -24,14 +24,23 @@ recognised an `if` with no `else`. The commonest way to reject a request in a
 That counted as three branches and was reported as business logic, which is the
 opposite of true: translating a domain error into a status code is the HTTP
 concern a controller exists for. A chain now counts as a guard when every one of
-its branches only throws. A branch that does anything else still counts, so an
-`else` that assigns or calls is a branch as before.
+its branches only throws, written either `else if` or `else { if }`. A branch
+that does anything else still counts, so an `else` that assigns or calls is a
+branch as before.
 
-Across 189 public projects this removes 21 findings and adds none. All 21 sit in
-one project, across 7 of its controllers, so the count is a weak signal of how
-often this happens; the argument is the shape rather than the frequency.
+A chain also counts as **one** branch rather than one per link. It used to be
+counted per link, so adding a rejection made the rule likelier to fire:
+`if (a) throw; else { r = 5 }` was clean while
+`if (a) throw; else if (b) throw; else { r = 5 }` reported "2 if". More ways to
+reject a request should never read as more business logic.
+
+Across 189 public projects this takes the rule from 223 findings to 196 and adds
+none. 21 of the 27 are error mapping in one project, across 7 of its
+controllers, so the count is a weak signal of how often this happens; the
+argument is the shape rather than the frequency.
 
 The threshold is unchanged. One non-guard `if` per handler is still allowed,
 which was measured against two stricter alternatives: counting every remaining
-`if` adds 226 findings, and counting only branches that assign churns 49 out and
-67 in, among them header parsing that belongs in a controller.
+`if` takes the rule to 424, and counting only branches that assign takes it to
+241 while silencing cases that should fire, among them header parsing that
+belongs in a controller.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-business-logic-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-business-logic-in-controllers.ts
@@ -17,6 +17,18 @@ function onlyThrows(branch: Statement): boolean {
 	);
 }
 
+/** The next link of a chain, written either `else if` or `else { if }`. */
+function chainedIf(alternative: Statement): IfStatement | undefined {
+	const direct = alternative.asKind(SyntaxKind.IfStatement);
+	if (direct) {
+		return direct;
+	}
+	const statements = alternative.asKind(SyntaxKind.Block)?.getStatements();
+	return statements?.length === 1
+		? statements[0].asKind(SyntaxKind.IfStatement)
+		: undefined;
+}
+
 /**
  * An if whose every branch only throws, including an else-if chain. Rejecting a
  * bad request is an HTTP concern, so it is not a branch in the method's logic.
@@ -29,8 +41,21 @@ function isGuardClause(statement: IfStatement): boolean {
 	if (!alternative) {
 		return true;
 	}
-	const chained = alternative.asKind(SyntaxKind.IfStatement);
+	const chained = chainedIf(alternative);
 	return chained ? isGuardClause(chained) : onlyThrows(alternative);
+}
+
+/** True when this if is a later link of a chain, which the head already counts. */
+function isChainLink(statement: IfStatement): boolean {
+	const parent = statement.getParent();
+	const owner =
+		parent?.asKind(SyntaxKind.IfStatement) ??
+		parent
+			?.asKind(SyntaxKind.Block)
+			?.getParent()
+			?.asKind(SyntaxKind.IfStatement);
+	const alternative = owner?.getElseStatement();
+	return Boolean(alternative && chainedIf(alternative) === statement);
 }
 
 export const noBusinessLogicInControllers: Rule = {
@@ -66,7 +91,9 @@ export const noBusinessLogicInControllers: Rule = {
 				// Count control flow statements
 				const ifStatements = body
 					.getDescendantsOfKind(SyntaxKind.IfStatement)
-					.filter((statement) => !isGuardClause(statement));
+					.filter(
+						(statement) => !(isChainLink(statement) || isGuardClause(statement))
+					);
 				const forStatements = body.getDescendantsOfKind(
 					SyntaxKind.ForStatement
 				);

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-business-logic-in-controllers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-business-logic-in-controllers.ts
@@ -1,19 +1,12 @@
-import { type IfStatement, SyntaxKind } from "ts-morph";
+import { type IfStatement, type Statement, SyntaxKind } from "ts-morph";
 import {
 	declaresRoutes,
 	HTTP_DECORATORS,
 } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
-/**
- * An if with no else whose branch only throws. Rejecting a bad request is an
- * HTTP concern, so it is not a branch in the method's logic.
- */
-function isGuardClause(statement: IfStatement): boolean {
-	if (statement.getElseStatement()) {
-		return false;
-	}
-	const branch = statement.getThenStatement();
+/** True when the branch is non-empty and every statement in it throws. */
+function onlyThrows(branch: Statement): boolean {
 	const statements =
 		branch.getKind() === SyntaxKind.Block
 			? branch.asKindOrThrow(SyntaxKind.Block).getStatements()
@@ -22,6 +15,22 @@ function isGuardClause(statement: IfStatement): boolean {
 		statements.length > 0 &&
 		statements.every((s) => s.getKind() === SyntaxKind.ThrowStatement)
 	);
+}
+
+/**
+ * An if whose every branch only throws, including an else-if chain. Rejecting a
+ * bad request is an HTTP concern, so it is not a branch in the method's logic.
+ */
+function isGuardClause(statement: IfStatement): boolean {
+	if (!onlyThrows(statement.getThenStatement())) {
+		return false;
+	}
+	const alternative = statement.getElseStatement();
+	if (!alternative) {
+		return true;
+	}
+	const chained = alternative.asKind(SyntaxKind.IfStatement);
+	return chained ? isGuardClause(chained) : onlyThrows(alternative);
 }
 
 export const noBusinessLogicInControllers: Rule = {
@@ -80,7 +89,8 @@ export const noBusinessLogicInControllers: Rule = {
 					forOfStatements.length +
 					whileStatements.length;
 
-				// Allow simple guard clauses (1 if), but flag complex logic
+				// One branch of the method's own logic is allowed. Guard clauses
+				// were filtered out above and do not count against it.
 				if (
 					ifStatements.length > 1 ||
 					loopCount > 0 ||

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -152,6 +152,62 @@ describe("no-business-logic-in-controllers", () => {
 		expect(diags[0].message).toContain("2 if");
 	});
 
+	it("does not count an if/else chain whose every branch throws", () => {
+		const diags = runRule(
+			noBusinessLogicInControllers,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('bills')
+      export class BillsController {
+        @Get(':id')
+        async find(id: string) {
+          try {
+            return await this.service.find(id);
+          } catch (e) {
+            if (e instanceof NotFoundError) {
+              throw new NotFoundException('Not found');
+            } else if (e instanceof Error) {
+              throw new BadRequestException(e.message);
+            } else {
+              throw new BadRequestException('Server error');
+            }
+          }
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("counts an if/else chain whose last branch does work", () => {
+		const diags = runRule(
+			noBusinessLogicInControllers,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('bills')
+      export class BillsController {
+        @Get(':id')
+        async find(id: string, kind: string) {
+          if (!id) {
+            throw new BadRequestException();
+          }
+          if (kind === 'a') {
+            throw new BadRequestException();
+          } else {
+            this.rate = 5;
+          }
+          if (kind === 'b') {
+            this.rate = 10;
+          }
+          return this.service.find(id);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("2 if");
+	});
+
 	it("counts an if/else as a branch even when it throws", () => {
 		const diags = runRule(
 			noBusinessLogicInControllers,

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -179,6 +179,81 @@ describe("no-business-logic-in-controllers", () => {
 		expect(diags).toHaveLength(0);
 	});
 
+	it("does not count a braced else that holds only a throwing chain", () => {
+		const diags = runRule(
+			noBusinessLogicInControllers,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('bills')
+      export class BillsController {
+        @Get(':id')
+        async find(id: string) {
+          if (!id) {
+            throw new BadRequestException();
+          } else {
+            if (id === 'x') {
+              throw new NotFoundException();
+            } else {
+              throw new BadRequestException();
+            }
+          }
+          if (id === 'y') {
+            this.rate = 5;
+          }
+          return this.service.find(id);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("counts a chain once however many links it has", () => {
+		const twoLinks = runRule(
+			noBusinessLogicInControllers,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('bills')
+      export class BillsController {
+        @Get(':id')
+        async find(id: string, kind: string) {
+          if (kind === 'a') {
+            throw new BadRequestException();
+          } else {
+            this.rate = 5;
+          }
+          return this.service.find(id);
+        }
+      }
+    `
+		);
+		const fourLinks = runRule(
+			noBusinessLogicInControllers,
+			`
+      import { Controller, Get } from '@nestjs/common';
+      @Controller('bills')
+      export class BillsController {
+        @Get(':id')
+        async find(id: string, kind: string) {
+          if (kind === 'a') {
+            throw new BadRequestException();
+          } else if (kind === 'b') {
+            throw new BadRequestException();
+          } else if (kind === 'c') {
+            throw new BadRequestException();
+          } else {
+            this.rate = 5;
+          }
+          return this.service.find(id);
+        }
+      }
+    `
+		);
+		// Adding rejection branches must not turn one branch into several.
+		expect(twoLinks).toHaveLength(0);
+		expect(fourLinks).toHaveLength(0);
+	});
+
 	it("counts an if/else chain whose last branch does work", () => {
 		const diags = runRule(
 			noBusinessLogicInControllers,


### PR DESCRIPTION
## 1. Context

`architecture/no-business-logic-in-controllers` counts the branches in a handler and reports when there is more than one. #182 taught it that a guard clause is not a branch, on the reasoning that rejecting a bad request is an HTTP concern rather than logic. It recognised a guard by one shape: an `if` with no `else` whose body only throws.

## 2. Problem

The commonest rejection in a controller is not that shape. It is a chain in a `catch`, and every branch of it throws. From `AdrianLopezGue/daruma-backend` in the corpus:

```ts
} catch (e) {
  if (e instanceof GroupIdNotFoundError) {
    throw new NotFoundException('Group not found');
  } else if (e instanceof Error) {
    throw new BadRequestException(`Unexpected error: ${e.message}`);
  } else {
    throw new BadRequestException('Server error');
  }
}
```

Three `if` nodes, none with a bare `else`, so none is a guard. The handler is reported for containing business logic. Translating a domain error into a status code is the one thing a controller is unambiguously for, so the rule has this exactly backwards.

**21 findings are this**, all in one corpus project, spread over 7 of its controllers. One project is thin evidence of frequency, so the case for the change is the shape rather than the count: a `catch` that maps domain errors to `NotFoundException` and `BadRequestException` is ordinary NestJS, and the rule should never have called it business logic.

## 3. Possible flows

| Shape in a handler | Guard before | Guard now |
|---|---|---|
| `if (!id) throw` | yes | yes |
| `if (!id) throw; else if (!x) throw` | no | yes |
| `if (a) throw; else if (b) throw; else throw` | no | yes |
| `if (a) throw; else { if (b) throw; else throw }` | no | yes |
| `if (a) throw; else { this.log() }` | no | no |
| `if (a) throw; else { rate = 5 }` | no | no |
| `if (a) { doWork() }` | no | no |
| `if (a) { throw; doWork() }` | no | no |
| loops, `switch` | not a guard, unaffected | same |

## 4. Solution

`isGuardClause` now walks the `else if` chain and asks whether every branch only throws. The branch test moved into `onlyThrows` so the recursion reads plainly. A branch that does anything besides throw still makes the whole chain a branch, so #182's own test, whose `else` calls a logger, still reports two ifs.

A chain also contributes **one** branch rather than one per link. Review caught that it was counted per link, so `if (a) throw; else { r = 5 }` was clean while `if (a) throw; else if (b) throw; else { r = 5 }` reported "2 if". Adding a way to reject a request made the rule likelier to fire, which is backwards.

What I did not do: move the threshold. The issue asked whether one non-guard `if` should still be allowed now that guards are filtered out separately. I measured the two stricter readings and both are worse, so the allowance stays, and the comment above it, which claimed the allowance existed for guard clauses, is rewritten to say what the code does.

All counts below are findings of this rule id across the 189 projects, on the same baseline.

| Variant | Findings |
|---|---|
| main | 223 |
| **this PR** | **196** |
| count every remaining `if` | 424 |
| count only branches that assign | 241 |

The last one looks close on the net but silences cases that should fire and adds ones that should not, among them `if (authorization) { const token = authorization.slice(7); ... }`, which is parsing a header.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| `catch` mapping errors with an if/else chain | reported | silent |
| `if (!id) throw` alone *(unchanged)* | silent | silent |
| two branches that do work *(unchanged)* | reported, "2 if" | reported, "2 if" |
| `else` that logs *(unchanged)* | reported | reported |
| a loop in a handler *(unchanged)* | reported | reported |
| a chain of N links that ends in work | "N if" | one branch |
| 189-project corpus | 13,583 | 13,556 |

## 6. Example

`daruma-backend`, whose four bill endpoints each map errors in a `catch`:

```
$ nestjs-doctor . --format json | jq -r '[.diagnostics[] | select(.rule=="architecture/no-business-logic-in-controllers")] | length'
```

Before:

```
21
```

After:

```
0
```

Every one of the twenty-one was a `catch` translating a domain error into an HTTP exception. They are the whole of this PR's corpus movement.

Closes #204.
