### PR TITLE
feat(report): show when a node's calls are drawn at an earlier call site

### DIFF
--- a/.changeset/render-expanded-elsewhere.md
+++ b/.changeset/render-expanded-elsewhere.md
@@ -1,0 +1,20 @@
+---
+"nestjs-doctor": patch
+---
+
+The endpoint graph in the HTML report now says when a node's calls are drawn
+somewhere else.
+
+When a trace reaches a class it has already expanded at an earlier call site, it
+collapses the repeat and marks the node `expandedElsewhere`. Nothing read that
+flag, so the node was drawn with no children and no explanation, which is
+exactly how a genuine leaf is drawn. A reader had no way to tell "this service
+calls nothing" from "this service's calls are up there".
+
+A marked node now carries a `SHOWN ABOVE` badge, and hovering it says "Calls
+drawn at an earlier call site" beneath the existing "Conditionally called". One
+report generated from a mid-sized public project has six such nodes.
+
+Also adds the first test over the report's client script. It is a template
+string, so `tsc` never sees it and a syntax error would only surface in a
+browser; the test parses it.

--- a/.changeset/render-expanded-elsewhere.md
+++ b/.changeset/render-expanded-elsewhere.md
@@ -2,18 +2,29 @@
 "nestjs-doctor": patch
 ---
 
-The endpoint graph in the HTML report now says when a node's calls are drawn
-somewhere else.
+`expandedElsewhere` now means what it says, and the report shows it.
 
-When a trace reaches a class it has already expanded at an earlier call site, it
-collapses the repeat and marks the node `expandedElsewhere`. Nothing read that
-flag, so the node was drawn with no children and no explanation, which is
-exactly how a genuine leaf is drawn. A reader had no way to tell "this service
-calls nothing" from "this service's calls are up there".
+The endpoint trace collapses a class it has already expanded and marks the node
+so a reader can be told the calls are drawn somewhere else. Two things were
+wrong with that.
 
-A marked node now carries a `SHOWN ABOVE` badge, and hovering it says "Calls
-drawn at an earlier call site" beneath the existing "Conditionally called". One
-report generated from a mid-sized public project has six such nodes.
+**The flag was set on classes that were never expanded.** It is written in the
+branch that runs when a repeat finds no cached subtree, and the cache is only
+written for a class that has a provider. So `CommandBus`, `ConfigService`, a
+TypeORM `Repository`, anything the scan has no source for, got flagged on every
+occurrence after the first, pointing at a subtree that does not exist. In one
+report of a mid-sized public project, all six flagged nodes were `CommandBus`,
+which has no children anywhere in it. Across two larger projects the flag fell
+from 946 to 520 and from 6 to 0. The remaining ones are real: a class expanded
+once, reached again by another path.
+
+**Nothing read the flag.** A collapsed node was drawn with no children and no
+explanation, which is how a genuine leaf is drawn too. A marked node now carries
+a `↱` on the info row and says "Calls drawn at another call site" on hover. The
+marker is a glyph rather than a label because a label wide enough to read did
+not fit beside a `REPOSITORY` or `CONTROLLER` type badge, and it says "another"
+rather than "above" because the layout puts roughly a fifth of them level with
+or below the node.
 
 Also adds the first test over the report's client script. It is a template
 string, so `tsc` never sees it and a syntax error would only surface in a

--- a/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
@@ -1384,6 +1384,8 @@ function classifyDependency(name: string): DependencyType {
  * far beyond the number of distinct classes it covers.
  */
 interface NodeBudget {
+	/** Classes expanded into at least one child, so a subtree is drawn for them. */
+	drawn: Set<string>;
 	exhausted: boolean;
 	/** Classes whose subtree has already been expanded somewhere in this endpoint. */
 	expanded: Set<string>;
@@ -1552,10 +1554,10 @@ function buildMethodDependencyTree(
 			if (cached && claim(budget, cached.size)) {
 				childNodes = cached.nodes;
 			} else {
-				collapsed = true;
+				collapsed = budget.drawn.has(className);
 			}
 		} else if (budget.expanded.has(className)) {
-			collapsed = true;
+			collapsed = budget.drawn.has(className);
 		} else if (provider) {
 			budget.expanded.add(className);
 			const childVisited = new Set(visited);
@@ -1705,6 +1707,9 @@ function buildMethodDependencyTree(
 				nodes: childNodes,
 				size: serialisedSize(childNodes, budget.remaining),
 			});
+			if (childNodes.length > 0) {
+				budget.drawn.add(className);
+			}
 		}
 
 		let line = 0;
@@ -1938,6 +1943,7 @@ function extractEndpointsFromFile(
 				cache
 			);
 			const budget: NodeBudget = {
+				drawn: new Set(),
 				expanded: new Set(),
 				exhausted: false,
 				remaining: MAX_DEPENDENCY_NODES,

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3500,20 +3500,14 @@ function epDraw() {
       epCtx.fillText(orderLabel, badgeRight + 8, infoY + 6);
     }
 
-    // Repeat marker: this class's calls are drawn at an earlier call site
+    // Repeat marker, right-aligned so it fits whatever the type badge is wide
     if (n.expandedElsewhere) {
-      var repeatLabel = "\u21B1 SHOWN ABOVE";
-      epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
-      var repeatW = epCtx.measureText(repeatLabel).width + 8;
-      var repeatX = n.order >= 0 ? badgeRight + 4 + orderW + 4 : badgeRight + 4;
-      if (repeatX + repeatW <= x + n.w - 8) {
-        epRoundRect(epCtx, repeatX, infoY, repeatW, 12, 3);
-        epCtx.fillStyle = "rgba(255,255,255,0.08)";
-        epCtx.fill();
-        epCtx.fillStyle = "#888";
-        epCtx.textBaseline = "middle";
-        epCtx.fillText(repeatLabel, repeatX + 4, infoY + 6);
-      }
+      epCtx.font = "bold 10px -apple-system, BlinkMacSystemFont, sans-serif";
+      epCtx.fillStyle = "#888";
+      epCtx.textAlign = "right";
+      epCtx.textBaseline = "middle";
+      epCtx.fillText("\u21B1", x + n.w - 8, infoY + 6);
+      epCtx.textAlign = "left";
     }
 
     // Method name
@@ -3565,7 +3559,7 @@ function epShowTooltip(node, screenX, screenY) {
   }
   var repeatLabel = "";
   if (node.expandedElsewhere) {
-    repeatLabel = '<div style="font-size:9px;color:#888;margin-top:4px">Calls drawn at an earlier call site</div>';
+    repeatLabel = '<div style="font-size:9px;color:#888;margin-top:4px">\u21B1 Calls drawn at another call site</div>';
   }
   epTooltipEl.innerHTML = '<div class="tt-name">' + escHtml(node.className) + '</div>' +
     '<div class="tt-table" style="color:' + color + '">' + escHtml(node.type) + '</div>' +

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3254,6 +3254,7 @@ function epBuildGraph(ep) {
         totalMethods: dep.totalMethods,
         filePath: dep.filePath,
         line: dep.line,
+        expandedElsewhere: dep.expandedElsewhere,
         x: 0, y: 0, w: 180, h: 60
       };
       epNodes.push(n);
@@ -3486,16 +3487,33 @@ function epDraw() {
 
     // Order badge (#N)
     var badgeRight = x + 8 + badgeW;
+    var orderW = 0;
     if (n.order >= 0) {
       var orderLabel = "#" + (n.order + 1);
       epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
-      var orderW = epCtx.measureText(orderLabel).width + 8;
+      orderW = epCtx.measureText(orderLabel).width + 8;
       epRoundRect(epCtx, badgeRight + 4, infoY, orderW, 12, 3);
       epCtx.fillStyle = "rgba(255,255,255,0.08)";
       epCtx.fill();
       epCtx.fillStyle = "#999";
       epCtx.textBaseline = "middle";
       epCtx.fillText(orderLabel, badgeRight + 8, infoY + 6);
+    }
+
+    // Repeat marker: this class's calls are drawn at an earlier call site
+    if (n.expandedElsewhere) {
+      var repeatLabel = "\u21B1 SHOWN ABOVE";
+      epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
+      var repeatW = epCtx.measureText(repeatLabel).width + 8;
+      var repeatX = n.order >= 0 ? badgeRight + 4 + orderW + 4 : badgeRight + 4;
+      if (repeatX + repeatW <= x + n.w - 8) {
+        epRoundRect(epCtx, repeatX, infoY, repeatW, 12, 3);
+        epCtx.fillStyle = "rgba(255,255,255,0.08)";
+        epCtx.fill();
+        epCtx.fillStyle = "#888";
+        epCtx.textBaseline = "middle";
+        epCtx.fillText(repeatLabel, repeatX + 4, infoY + 6);
+      }
     }
 
     // Method name
@@ -3545,9 +3563,13 @@ function epShowTooltip(node, screenX, screenY) {
   if (node.conditional) {
     condLabel = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">Conditionally called</div>';
   }
+  var repeatLabel = "";
+  if (node.expandedElsewhere) {
+    repeatLabel = '<div style="font-size:9px;color:#888;margin-top:4px">Calls drawn at an earlier call site</div>';
+  }
   epTooltipEl.innerHTML = '<div class="tt-name">' + escHtml(node.className) + '</div>' +
     '<div class="tt-table" style="color:' + color + '">' + escHtml(node.type) + '</div>' +
-    methodHtml + condLabel;
+    methodHtml + condLabel + repeatLabel;
   epTooltipEl.style.display = "block";
 
   var mainRect = epCanvas.parentElement.getBoundingClientRect();

--- a/packages/nestjs-doctor/tests/unit/endpoint-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/endpoint-graph.test.ts
@@ -2325,6 +2325,55 @@ describe("endpoint-graph", () => {
 		expect(second?.expandedElsewhere).toBe(true);
 	});
 
+	it("does not mark repeats of a class that has no subtree anywhere", () => {
+		const { project, paths } = createProject({
+			"bills.controller.ts": `
+				import { Controller, Post } from '@nestjs/common';
+				@Controller('bills')
+				export class BillsController {
+					constructor(private readonly bills: BillsService) {}
+
+					@Post()
+					update() {
+						return this.bills.update();
+					}
+				}
+			`,
+			"bills.service.ts": `
+				import { Injectable } from '@nestjs/common';
+				@Injectable()
+				export class BillsService {
+					constructor(private readonly commandBus: CommandBus) {}
+					update() {
+						this.commandBus.execute('a');
+						this.commandBus.execute('b');
+						return this.commandBus.execute('c');
+					}
+				}
+			`,
+		});
+
+		const graph = buildEndpointGraph(
+			project,
+			paths,
+			resolveProviders(project, paths)
+		);
+		const service = graph.endpoints[0]?.dependencies.find(
+			(d) => d.className === "BillsService"
+		);
+		const busCalls = service?.dependencies.filter(
+			(d) => d.className === "CommandBus"
+		);
+
+		// CommandBus has no provider, so nothing was ever expanded for it and
+		// there is no subtree elsewhere for a later call site to point at.
+		expect(busCalls).toHaveLength(3);
+		for (const call of busCalls ?? []) {
+			expect(call.dependencies).toHaveLength(0);
+			expect(call.expandedElsewhere).toBeUndefined();
+		}
+	});
+
 	it("repeated method nodes share the same children", () => {
 		const { project, paths } = createProject({
 			"items.controller.ts": `

--- a/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
@@ -29,13 +29,13 @@ describe("report scripts", () => {
 		expect(scripts).toContain("expandedElsewhere: dep.expandedElsewhere");
 	});
 
-	it("marks a node whose subtree was expanded earlier", () => {
+	it("marks a node whose subtree is drawn elsewhere", () => {
 		expect(scripts).toContain("n.expandedElsewhere");
-		expect(scripts).toContain("SHOWN ABOVE");
+		expect(scripts).toContain("\u21B1");
 	});
 
 	it("says so in the tooltip", () => {
 		expect(scripts).toContain("node.expandedElsewhere");
-		expect(scripts).toContain("Calls drawn at an earlier call site");
+		expect(scripts).toContain("Calls drawn at another call site");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+	getReportScripts,
+	type ReportScriptData,
+} from "../../src/report/ui/scripts.js";
+
+const EMPTY: ReportScriptData = {
+	diagnosticsJson: "[]",
+	elapsedMsJson: "0",
+	endpointsJson: '{"endpoints":[]}',
+	examplesJson: "[]",
+	fileSourcesJson: "{}",
+	graphJson: '{"modules":[],"edges":[]}',
+	projectJson: "{}",
+	providersJson: "[]",
+	schemaJson: "null",
+	sourceLinesJson: "{}",
+	summaryJson: "{}",
+};
+
+describe("report scripts", () => {
+	const scripts = getReportScripts(EMPTY);
+
+	it("parses as JavaScript", () => {
+		expect(() => new Function(scripts)).not.toThrow();
+	});
+
+	it("carries expandedElsewhere onto the drawn node", () => {
+		expect(scripts).toContain("expandedElsewhere: dep.expandedElsewhere");
+	});
+
+	it("marks a node whose subtree was expanded earlier", () => {
+		expect(scripts).toContain("n.expandedElsewhere");
+		expect(scripts).toContain("SHOWN ABOVE");
+	});
+
+	it("says so in the tooltip", () => {
+		expect(scripts).toContain("node.expandedElsewhere");
+		expect(scripts).toContain("Calls drawn at an earlier call site");
+	});
+});


### PR DESCRIPTION
## 1. Context

The report's endpoint tab draws a call graph per endpoint. When the trace reaches a class it has already expanded at an earlier call site, it stops rather than drawing the same subtree twice, and marks the node so the reader can be told:

```ts
/** Set when this class's subtree was already expanded at an earlier call site */
expandedElsewhere?: true;
```

## 2. Problem

Two problems, and the second is why this PR grew.

**Nothing read the flag.** Grep across `packages/nestjs-doctor/src` returned the declaration and the assignment, no third occurrence. A collapsed node was drawn with no children and no explanation, which is exactly how a genuine leaf is drawn.

**The flag was also wrong.** It is set in the branch that runs when a repeat finds no cached subtree, and the cache is only ever written for a class that has a provider:

```ts
if (!isFirst) {
  const cached = computedChildNodes.get(className);
  if (cached && claim(budget, cached.size)) { childNodes = cached.nodes; }
  else { collapsed = true; }
}
```

So `CommandBus`, `ConfigService`, a TypeORM `Repository`, anything the scan has no source for, was flagged on every occurrence after the first while nothing had ever been expanded for it. In a `daruma-backend` report **all six** flagged nodes were `CommandBus`, which has zero children anywhere in that report. Rendering the flag would have put a marker on a node pointing at a subtree that does not exist.

## 3. Possible flows

| Node | Flagged before | Flagged now |
|---|---|---|
| class expanded once, reached again by another path | yes | yes |
| class expanded once, repeat denied by the node budget | yes | yes |
| class with a provider that expands to nothing | yes | no |
| class with no provider, repeated | yes | **no** |
| first occurrence of anything | no | no |
| `--format json` consumers | flag present | flag present, now truthful |

## 4. Solution

The budget records which classes expanded into at least one child, and a repeat consults that instead of the absence of a cache entry. The budget is per endpoint, which is the scope a reader is looking at.

The report then carries the flag onto the canvas node and shows it twice: a `↱` on the info row and a tooltip line under the existing "Conditionally called".

Two things the review changed. The marker is a glyph, not a `SHOWN ABOVE` label, because the label did not fit beside a `REPOSITORY` or `CONTROLLER` type badge and was silently dropped there. And the tooltip says "another call site" rather than "an earlier" one, because dagre lays out top to bottom and roughly a fifth of these nodes refer to something level with or below them.

What I did not do: link a collapsed node to where its subtree was drawn. That needs node identity the canvas does not track.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| `CommandBus` repeated, no provider | flagged, drawn as a leaf | not flagged |
| class genuinely expanded elsewhere | flagged, drawn as a leaf | flagged, `↱` plus tooltip |
| genuine leaf *(unchanged)* | not flagged | not flagged |
| conditional node *(unchanged)* | amber dashed | same |
| any diagnostic or the score *(unchanged)* | | no rule change |

## 6. Example

```
$ nestjs-doctor ./<project> --report
$ grep -o '"expandedElsewhere":true' nestjs-doctor-report.html | wc -l
```

| Project | Before | After |
|---|---|---|
| `AdrianLopezGue/daruma-backend` | 6 | **0** |
| `amplication/amplication` | 946 | **520** |

All six of daruma's were `CommandBus`. Amplication's 426 removed are the same class of node; the 520 that remain are classes that really were expanded once and reached again.

## 7. One extra thing

This adds `tests/unit/report-scripts.test.ts`, the first test over the report's client script. That script lives in a template string, so `tsc` never sees it and a syntax error would only appear when someone opens a report in a browser. The first test parses it.

Closes #205.
