### PR TITLE
fix(engine): find UseGuards inside a ternary or a spread

### DIFF
--- a/.changeset/guard-decorator-ternary.md
+++ b/.changeset/guard-decorator-ternary.md
@@ -1,0 +1,31 @@
+---
+"nestjs-doctor": patch
+---
+
+`security/require-guards-on-endpoints` no longer calls a guarded endpoint
+unguarded when the guard is chosen by a ternary.
+
+A composed auth decorator is recognised by looking for `UseGuards(...)` among
+the arguments of `applyDecorators(...)`, and the check required an argument to
+*be* that call. It commonly is not:
+
+```ts
+export function Auth(allowApiKeyAuth = false, isOptionalAuth = false) {
+  return applyDecorators(
+    SetMetadata(IS_OPTIONAL_AUTH_KEY, isOptionalAuth),
+    allowApiKeyAuth
+      ? UseGuards(MultiAuthGuard, ApiKeyRateLimitGuard, AuthenticationGuard)
+      : UseGuards(JwtAccessTokenGuard, AuthenticationGuard),
+  )
+}
+```
+
+Both branches apply a guard, but the argument is a conditional expression rather
+than a call, so `Auth` was not recorded and every `@Auth()` endpoint was
+reported as having no guard. A spread such as `applyDecorators(...guards)` fell
+out the same way. The argument's whole subtree is now searched.
+
+This is the worst direction for a security rule to be wrong in: it says an
+endpoint is unprotected when it is protected. Across 189 public projects it
+removes 138 findings, all in one project that uses the ternary form, and adds
+none. That project still reports its 14 genuinely unguarded endpoints.

--- a/.changeset/guard-decorator-ternary.md
+++ b/.changeset/guard-decorator-ternary.md
@@ -22,8 +22,14 @@ export function Auth(allowApiKeyAuth = false, isOptionalAuth = false) {
 
 Both branches apply a guard, but the argument is a conditional expression rather
 than a call, so `Auth` was not recorded and every `@Auth()` endpoint was
-reported as having no guard. A spread such as `applyDecorators(...guards)` fell
-out the same way. The argument's whole subtree is now searched.
+reported as having no guard.
+
+An argument now counts when it is a `UseGuards` call, when it is a ternary whose
+**both** branches apply one, or when it spreads an inline array holding one. A
+ternary that guards only one way round does not count, and neither does an
+argument that merely mentions `UseGuards` somewhere inside it, such as
+`SetMetadata('factory', () => UseGuards(G))`. Spreading a variable rather than
+an array literal is still not followed.
 
 This is the worst direction for a security rule to be wrong in: it says an
 endpoint is unprotected when it is protected. Across 189 public projects it

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -11,20 +11,28 @@ const FUNCTION_KINDS = new Set([
 	SyntaxKind.MethodDeclaration,
 ]);
 
+function isUseGuardsCall(node: Node): boolean {
+	return (
+		node.asKind(SyntaxKind.CallExpression)?.getExpression().getText() ===
+		"UseGuards"
+	);
+}
+
 /** True for `applyDecorators(..., UseGuards(...), ...)`. */
 function appliesGuards(expression: Node | undefined): boolean {
 	const call = expression?.asKind(SyntaxKind.CallExpression);
 	if (call?.getExpression().getText() !== "applyDecorators") {
 		return false;
 	}
+	// A guard can sit inside a ternary or a spread, so the whole argument is read.
 	return call
 		.getArguments()
 		.some(
 			(argument) =>
+				isUseGuardsCall(argument) ||
 				argument
-					.asKind(SyntaxKind.CallExpression)
-					?.getExpression()
-					.getText() === "UseGuards"
+					.getDescendantsOfKind(SyntaxKind.CallExpression)
+					.some(isUseGuardsCall)
 		);
 }
 

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -19,8 +19,8 @@ function isUseGuardsCall(node: Node): boolean {
 }
 
 /**
- * True for an argument that always applies a guard. A ternary counts only when
- * both of its branches do, so a decorator guarding one way round does not.
+ * True for an argument that always applies a guard: the call itself, a ternary
+ * whose both branches do, or a spread of an inline array holding one.
  */
 function argumentApplies(argument: Node): boolean {
 	if (isUseGuardsCall(argument)) {
@@ -41,7 +41,7 @@ function argumentApplies(argument: Node): boolean {
 	return elements ? elements.some(argumentApplies) : false;
 }
 
-/** True for `applyDecorators(..., UseGuards(...), ...)`. */
+/** True when an argument of `applyDecorators(...)` always applies a guard. */
 function appliesGuards(expression: Node | undefined): boolean {
 	const call = expression?.asKind(SyntaxKind.CallExpression);
 	if (call?.getExpression().getText() !== "applyDecorators") {

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -18,22 +18,36 @@ function isUseGuardsCall(node: Node): boolean {
 	);
 }
 
+/**
+ * True for an argument that always applies a guard. A ternary counts only when
+ * both of its branches do, so a decorator guarding one way round does not.
+ */
+function argumentApplies(argument: Node): boolean {
+	if (isUseGuardsCall(argument)) {
+		return true;
+	}
+	const conditional = argument.asKind(SyntaxKind.ConditionalExpression);
+	if (conditional) {
+		return (
+			argumentApplies(conditional.getWhenTrue()) &&
+			argumentApplies(conditional.getWhenFalse())
+		);
+	}
+	const spread = argument.asKind(SyntaxKind.SpreadElement);
+	const elements = spread
+		?.getExpression()
+		.asKind(SyntaxKind.ArrayLiteralExpression)
+		?.getElements();
+	return elements ? elements.some(argumentApplies) : false;
+}
+
 /** True for `applyDecorators(..., UseGuards(...), ...)`. */
 function appliesGuards(expression: Node | undefined): boolean {
 	const call = expression?.asKind(SyntaxKind.CallExpression);
 	if (call?.getExpression().getText() !== "applyDecorators") {
 		return false;
 	}
-	// A guard can sit inside a ternary or a spread, so the whole argument is read.
-	return call
-		.getArguments()
-		.some(
-			(argument) =>
-				isUseGuardsCall(argument) ||
-				argument
-					.getDescendantsOfKind(SyntaxKind.CallExpression)
-					.some(isUseGuardsCall)
-		);
+	return call.getArguments().some(argumentApplies);
 }
 
 /**

--- a/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
+++ b/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
@@ -87,6 +87,41 @@ describe("buildGuardDecoratorIndex", () => {
 		expect([...names]).toEqual(["Auth"]);
 	});
 
+	it("finds a guard chosen by a ternary", () => {
+		const names = index(`
+      import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+      export function Auth(allowApiKey = false) {
+        return applyDecorators(
+          SetMetadata('optional', false),
+          allowApiKey
+            ? UseGuards(MultiAuthGuard, RateLimitGuard)
+            : UseGuards(JwtAccessTokenGuard),
+        );
+      }
+    `);
+		expect([...names]).toEqual(["Auth"]);
+	});
+
+	it("finds a guard spread into the argument list", () => {
+		const names = index(`
+      import { applyDecorators, UseGuards } from '@nestjs/common';
+      export function Auth() {
+        return applyDecorators(...[UseGuards(AuthGuard)], SetMetadata('x', 1));
+      }
+    `);
+		expect([...names]).toEqual(["Auth"]);
+	});
+
+	it("does not treat an unrelated nested call as a guard", () => {
+		const names = index(`
+      import { applyDecorators, SetMetadata } from '@nestjs/common';
+      export function Meta(flag = false) {
+        return applyDecorators(flag ? SetMetadata('a', 1) : SetMetadata('b', 2));
+      }
+    `);
+		expect([...names]).toEqual([]);
+	});
+
 	it("returns an empty set for a file it was not given", () => {
 		const project = new Project({ useInMemoryFileSystem: true });
 		project.createSourceFile(

--- a/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
+++ b/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
@@ -112,6 +112,26 @@ describe("buildGuardDecoratorIndex", () => {
 		expect([...names]).toEqual(["Auth"]);
 	});
 
+	it("does not treat a guard merely mentioned inside an argument as applied", () => {
+		const names = index(`
+      import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+      export function Meta() {
+        return applyDecorators(SetMetadata('factory', () => UseGuards(AuthGuard)));
+      }
+    `);
+		expect([...names]).toEqual([]);
+	});
+
+	it("does not count a ternary that guards on only one branch", () => {
+		const names = index(`
+      import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+      export function Maybe(on = false) {
+        return applyDecorators(on ? UseGuards(AuthGuard) : SetMetadata('x', 1));
+      }
+    `);
+		expect([...names]).toEqual([]);
+	});
+
 	it("does not treat an unrelated nested call as a guard", () => {
 		const names = index(`
       import { applyDecorators, SetMetadata } from '@nestjs/common';


### PR DESCRIPTION
## 1. Context

`security/require-guards-on-endpoints` looks for `@UseGuards()` on a handler or its controller. Nest users rarely write that directly; they wrap it in one decorator, and the engine keeps an index of names that compose it by scanning for `applyDecorators(..., UseGuards(...), ...)`.

## 2. Problem

The index required an argument of `applyDecorators` to **be** the `UseGuards` call. From `Swetrix/swetrix` in the corpus:

```ts
export function Auth(allowApiKeyAuth = false, isOptionalAuth = false) {
  return applyDecorators(
    SetMetadata(IS_OPTIONAL_AUTH_KEY, isOptionalAuth),
    allowApiKeyAuth
      ? UseGuards(MultiAuthGuard, ApiKeyRateLimitGuard, AuthenticationGuard)
      : UseGuards(JwtAccessTokenGuard, AuthenticationGuard),
  )
}
```

Every branch applies a guard. The argument is a `ConditionalExpression`, not a `CallExpression`, so `asKind(CallExpression)` returned undefined, `Auth` was never recorded, and **138 endpoints carrying `@Auth()` were reported as having no guard at all.**

For a security rule this is the wrong direction to be wrong in. A missed finding is a gap; a false one tells you an endpoint is unprotected when it is protected, and the next reader either wastes time or stops trusting the rule.

## 3. Possible flows

| How the guard is written | Indexed before | Indexed now |
|---|---|---|
| `applyDecorators(UseGuards(G))` | yes | yes |
| `export const Auth = () => applyDecorators(UseGuards(G))` | yes | yes |
| `applyDecorators(flag ? UseGuards(A) : UseGuards(B))` | **no** | yes |
| `applyDecorators(...[UseGuards(G)])`, inline array | **no** | yes |
| `applyDecorators(...guards)` where `guards` is a variable | no | no |
| `applyDecorators(on ? UseGuards(A) : SetMetadata(...))`, one branch | no | no |
| `applyDecorators(SetMetadata('f', () => UseGuards(G)))`, mention only | no | no |
| `applyDecorators(SetMetadata('a', 1))`, no guard | no | no |
| `applyDecorators(flag ? SetMetadata(…) : SetMetadata(…))` | no | no |
| `@UseGuards()` written directly | n/a | n/a |
| a guard applied by a runtime call the scan cannot see | no | no |

## 4. Solution

An argument counts when it **is** a `UseGuards` call, when it is a ternary whose **both** branches apply one, or when it spreads an inline array holding one. The walk is structural, not a subtree search: a decorator that merely mentions `UseGuards` somewhere inside an argument, such as `SetMetadata('factory', () => UseGuards(G))`, stays unindexed, and so does a ternary that guards only one way round. PR #149 tightened this same file for exactly that reason, and the shape it fixed stays fixed.

What I did not do: resolve the guard classes. The index records only that a name applies some guard, which is all the rule asks.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| endpoint with `@Auth()`, guard behind a ternary | reported unguarded | silent |
| endpoint with a metadata-only composed decorator *(unchanged)* | reported | reported |
| endpoint with plain `@UseGuards()` *(unchanged)* | silent | silent |
| endpoint with no guard at all *(unchanged)* | reported | reported |
| 189-project corpus | 819 | 681 |

## 6. Example

`Swetrix/swetrix`, whose controllers use `@Auth()` throughout:

```
$ nestjs-doctor . --format json | jq -r '[.diagnostics[] | select(.rule=="security/require-guards-on-endpoints")] | length'
```

Before:

```
152
```

After:

```
14
```

The 138 that went away all carry `@Auth(...)`. The 14 that remain carry no guard of any kind, which is what the rule is for.
