### PR TITLE
fix(rules): say it once per service, not once per repository

### DIFF
--- a/.changeset/orm-in-services-once-per-service.md
+++ b/.changeset/orm-in-services-once-per-service.md
@@ -1,0 +1,24 @@
+---
+"nestjs-doctor": patch
+---
+
+`architecture/no-orm-in-services` no longer repeats itself once per injected
+repository.
+
+The rule walks a service's constructor parameters and reports on each
+`@InjectRepository()`, `@InjectModel()` or `@InjectEntityManager()` it finds.
+The message it produces does not name the parameter:
+
+> Service uses @InjectRepository() directly. Consider wrapping in a repository class.
+
+so a service holding nine repositories produced nine identical lines on nine
+consecutive lines of the same constructor. `Swetrix/swetrix`'s `UserService` is
+exactly that. The advice is about the service, and reading it nine times does
+not make it nine times more actionable.
+
+Each distinct reason is now reported once per service. A service that injects
+repositories, a Mongoose model and `PrismaService` still gets three findings,
+because those are three different things to say.
+
+Across 189 public projects this removes 196 findings and adds none. The number
+of services flagged is unchanged.

--- a/.changeset/orm-in-services-once-per-service.md
+++ b/.changeset/orm-in-services-once-per-service.md
@@ -20,5 +20,9 @@ Each distinct reason is now reported once per service. A service that injects
 repositories, a Mongoose model and `PrismaService` still gets three findings,
 because those are three different things to say.
 
-Across 189 public projects this removes 196 findings and adds none. The number
-of services flagged is unchanged.
+Across 189 public projects this removes 196 findings and adds none. The set of
+services flagged is unchanged, not merely its size.
+
+One consequence worth knowing: the surviving diagnostic sits on the first
+matching parameter, so an inline `nestjs-doctor-ignore-next-line` on that line
+now silences the service rather than one of its repositories.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
@@ -47,6 +47,8 @@ export const noOrmInServices: Rule = {
 				continue;
 			}
 
+			// The advice is about the service, so each reason is reported once.
+			const reported = new Set<string>();
 			for (const param of ctor.getParameters()) {
 				// Reads the written annotation, falling back to the checker.
 				const typeNode = param.getTypeNode();
@@ -55,7 +57,8 @@ export const noOrmInServices: Rule = {
 					: param.getType().getText();
 				const typeName = extractSimpleTypeName(typeText);
 
-				if (ORM_TYPES.has(typeName)) {
+				if (ORM_TYPES.has(typeName) && !reported.has(typeName)) {
+					reported.add(typeName);
 					const nameNode = param.getNameNode();
 					context.report({
 						filePath: context.filePath,
@@ -70,10 +73,12 @@ export const noOrmInServices: Rule = {
 				for (const decorator of param.getDecorators()) {
 					const name = decorator.getName();
 					if (
-						name === "InjectRepository" ||
-						name === "InjectModel" ||
-						name === "InjectEntityManager"
+						(name === "InjectRepository" ||
+							name === "InjectModel" ||
+							name === "InjectEntityManager") &&
+						!reported.has(name)
 					) {
+						reported.add(name);
 						context.report({
 							filePath: context.filePath,
 							message: `Service uses @${name}() directly. Consider wrapping in a repository class.`,

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
@@ -48,6 +48,7 @@ export const noOrmInServices: Rule = {
 			}
 
 			// The advice is about the service, so each reason is reported once.
+			// Prefixed because an ORM type and a decorator could share a name.
 			const reported = new Set<string>();
 			for (const param of ctor.getParameters()) {
 				// Reads the written annotation, falling back to the checker.
@@ -57,8 +58,8 @@ export const noOrmInServices: Rule = {
 					: param.getType().getText();
 				const typeName = extractSimpleTypeName(typeText);
 
-				if (ORM_TYPES.has(typeName) && !reported.has(typeName)) {
-					reported.add(typeName);
+				if (ORM_TYPES.has(typeName) && !reported.has(`type:${typeName}`)) {
+					reported.add(`type:${typeName}`);
 					const nameNode = param.getNameNode();
 					context.report({
 						filePath: context.filePath,
@@ -76,9 +77,9 @@ export const noOrmInServices: Rule = {
 						(name === "InjectRepository" ||
 							name === "InjectModel" ||
 							name === "InjectEntityManager") &&
-						!reported.has(name)
+						!reported.has(`decorator:${name}`)
 					) {
-						reported.add(name);
+						reported.add(`decorator:${name}`);
 						context.report({
 							filePath: context.filePath,
 							message: `Service uses @${name}() directly. Consider wrapping in a repository class.`,

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -1227,6 +1227,40 @@ describe("no-orm-in-services duplicates", () => {
 		expect(diags).toHaveLength(1);
 	});
 
+	it("reports one diagnostic for two parameters of the same ORM type", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class ReportService {
+        constructor(
+          private readonly primary: PrismaService,
+          private readonly replica: PrismaService,
+        ) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("still reports two different ORM types", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class ReportService {
+        constructor(
+          private readonly prisma: PrismaService,
+          private readonly source: DataSource,
+        ) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(2);
+	});
+
 	it("still reports each distinct reason once", () => {
 		const diags = runRule(
 			noOrmInServices,

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -1208,6 +1208,45 @@ describe("require-module-boundaries", () => {
 	});
 });
 
+describe("no-orm-in-services duplicates", () => {
+	it("reports one diagnostic however many repositories are injected", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class UserService {
+        constructor(
+          @InjectRepository(User) private a: Repository<User>,
+          @InjectRepository(Role) private b: Repository<Role>,
+          @InjectRepository(Team) private c: Repository<Team>,
+        ) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("still reports each distinct reason once", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class UserService {
+        constructor(
+          @InjectRepository(User) private a: Repository<User>,
+          @InjectRepository(Role) private b: Repository<Role>,
+          @InjectModel(Doc.name) private c: Model<Doc>,
+          private d: PrismaService,
+        ) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(3);
+	});
+});
+
 describe("no-barrel-export-internals", () => {
 	it("flags re-exporting repositories from barrel files", () => {
 		const diags = runRule(


### PR DESCRIPTION
## 1. Context

`architecture/no-orm-in-services` is an `info` rule suggesting a service wrap its ORM access rather than injecting it. It walks the constructor parameters and reports on each ORM type and each `@InjectRepository()` style decorator it finds.

## 2. Problem

The message for the decorator case names neither the parameter nor the entity:

> Service uses @InjectRepository() directly. Consider wrapping in a repository class.

so every repository in a constructor produces the same line. `Swetrix/swetrix`'s `UserService` injects nine:

```ts
constructor(
  @InjectRepository(User) private usersRepository: Repository<User>,
  @InjectRepository(RefreshToken) private readonly refreshTokenRepository: Repository<RefreshToken>,
  @InjectRepository(DeleteFeedback) private readonly deleteFeedbackRepository: Repository<DeleteFeedback>,
  ... six more
) {}
```

That is **nine identical findings on nine consecutive lines of one constructor**. Across the corpus 120 files carry more than one, three of them nine.

The advice is about the service. Reading it nine times does not make it nine times more actionable, and it inflates the rule's share of a report against services that are no worse than a service injecting one.

## 3. Possible flows

| Constructor | Before | After |
|---|---|---|
| one `@InjectRepository()` | 1 | 1 |
| nine `@InjectRepository()` | 9 | **1** |
| `@InjectRepository()` + `@InjectModel()` | 2 | 2 |
| `@InjectRepository()` ×3 + `@InjectModel()` ×2 + `PrismaService` | 6 | **3** |
| two params both typed `PrismaService` | 2 | **1** |
| `PrismaService` + `DataSource` | 2 | 2 |
| a class named `*Repository` *(skipped already)* | 0 | 0 |

## 4. Solution

Each distinct reason is reported once per service. A reason is the ORM type name, or the decorator name for the inject case, so a service really doing three different things still gets three findings.

What I did not do: change which services are flagged, or the severity. Only the repetition goes.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| nine repositories in one service | 9 findings | 1 finding |
| services flagged, corpus-wide *(unchanged)* | 866 | 866 |
| 189-project corpus, this rule | 1,133 | 937 |

## 6. Example

`Swetrix/swetrix`:

```
$ nestjs-doctor . --format json | jq -r '[.diagnostics[] | select(.rule=="architecture/no-orm-in-services" and (.filePath | endswith("user/user.service.ts")))] | length'
```

Before:

```
9
```

After:

```
1
```

The nine were lines 288, 290, 292, 294, 296, 298, 300, 302 and 304, all inside the same constructor, all with the same text.
