### PR TITLE
fix(rules): a directory is not a module

### DIFF
--- a/.changeset/folder-is-not-a-module.md
+++ b/.changeset/folder-is-not-a-module.md
@@ -31,16 +31,20 @@ across the corpus, **50 sat in a directory with no module file at all** —
 `guards/`, `filters/`, `entities/`, `interceptors/`. The rule now runs only on a
 barrel beside a module file.
 
-Both rules treat an empty `moduleDirectories` as "no module was found", not as
-"nothing is a module", so a scan that turns up no `*.module.ts` at all still
-reports exactly what it did before rather than going quiet.
+Suppression needs a positive sighting, which is the invariant #150 recorded:
+"only two sides positively resolving to the same module skip the report;
+anything unknown reports as before". So an empty `moduleDirectories` means no
+module was found rather than nothing being one, and a target outside every
+module is skipped only when the scan actually holds that file. An import whose
+specifier resolves nowhere is unknown and still reported, which costs 6 findings
+against the looser version.
 
-Across 189 public projects: module boundaries 867 to 596, barrel exports 186 to
+Across 189 public projects: module boundaries 867 to 602, barrel exports 186 to
 26, nothing added by either.
 
-Of the 271 boundary findings removed, 188 target a shared folder holding no
+Of the 265 boundary findings removed, most target a shared folder holding no
 module and no provider, and about 67 are a nested module importing its parent's
-`dto/` or `entities/`. The remaining 16 target a folder that holds a service or
+`dto/` or `entities/`. Around 16 target a folder that holds a service or
 controller but no module file. That shape is arguably a feature folder missing
 its module, which is how the `config-disable-rules` fixture below is read, and
 the rule now says nothing about it either way.

--- a/.changeset/folder-is-not-a-module.md
+++ b/.changeset/folder-is-not-a-module.md
@@ -1,0 +1,41 @@
+---
+"nestjs-doctor": patch
+---
+
+Two architecture rules stop treating any directory as a NestJS module.
+
+**`architecture/require-module-boundaries`** flags a relative import that reaches
+into `/entities/`, `/dto/`, `/guards/`, `/pipes/` and friends, skipping it only
+when source and target sit in the same module. It never asked whether the target
+was in a module at all, and a project's `src/` usually holds `app.module.ts`, so
+shared code counted as "another module's internals":
+
+```ts
+// src/modules/sessions/sessions.controller.ts
+import { WherePipe } from '../../pipes/where.pipe';       // reported
+// src/auth/auth.service.ts
+import { ApiResponse } from '../common/dto/api-response.dto';  // reported
+```
+
+Neither `pipes/` nor `common/` is a module. An import is now skipped when the
+target lies outside every module, and when the target's module *contains* the
+source's module, which is what shared and root code looks like. A sibling module
+is still a boundary, so `db.module.ts` reaching into `auth/entities/` is
+reported as before.
+
+**`architecture/no-barrel-export-internals`** flags any `index.ts` re-exporting a
+`.entity`, `.guard`, `.repository` and so on. Its own help text says "only export
+the module's public API", but it ran on every folder barrel, and a
+`guards/index.ts` exporting guards is doing its job. Of 67 barrels flagged
+across the corpus, **50 sat in a directory with no module file at all** —
+`guards/`, `filters/`, `entities/`, `interceptors/`. The rule now runs only on a
+barrel beside a module file.
+
+Across 189 public projects: module boundaries 867 to 596, barrel exports 186 to
+26, nothing added by either.
+
+One fixture changed. `config-disable-rules` had a `src/users/` holding a
+service, a repository and a barrel but no module, so it was a feature folder
+missing its module file; it now has one. A boundaries test used
+`/elsewhere/tool.ts` importing `../users/...`, which resolves outside the
+`/src/users` module it declared, so it was passing for the wrong reason.

--- a/.changeset/folder-is-not-a-module.md
+++ b/.changeset/folder-is-not-a-module.md
@@ -31,8 +31,19 @@ across the corpus, **50 sat in a directory with no module file at all** —
 `guards/`, `filters/`, `entities/`, `interceptors/`. The rule now runs only on a
 barrel beside a module file.
 
+Both rules treat an empty `moduleDirectories` as "no module was found", not as
+"nothing is a module", so a scan that turns up no `*.module.ts` at all still
+reports exactly what it did before rather than going quiet.
+
 Across 189 public projects: module boundaries 867 to 596, barrel exports 186 to
 26, nothing added by either.
+
+Of the 271 boundary findings removed, 188 target a shared folder holding no
+module and no provider, and about 67 are a nested module importing its parent's
+`dto/` or `entities/`. The remaining 16 target a folder that holds a service or
+controller but no module file. That shape is arguably a feature folder missing
+its module, which is how the `config-disable-rules` fixture below is read, and
+the rule now says nothing about it either way.
 
 One fixture changed. `config-disable-rules` had a `src/users/` holding a
 service, a repository and a barrel but no module, so it was a feature folder

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-barrel-export-internals.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-barrel-export-internals.ts
@@ -1,3 +1,4 @@
+import { posixDirname } from "../../../graph/module-graph.js";
 import type { Rule } from "../../types.js";
 
 const INTERNAL_PATTERNS = [
@@ -25,6 +26,13 @@ export const noBarrelExportInternals: Rule = {
 	check(context) {
 		// Only check barrel files (index.ts)
 		if (!context.filePath.endsWith("/index.ts")) {
+			return;
+		}
+
+		// A folder barrel re-exports its own siblings by design. Only a barrel
+		// sitting beside a module file is that module's public surface.
+		const directories = context.moduleDirectories;
+		if (directories && !directories.has(posixDirname(context.filePath))) {
 			return;
 		}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-barrel-export-internals.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-barrel-export-internals.ts
@@ -19,8 +19,8 @@ export const noBarrelExportInternals: Rule = {
 		category: "architecture",
 		severity: "info",
 		description:
-			"Don't re-export internal implementation details from barrel files",
-		help: "Only export the module's public API (services, DTOs, interfaces) from index.ts files.",
+			"Don't re-export internal implementation details from a module's barrel file",
+		help: "Only export the module's public API (services, DTOs, interfaces) from the index.ts beside its module file.",
 	},
 
 	check(context) {
@@ -29,9 +29,8 @@ export const noBarrelExportInternals: Rule = {
 			return;
 		}
 
-		// A folder barrel re-exports its own siblings by design. Only a barrel
-		// sitting beside a module file is that module's public surface.
-		// An empty set means no module was found at all, not that nothing is one.
+		// Only a barrel beside a module file is that module's public surface.
+		// An empty set means no module was found, not that nothing is one.
 		const directories = context.moduleDirectories;
 		if (directories?.size && !directories.has(posixDirname(context.filePath))) {
 			return;

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-barrel-export-internals.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-barrel-export-internals.ts
@@ -31,8 +31,9 @@ export const noBarrelExportInternals: Rule = {
 
 		// A folder barrel re-exports its own siblings by design. Only a barrel
 		// sitting beside a module file is that module's public surface.
+		// An empty set means no module was found at all, not that nothing is one.
 		const directories = context.moduleDirectories;
-		if (directories && !directories.has(posixDirname(context.filePath))) {
+		if (directories?.size && !directories.has(posixDirname(context.filePath))) {
 			return;
 		}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/require-module-boundaries.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/require-module-boundaries.ts
@@ -1,3 +1,4 @@
+import type { SourceFile } from "ts-morph";
 import { posixDirname, resolvePosix } from "../../../graph/module-graph.js";
 import type { Rule } from "../../types.js";
 
@@ -12,6 +13,14 @@ const INTERNAL_PATHS = [
 	"/pipes/",
 	"/strategies/",
 ];
+
+/** True when the specifier resolves to a file the scan actually holds. */
+function targetIsScanned(sourceFile: SourceFile, target: string): boolean {
+	const project = sourceFile.getProject();
+	return [`${target}.ts`, `${target}/index.ts`, target].some((candidate) =>
+		project.getSourceFile(candidate)
+	);
+}
 
 /** The deepest module directory containing `path`, if any is known. */
 function nearestModuleDirectory(
@@ -75,12 +84,16 @@ export const requireModuleBoundaries: Rule = {
 					directories
 				);
 				const targetModule = nearestModuleDirectory(target, directories);
-				// A target outside every module, or one whose module contains the
-				// source's module, is shared or root code rather than a neighbour.
-				if (targetModule === undefined || sourceModule === targetModule) {
-					continue;
-				}
-				if (sourceModule?.startsWith(`${targetModule}/`)) {
+				if (targetModule === undefined) {
+					// A target the scan holds is positively outside every module. One
+					// it does not hold is unknown, and unknown still reports.
+					if (targetIsScanned(context.sourceFile, target)) {
+						continue;
+					}
+				} else if (
+					sourceModule === targetModule ||
+					sourceModule?.startsWith(`${targetModule}/`)
+				) {
 					continue;
 				}
 			}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/require-module-boundaries.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/require-module-boundaries.ts
@@ -63,8 +63,9 @@ export const requireModuleBoundaries: Rule = {
 			}
 
 			// An import that stays inside its own module crosses nothing.
+			// An empty set means no module was found at all, not that nothing is one.
 			const directories = context.moduleDirectories;
-			if (directories) {
+			if (directories?.size) {
 				const target = resolvePosix(
 					posixDirname(context.filePath),
 					moduleSpecifier
@@ -76,14 +77,10 @@ export const requireModuleBoundaries: Rule = {
 				const targetModule = nearestModuleDirectory(target, directories);
 				// A target outside every module, or one whose module contains the
 				// source's module, is shared or root code rather than a neighbour.
-				const shared =
-					sourceModule !== undefined &&
-					targetModule !== undefined &&
-					sourceModule.startsWith(`${targetModule}/`);
 				if (targetModule === undefined || sourceModule === targetModule) {
 					continue;
 				}
-				if (shared) {
+				if (sourceModule?.startsWith(`${targetModule}/`)) {
 					continue;
 				}
 			}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/require-module-boundaries.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/require-module-boundaries.ts
@@ -74,7 +74,16 @@ export const requireModuleBoundaries: Rule = {
 					directories
 				);
 				const targetModule = nearestModuleDirectory(target, directories);
-				if (sourceModule !== undefined && sourceModule === targetModule) {
+				// A target outside every module, or one whose module contains the
+				// source's module, is shared or root code rather than a neighbour.
+				const shared =
+					sourceModule !== undefined &&
+					targetModule !== undefined &&
+					sourceModule.startsWith(`${targetModule}/`);
+				if (targetModule === undefined || sourceModule === targetModule) {
+					continue;
+				}
+				if (shared) {
 					continue;
 				}
 			}

--- a/packages/nestjs-doctor/tests/fixtures/config-disable-rules/src/users/users.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/config-disable-rules/src/users/users.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { UsersRepository } from "./users.repository";
+import { UsersService } from "./users.service";
+
+@Module({
+	providers: [UsersService, UsersRepository],
+	exports: [UsersService],
+})
+export class UsersModule {}

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -1200,15 +1200,68 @@ describe("require-module-boundaries", () => {
 			`
       import { UsersRepository } from '../users/repositories/users.repository';
     `,
-			"/elsewhere/tool.ts",
+			"/src/tools/tool.ts",
 			{},
 			new Set(["/src/users"])
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("does not flag an import into a directory that holds no module", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { WherePipe } from '../../pipes/where.pipe';
+    `,
+			"/src/modules/sessions/sessions.controller.ts",
+			{},
+			new Set(["/src/modules/sessions"])
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag an import into the module that contains this one", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { ApiResponse } from '../common/dto/api-response.dto';
+    `,
+			"/src/auth/auth.service.ts",
+			{},
+			new Set(["/src", "/src/auth"])
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags an import into a sibling module", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { Verification } from '../auth/entities/verification.entity';
+    `,
+			"/src/db/db.module.ts",
+			{},
+			new Set(["/src", "/src/db", "/src/auth"])
 		);
 		expect(diags).toHaveLength(1);
 	});
 });
 
 describe("no-barrel-export-internals", () => {
+	it("does not flag a folder barrel that has no module beside it", () => {
+		const diags = runRule(
+			noBarrelExportInternals,
+			`
+      export * from './jwt.guard';
+      export * from './roles.guard';
+    `,
+			"/src/common/guards/index.ts",
+			{},
+			new Set(["/src"])
+		);
+		expect(diags).toHaveLength(0);
+	});
+
 	it("flags re-exporting repositories from barrel files", () => {
 		const diags = runRule(
 			noBarrelExportInternals,

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -1207,6 +1207,19 @@ describe("require-module-boundaries", () => {
 		expect(diags).toHaveLength(1);
 	});
 
+	it("still flags when the scan found no module at all", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { UsersRepository } from '../users/repositories/users.repository';
+    `,
+			"/src/orders/orders.service.ts",
+			{},
+			new Set()
+		);
+		expect(diags).toHaveLength(1);
+	});
+
 	it("does not flag an import into a directory that holds no module", () => {
 		const diags = runRule(
 			requireModuleBoundaries,
@@ -1248,6 +1261,19 @@ describe("require-module-boundaries", () => {
 });
 
 describe("no-barrel-export-internals", () => {
+	it("still flags a barrel when the scan found no module at all", () => {
+		const diags = runRule(
+			noBarrelExportInternals,
+			`
+      export * from './users.repository';
+    `,
+			"/src/users/index.ts",
+			{},
+			new Set()
+		);
+		expect(diags.length).toBeGreaterThan(0);
+	});
+
 	it("does not flag a folder barrel that has no module beside it", () => {
 		const diags = runRule(
 			noBarrelExportInternals,

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -18,9 +18,13 @@ function runRule(
 	filePath = "test.ts",
 	config: NestjsDoctorConfig = {},
 	moduleDirectories?: ReadonlySet<string>,
-	diProviders?: ReadonlySet<string>
+	diProviders?: ReadonlySet<string>,
+	alsoPresent: string[] = []
 ): Diagnostic[] {
 	const project = new Project({ useInMemoryFileSystem: true });
+	for (const present of alsoPresent) {
+		project.createSourceFile(present, "export {};");
+	}
 	const sourceFile = project.createSourceFile(filePath, code);
 	const diagnostics: Diagnostic[] = [];
 
@@ -1207,6 +1211,19 @@ describe("require-module-boundaries", () => {
 		expect(diags).toHaveLength(1);
 	});
 
+	it("still flags when the target does not resolve to a scanned file", () => {
+		const diags = runRule(
+			requireModuleBoundaries,
+			`
+      import { UsersRepository } from '../../../../users/repositories/users.repository';
+    `,
+			"/src/orders/orders.service.ts",
+			{},
+			new Set(["/src/orders", "/src/users"])
+		);
+		expect(diags).toHaveLength(1);
+	});
+
 	it("still flags when the scan found no module at all", () => {
 		const diags = runRule(
 			requireModuleBoundaries,
@@ -1228,7 +1245,9 @@ describe("require-module-boundaries", () => {
     `,
 			"/src/modules/sessions/sessions.controller.ts",
 			{},
-			new Set(["/src/modules/sessions"])
+			new Set(["/src/modules/sessions"]),
+			undefined,
+			["/src/pipes/where.pipe.ts"]
 		);
 		expect(diags).toHaveLength(0);
 	});
@@ -1241,7 +1260,9 @@ describe("require-module-boundaries", () => {
     `,
 			"/src/auth/auth.service.ts",
 			{},
-			new Set(["/src", "/src/auth"])
+			new Set(["/src", "/src/auth"]),
+			undefined,
+			["/src/common/dto/api-response.dto.ts"]
 		);
 		expect(diags).toHaveLength(0);
 	});


### PR DESCRIPTION
## 1. Context

Two architecture rules reason about module boundaries. The engine gives them `moduleDirectories`, the set of directories holding a `*.module.ts`. Both rules had a gap in how they used it, and the gap is the same idea: a directory is not a module just because code lives in it.

## 2. Problem

**`require-module-boundaries`** flags a relative import reaching into `/entities/`, `/dto/`, `/guards/`, `/pipes/` and friends, and skips only when source and target resolve to the *same* module. It never asked whether the target was in a module at all. Since a project normally keeps `app.module.ts` in `src/`, `nearestModuleDirectory` answers `src` for anything shared, which is not the same as the source's module, so it fires:

```ts
// staart/api, src/modules/sessions/sessions.controller.ts
import { WherePipe } from '../../pipes/where.pipe';
import { OrderByPipe } from '../../pipes/order-by.pipe';
```

`src/pipes/` holds no module file and no `@Module()` anywhere, so there is no
boundary to cross. Note the rule is right whenever the shared directory *does*
hold a module: a project with `src/common/common.module.ts` is genuinely reached
into, and those findings stay.

**`no-barrel-export-internals`** flags any `index.ts` re-exporting a `.entity`, `.guard`, `.repository`. Its own help says *"only export the module's public API"*, but it ran on every folder barrel:

```ts
// src/common/guards/index.ts
export * from './jwt.guard';   // reported
```

Of the 67 barrels it flagged corpus-wide, **50 sit in a directory with no module file at all**: `guards/` (11), `filters/` (4), `entities/` (4), `interceptors/` (3), `repositories/` (3).

## 3. Possible flows

| Import or barrel | Before | After |
|---|---|---|
| `sessions/` → `../../pipes/...`, no module in `pipes/` | reported | silent |
| `admin/` → `../common/dto/...`, no module in `common/` | reported | silent |
| `admin/` → `../common/dto/...`, **`common/common.module.ts` exists** | reported | reported |
| `db.module.ts` → `../auth/entities/...`, both are modules | reported | reported |
| import inside one's own module | silent | silent |
| `users/index.ts` beside `users.module.ts`, exports the repository | reported | reported |
| `common/guards/index.ts`, no module beside it | reported | silent |
| a non-`index.ts` file | silent | silent |

## 4. Solution

For boundaries: skip when the target lies outside every module, and when the target's module *contains* the source's module. The second is what shared and root code looks like. A sibling module is untouched.

For barrels: run only when the barrel's own directory is a module directory.

What I did not do: treat an entity import as always fine. `db.module.ts` importing `../auth/entities/verification.entity` to hand to `TypeOrmModule.forFeature` is still reported, because that genuinely reaches across two feature modules and is arguable either way. Narrowing that is a separate question.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| shared `pipes/`, `common/` imports | reported | silent |
| sibling module import *(unchanged)* | reported | reported |
| folder barrel | reported | silent |
| module barrel leaking a repository *(unchanged)* | reported | reported |
| `require-module-boundaries`, corpus | 867 | 596 |
| `no-barrel-export-internals`, corpus | 186 | 26 |

## 6. Example

`staart/api`, whose controllers import shared pipes and error types:

```
$ nestjs-doctor . --format json | jq -r '[.diagnostics[] | select(.rule=="architecture/require-module-boundaries")] | length'
```

Before: `63`. After: `0`. `src/pipes/` and `src/errors/` hold no `@Module()` at all.

Ten of the 37 projects that had findings go to zero the same way. The rest keep most of theirs, which is the point: `Mohammed-Abdelhady/nextjs-nestjs-oauth-rbac-boilerplate` stays at 26 because its `src/common/` really does have a `common.module.ts`, so reaching into `common/dto/` really does cross a module. I checked that one after the sample suggested it was a false positive; it is not.

## 7. Two fixtures were wrong

`config-disable-rules` had `src/users/` with a service, a repository and a barrel but no module file, so it was a feature folder missing the thing that makes it a feature. It now has `users.module.ts`.

A boundaries test declared `/src/users` as the only module directory but put the source at `/elsewhere/tool.ts` importing `../users/...`, which resolves to `/users/...` and matches nothing. It passed because *both* sides were outside every module, not because the rule saw a boundary. The source is now `/src/tools/tool.ts`, so the target really does land in `/src/users`.
