### PR TITLE
fix(rules): a resolver is an entry point too

### DIFF
--- a/.changeset/framework-handlers-async.md
+++ b/.changeset/framework-handlers-async.md
@@ -23,4 +23,7 @@ async messages(@Args('roomId') roomId: string): Promise<Message[]> {
 now count the same way `@Get` does. A plain method with no await is still
 reported.
 
+The rule's own comment and help text said only ts-rest and gRPC, and only HTTP
+handlers; both now name what is actually exempt.
+
 Across 189 public projects this removes 141 findings and adds none.

--- a/.changeset/framework-handlers-async.md
+++ b/.changeset/framework-handlers-async.md
@@ -1,0 +1,26 @@
+---
+"nestjs-doctor": patch
+---
+
+`correctness/no-async-without-await` no longer flags a GraphQL resolver, a
+WebSocket handler or a microservice handler.
+
+The rule already exempts HTTP handlers, on the reasoning its own comment gives:
+NestJS resolves the returned promise, so `async` without `await` is fine on a
+route. The exemption list for other entry points held only `TsRestHandler`,
+`GrpcMethod` and `GrpcStreamMethod`, so the same code under a different
+transport was reported:
+
+```ts
+@Query()
+async messages(@Args('roomId') roomId: string): Promise<Message[]> {
+  return getMongoRepository(Message).find({ where: { roomId } });
+}
+```
+
+`@Query`, `@Mutation`, `@Subscription`, `@ResolveField`, `@ResolveProperty`,
+`@ResolveReference`, `@SubscribeMessage`, `@MessagePattern` and `@EventPattern`
+now count the same way `@Get` does. A plain method with no await is still
+reported.
+
+Across 189 public projects this removes 141 findings and adds none.

--- a/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
+++ b/packages/nestjs-doctor/src/engine/nest-class-inspector.ts
@@ -100,10 +100,21 @@ export function isHttpHandler(method: MethodDeclaration): boolean {
 	return method.getDecorators().some((d) => HTTP_DECORATORS.has(d.getName()));
 }
 
+// Entry points the framework awaits for you, the same way it awaits a route
+// handler: GraphQL, WebSockets, microservice patterns, ts-rest and gRPC.
 const FRAMEWORK_HANDLER_DECORATORS = new Set([
-	"TsRestHandler",
+	"EventPattern",
 	"GrpcMethod",
 	"GrpcStreamMethod",
+	"MessagePattern",
+	"Mutation",
+	"Query",
+	"ResolveField",
+	"ResolveProperty",
+	"ResolveReference",
+	"SubscribeMessage",
+	"Subscription",
+	"TsRestHandler",
 ]);
 
 export function isFrameworkHandler(method: MethodDeclaration): boolean {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-async-without-await.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-async-without-await.ts
@@ -28,7 +28,7 @@ export const noAsyncWithoutAwait: Rule = {
 		severity: "warning",
 		description:
 			"Async functions/methods should contain at least one await expression",
-		help: "Either add an await expression or remove the async keyword. HTTP handlers with route decorators are exempted, as async is conventional for controller methods.",
+		help: "Either add an await expression or remove the async keyword. Framework entry points are exempted, since Nest awaits what they return: route handlers, GraphQL resolvers, WebSocket and microservice handlers.",
 	},
 
 	check(context) {
@@ -45,7 +45,8 @@ export const noAsyncWithoutAwait: Rule = {
 					continue;
 				}
 
-				// Skip framework handler decorators (ts-rest, gRPC) where async is conventional
+				// Skip the other entry points the framework awaits: GraphQL,
+				// WebSockets, microservice patterns, ts-rest and gRPC. where async is conventional
 				if (isFrameworkHandler(method)) {
 					continue;
 				}

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-async-without-await.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-async-without-await.ts
@@ -28,7 +28,7 @@ export const noAsyncWithoutAwait: Rule = {
 		severity: "warning",
 		description:
 			"Async functions/methods should contain at least one await expression",
-		help: "Either add an await expression or remove the async keyword. Framework entry points are exempted, since Nest awaits what they return: route handlers, GraphQL resolvers, WebSocket and microservice handlers.",
+		help: "Either add an await expression or remove the async keyword. Framework entry points are exempted, since Nest awaits what they return: route handlers, GraphQL resolvers, WebSocket, microservice, ts-rest and gRPC handlers.",
 	},
 
 	check(context) {
@@ -45,8 +45,8 @@ export const noAsyncWithoutAwait: Rule = {
 					continue;
 				}
 
-				// Skip the other entry points the framework awaits: GraphQL,
-				// WebSockets, microservice patterns, ts-rest and gRPC. where async is conventional
+				// The other entry points the framework awaits: GraphQL, WebSockets,
+				// microservice patterns, ts-rest and gRPC.
 				if (isFrameworkHandler(method)) {
 					continue;
 				}

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1040,6 +1040,49 @@ describe("require-inject-decorator", () => {
 	});
 });
 
+describe("no-async-without-await framework handlers", () => {
+	const shapes: [string, string][] = [
+		["Query", "@Query()"],
+		["Mutation", "@Mutation()"],
+		["Subscription", "@Subscription()"],
+		["ResolveField", "@ResolveField()"],
+		["SubscribeMessage", "@SubscribeMessage('event')"],
+		["MessagePattern", "@MessagePattern({ cmd: 'x' })"],
+		["EventPattern", "@EventPattern('created')"],
+	];
+
+	for (const [name, decorator] of shapes) {
+		it(`does not flag a ${name} handler`, () => {
+			const diags = runRule(
+				noAsyncWithoutAwait,
+				`
+      export class Handler {
+        ${decorator}
+        async handle() {
+          return this.service.find();
+        }
+      }
+    `
+			);
+			expect(diags).toHaveLength(0);
+		});
+	}
+
+	it("still flags a plain async method with no await", () => {
+		const diags = runRule(
+			noAsyncWithoutAwait,
+			`
+      export class Handler {
+        async helper() {
+          return this.service.find();
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+	});
+});
+
 describe("no-fire-and-forget-async", () => {
 	it("flags a bare .catch() with no handler", () => {
 		const diags = runRule(

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1046,6 +1046,8 @@ describe("no-async-without-await framework handlers", () => {
 		["Mutation", "@Mutation()"],
 		["Subscription", "@Subscription()"],
 		["ResolveField", "@ResolveField()"],
+		["ResolveProperty", "@ResolveProperty()"],
+		["ResolveReference", "@ResolveReference()"],
 		["SubscribeMessage", "@SubscribeMessage('event')"],
 		["MessagePattern", "@MessagePattern({ cmd: 'x' })"],
 		["EventPattern", "@EventPattern('created')"],


### PR DESCRIPTION
## 1. Context

`correctness/no-async-without-await` reports an `async` method with no `await` in it. It skips HTTP handlers, and its own comment says why:

```ts
// Skip HTTP handlers — NestJS resolves returned Promises automatically; async without await is valid.
```

A second list covers non-HTTP entry points the framework drives. It held three names.

## 2. Problem

The three were `TsRestHandler`, `GrpcMethod` and `GrpcStreamMethod`. Everything else Nest drives was missing, so the same code was fine under `@Get` and reported under `@Query`:

```ts
@Resolver('Message')
export class MessageResolver {
  @Query()
  async messages(@Args('roomId') roomId: string): Promise<Message[]> {
    return getMongoRepository(Message).find({ where: { roomId } });
  }
}
```

A GraphQL resolver, a `@SubscribeMessage` gateway method and a `@MessagePattern` handler are all awaited by the framework exactly as a route handler is. **141 findings across the corpus are this**, mostly `@Query` and `@Mutation`.

## 3. Possible flows

| Method | Before | After |
|---|---|---|
| `@Get` / `@Post` handler | exempt | exempt |
| `@TsRestHandler`, `@GrpcMethod` | exempt | exempt |
| `@Query`, `@Mutation`, `@Subscription` | **reported** | exempt |
| `@ResolveField`, `@ResolveProperty`, `@ResolveReference` | **reported** | exempt |
| `@SubscribeMessage` | **reported** | exempt |
| `@MessagePattern`, `@EventPattern` | **reported** | exempt |
| plain `async` method, no await | reported | reported |
| standalone `async function` | reported | reported |

## 4. Solution

The nine decorators join `FRAMEWORK_HANDLER_DECORATORS`. `isFrameworkHandler` has exactly one consumer, this rule, so nothing else in the engine changes.

What I did not do: exempt a method just because it returns a promise. A service method that is `async` for no reason is still worth reporting, and that is most of the rule's 2,142 remaining findings.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| `@Query() async find()` returning a repository call | reported | silent |
| `@Get() async find()` *(unchanged)* | silent | silent |
| `private async helper()` with no await *(unchanged)* | reported | reported |
| 189-project corpus, this rule | 2,283 | 2,142 |

## 6. Example

`notadd/notadd`, which is resolvers throughout:

```
$ nestjs-doctor . --format json | jq -r '[.diagnostics[] | select(.rule=="correctness/no-async-without-await")] | length'
```

Before: `45`. After: `1`. The one left is a plain helper method; the 44 that went away are `@Query` and `@Mutation` resolvers.

`chnirt/nestjs-graphql-best-practice` goes 24 to 2 the same way.
