### PR TITLE
fix(rules): a lifecycle hook is a reason to exist

### DIFF
--- a/.changeset/providers-nest-activates.md
+++ b/.changeset/providers-nest-activates.md
@@ -26,4 +26,9 @@ A class implementing `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`
 counts as self-activating. A provider implementing an unrelated interface is
 still reported.
 
+A namespace-qualified clause such as `implements common.PipeTransform<A, B>`
+counts too. A class that only inherits the hook from a base it extends, without
+an `implements` clause of its own, is still reported; that shape does not occur
+in the corpus.
+
 Across 189 public projects this removes 65 findings and adds none.

--- a/.changeset/providers-nest-activates.md
+++ b/.changeset/providers-nest-activates.md
@@ -1,0 +1,29 @@
+---
+"nestjs-doctor": patch
+---
+
+`performance/no-unused-providers` no longer suggests deleting a provider the
+framework activates for you.
+
+The rule already knows about self-activating providers and skips a class
+carrying `@Cron`, `@OnEvent`, `@Process` or `@WebSocketGateway`. It looked only
+at decorators, so a provider that earns its registration by implementing a Nest
+contract was reported as never injected:
+
+```ts
+@Injectable()
+export class AiImageService implements OnModuleInit {
+  async onModuleInit() { /* startup work */ }
+}
+```
+
+Nothing injects it, and nothing should: Nest instantiates it and calls the hook.
+Acting on the advice would delete the startup work.
+
+A class implementing `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`,
+`OnApplicationShutdown`, `BeforeApplicationShutdown`, `CanActivate`,
+`NestInterceptor`, `ExceptionFilter`, `PipeTransform` or `NestMiddleware` now
+counts as self-activating. A provider implementing an unrelated interface is
+still reported.
+
+Across 189 public projects this removes 65 findings and adds none.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
@@ -144,7 +144,7 @@ export const noUnusedProviders: ProjectRule = {
 				continue;
 			}
 
-			// Skip self-activating providers (e.g. @Cron, @OnEvent, @Process)
+			// Skip providers the framework activates, by decorator or by contract.
 			if (
 				hasSelfActivatingDecorator(provider.classDeclaration) ||
 				implementsSelfActivating(provider.classDeclaration)

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
@@ -24,6 +24,28 @@ const SELF_ACTIVATING_DECORATORS = new Set([
 	"WebSocketGateway",
 ]);
 
+// Contracts the framework calls without anyone injecting the class: lifecycle
+// hooks, and the guard/interceptor/filter/pipe/middleware roles.
+const SELF_ACTIVATING_INTERFACES = new Set([
+	"BeforeApplicationShutdown",
+	"CanActivate",
+	"ExceptionFilter",
+	"NestInterceptor",
+	"NestMiddleware",
+	"OnApplicationBootstrap",
+	"OnApplicationShutdown",
+	"OnModuleDestroy",
+	"OnModuleInit",
+	"PipeTransform",
+]);
+
+function implementsSelfActivating(cls: ClassDeclaration): boolean {
+	return cls.getImplements().some((clause) => {
+		const name = clause.getExpression().getText().split("<")[0];
+		return SELF_ACTIVATING_INTERFACES.has(name);
+	});
+}
+
 function hasSelfActivatingDecorator(cls: ClassDeclaration): boolean {
 	// Check class-level decorators
 	for (const decorator of cls.getDecorators()) {
@@ -122,7 +144,10 @@ export const noUnusedProviders: ProjectRule = {
 			}
 
 			// Skip self-activating providers (e.g. @Cron, @OnEvent, @Process)
-			if (hasSelfActivatingDecorator(provider.classDeclaration)) {
+			if (
+				hasSelfActivatingDecorator(provider.classDeclaration) ||
+				implementsSelfActivating(provider.classDeclaration)
+			) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
@@ -41,7 +41,8 @@ const SELF_ACTIVATING_INTERFACES = new Set([
 
 function implementsSelfActivating(cls: ClassDeclaration): boolean {
 	return cls.getImplements().some((clause) => {
-		const name = clause.getExpression().getText().split("<")[0];
+		const text = clause.getExpression().getText();
+		const name = text.split(".").pop()?.split("<")[0] ?? text;
 		return SELF_ACTIVATING_INTERFACES.has(name);
 	});
 }
@@ -72,8 +73,8 @@ export const noUnusedProviders: ProjectRule = {
 		category: "performance",
 		severity: "warning",
 		description:
-			"Injectable providers that are never injected and have no self-activating decorators may be dead code",
-		help: "Remove the unused provider, inject it where needed, or verify it is activated by a framework decorator (e.g. @Cron, @OnEvent).",
+			"Injectable providers that are never injected and that the framework does not activate may be dead code",
+		help: "Remove the unused provider, inject it where needed, or verify the framework activates it, through a decorator such as @Cron or @OnEvent or a contract such as OnModuleInit or CanActivate.",
 		scope: "project",
 	},
 

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -327,6 +327,54 @@ describe("no-circular-module-deps", () => {
 });
 
 describe("no-unused-providers", () => {
+	const selfActivating: [string, string][] = [
+		["OnModuleInit", "OnModuleInit"],
+		["OnApplicationBootstrap", "OnApplicationBootstrap"],
+		["CanActivate", "CanActivate"],
+		["NestInterceptor", "NestInterceptor"],
+		["ExceptionFilter", "ExceptionFilter"],
+		["PipeTransform", "PipeTransform"],
+		["NestMiddleware", "NestMiddleware"],
+	];
+
+	for (const [name, iface] of selfActivating) {
+		it(`does not flag a provider implementing ${name}`, () => {
+			const diags = runProjectRule(noUnusedProviders, {
+				"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { DataSync } from './data-sync.js';
+        @Module({ providers: [DataSync] })
+        export class AppModule {}
+      `,
+				"data-sync.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class DataSync implements ${iface} {}
+      `,
+			});
+			expect(diags.filter((d) => d.message.includes("DataSync"))).toHaveLength(
+				0
+			);
+		});
+	}
+
+	it("still flags a provider that implements nothing and is never injected", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { Idle } from './idle.service';
+        @Module({ providers: [Idle] })
+        export class AppModule {}
+      `,
+			"idle.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class Idle {}
+      `,
+		});
+		expect(diags.filter((d) => d.message.includes("Idle"))).toHaveLength(1);
+	});
+
 	it("does not flag a class registered with useClass", () => {
 		const diags = runProjectRule(noUnusedProviders, {
 			"app.module.ts": `

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -358,6 +358,23 @@ describe("no-unused-providers", () => {
 		});
 	}
 
+	it("does not flag a provider implementing a namespace-qualified contract", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { DataSync } from './data-sync.js';
+        @Module({ providers: [DataSync] })
+        export class AppModule {}
+      `,
+			"data-sync.ts": `
+        import * as common from '@nestjs/common';
+        @common.Injectable()
+        export class DataSync implements common.PipeTransform<string, number> {}
+      `,
+		});
+		expect(diags.filter((d) => d.message.includes("DataSync"))).toHaveLength(0);
+	});
+
 	it("still flags a provider that implements nothing and is never injected", () => {
 		const diags = runProjectRule(noUnusedProviders, {
 			"app.module.ts": `


### PR DESCRIPTION
## 1. Context

`performance/no-unused-providers` reports a provider nothing injects, and advises removing it. It already understands that some providers do not need injecting, and skips a class carrying `@Cron`, `@Interval`, `@OnEvent`, `@Process`, `@EventSubscriber`, `@SubscribeMessage` or `@WebSocketGateway`. It also skips classes whose name ends in an infrastructure suffix such as `Guard` or `Worker`.

## 2. Problem

That list is decorators only. A provider can equally earn its registration by implementing a contract, and then nothing injects it by design:

```ts
@Injectable()
export class AiImageService implements OnModuleInit {
  private readonly logger = new Logger(AiImageService.name)
  async onModuleInit() { /* startup work */ }
}
```

Nest instantiates it and calls the hook. Following the rule's advice would delete the startup work.

The same holds for the framework roles. A `CanActivate` is reached through `@UseGuards(X)` or an `APP_GUARD` token, a `NestMiddleware` through `configure()`, never through a constructor. Those escape today only when the class name happens to end in `Guard` or `Middleware`; **65 findings across the corpus are classes that implement one of these and are named something else.**

## 3. Possible flows

| Provider | Before | After |
|---|---|---|
| `@Cron` / `@OnEvent` / `@Process` | skipped | skipped |
| name ends in `Guard`, `Worker`, `Processor` | skipped | skipped |
| `implements OnModuleInit`, neutral name | **reported** | skipped |
| `implements OnApplicationBootstrap` and friends | **reported** | skipped |
| `implements CanActivate` / `NestInterceptor` / `ExceptionFilter` / `PipeTransform` / `NestMiddleware` | **reported** | skipped |
| `implements SomeDomainInterface` | reported | reported |
| plain provider nothing injects | reported | reported |
| provider listed in a module's `exports` | skipped | skipped |

## 4. Solution

A `SELF_ACTIVATING_INTERFACES` set alongside the existing decorator set, checked against the class's `implements` clauses. The generic parameter is stripped, so `PipeTransform<string, number>` counts.

What I did not do: infer anything from method names. A class with an `onModuleInit` method but no `implements` clause is still reported, because that method might be its own.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| `implements OnModuleInit`, nothing injects it | reported | silent |
| `implements CanActivate`, name not `*Guard` | reported | silent |
| `implements SomeDomainInterface` *(unchanged)* | reported | reported |
| plain unused provider *(unchanged)* | reported | reported |
| 189-project corpus, this rule | 511 | 446 |

## 6. Example

`apitable/apitable`:

```
$ nestjs-doctor . --format json | jq -r '[.diagnostics[] | select(.rule=="performance/no-unused-providers")] | length'
```

Before: `27`. After: `0`. All 27 implement a lifecycle hook or a framework contract under a name that does not end in an infrastructure suffix.
