### PR TITLE
fix(rules): a base class is registered by its subclasses

### DIFF
--- a/.changeset/injectable-base-class.md
+++ b/.changeset/injectable-base-class.md
@@ -1,0 +1,18 @@
+---
+"nestjs-doctor": patch
+---
+
+`correctness/injectable-must-be-provided` no longer asks you to register a base
+class.
+
+The rule reports an `@Injectable()` class that appears in no module's
+`providers`, and suggests adding it or dropping the decorator. A base class is
+neither: it is registered through every subclass that extends it, and dropping
+its `@Injectable()` breaks the constructor injection those subclasses inherit.
+`immich`'s `BaseService` is extended by 50 classes and was reported.
+
+A class named in an `extends` clause anywhere in the project is now skipped. The
+engine already collected that set for `no-unused-providers`; this rule just was
+not using it.
+
+Across 189 public projects this removes 5 findings and adds none.

--- a/.changeset/injectable-base-class.md
+++ b/.changeset/injectable-base-class.md
@@ -11,8 +11,14 @@ neither: it is registered through every subclass that extends it, and dropping
 its `@Injectable()` breaks the constructor injection those subclasses inherit.
 `immich`'s `BaseService` is extended by 50 classes and was reported.
 
-A class named in an `extends` clause anywhere in the project is now skipped. The
-engine already collected that set for `no-unused-providers`; this rule just was
-not using it.
+A class named in an `extends` clause is now skipped. The engine already
+collected that set for `no-unused-providers`; this rule just was not using it.
+Test files are left out of the collection, so a stub such as
+`class Stub extends OrphanThing {}` in a spec cannot exempt a production class.
+
+Two limitations, both inherent to matching on a bare class name, which is the
+contract `collectExtendedClasses` already had: an unrelated class sharing a base
+class's name is exempted too, and a base extended only by subclasses that are
+themselves unregistered goes quiet while those subclasses are still reported.
 
 Across 189 public projects this removes 5 findings and adds none.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
@@ -17,6 +17,12 @@ export const injectableMustBeProvided: ProjectRule = {
 	},
 
 	check(context) {
+		const isTestFile = (filePath: string): boolean =>
+			filePath.includes(".spec.") ||
+			filePath.includes(".test.") ||
+			filePath.includes("__test__") ||
+			filePath.includes("__tests__");
+
 		// Collect all provider names registered in module metadata
 		const registeredProviders = new Set<string>();
 		for (const mod of context.moduleGraph.modules.values()) {
@@ -35,18 +41,16 @@ export const injectableMustBeProvided: ProjectRule = {
 			registeredProviders.add(implementation);
 		}
 
-		// A base class is registered through its subclasses, not on its own.
-		const extended = collectExtendedClasses(context.project, context.files);
+		// A base class is registered through its subclasses, not on its own. Test
+		// files are left out so a stub cannot exempt a production class.
+		const extended = collectExtendedClasses(
+			context.project,
+			context.files.filter((filePath) => !isTestFile(filePath))
+		);
 
 		// Scan all files for @Injectable() classes
 		for (const filePath of context.files) {
-			// Skip test files
-			if (
-				filePath.includes(".spec.") ||
-				filePath.includes(".test.") ||
-				filePath.includes("__test__") ||
-				filePath.includes("__tests__")
-			) {
+			if (isTestFile(filePath)) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
@@ -1,4 +1,7 @@
-import { collectProviderImplementations } from "../../../graph/custom-providers.js";
+import {
+	collectExtendedClasses,
+	collectProviderImplementations,
+} from "../../../graph/custom-providers.js";
 import { INFRA_SUFFIXES } from "../../constants.js";
 import type { ProjectRule } from "../../types.js";
 
@@ -31,6 +34,9 @@ export const injectableMustBeProvided: ProjectRule = {
 		)) {
 			registeredProviders.add(implementation);
 		}
+
+		// A base class is registered through its subclasses, not on its own.
+		const extended = collectExtendedClasses(context.project, context.files);
 
 		// Scan all files for @Injectable() classes
 		for (const filePath of context.files) {
@@ -67,6 +73,11 @@ export const injectableMustBeProvided: ProjectRule = {
 
 				// Skip if registered in any module
 				if (registeredProviders.has(className)) {
+					continue;
+				}
+
+				// Skip a base class: its subclasses carry the registration.
+				if (extended.has(className)) {
 					continue;
 				}
 

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../src/engine/graph/module-graph.js";
 import { resolveProviders } from "../../../src/engine/graph/type-resolver.js";
 import { noCircularModuleDeps } from "../../../src/engine/rules/definitions/architecture/no-circular-module-deps.js";
+import { injectableMustBeProvided } from "../../../src/engine/rules/definitions/correctness/injectable-must-be-provided.js";
 import { noOrphanModules } from "../../../src/engine/rules/definitions/performance/no-orphan-modules.js";
 import { noUnusedModuleExports } from "../../../src/engine/rules/definitions/performance/no-unused-module-exports.js";
 import { noUnusedProviders } from "../../../src/engine/rules/definitions/performance/no-unused-providers.js";
@@ -590,5 +591,48 @@ describe("project rules on a detached graph", () => {
 		expect(diagnostics).toHaveLength(1);
 		expect(diagnostics[0].message).toContain("ForgottenModule");
 		expect("line" in diagnostics[0] && diagnostics[0].line).toBe(1);
+	});
+});
+
+describe("injectable-must-be-provided", () => {
+	it("does not flag a base class that subclasses extend", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { PhotoHandler } from './photo.handler';
+        @Module({ providers: [PhotoHandler] })
+        export class AppModule {}
+      `,
+			"base.handler.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class BaseHandler {}
+      `,
+			"photo.handler.ts": `
+        import { Injectable } from '@nestjs/common';
+        import { BaseHandler } from './base.handler';
+        @Injectable()
+        export class PhotoHandler extends BaseHandler {}
+      `,
+		});
+		expect(diags.filter((d) => d.message.includes("BaseHandler"))).toHaveLength(
+			0
+		);
+	});
+
+	it("still flags an unregistered class nobody extends", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AppModule {}
+      `,
+			"lonely.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class Lonely {}
+      `,
+		});
+		expect(diags.filter((d) => d.message.includes("Lonely"))).toHaveLength(1);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -620,6 +620,28 @@ describe("injectable-must-be-provided", () => {
 		);
 	});
 
+	it("does not let a stub in a test file exempt a production class", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AppModule {}
+      `,
+			"orphan.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class OrphanThing {}
+      `,
+			"orphan.spec.ts": `
+        import { OrphanThing } from './orphan';
+        class Stub extends OrphanThing {}
+      `,
+		});
+		expect(diags.filter((d) => d.message.includes("OrphanThing"))).toHaveLength(
+			1
+		);
+	});
+
 	it("still flags an unregistered class nobody extends", () => {
 		const diags = runProjectRule(injectableMustBeProvided, {
 			"app.module.ts": `


### PR DESCRIPTION
## 1. Context

`correctness/injectable-must-be-provided` reports an `@Injectable()` class that appears in no module's `providers` array. Its help offers two remedies: register it, or remove the decorator if it is unused.

## 2. Problem

A base class is neither unused nor missing a registration. It reaches the container through every subclass that extends it, and removing `@Injectable()` breaks the constructor injection those subclasses inherit from it. From `immich-app/immich`:

```ts
@Injectable()
export class BaseService {
  protected storageCore: StorageCore;
  ...
}
```

**50 classes extend it.** The rule reported it as not registered anywhere.

The engine already computes the set of names appearing in an `extends` clause, in `collectExtendedClasses`, precisely so `no-unused-providers` can avoid the same mistake. This rule was not using it.

## 3. Possible flows

| Class | Before | After |
|---|---|---|
| `@Injectable()` in a module's `providers` | silent | silent |
| `@Injectable()` registered via `useClass` | silent | silent |
| `@Injectable()` base class, subclasses registered | **reported** | silent |
| `@Injectable()` nothing extends, nothing registers | reported | reported |
| name ends in an infra suffix *(already skipped)* | silent | silent |
| a spec or test file *(already skipped)* | silent | silent |

## 4. Solution

The rule consults `collectExtendedClasses` and skips a class whose name appears in an `extends` clause anywhere in the scanned files.

What I did not do: check that the extending class is itself registered. A base class extended only by unregistered classes is a rarer shape, and following the chain would need the provider graph rather than a name set.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| base class with registered subclasses | reported | silent |
| unregistered class nobody extends *(unchanged)* | reported | reported |
| 189-project corpus, this rule | 258 | 253 |

## 6. Example

`immich-app/immich`:

```
$ nestjs-doctor . --format json | jq -r '.diagnostics[] | select(.rule=="correctness/injectable-must-be-provided") | .message'
```

Before:

```
@Injectable() class 'BaseService' is not registered in any module's providers array.
@Injectable() class 'EventRepository' is not registered in any module's providers array.
```

After: only the second line. `BaseService` is what 50 other services extend.
