### PR TITLE
fix(rules): the root module is the one in app.module.ts

### DIFF
--- a/.changeset/root-module-by-file.md
+++ b/.changeset/root-module-by-file.md
@@ -13,8 +13,15 @@ reported as never imported:
 - `ImmichAdminModule` in `immich`'s `src/app.module.ts`
 - `ApplicationModule` in `Saluki/nestjs-template`'s `src/modules/app.module.ts`
 
-A module declared in `app.module.ts`, `main.module.ts` or `root.module.ts` is now
-treated as the root whatever the class is called. A module nobody imports under
-any other filename is still reported.
+A module declared in `app.module.ts` or `root.module.ts` is now treated as the
+root whatever the class is called. A module nobody imports under any other
+filename is still reported, `main.module.ts` included: that name reads as a
+feature's main module far more often than as an application root, and leaving it
+out costs nothing on the corpus since all four findings removed are
+`app.module.ts` paths.
+
+The trade this does make: a dead `src/legacy/app.module.ts` that nothing imports
+or bootstraps is now silent, and a monorepo with one `app.module.ts` per sub-app
+exempts them all, which is right while each is live.
 
 Across 189 public projects this removes 4 findings and adds none.

--- a/.changeset/root-module-by-file.md
+++ b/.changeset/root-module-by-file.md
@@ -1,0 +1,20 @@
+---
+"nestjs-doctor": patch
+---
+
+`performance/no-orphan-modules` no longer reports a root module whose class is
+not called `AppModule`.
+
+The rule skips a module that `NestFactory.create()` bootstraps, and falls back
+to the name `AppModule` for projects whose bootstrap sits outside the scan. The
+fallback keys on the class name, so a root module named anything else was
+reported as never imported:
+
+- `ImmichAdminModule` in `immich`'s `src/app.module.ts`
+- `ApplicationModule` in `Saluki/nestjs-template`'s `src/modules/app.module.ts`
+
+A module declared in `app.module.ts`, `main.module.ts` or `root.module.ts` is now
+treated as the root whatever the class is called. A module nobody imports under
+any other filename is still reported.
+
+Across 189 public projects this removes 4 findings and adds none.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
@@ -1,7 +1,7 @@
 import { collectBootstrappedModules } from "../../../graph/entry-points.js";
 
 /** A module declared here is the application root whatever its class is called. */
-const ROOT_MODULE_FILE = /(^|\/)(app|main|root)\.module\.[mc]?ts$/;
+const ROOT_MODULE_FILE = /(^|\/)(app|root)\.module\.[mc]?ts$/;
 
 import type { ProjectRule } from "../../types.js";
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
@@ -1,9 +1,9 @@
 import { collectBootstrappedModules } from "../../../graph/entry-points.js";
 
+import type { ProjectRule } from "../../types.js";
+
 /** A module declared here is the application root whatever its class is called. */
 const ROOT_MODULE_FILE = /(^|\/)(app|root)\.module\.[mc]?ts$/;
-
-import type { ProjectRule } from "../../types.js";
 
 export const noOrphanModules: ProjectRule = {
 	meta: {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
@@ -1,4 +1,8 @@
 import { collectBootstrappedModules } from "../../../graph/entry-points.js";
+
+/** A module declared here is the application root whatever its class is called. */
+const ROOT_MODULE_FILE = /(^|\/)(app|main|root)\.module\.[mc]?ts$/;
+
 import type { ProjectRule } from "../../types.js";
 
 export const noOrphanModules: ProjectRule = {
@@ -29,7 +33,11 @@ export const noOrphanModules: ProjectRule = {
 		);
 
 		for (const mod of context.moduleGraph.modules.values()) {
-			if (mod.name === "AppModule" || entryPoints.has(mod.name)) {
+			if (
+				mod.name === "AppModule" ||
+				ROOT_MODULE_FILE.test(mod.filePath) ||
+				entryPoints.has(mod.name)
+			) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-orphan-modules.ts
@@ -25,8 +25,9 @@ export const noOrphanModules: ProjectRule = {
 			}
 		}
 
-		// A bootstrapped module is an entry point, so nothing imports it. AppModule
-		// stays as a fallback for projects whose bootstrap is outside the scan.
+		// A bootstrapped module is an entry point, so nothing imports it. The name
+		// AppModule and a root filename are fallbacks when the bootstrap is
+		// outside the scan.
 		const entryPoints = collectBootstrappedModules(
 			context.project,
 			context.files

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -613,6 +613,24 @@ describe("no-orphan-modules", () => {
 		).toHaveLength(0);
 	});
 
+	it("still flags an orphan feature module named main.module.ts", () => {
+		const diags = runProjectRule(noOrphanModules, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AppModule {}
+      `,
+			"billing/main.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class BillingMainModule {}
+      `,
+		});
+		expect(
+			diags.filter((d) => d.message.includes("BillingMainModule"))
+		).toHaveLength(1);
+	});
+
 	it("still flags a module nobody imports", () => {
 		const diags = runProjectRule(noOrphanModules, {
 			"app.module.ts": `

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -592,3 +592,42 @@ describe("project rules on a detached graph", () => {
 		expect("line" in diagnostics[0] && diagnostics[0].line).toBe(1);
 	});
 });
+
+describe("no-orphan-modules", () => {
+	it("does not flag a root module named something other than AppModule", () => {
+		const diags = runProjectRule(noOrphanModules, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { UsersModule } from './users.module';
+        @Module({ imports: [UsersModule] })
+        export class ImmichAdminModule {}
+      `,
+			"users.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class UsersModule {}
+      `,
+		});
+		expect(
+			diags.filter((d) => d.message.includes("ImmichAdminModule"))
+		).toHaveLength(0);
+	});
+
+	it("still flags a module nobody imports", () => {
+		const diags = runProjectRule(noOrphanModules, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AppModule {}
+      `,
+			"lonely.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class LonelyModule {}
+      `,
+		});
+		expect(
+			diags.filter((d) => d.message.includes("LonelyModule"))
+		).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## 1. Context

`performance/no-orphan-modules` reports a module no other module imports. The application's root module is exactly that by definition, so the rule skips it two ways: any module passed to `NestFactory.create()`, found by scanning entry points, and a fallback on the class name `AppModule` for projects whose bootstrap sits outside the scanned files.

## 2. Problem

The fallback reads the class name. Nothing requires the root module to be called `AppModule`, and four projects in the corpus call it something else while still declaring it in `app.module.ts`:

| Project | File | Class |
|---|---|---|
| `immich-app/immich` | `server/src/app.module.ts` | `ImmichAdminModule` |
| `Saluki/nestjs-template` | `src/modules/app.module.ts` | `ApplicationModule` |
| `nestjs/swagger` | `test/plugin/fixtures/project/app.module.ts` | `ApplicationModule` |
| `kepelrs/nestjs-prisma-crud` | `test/src/app.module.ts` | `StrictModeAppModule` |

Each was reported as never imported, which is true and is not a problem. The advice, remove it or import it somewhere, would break the app.

## 3. Possible flows

| Module | Before | After |
|---|---|---|
| passed to `NestFactory.create()` in the scan | skipped | skipped |
| class named `AppModule` | skipped | skipped |
| class named otherwise, in `app.module.ts` | **reported** | skipped |
| class named otherwise, in `root.module.ts` | **reported** | skipped |
| a feature's own `billing/main.module.ts` that nobody imports | reported | reported |
| a feature module nobody imports | reported | reported |
| a feature module in `users.module.ts` nobody imports | reported | reported |

## 4. Solution

The filename joins the fallback. A module declared in `app.module.ts` or `root.module.ts` is the root whatever the class is called. `main.module.ts` is deliberately not in the list: it reads as a feature's main module far more often than as an application root, and leaving it out costs nothing, since all four corpus removals are `app.module.ts` paths.

What I did not do: widen the entry-point scan. Reading the bootstrap out of a `main.ts` that the scan does not cover is the real answer for the case this fallback exists to paper over, and it is a bigger change than a filename.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| `ImmichAdminModule` in `app.module.ts` | reported | silent |
| `AppModule` *(unchanged)* | silent | silent |
| `LonelyModule` in `lonely.module.ts` *(unchanged)* | reported | reported |
| 189-project corpus, this rule | 175 | 171 |

## 6. Example

`immich-app/immich`:

```
$ nestjs-doctor . --format json | jq -r '.diagnostics[] | select(.rule=="performance/no-orphan-modules") | .message'
```

Before:

```
Module 'ImmichAdminModule' is never imported by any other module.
```

After: nothing. `ImmichAdminModule` is what `main.ts` bootstraps.
