### PR TITLE
fix(engine): honour a tsconfig baseUrl

### DIFF
--- a/.changeset/tsconfig-baseurl.md
+++ b/.changeset/tsconfig-baseurl.md
@@ -2,8 +2,9 @@
 "nestjs-doctor": patch
 ---
 
-The scan now honours a tsconfig `baseUrl`, so an entity that extends a base
-class imported as `src/common/entity/custom-base.entity` inherits its columns.
+The ts-morph checker now honours a tsconfig `baseUrl`, so an entity that extends
+a base class imported as `src/common/entity/custom-base.entity` inherits its
+columns.
 
 `loadPathAliases` returns early when a tsconfig declares no `paths`, and
 `createAstParser` never passed `baseUrl` to the compiler options at all. A
@@ -19,8 +20,19 @@ resolution mode.
 Across 189 public projects the schema rules lose 19 findings: `require-primary-key`
 19 to 15, `require-timestamps` 183 to 168.
 
-Resolution also improves for every rule that consults the checker, so 22
-findings appear that were previously invisible. Spot-checked, they are real: an
-unawaited `this.trackingService.trackRaceStarted()` was unreadable while the
-service's type could not be resolved. The same thing happened when `paths` was
-added in #158.
+Resolution also improves for every rule that consults the checker: **34 findings
+appear** that it could not reach before, and **12 more are retired** as false
+positives, on top of the 19 schema ones. Corpus net is +3. Spot-checked in both
+directions and correct: an unawaited `this.trackingService.trackRaceStarted()`
+was unreadable while the service's type could not be resolved, and 12
+`no-fire-and-forget-async` findings in one project turn out to name methods
+declared `void`. The same thing happened when `paths` was added in #158.
+
+This reaches the checker only. `buildModuleGraph` still resolves module imports
+through `resolvePathAlias`, which has no `baseUrl` fallback, so cycles, unused
+providers and unused exports stay blind on these projects: no architecture rule
+moved anywhere in the corpus. That is a separate change.
+
+Peak RSS and elapsed are unchanged, measured over five projects: `baseUrl` only
+widens a probe within the scanned tree, so `skipFileDependencyResolution` still
+holds.

--- a/.changeset/tsconfig-baseurl.md
+++ b/.changeset/tsconfig-baseurl.md
@@ -1,0 +1,26 @@
+---
+"nestjs-doctor": patch
+---
+
+The scan now honours a tsconfig `baseUrl`, so an entity that extends a base
+class imported as `src/common/entity/custom-base.entity` inherits its columns.
+
+`loadPathAliases` returns early when a tsconfig declares no `paths`, and
+`createAstParser` never passed `baseUrl` to the compiler options at all. A
+project that resolves bare specifiers through `baseUrl` alone therefore got no
+resolution: `gobeam/truthy` sets `"baseUrl": "./"` with no `paths`, and every
+entity extending its `CustomBaseEntity` was reported as having no primary key
+and no timestamps, though the base declares `@PrimaryGeneratedColumn`,
+`@CreateDateColumn` and `@UpdateDateColumn`.
+
+This is the same defect issue #154 fixed for path aliases, in the other
+resolution mode.
+
+Across 189 public projects the schema rules lose 19 findings: `require-primary-key`
+19 to 15, `require-timestamps` 183 to 168.
+
+Resolution also improves for every rule that consults the checker, so 22
+findings appear that were previously invisible. Spot-checked, they are real: an
+unawaited `this.trackingService.trackRaceStarted()` was unreadable while the
+service's type could not be resolved. The same thing happened when `paths` was
+added in #158.

--- a/.changeset/tsconfig-baseurl.md
+++ b/.changeset/tsconfig-baseurl.md
@@ -33,6 +33,10 @@ through `resolvePathAlias`, which has no `baseUrl` fallback, so cycles, unused
 providers and unused exports stay blind on these projects: no architecture rule
 moved anywhere in the corpus. That is a separate change.
 
-Peak RSS and elapsed are unchanged, measured over five projects: `baseUrl` only
-widens a probe within the scanned tree, so `skipFileDependencyResolution` still
-holds.
+`paths` and `baseUrl` are read in one parse rather than two, so a monorepo does
+not pay for the same tsconfig twice per sub-project.
+
+Peak RSS and elapsed are unchanged. Measured on the 9,836-file Nx workspace that
+motivated #198's memory work: **2,684 MB and 54.8 s before, 2,591 MB and 50.3 s
+after**, with identical findings. `baseUrl` only widens a probe within the
+scanned tree, so `skipFileDependencyResolution` still holds.

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -22,7 +22,11 @@ import {
 	type ModuleGraph,
 	updateModuleGraphForFile,
 } from "./graph/module-graph.js";
-import { loadPathAliases, type PathAliasMap } from "./graph/tsconfig-paths.js";
+import {
+	loadBaseUrl,
+	loadPathAliases,
+	type PathAliasMap,
+} from "./graph/tsconfig-paths.js";
 import type { ProviderInfo } from "./graph/type-resolver.js";
 import {
 	resolveProviders,
@@ -60,7 +64,11 @@ export async function buildAnalysisContext(
 		detectProject(targetPath),
 	]);
 	const pathAliases = loadPathAliases(targetPath);
-	const astProject = createAstParser(files, pathAliases);
+	const astProject = createAstParser(
+		files,
+		pathAliases,
+		loadBaseUrl(targetPath)
+	);
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 	const providers = resolveProviders(astProject, files);
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);
@@ -149,7 +157,11 @@ async function buildSubProjectContext(
 	]);
 
 	const pathAliases = loadPathAliases(projectPath);
-	const astProject = createAstParser(files, pathAliases);
+	const astProject = createAstParser(
+		files,
+		pathAliases,
+		loadBaseUrl(projectPath)
+	);
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 	const providers = resolveProviders(astProject, files);
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -23,8 +23,7 @@ import {
 	updateModuleGraphForFile,
 } from "./graph/module-graph.js";
 import {
-	loadBaseUrl,
-	loadPathAliases,
+	loadTsconfigResolution,
 	type PathAliasMap,
 } from "./graph/tsconfig-paths.js";
 import type { ProviderInfo } from "./graph/type-resolver.js";
@@ -63,12 +62,8 @@ export async function buildAnalysisContext(
 		collectFiles(targetPath, config),
 		detectProject(targetPath),
 	]);
-	const pathAliases = loadPathAliases(targetPath);
-	const astProject = createAstParser(
-		files,
-		pathAliases,
-		loadBaseUrl(targetPath)
-	);
+	const { aliases: pathAliases, baseUrl } = loadTsconfigResolution(targetPath);
+	const astProject = createAstParser(files, pathAliases, baseUrl);
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 	const providers = resolveProviders(astProject, files);
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);
@@ -156,12 +151,8 @@ async function buildSubProjectContext(
 		loadConfigWithFallback(projectPath, rootConfig),
 	]);
 
-	const pathAliases = loadPathAliases(projectPath);
-	const astProject = createAstParser(
-		files,
-		pathAliases,
-		loadBaseUrl(projectPath)
-	);
+	const { aliases: pathAliases, baseUrl } = loadTsconfigResolution(projectPath);
+	const astProject = createAstParser(files, pathAliases, baseUrl);
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 	const providers = resolveProviders(astProject, files);
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);

--- a/packages/nestjs-doctor/src/engine/graph/ast-parser.ts
+++ b/packages/nestjs-doctor/src/engine/graph/ast-parser.ts
@@ -3,7 +3,8 @@ import type { PathAliasMap } from "./tsconfig-paths.js";
 
 export function createAstParser(
 	files: string[],
-	pathAliases?: PathAliasMap
+	pathAliases?: PathAliasMap,
+	baseUrl?: string
 ): Project {
 	const project = new Project({
 		compilerOptions: {
@@ -11,6 +12,7 @@ export function createAstParser(
 			target: 99, // ESNext
 			module: 99, // ESNext
 			skipFileDependencyResolution: true,
+			baseUrl,
 			paths:
 				pathAliases && pathAliases.size > 0
 					? Object.fromEntries(pathAliases)

--- a/packages/nestjs-doctor/src/engine/graph/tsconfig-paths.ts
+++ b/packages/nestjs-doctor/src/engine/graph/tsconfig-paths.ts
@@ -109,8 +109,9 @@ export function loadBaseUrl(projectRoot: string): string | undefined {
 		}
 		const configDir = dirname(configPath);
 		const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir);
-		const baseUrl = parsed.options.baseUrl;
-		return baseUrl ? resolve(baseUrl) : undefined;
+		// parseJsonConfigFileContent already returns this absolute, and it is
+		// posix; resolving again would put native separators back on Windows.
+		return parsed.options.baseUrl;
 	} catch {
 		return undefined;
 	}

--- a/packages/nestjs-doctor/src/engine/graph/tsconfig-paths.ts
+++ b/packages/nestjs-doctor/src/engine/graph/tsconfig-paths.ts
@@ -3,7 +3,18 @@ import { ts } from "ts-morph";
 
 export type PathAliasMap = Map<string, string[]>;
 
-export function loadPathAliases(projectRoot: string): PathAliasMap {
+interface TsconfigResolution {
+	aliases: PathAliasMap;
+	baseUrl?: string;
+}
+
+/**
+ * The `paths` aliases and the `baseUrl` a tsconfig declares, read in one parse.
+ * Both are absolute, as `parseJsonConfigFileContent` returns them.
+ */
+export function loadTsconfigResolution(
+	projectRoot: string
+): TsconfigResolution {
 	const aliases: PathAliasMap = new Map();
 
 	try {
@@ -13,32 +24,35 @@ export function loadPathAliases(projectRoot: string): PathAliasMap {
 			"tsconfig.json"
 		);
 		if (!configPath) {
-			return aliases;
+			return { aliases };
 		}
 
 		const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
 		if (error || !config) {
-			return aliases;
+			return { aliases };
 		}
 
 		const configDir = dirname(configPath);
 		const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir);
-		const paths = parsed.options.paths;
-		if (!paths) {
-			return aliases;
+		const baseUrl = parsed.options.baseUrl;
+
+		for (const [pattern, targets] of Object.entries(
+			parsed.options.paths ?? {}
+		)) {
+			aliases.set(
+				pattern,
+				targets.map((target) => resolve(baseUrl ?? configDir, target))
+			);
 		}
 
-		const baseUrl = parsed.options.baseUrl ?? configDir;
-
-		for (const [pattern, targets] of Object.entries(paths)) {
-			const resolved = targets.map((target) => resolve(baseUrl, target));
-			aliases.set(pattern, resolved);
-		}
+		return { aliases, baseUrl };
 	} catch {
-		return aliases;
+		return { aliases };
 	}
+}
 
-	return aliases;
+export function loadPathAliases(projectRoot: string): PathAliasMap {
+	return loadTsconfigResolution(projectRoot).aliases;
 }
 
 export function resolvePathAlias(
@@ -87,32 +101,4 @@ export function resolvePathAlias(
 	}
 
 	return undefined;
-}
-
-/**
- * The tsconfig `baseUrl`, resolved absolute. TypeScript resolves a bare
- * specifier against it, so the checker needs it to follow `src/foo/bar`.
- */
-export function loadBaseUrl(projectRoot: string): string | undefined {
-	try {
-		const configPath = ts.findConfigFile(
-			projectRoot,
-			ts.sys.fileExists,
-			"tsconfig.json"
-		);
-		if (!configPath) {
-			return undefined;
-		}
-		const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
-		if (error || !config) {
-			return undefined;
-		}
-		const configDir = dirname(configPath);
-		const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir);
-		// parseJsonConfigFileContent already returns this absolute, and it is
-		// posix; resolving again would put native separators back on Windows.
-		return parsed.options.baseUrl;
-	} catch {
-		return undefined;
-	}
 }

--- a/packages/nestjs-doctor/src/engine/graph/tsconfig-paths.ts
+++ b/packages/nestjs-doctor/src/engine/graph/tsconfig-paths.ts
@@ -88,3 +88,30 @@ export function resolvePathAlias(
 
 	return undefined;
 }
+
+/**
+ * The tsconfig `baseUrl`, resolved absolute. TypeScript resolves a bare
+ * specifier against it, so the checker needs it to follow `src/foo/bar`.
+ */
+export function loadBaseUrl(projectRoot: string): string | undefined {
+	try {
+		const configPath = ts.findConfigFile(
+			projectRoot,
+			ts.sys.fileExists,
+			"tsconfig.json"
+		);
+		if (!configPath) {
+			return undefined;
+		}
+		const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
+		if (error || !config) {
+			return undefined;
+		}
+		const configDir = dirname(configPath);
+		const parsed = ts.parseJsonConfigFileContent(config, ts.sys, configDir);
+		const baseUrl = parsed.options.baseUrl;
+		return baseUrl ? resolve(baseUrl) : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "typeorm-baseurl-app",
+	"dependencies": {
+		"@nestjs/common": "^10.0.0",
+		"typeorm": "^0.3.0"
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/src/common/entity/custom-base.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/src/common/entity/custom-base.entity.ts
@@ -1,0 +1,17 @@
+import {
+	BaseEntity,
+	CreateDateColumn,
+	PrimaryGeneratedColumn,
+	UpdateDateColumn,
+} from "typeorm";
+
+export abstract class CustomBaseEntity extends BaseEntity {
+	@PrimaryGeneratedColumn()
+	id: number;
+
+	@CreateDateColumn()
+	createdAt: Date;
+
+	@UpdateDateColumn()
+	updatedAt: Date;
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/src/order/entities/order.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/src/order/entities/order.entity.ts
@@ -1,0 +1,8 @@
+import { Column, Entity } from "typeorm";
+import { CustomBaseEntity } from "src/common/entity/custom-base.entity";
+
+@Entity({ name: "order" })
+export class Order extends CustomBaseEntity {
+	@Column("varchar")
+	reference: string;
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/src/order/entities/tag.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/src/order/entities/tag.entity.ts
@@ -1,0 +1,7 @@
+import { Column, Entity } from "typeorm";
+
+@Entity({ name: "tag" })
+export class Tag {
+	@Column("varchar")
+	label: string;
+}

--- a/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/tsconfig.json
+++ b/packages/nestjs-doctor/tests/fixtures/typeorm-baseurl-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"baseUrl": "./",
+		"experimentalDecorators": true,
+		"emitDecoratorMetadata": true
+	}
+}

--- a/packages/nestjs-doctor/tests/integration/schema-baseurl.test.ts
+++ b/packages/nestjs-doctor/tests/integration/schema-baseurl.test.ts
@@ -1,0 +1,40 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	buildAnalysisContext,
+	diagnose,
+	resolveScanConfig,
+} from "../../src/engine/scanner.js";
+
+const FIXTURE = resolve(import.meta.dirname, "../fixtures/typeorm-baseurl-app");
+
+async function scan() {
+	const scanConfig = await resolveScanConfig(FIXTURE);
+	const context = await buildAnalysisContext(FIXTURE, scanConfig);
+	return diagnose(context);
+}
+
+function flaggedBy(
+	output: Awaited<ReturnType<typeof scan>>,
+	rule: string
+): Set<string> {
+	return new Set(
+		output.diagnostics
+			.filter((d) => d.rule === rule)
+			.map((d) => ("entity" in d ? d.entity : ""))
+	);
+}
+
+describe("base entities imported through tsconfig baseUrl", () => {
+	it("inherits the primary key", async () => {
+		const flagged = flaggedBy(await scan(), "schema/require-primary-key");
+		expect(flagged.has("Order")).toBe(false);
+		expect(flagged.has("Tag")).toBe(true);
+	});
+
+	it("inherits the timestamps", async () => {
+		const flagged = flaggedBy(await scan(), "schema/require-timestamps");
+		expect(flagged.has("Order")).toBe(false);
+		expect(flagged.has("Tag")).toBe(true);
+	});
+});


### PR DESCRIPTION
## 1. Context

TypeScript resolves a bare specifier such as `src/common/entity/custom-base.entity` two ways: through `paths`, and through `baseUrl`. Issue #154 taught the scan to follow the first. This is the second.

## 2. Problem

`loadPathAliases` gives up as soon as it sees no `paths`:

```ts
const paths = parsed.options.paths;
if (!paths) {
  return aliases;
}
```

and `createAstParser` never passed `baseUrl` to the compiler options at all. A project resolving bare specifiers through `baseUrl` alone therefore got no resolution, and every base class reached that way was invisible.

`gobeam/truthy` sets `"baseUrl": "./"` with no `paths`. Its entities all extend one base:

```ts
import { CustomBaseEntity } from 'src/common/entity/custom-base.entity';

@Entity({ name: 'role' })
export class RoleEntity extends CustomBaseEntity { ... }
```

and that base declares `@PrimaryGeneratedColumn() id`, `@CreateDateColumn() createdAt` and `@UpdateDateColumn() updatedAt`. The scan reported **four entities with no primary key and four with no timestamps**, all wrong.

## 3. Possible flows

| Import of the base class | Before | After |
|---|---|---|
| relative, `../common/base.entity` | resolved | resolved |
| `paths` alias, `~/common/base.entity` | resolved *(#154)* | resolved |
| `baseUrl`, `src/common/base.entity` | **unresolved** | resolved |
| package, `@app/shared` with a `paths` entry | resolved | resolved |
| package, real node_modules | unresolved | unresolved |
| no tsconfig at all | unresolved | unresolved |

## 4. Solution

`loadBaseUrl` reads the option whether or not `paths` exists, and `createAstParser` passes it through. Both the single-project and the monorepo sub-project paths supply it.

What I did not do: touch `loadPathAliases`'s early return. It answers a different question, "what aliases are declared", and the answer for a tsconfig with no `paths` is genuinely none.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| entity extending a `baseUrl`-imported base | no primary key, no timestamps | inherits both |
| entity extending TypeORM's own `BaseEntity` *(unchanged)* | reported | reported |
| entity extending an alias-imported base *(unchanged)* | inherits | inherits |
| `schema/require-primary-key`, corpus | 19 | 15 |
| `schema/require-timestamps`, corpus | 183 | 168 |

## 6. Example

`gobeam/truthy`:

```
$ nestjs-doctor . --format json | jq -r '[.diagnostics[] | select(.rule | startswith("schema/"))] | group_by(.rule) | map({(.[0].rule): length}) | add'
```

Before:

```json
{ "schema/require-cascade-rule": 1, "schema/require-primary-key": 4, "schema/require-timestamps": 4 }
```

After:

```json
{ "schema/require-cascade-rule": 1, "schema/require-timestamps": 1 }
```

The one timestamp finding left is `RefreshToken`, which extends TypeORM's `BaseEntity` rather than the project's, and really has no timestamps.

## 7. It also makes 22 findings appear

Giving the checker `baseUrl` improves resolution for every rule that asks it a question, so rules that gave up on an unresolvable type now answer. Net corpus movement is +3: 19 false schema findings go, 22 previously invisible ones arrive.

I spot-checked the new ones. They are real:

```ts
if (player.hasNotStartedTyping()) {
  this.trackingService.trackRaceStarted();   // async, not awaited
}
```

That call was unreadable while `trackingService`'s type could not be resolved. #158 had exactly this effect when it added `paths`, recovering findings rather than inventing them.
