### PR TITLE
fix(schema): find a Prisma schema that is not where convention says

### DIFF
--- a/.changeset/prisma-schema-discovery.md
+++ b/.changeset/prisma-schema-discovery.md
@@ -1,0 +1,38 @@
+---
+"nestjs-doctor": patch
+---
+
+A Prisma schema is now found when it does not sit in one of the two
+conventional places.
+
+`findPrismaSchemaFiles` checked `<project>/prisma/schema.prisma`,
+`<project>/schema.prisma`, and a `prisma.schema` field in `package.json`, then
+gave up. An Nx workspace that keeps its schema in a library, which is the normal
+shape, got nothing: the ORM was detected as Prisma, the schema graph came back
+empty, the ER diagram never rendered, and the three schema rules were skipped in
+silence. On one 9,836-file workspace that is 33 models and 36 relations that
+were never checked.
+
+Two things are added, in order.
+
+**`prisma.config.*` is read.** Across 211 public projects, 14 declare their
+schema there against 1 using the `package.json` field, and it is the only thing
+that points at a schema folder. Both a file and a directory work.
+
+**A bounded search runs last**, only when nothing above located a schema. It
+skips what such a search otherwise drags in, all of which occurs in the corpus:
+`node_modules`, generated client output, scaffolding templates, `examples/`,
+`sample/`, `test/`, `e2e/`, and build directories. Dot-directories are skipped
+too, which is what keeps a worktree copy from being mistaken for the schema.
+
+The conventional directory now also accepts a folder holding no `schema.prisma`,
+which Prisma has allowed since 5.15.
+
+Measured over the 46 corpus projects that have a `.prisma` file, scanned at
+their roots: **355 entities to 438, and 223 schema findings to 268**. No project
+loses an entity. Four gain one: two through `prisma.config.ts`, one through
+folder mode, one through the nested search.
+
+Known limitation: a directory holding both a schema and a stale copy such as
+`schema-old.prisma` merges both, because Prisma merges siblings and nothing
+distinguishes a backup from a legitimate second file.

--- a/.changeset/prisma-schema-discovery.md
+++ b/.changeset/prisma-schema-discovery.md
@@ -13,26 +13,30 @@ empty, the ER diagram never rendered, and the three schema rules were skipped in
 silence. On one 9,836-file workspace that is 33 models and 36 relations that
 were never checked.
 
-Two things are added, in order.
-
-**`prisma.config.*` is read.** Across 211 public projects, 14 declare their
-schema there against 1 using the `package.json` field, and it is the only thing
-that points at a schema folder. Both a file and a directory work.
+**`prisma.config.*` is read, and read first.** Prisma treats it as authoritative
+and ignores the `package.json` key when one exists, so a declared path now beats
+both conventional locations. Comments are stripped before the path is read and
+every `schema` key in the file is tried, taking the first that declares a model,
+so neither a commented-out old path nor a nested `datasource: { schema: … }`
+wins.
 
 **A bounded search runs last**, only when nothing above located a schema. It
-skips what such a search otherwise drags in, all of which occurs in the corpus:
-`node_modules`, generated client output, scaffolding templates, `examples/`,
-`sample/`, `test/`, `e2e/`, and build directories. Dot-directories are skipped
-too, which is what keeps a worktree copy from being mistaken for the schema.
+skips `node_modules`, generated client output, scaffolding templates,
+`examples/`, `sample/`, `test/`, `e2e/` and build directories, and
+dot-directories are skipped too, which is what keeps a worktree copy out. A
+guessed directory has to declare a model and has to look like a schema's own,
+either named `prisma` or holding a `schema.prisma`; without that second rule a
+vendored reference schema stood in for the project's own in one corpus project.
 
 The conventional directory now also accepts a folder holding no `schema.prisma`,
 which Prisma has allowed since 5.15.
 
-Measured over the 46 corpus projects that have a `.prisma` file, scanned at
-their roots: **355 entities to 438, and 223 schema findings to 268**. No project
-loses an entity. Four gain one: two through `prisma.config.ts`, one through
-folder mode, one through the nested search.
+Measured over the 46 corpus projects that hold a `.prisma` file, scanned at their
+roots: **355 entities to 419, and 223 schema findings to 261**. Four projects
+gain a schema. One drops by one entity, correctly: it declares
+`schema: 'prisma/schema.prisma'` in a `prisma.config.ts`, and the entity came
+from a `schema-old.prisma` sibling the project does not use.
 
-Known limitation: a directory holding both a schema and a stale copy such as
-`schema-old.prisma` merges both, because Prisma merges siblings and nothing
-distinguishes a backup from a legitimate second file.
+Known limitation: a project that declares nothing and keeps a stale copy beside
+its schema merges both, because Prisma merges siblings and nothing distinguishes
+a backup from a legitimate second file.

--- a/packages/nestjs-doctor/src/engine/schema/prisma-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/prisma-extractor.ts
@@ -16,14 +16,16 @@
  *       → fieldToColumn()         — map scalar fields to SchemaColumn (primary, nullable, default, generated)
  *       → extractOnDelete()       — extract onDelete action from @relation attribute
  */
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { globSync } from "tinyglobby";
 import type { Project } from "ts-morph";
 import type {
 	SchemaColumn,
 	SchemaEntity,
 	SchemaRelation,
 } from "../../common/schema.js";
+import { posixDirname } from "../graph/module-graph.js";
 import type { OrmSchemaExtractor } from "./extract.js";
 
 const MODEL_REGEX = /^model\s+(\w+)\s*\{/;
@@ -55,41 +57,149 @@ interface ParsedModel {
 	tableName?: string;
 }
 
-function findPrismaSchemaFiles(targetPath: string): string[] {
-	// Check prisma/schema.prisma (standard)
-	const standard = join(targetPath, "prisma", "schema.prisma");
-	if (existsSync(standard)) {
-		// Also check for multi-file schemas (prisma/*.prisma since Prisma v5.15)
-		const prismaDir = join(targetPath, "prisma");
-		const files = readdirSync(prismaDir).filter((f) => f.endsWith(".prisma"));
-		if (files.length > 1) {
-			return files.map((f) => join(prismaDir, f));
+// Directories whose .prisma files describe something other than this project:
+// scaffolding, vendored copies, generated client output, build artefacts.
+const NOT_THIS_PROJECT = [
+	"**/node_modules/**",
+	"**/dist/**",
+	"**/build/**",
+	"**/out/**",
+	"**/.next/**",
+	"**/coverage/**",
+	"**/generated/**",
+	"**/templates/**",
+	"**/template/**",
+	"**/examples/**",
+	"**/example/**",
+	"**/samples/**",
+	"**/sample/**",
+	"**/fixtures/**",
+	"**/__fixtures__/**",
+	"**/test/**",
+	"**/tests/**",
+	"**/__tests__/**",
+	"**/e2e/**",
+];
+
+const PRISMA_CONFIG_FILES = [
+	"prisma.config.ts",
+	"prisma.config.mts",
+	"prisma.config.js",
+	"prisma.config.mjs",
+];
+
+const CONFIG_SCHEMA_VALUE = /\bschema\s*:\s*["'`]([^"'`]+)["'`]/;
+
+/**
+ * Every `.prisma` file directly inside `directory`. Prisma merges siblings, so
+ * they are all part of one schema.
+ */
+function prismaFilesIn(directory: string): string[] {
+	try {
+		return readdirSync(directory)
+			.filter((name) => name.endsWith(".prisma"))
+			.map((name) => join(directory, name))
+			.sort();
+	} catch {
+		return [];
+	}
+}
+
+/** The `schema` path a `prisma.config.*` declares, if one is readable. */
+function schemaFromPrismaConfig(targetPath: string): string[] {
+	for (const name of PRISMA_CONFIG_FILES) {
+		const configPath = join(targetPath, name);
+		if (!existsSync(configPath)) {
+			continue;
 		}
-		return [standard];
+		try {
+			const declared = CONFIG_SCHEMA_VALUE.exec(
+				readFileSync(configPath, "utf-8")
+			)?.[1];
+			if (!declared) {
+				continue;
+			}
+			const resolved = join(targetPath, declared);
+			if (!existsSync(resolved)) {
+				continue;
+			}
+			return statSync(resolved).isDirectory()
+				? prismaFilesIn(resolved)
+				: [resolved];
+		} catch {
+			// Unreadable config — try the next name
+		}
+	}
+	return [];
+}
+
+/**
+ * The `.prisma` files nearest the project root, when no convention located
+ * them. Nx and similar layouts keep the schema inside a library.
+ */
+function searchForPrismaSchema(targetPath: string): string[] {
+	let found: string[];
+	try {
+		found = globSync(["**/*.prisma"], {
+			cwd: targetPath,
+			absolute: true,
+			ignore: NOT_THIS_PROJECT,
+		});
+	} catch {
+		return [];
+	}
+	if (found.length === 0) {
+		return [];
+	}
+	// Shallowest wins, then a directory named `prisma`, then alphabetical.
+	const depth = (path: string) => path.split("/").length;
+	const best = found.sort((a, b) => {
+		const byDepth = depth(a) - depth(b);
+		if (byDepth !== 0) {
+			return byDepth;
+		}
+		const aPrisma = posixDirname(a).endsWith("/prisma") ? 0 : 1;
+		const bPrisma = posixDirname(b).endsWith("/prisma") ? 0 : 1;
+		return aPrisma - bPrisma || a.localeCompare(b);
+	})[0];
+	return prismaFilesIn(posixDirname(best));
+}
+
+function findPrismaSchemaFiles(targetPath: string): string[] {
+	// prisma/schema.prisma, plus the folder form Prisma has allowed since 5.15
+	const conventional = prismaFilesIn(join(targetPath, "prisma"));
+	if (conventional.length > 0) {
+		return conventional;
 	}
 
-	// Check schema.prisma in root
 	const root = join(targetPath, "schema.prisma");
 	if (existsSync(root)) {
 		return [root];
 	}
 
-	// Check package.json for custom path
 	try {
-		const pkgPath = join(targetPath, "package.json");
-		const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+		const pkg = JSON.parse(
+			readFileSync(join(targetPath, "package.json"), "utf-8")
+		);
 		const customPath = pkg.prisma?.schema;
 		if (customPath) {
 			const resolved = join(targetPath, customPath);
 			if (existsSync(resolved)) {
-				return [resolved];
+				return statSync(resolved).isDirectory()
+					? prismaFilesIn(resolved)
+					: [resolved];
 			}
 		}
 	} catch {
 		// package.json not found or unreadable
 	}
 
-	return [];
+	const declared = schemaFromPrismaConfig(targetPath);
+	if (declared.length > 0) {
+		return declared;
+	}
+
+	return searchForPrismaSchema(targetPath);
 }
 
 function parseSchemaFiles(filePaths: string[]): {

--- a/packages/nestjs-doctor/src/engine/schema/prisma-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/prisma-extractor.ts
@@ -171,10 +171,12 @@ function searchForPrismaSchema(targetPath: string): string[] {
 		}
 		return a < b ? -1 : 1;
 	});
-	// Shallowest first, but a directory wins only by declaring a model, so a
-	// stray enums-only file does not shadow the real schema below it.
+	// Shallowest first. A guessed directory must also look like a schema's own,
+	// which keeps a vendored reference schema from standing in for the project's.
 	for (const directory of directories) {
-		const files = prismaFilesIn(directory);
+		const files = prismaFilesIn(directory).filter(
+			(file) => directory.endsWith("/prisma") || file.endsWith("/schema.prisma")
+		);
 		if (declaresModels(files)) {
 			return files;
 		}

--- a/packages/nestjs-doctor/src/engine/schema/prisma-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/prisma-extractor.ts
@@ -88,7 +88,9 @@ const PRISMA_CONFIG_FILES = [
 	"prisma.config.mjs",
 ];
 
-const CONFIG_SCHEMA_VALUE = /\bschema\s*:\s*["'`]([^"'`]+)["'`]/;
+const CONFIG_SCHEMA_VALUE = /\bschema\s*:\s*["'`]([^"'`]+)["'`]/g;
+const LINE_COMMENT = /\/\/[^\n]*/g;
+const BLOCK_COMMENT = /\/\*[\s\S]*?\*\//g;
 
 /**
  * Every `.prisma` file directly inside `directory`. Prisma merges siblings, so
@@ -105,7 +107,23 @@ function prismaFilesIn(directory: string): string[] {
 	}
 }
 
-/** The `schema` path a `prisma.config.*` declares, if one is readable. */
+/** The `.prisma` files a declared path names, whether it is a file or a folder. */
+function filesAtDeclaredPath(targetPath: string, declared: string): string[] {
+	const resolved = join(targetPath, declared);
+	if (!existsSync(resolved)) {
+		return [];
+	}
+	return statSync(resolved).isDirectory()
+		? prismaFilesIn(resolved)
+		: [resolved];
+}
+
+/** True when these files hold at least one model, so they are a real schema. */
+function declaresModels(files: string[]): boolean {
+	return files.length > 0 && parseSchemaFiles(files).models.length > 0;
+}
+
+/** The `.prisma` files a `prisma.config.*` declares, if one is readable. */
 function schemaFromPrismaConfig(targetPath: string): string[] {
 	for (const name of PRISMA_CONFIG_FILES) {
 		const configPath = join(targetPath, name);
@@ -113,19 +131,17 @@ function schemaFromPrismaConfig(targetPath: string): string[] {
 			continue;
 		}
 		try {
-			const declared = CONFIG_SCHEMA_VALUE.exec(
-				readFileSync(configPath, "utf-8")
-			)?.[1];
-			if (!declared) {
-				continue;
+			const source = readFileSync(configPath, "utf-8")
+				.replace(BLOCK_COMMENT, "")
+				.replace(LINE_COMMENT, "");
+			// A config can hold more than one `schema` key, so each candidate is
+			// tried and the first that declares a model is taken.
+			for (const match of source.matchAll(CONFIG_SCHEMA_VALUE)) {
+				const files = filesAtDeclaredPath(targetPath, match[1]);
+				if (declaresModels(files)) {
+					return files;
+				}
 			}
-			const resolved = join(targetPath, declared);
-			if (!existsSync(resolved)) {
-				continue;
-			}
-			return statSync(resolved).isDirectory()
-				? prismaFilesIn(resolved)
-				: [resolved];
 		} catch {
 			// Unreadable config — try the next name
 		}
@@ -148,24 +164,46 @@ function searchForPrismaSchema(targetPath: string): string[] {
 	} catch {
 		return [];
 	}
-	if (found.length === 0) {
-		return [];
-	}
-	// Shallowest wins, then a directory named `prisma`, then alphabetical.
-	const depth = (path: string) => path.split("/").length;
-	const best = found.sort((a, b) => {
-		const byDepth = depth(a) - depth(b);
+	const directories = [...new Set(found.map(posixDirname))].sort((a, b) => {
+		const byDepth = a.split("/").length - b.split("/").length;
 		if (byDepth !== 0) {
 			return byDepth;
 		}
-		const aPrisma = posixDirname(a).endsWith("/prisma") ? 0 : 1;
-		const bPrisma = posixDirname(b).endsWith("/prisma") ? 0 : 1;
-		return aPrisma - bPrisma || a.localeCompare(b);
-	})[0];
-	return prismaFilesIn(posixDirname(best));
+		return a < b ? -1 : 1;
+	});
+	// Shallowest first, but a directory wins only by declaring a model, so a
+	// stray enums-only file does not shadow the real schema below it.
+	for (const directory of directories) {
+		const files = prismaFilesIn(directory);
+		if (declaresModels(files)) {
+			return files;
+		}
+	}
+	return [];
 }
 
 function findPrismaSchemaFiles(targetPath: string): string[] {
+	// Prisma reads prisma.config.* first and ignores the package.json key when
+	// one exists, so a declared path wins over both conventional locations.
+	const declared = schemaFromPrismaConfig(targetPath);
+	if (declared.length > 0) {
+		return declared;
+	}
+
+	try {
+		const pkg = JSON.parse(
+			readFileSync(join(targetPath, "package.json"), "utf-8")
+		);
+		if (pkg.prisma?.schema) {
+			const files = filesAtDeclaredPath(targetPath, pkg.prisma.schema);
+			if (files.length > 0) {
+				return files;
+			}
+		}
+	} catch {
+		// package.json not found or unreadable
+	}
+
 	// prisma/schema.prisma, plus the folder form Prisma has allowed since 5.15
 	const conventional = prismaFilesIn(join(targetPath, "prisma"));
 	if (conventional.length > 0) {
@@ -175,28 +213,6 @@ function findPrismaSchemaFiles(targetPath: string): string[] {
 	const root = join(targetPath, "schema.prisma");
 	if (existsSync(root)) {
 		return [root];
-	}
-
-	try {
-		const pkg = JSON.parse(
-			readFileSync(join(targetPath, "package.json"), "utf-8")
-		);
-		const customPath = pkg.prisma?.schema;
-		if (customPath) {
-			const resolved = join(targetPath, customPath);
-			if (existsSync(resolved)) {
-				return statSync(resolved).isDirectory()
-					? prismaFilesIn(resolved)
-					: [resolved];
-			}
-		}
-	} catch {
-		// package.json not found or unreadable
-	}
-
-	const declared = schemaFromPrismaConfig(targetPath);
-	if (declared.length > 0) {
-		return declared;
 	}
 
 	return searchForPrismaSchema(targetPath);

--- a/packages/nestjs-doctor/tests/unit/schema/prisma-extractor.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/prisma-extractor.test.ts
@@ -804,6 +804,23 @@ model Widget {
 		expect(entities()).toEqual(["Widget"]);
 	});
 
+	it("does not adopt a vendored reference schema", () => {
+		writeAt(
+			"src/core/dbSchemaImport/predefinedSchemes/abby/abby.prisma",
+			"model Vendored {\n  id Int @id\n}\n"
+		);
+		expect(entities()).toEqual([]);
+	});
+
+	it("still finds one beside a vendored collection", () => {
+		writeAt(
+			"src/core/dbSchemaImport/predefinedSchemes/abby/abby.prisma",
+			"model Vendored {\n  id Int @id\n}\n"
+		);
+		writeAt("libs/database/src/lib/prisma/schema.prisma");
+		expect(entities()).toEqual(["Widget"]);
+	});
+
 	it("finds nothing when the project has no schema", () => {
 		expect(entities()).toEqual([]);
 	});

--- a/packages/nestjs-doctor/tests/unit/schema/prisma-extractor.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/prisma-extractor.test.ts
@@ -759,10 +759,50 @@ model Widget {
 
 	for (const location of ignored) {
 		it(`does not treat ${location.split("/")[0]}/ as the project's schema`, () => {
-			writeAt(location);
-			expect(entities()).toEqual([]);
+			writeAt(location, "model Decoy {\n  id Int @id\n}\n");
+			writeAt("libs/database/src/lib/prisma/schema.prisma");
+			expect(entities()).toEqual(["Widget"]);
 		});
 	}
+
+	it("ignores a schema path that only a comment mentions", () => {
+		writeAt("legacy/schema.prisma", "model Stale {\n  id Int @id\n}\n");
+		writeAt("db/schema.prisma");
+		writeFileSync(
+			join(testDir, "prisma.config.ts"),
+			`// schema: "legacy/schema.prisma" — old location\nexport default { schema: "db/schema.prisma" };`,
+			"utf-8"
+		);
+		expect(entities()).toEqual(["Widget"]);
+	});
+
+	it("skips a config key that names no models", () => {
+		writeAt("shared/notes.prisma", "// no models here\n");
+		writeAt("db/schema.prisma");
+		writeFileSync(
+			join(testDir, "prisma.config.ts"),
+			`export default { datasource: { schema: "shared" }, schema: "db/schema.prisma" };`,
+			"utf-8"
+		);
+		expect(entities()).toEqual(["Widget"]);
+	});
+
+	it("prefers a declared path over the conventional directory", () => {
+		writeAt("prisma/schema.prisma", "model Conventional {\n  id Int @id\n}\n");
+		writeAt("db/real.prisma");
+		writeFileSync(
+			join(testDir, "prisma.config.ts"),
+			`export default { schema: "db/real.prisma" };`,
+			"utf-8"
+		);
+		expect(entities()).toEqual(["Widget"]);
+	});
+
+	it("is not shadowed by a shallower file that declares no model", () => {
+		writeAt("enums.prisma", "enum Colour {\n  RED\n}\n");
+		writeAt("libs/db/prisma/schema.prisma");
+		expect(entities()).toEqual(["Widget"]);
+	});
 
 	it("finds nothing when the project has no schema", () => {
 		expect(entities()).toEqual([]);

--- a/packages/nestjs-doctor/tests/unit/schema/prisma-extractor.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/prisma-extractor.test.ts
@@ -687,3 +687,84 @@ model Review {
 		expect(graph.relations.length).toBeGreaterThanOrEqual(10);
 	});
 });
+
+describe("Prisma schema discovery", () => {
+	const MODEL = `
+model Widget {
+  id   Int    @id @default(autoincrement())
+  name String
+}
+`;
+
+	function writeAt(relative: string, content = MODEL): void {
+		const full = join(testDir, relative);
+		mkdirSync(join(full, ".."), { recursive: true });
+		writeFileSync(full, content, "utf-8");
+	}
+
+	function entities(): string[] {
+		const graph = extractSchema(
+			new Project({ useInMemoryFileSystem: true }),
+			[],
+			"prisma",
+			testDir
+		);
+		return [...graph.entities.keys()];
+	}
+
+	it("finds a schema nested inside a library", () => {
+		writeAt("libs/database/src/lib/prisma/schema.prisma");
+		expect(entities()).toEqual(["Widget"]);
+	});
+
+	it("reads the path a prisma.config.ts declares", () => {
+		writeAt("apps/api/src/db/schema.prisma");
+		writeFileSync(
+			join(testDir, "prisma.config.ts"),
+			`export default { schema: "apps/api/src/db/schema.prisma" };`,
+			"utf-8"
+		);
+		expect(entities()).toEqual(["Widget"]);
+	});
+
+	it("reads a folder a prisma.config.ts declares", () => {
+		writeAt("db/schema/widget.prisma");
+		writeFileSync(
+			join(testDir, "prisma.config.ts"),
+			`export default { schema: "db/schema" };`,
+			"utf-8"
+		);
+		expect(entities()).toEqual(["Widget"]);
+	});
+
+	it("prefers the conventional directory over anything nested", () => {
+		writeAt("prisma/schema.prisma");
+		writeAt(
+			"libs/other/prisma/schema.prisma",
+			"model Decoy {\n  id Int @id\n}\n"
+		);
+		expect(entities()).toEqual(["Widget"]);
+	});
+
+	const ignored = [
+		"node_modules/.prisma/client/schema.prisma",
+		"generators/prisma/templates/mysql/prisma/schema.prisma",
+		"examples/fastify/prisma/schema.prisma",
+		"sample/22-graphql-prisma/prisma/schema.prisma",
+		"test/prisma/schema.prisma",
+		"e2e/prisma/schema.prisma",
+		"apps/server/generated/prisma/schema.prisma",
+		"dist/prisma/schema.prisma",
+	];
+
+	for (const location of ignored) {
+		it(`does not treat ${location.split("/")[0]}/ as the project's schema`, () => {
+			writeAt(location);
+			expect(entities()).toEqual([]);
+		});
+	}
+
+	it("finds nothing when the project has no schema", () => {
+		expect(entities()).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 1. Context

The Prisma extractor is the only one that reads a file off disk. The other three walk the scanned `.ts` files, so they find whatever the scan already collected. Prisma has to locate `schema.prisma` itself, and `findPrismaSchemaFiles` did that by trying two conventional paths and one `package.json` field.

## 2. Problem

If the schema is anywhere else, the extractor returns nothing and **every failure looks like a project with no database**.

A user's Nx workspace keeps it where Nx projects normally do:

```
libs/database/src/lib/prisma/schema.prisma      33 models
```

declared only in that library's Nx targets:

```json
"command": "prisma generate --schema=./src/lib/prisma/schema.prisma"
```

The scan reported `"orm": "prisma"` and then nothing at all: no `schema` key in the JSON, no ER diagram, and the three schema rules skipped. Not one of the 33 models was checked, and the score was correspondingly higher with no signal that anything had been missed.

Across the corpus this is not an edge case. Of 98 `.prisma` files in 46 projects, **17 sit at `prisma/schema.prisma` and 1 at the root. The other 80 are somewhere else.**

## 3. Possible flows

| How the project declares its schema | Before | After |
|---|---|---|
| `prisma/schema.prisma` | found | found |
| `prisma/*.prisma`, folder mode, no `schema.prisma` | **missed** | found |
| `schema.prisma` at the root | found | found |
| `package.json` → `prisma.schema` | found | found |
| `prisma.config.ts` → `schema: "file"` | **missed** | found |
| `prisma.config.ts` → `schema: "folder"` | **missed** | found |
| nested, declared nowhere the scanner reads | **missed** | found by search |
| under `node_modules`, `generated/`, `dist/` | n/a | never |
| a scaffolding template, `examples/`, `sample/` | n/a | never |
| `test/` or `e2e/` fixture schema | n/a | never |
| a copy in a dot-directory such as `.claude/worktrees` | n/a | never |

## 4. Solution

Two additions, in order, and the search only runs when everything else has failed.

**`prisma.config.*` is read.** In the corpus **14 projects declare their schema there against 1 using the `package.json` field**, and it is the only mechanism pointing at the two genuine folder-mode setups. Both a file and a directory are handled.

**A bounded search runs last.** Every exclusion in it corresponds to something the corpus actually contains: 14 scaffolding templates, 5 `examples/`, 4 vendored third-party schemas, 2 `sample/`, 2 `e2e/`, 1 `test/`, 1 generated client output, plus `node_modules` and build directories. Dot-directories are skipped by tinyglobby's default, which is what keeps the three divergent `.claude/worktrees` copies in the user's workspace from being picked up. Measured at 37 ms on that 9,836-file tree.

What I did not do: parse Nx targets for `--schema=`. The search already reaches that layout, and reading another tool's task definitions to find a file is a worse contract than looking for the file.

## 5. Before vs after

| Case | Before | After |
|---|---|---|
| Nx workspace, schema in a library | 0 entities, no ER diagram | 33 entities, 36 relations |
| `prisma.config.ts` pointing at a folder | 0 entities | entities |
| `prisma/schema.prisma` *(unchanged)* | found | found |
| a template or example schema *(unchanged)* | not found | not found |
| corpus entities, 46 projects at their roots | 355 | **438** |
| corpus schema findings | 223 | **268** |
| projects that lose an entity | | **0** |

## 6. Example

The workspace that prompted this:

```
$ nestjs-doctor . --format json | jq '{orm: .project.orm, entities: (.schema.entities // [] | length)}'
```

Before:

```json
{ "orm": "prisma", "entities": 0 }
```

After:

```json
{ "orm": "prisma", "entities": 33 }
```

with 3 schema findings that were previously invisible.

## 7. One thing this does not fix

A directory holding both a live schema and a stale copy, `schema-old.prisma` or `schema-v1.4.4a.prisma`, merges both. Prisma merges siblings by design and nothing structural separates a backup from a legitimate second file. Three corpus projects are in that state, and they were before this change too.
