### PR TITLE
perf(engine): resolve the workspace-root schema once per scan

### DIFF
--- a/.changeset/root-schema-once.md
+++ b/.changeset/root-schema-once.md
@@ -1,0 +1,26 @@
+---
+"nestjs-doctor": patch
+---
+
+A monorepo scan resolves the workspace-root schema once instead of once per
+sub-project.
+
+`buildSubProjectContext` falls back to the workspace root when a sub-project's
+own extraction comes back empty, and the answer is the same every time. On a
+9,836-file Nx workspace it ran **42 times**, each repeating the file lookup
+across the whole tree. #217 made that lookup more expensive by giving it a
+search. The root is one path per scan, so it is now resolved once and shared.
+
+The fallback also no longer runs for an ORM it cannot help. `extractSchema`
+passes the target path only to the Prisma extractor; TypeORM, Drizzle and
+MikroORM take the source files they are handed and ignore it, so for those the
+fallback re-ran the identical extraction with identical inputs and could only
+reach the identical empty result. On a large TypeORM monorepo that was a second
+walk over every file, per sub-project, that could never change an outcome.
+
+No finding moves: the 46-project schema corpus is unchanged at 419 entities and
+261 findings, and the workspace above still reports 33 entities and 36
+relations.
+
+This closes the follow-up #194 recorded when it added the fallback: "sharing one
+extraction across sub-projects… deduplicating the work is a separate question".

--- a/.changeset/root-schema-once.md
+++ b/.changeset/root-schema-once.md
@@ -6,21 +6,22 @@ A monorepo scan resolves the workspace-root schema once instead of once per
 sub-project.
 
 `buildSubProjectContext` falls back to the workspace root when a sub-project's
-own extraction comes back empty, and the answer is the same every time. On a
-9,836-file Nx workspace it ran **42 times**, each repeating the file lookup
-across the whole tree. #217 made that lookup more expensive by giving it a
+own extraction comes back empty, and the answer is the same every time. On an Nx
+workspace with 29 Nest sub-projects it ran **28 times**, each repeating the file
+lookup across the whole tree. #217 made that lookup more expensive by giving it a
 search. The root is one path per scan, so it is now resolved once and shared.
 
-The fallback also no longer runs for an ORM it cannot help. `extractSchema`
-passes the target path only to the Prisma extractor; TypeORM, Drizzle and
-MikroORM take the source files they are handed and ignore it, so for those the
-fallback re-ran the identical extraction with identical inputs and could only
-reach the identical empty result. On a large TypeORM monorepo that was a second
-walk over every file, per sub-project, that could never change an outcome.
+The fallback also no longer runs for an ORM it cannot help. Only Prisma locates
+its schema from the target path; TypeORM, Drizzle and MikroORM read the source
+files they are handed, so for those the fallback re-ran the identical extraction
+with identical inputs and could only reach the identical empty result. Each
+extractor now declares this on `OrmSchemaExtractor`, so the compiler asks for it
+when an ORM is added. On a TypeORM monorepo the root extractions drop from 2 to
+0.
 
 No finding moves: the 46-project schema corpus is unchanged at 419 entities and
-261 findings, and the workspace above still reports 33 entities and 36
-relations.
+261 findings, every repo individually, and the workspace above still reports 34
+entities, 36 relations and the same 237 diagnostics.
 
 This closes the follow-up #194 recorded when it added the fallback: "sharing one
 extraction across sub-projects… deduplicating the work is a separate question".

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -36,7 +36,7 @@ import { filterRules, separateRules } from "./rules/rule-pipeline.js";
 import type { ProjectRule, Rule, SchemaRule } from "./rules/types.js";
 import {
 	extractSchema,
-	ORMS_READ_FROM_TARGET_PATH,
+	ormReadsFromTargetPath,
 	updateSchemaForFile,
 } from "./schema/extract.js";
 
@@ -140,14 +140,14 @@ export function updateFile(context: AnalysisContext, filePath: string): void {
 	}
 }
 
-/** Builds the context for a single sub-project. */
-/** Resolves the workspace-root schema for an ORM, computing it at most once. */
+/** Resolves the workspace-root schema for an ORM. */
 type RootSchemaLookup = (
 	orm: string,
 	astProject: Project,
 	files: string[]
 ) => SchemaGraph;
 
+/** Builds the context for a single sub-project. */
 async function buildSubProjectContext(
 	targetPath: string,
 	scanConfig: ScanConfig,
@@ -168,12 +168,11 @@ async function buildSubProjectContext(
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
 	const providers = resolveProviders(astProject, files);
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);
-	// Falls back to the workspace root, where a monorepo usually keeps its schema.
-	// Only an ORM read from the target path can answer differently there.
 	let schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
+	// Falls back to the workspace root, where a monorepo usually keeps its schema.
 	if (
 		project.orm &&
-		ORMS_READ_FROM_TARGET_PATH.has(project.orm) &&
+		ormReadsFromTargetPath(project.orm) &&
 		schemaGraph.entities.size === 0
 	) {
 		schemaGraph = rootSchemaFor(project.orm, astProject, files);

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -34,7 +34,11 @@ import {
 import { detectProject, type MonorepoInfo } from "./project-detector.js";
 import { filterRules, separateRules } from "./rules/rule-pipeline.js";
 import type { ProjectRule, Rule, SchemaRule } from "./rules/types.js";
-import { extractSchema, updateSchemaForFile } from "./schema/extract.js";
+import {
+	extractSchema,
+	ORMS_READ_FROM_TARGET_PATH,
+	updateSchemaForFile,
+} from "./schema/extract.js";
 
 export interface AnalysisContext {
 	astProject: Project;
@@ -137,12 +141,20 @@ export function updateFile(context: AnalysisContext, filePath: string): void {
 }
 
 /** Builds the context for a single sub-project. */
+/** Resolves the workspace-root schema for an ORM, computing it at most once. */
+type RootSchemaLookup = (
+	orm: string,
+	astProject: Project,
+	files: string[]
+) => SchemaGraph;
+
 async function buildSubProjectContext(
 	targetPath: string,
 	scanConfig: ScanConfig,
 	monorepo: MonorepoInfo,
 	name: string,
-	files: string[]
+	files: string[],
+	rootSchemaFor: RootSchemaLookup
 ): Promise<AnalysisContext> {
 	const { config: rootConfig, combinedRules } = scanConfig;
 	const projectPath = join(targetPath, monorepo.projects.get(name)!);
@@ -157,9 +169,14 @@ async function buildSubProjectContext(
 	const providers = resolveProviders(astProject, files);
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);
 	// Falls back to the workspace root, where a monorepo usually keeps its schema.
+	// Only an ORM read from the target path can answer differently there.
 	let schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
-	if (project.orm && schemaGraph.entities.size === 0) {
-		schemaGraph = extractSchema(astProject, files, project.orm, targetPath);
+	if (
+		project.orm &&
+		ORMS_READ_FROM_TARGET_PATH.has(project.orm) &&
+		schemaGraph.entities.size === 0
+	) {
+		schemaGraph = rootSchemaFor(project.orm, astProject, files);
 	}
 	const rules = filterRules(projectConfig, combinedRules);
 	const { fileRules, projectRules, schemaRules } = separateRules(rules);
@@ -198,6 +215,19 @@ export async function reduceSubProjects<T>(
 		scanConfig.config
 	);
 
+	// One workspace root, so one answer; every sub-project that needs it reuses
+	// the same extraction instead of repeating the file lookup.
+	const rootSchemas = new Map<string, SchemaGraph>();
+	const rootSchemaFor: RootSchemaLookup = (orm, astProject, files) => {
+		const cached = rootSchemas.get(orm);
+		if (cached) {
+			return cached;
+		}
+		const graph = extractSchema(astProject, files, orm, targetPath);
+		rootSchemas.set(orm, graph);
+		return graph;
+	};
+
 	const results = new Map<string, T>();
 	for (const [name, files] of filesByProject) {
 		if (files.length === 0) {
@@ -208,7 +238,8 @@ export async function reduceSubProjects<T>(
 			scanConfig,
 			monorepo,
 			name,
-			files
+			files,
+			rootSchemaFor
 		);
 		results.set(name, consume(name, context));
 	}

--- a/packages/nestjs-doctor/src/engine/schema/drizzle-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/drizzle-extractor.ts
@@ -394,6 +394,7 @@ function extractTablesFromFile(sourceFile: SourceFile): SchemaEntity[] {
 
 export const drizzleExtractor: OrmSchemaExtractor = {
 	supportsIncrementalUpdate: true,
+	readsFromTargetPath: false,
 	extract(project: Project, files: string[]): SchemaEntity[] {
 		const entities: SchemaEntity[] = [];
 

--- a/packages/nestjs-doctor/src/engine/schema/extract.ts
+++ b/packages/nestjs-doctor/src/engine/schema/extract.ts
@@ -16,6 +16,11 @@ export interface OrmSchemaExtractor {
 		files: string[],
 		targetPath: string
 	): SchemaEntity[];
+	/**
+	 * Whether the schema is a file this extractor locates from the target path.
+	 * The others read the source files they are handed, so the path changes nothing.
+	 */
+	readsFromTargetPath: boolean;
 	/** Whether this extractor supports incremental per-file updates (LSP path). */
 	supportsIncrementalUpdate: boolean;
 }
@@ -28,13 +33,10 @@ const extractors: Record<string, OrmSchemaExtractor> = {
 	"mikro-orm": mikroOrmExtractor,
 };
 
-/**
- * ORMs whose schema is a file the extractor locates from the target path. The
- * others read the source files they are handed, so the path changes nothing.
- */
-export const ORMS_READ_FROM_TARGET_PATH: ReadonlySet<string> = new Set([
-	"prisma",
-]);
+/** True when re-running this ORM's extraction from another path can differ. */
+export function ormReadsFromTargetPath(orm: string): boolean {
+	return extractors[orm]?.readsFromTargetPath === true;
+}
 
 export function extractSchema(
 	project: Project,

--- a/packages/nestjs-doctor/src/engine/schema/extract.ts
+++ b/packages/nestjs-doctor/src/engine/schema/extract.ts
@@ -28,6 +28,14 @@ const extractors: Record<string, OrmSchemaExtractor> = {
 	"mikro-orm": mikroOrmExtractor,
 };
 
+/**
+ * ORMs whose schema is a file the extractor locates from the target path. The
+ * others read the source files they are handed, so the path changes nothing.
+ */
+export const ORMS_READ_FROM_TARGET_PATH: ReadonlySet<string> = new Set([
+	"prisma",
+]);
+
 export function extractSchema(
 	project: Project,
 	files: string[],

--- a/packages/nestjs-doctor/src/engine/schema/mikro-orm-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/mikro-orm-extractor.ts
@@ -447,6 +447,7 @@ function extractEntityFromClass(cls: ClassDeclaration): SchemaEntity | null {
 
 export const mikroOrmExtractor: OrmSchemaExtractor = {
 	supportsIncrementalUpdate: true,
+	readsFromTargetPath: false,
 	extract(project: Project, files: string[]): SchemaEntity[] {
 		const entities: SchemaEntity[] = [];
 

--- a/packages/nestjs-doctor/src/engine/schema/prisma-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/prisma-extractor.ts
@@ -492,6 +492,7 @@ function buildEntities(
 
 export const prismaExtractor: OrmSchemaExtractor = {
 	supportsIncrementalUpdate: false,
+	readsFromTargetPath: true,
 	extract(
 		_project: Project,
 		_files: string[],

--- a/packages/nestjs-doctor/src/engine/schema/typeorm-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/typeorm-extractor.ts
@@ -341,6 +341,7 @@ function extractEntityFromClass(cls: ClassDeclaration): SchemaEntity | null {
 
 export const typeormExtractor: OrmSchemaExtractor = {
 	supportsIncrementalUpdate: true,
+	readsFromTargetPath: false,
 	extract(project: Project, files: string[]): SchemaEntity[] {
 		const entities: SchemaEntity[] = [];
 

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -592,6 +592,23 @@ describe("scanner integration", () => {
 			}
 		});
 
+		it("extracts the root schema once and shares it", async () => {
+			const targetPath = resolve(FIXTURES, "root-schema-monorepo");
+			const monorepo = await detectMonorepo(targetPath);
+			const scanConfig = await resolveScanConfig(targetPath);
+			const graphs = await reduceSubProjects(
+				targetPath,
+				scanConfig,
+				monorepo!,
+				(_name, context) => context.schemaGraph
+			);
+
+			// Every sub-project falls back, so they all hold the same extraction.
+			const distinct = new Set(graphs.values());
+			expect(graphs.size).toBeGreaterThan(1);
+			expect(distinct.size).toBe(1);
+		});
+
 		it("still prefers a schema the sub-project owns", async () => {
 			const targetPath = resolve(FIXTURES, "turborepo-app");
 			const monorepo = await detectMonorepo(targetPath);


### PR DESCRIPTION
## 1. Context

In monorepo mode `buildSubProjectContext` runs once per sub-project. When a sub-project's own schema extraction comes back empty it falls back to the workspace root, which is where a monorepo usually keeps its schema. #194 added that fallback and recorded the follow-up in its own words:

> Not done: sharing one extraction across sub-projects… deduplicating the work is a separate question.

## 2. Problem

The root is one path per scan, so the fallback computes the same answer every time. Instrumented on the Nx workspace that prompted #217, which has 29 Nest sub-projects:

```
root-fallback extractions: 28
```

Each one repeats the file lookup across the whole tree, and #217 made that lookup more expensive by giving it a search to run when convention fails.

There is a second, quieter waste. Only Prisma locates its schema from the target path. The other three take the files they are given:

```ts
extract(project: Project, files: string[]): SchemaEntity[]   // typeorm, drizzle, mikro-orm
```

The third argument is unreachable in those, so the fallback re-ran the **identical** extraction with **identical** inputs and could only reach the identical empty result.

## 3. Possible flows

| Scan | Before | After |
|---|---|---|
| single project, any ORM | one extraction, no fallback | unchanged |
| monorepo, Prisma, sub-project owns a schema | no fallback | unchanged |
| monorepo, Prisma, N sub-projects fall back | N root extractions | **1**, shared |
| monorepo, TypeORM / Drizzle / MikroORM | N pointless re-extractions | **0** |
| monorepo, no ORM detected | no fallback | unchanged |
| LSP incremental update | untouched | untouched |

The last row holds because the LSP goes through `buildAnalysisContext`, not `reduceSubProjects`, so it never sees a shared graph.

## 4. Solution

`reduceSubProjects` holds a per-scan lookup that extracts the root schema at most once and hands the same graph to every sub-project that needs it. The memo lives for the duration of one call, so nothing survives into a later scan. That matters because a process-lifetime cache would go stale invisibly the moment someone added a schema.

The fallback is also gated on whether the ORM reads from the target path, and each extractor declares that on `OrmSchemaExtractor` next to `supportsIncrementalUpdate`. Putting it on the interface rather than in a list means the compiler asks for it when an ORM is added to the dispatch map, instead of the fallback silently going stale.

Sharing one graph is safe because nothing mutates one. `updateSchemaForFile` is the only writer, and its only path is the LSP worker through `buildAnalysisContext`, which is the single-project pipeline.

What I did not do: drop the search from the root fallback. That would remove these passes too **and** the risk that a monorepo with two databases lets a schema-less sub-project adopt whichever schema is shallowest instead of warning. It also costs coverage, since a schema in a library that is not itself a detected Nest project would stop being found, and I have not measured that. It is a separate change.

## 5. Before vs after

| | Before | After |
|---|---|---|
| root extractions, 29-sub-project Nx workspace | 28 | **1** |
| all schema extractions, same workspace | 57 | **30** |
| root extractions, a TypeORM monorepo | 2 | **0** |
| that Nx workspace's entities / relations *(unchanged)* | 34 / 36 | 34 / 36 |
| that Nx workspace's diagnostics and score *(unchanged)* | 237, 97 | 237, 97 |
| 46-project schema corpus, entities *(unchanged)* | 419 | 419 |
| 46-project schema corpus, findings *(unchanged)* | 261 | 261 |
| single-project scans *(unchanged)* | one extraction | one extraction |

The corpus is unchanged per repo, not only in total.

## 6. Example

Counting root extractions on that workspace, same command on both revisions:

```
$ nestjs-doctor . --format json > /dev/null      # with stderr instrumentation
```

```
before:  57 schema extractions, 28 of them at the workspace root
after:   30 schema extractions,  1 of them at the workspace root
```

Reported output is the same either way: 34 entities, 36 relations, 237 diagnostics, score 97.

---

Two things I noticed while measuring that are **pre-existing and not touched here**, both reproduced on `main`:

- Diagnostic ordering in `--format json` is not stable run to run. The set of findings is identical, only the array order moves.
- ORM detection is not stable for a project that declares several ORMs. `@nestjs/terminus` depends on Prisma, TypeORM and MikroORM, and two consecutive runs of the same build reported different ORMs for it.

Happy to file both as issues.
