### PR TITLE
feat(report): see the whole schema in the report diagram

### DIFF
--- a/.changeset/canvas-trackpad-pan.md
+++ b/.changeset/canvas-trackpad-pan.md
@@ -1,0 +1,15 @@
+---
+"nestjs-doctor": patch
+---
+
+Two-finger scrolling a diagram in the HTML report now pans instead of zooming.
+
+Every canvas in the report treated a wheel event as zoom, and a trackpad sends
+one for a plain two-finger scroll, so trying to move around the diagram zoomed it
+instead. A pinch arrives as a wheel event with `ctrlKey` set, which is what now
+zooms. This matches how the rest of the diagram already behaves, since dragging
+the background has always panned.
+
+Applies to all three diagrams: the modules graph, the endpoints graph and the
+relational schema. On a mouse, the wheel now scrolls the diagram and ctrl or
+command with the wheel zooms.

--- a/.changeset/schema-diagram-controls.md
+++ b/.changeset/schema-diagram-controls.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Three additions to the schema diagram: deselecting by clicking away, a zoom bar,

--- a/.changeset/schema-diagram-controls.md
+++ b/.changeset/schema-diagram-controls.md
@@ -1,0 +1,18 @@
+---
+"nestjs-doctor": minor
+---
+
+Three additions to the schema diagram: deselecting by clicking away, a zoom bar,
+and a control to show every column.
+
+Clicking a table selected it and dimmed the rest, but the only way back was to
+click the same table again. Clicking empty canvas now clears the selection.
+Dragging the background still pans without losing it.
+
+The top right corner gains a zoom bar with a slider, plus and minus buttons, and
+a readout that fits the diagram to the view when clicked, so zooming no longer
+depends on a trackpad gesture.
+
+Tables were capped at seven columns with a "+N more" line and no way to see the
+rest. A new toolbar control shows every column, and the diagram is laid out again
+afterwards so the taller boxes do not overlap.

--- a/.changeset/schema-overview-mode.md
+++ b/.changeset/schema-overview-mode.md
@@ -16,9 +16,12 @@ the empty state itself, which is where a large schema lands.
 Tables are laid out per connected component and the components are packed
 together, because one dagre pass puts every unrelated table in a single rank. The
 same 34-table schema is 18 components with 12 tables that have no relation at
-all, so that rank was most of the diagram. Fitting the result also meant letting
-the camera zoom past the old hard floor, though not so far that column text stops
-being readable.
+all, so that rank was most of the diagram.
+
+The overview opens with columns showing, at a zoom where they are readable,
+anchored at the top left so you pan through the diagram rather than starting in
+the middle of it. Minimising the tables switches back to the fit-everything
+bird's eye view, which can now zoom out further than the old hard floor allowed.
 
 Node labels are now measured once when the layout is built instead of on every
 frame, which makes panning cheaper in both modes.

--- a/.changeset/schema-overview-mode.md
+++ b/.changeset/schema-overview-mode.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 The HTML report's schema diagram can now show every table at once.

--- a/.changeset/schema-overview-mode.md
+++ b/.changeset/schema-overview-mode.md
@@ -1,0 +1,24 @@
+---
+"nestjs-doctor": minor
+---
+
+The HTML report's schema diagram can now show every table at once.
+
+The schema tab decided its mode at render time with `entities.length > 7` and
+never revisited it, so any schema past that size could only ever show one table
+and its direct neighbours. There was no control to leave that view, and the
+all-tables layout already existed but was unreachable. On a real 34-table schema
+you landed on an empty canvas and stayed there.
+
+There is now a toggle in the diagram toolbar, and a **Show all tables** button on
+the empty state itself, which is where a large schema lands.
+
+Tables are laid out per connected component and the components are packed
+together, because one dagre pass puts every unrelated table in a single rank. The
+same 34-table schema is 18 components with 12 tables that have no relation at
+all, so that rank was most of the diagram. Fitting the result also meant letting
+the camera zoom past the old hard floor, though not so far that column text stops
+being readable.
+
+Node labels are now measured once when the layout is built instead of on every
+frame, which makes panning cheaper in both modes.

--- a/.changeset/schema-review-fixes.md
+++ b/.changeset/schema-review-fixes.md
@@ -1,0 +1,25 @@
+---
+"nestjs-doctor": patch
+---
+
+Fixes found reviewing the schema diagram work.
+
+A schema of five tables or fewer laid itself out against the wrong box heights.
+The initial layout ran before the boxes were sized, so dagre spacing, the edge
+ports and the fit zoom were all computed for 52px rows and the tables then drew
+up to twice that. It sizes them first now.
+
+The zoom slider and the pinch gesture used different floors, so dragging the
+slider to 5% and then pinching once snapped the view back in to 20%. Both use one
+floor, and the slider covers the full range the camera allows.
+
+Visiting the all-tables view latched columns on for good, so going back to a
+focused table showed full column lists however many neighbours it had. Whether
+columns show is one rule again, and an explicit choice still wins.
+
+A foreign key column named `user_id` was marked as merely indexed, because the
+match ignored punctuation. Names are compared without it, so a renamed or
+snake_case key column reads as a foreign key.
+
+The two toggles keep their accessible name in step with what they do and report
+their pressed state, and the tooltips appear on keyboard focus, not only on hover.

--- a/.changeset/schema-sidebar-collapse-sync.md
+++ b/.changeset/schema-sidebar-collapse-sync.md
@@ -1,0 +1,19 @@
+---
+"nestjs-doctor": minor
+---
+
+The schema tab's table list can be hidden, and it follows the diagram by default.
+
+A button in the list header hides it so the diagram gets the whole width, and a
+button on the diagram brings it back. The view stays put across the change rather
+than jumping, because the camera shifts by half the width it gained or lost.
+
+A **Sync with diagram** checkbox, on by default, ties the two together. Picking a
+table in the diagram opens that table in the list, opens its columns, and scrolls
+to it. Clicking empty canvas clears the selection and closes everything. Unchecking
+it leaves the list alone, so the two can be driven separately.
+
+Also fixes three things in the list: the tooltips were cut off, because the list
+scrolls and so clips anything drawn outside it; a row's trailing detail such as
+`= uuid()` ran under the right edge, since the name never gave up space; and the
+new checkbox sat flush against the header.

--- a/.changeset/schema-sidebar-collapse-sync.md
+++ b/.changeset/schema-sidebar-collapse-sync.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 The schema tab's table list can be hidden, and it follows the diagram by default.

--- a/.changeset/schema-sidebar-icon-parity.md
+++ b/.changeset/schema-sidebar-icon-parity.md
@@ -1,0 +1,15 @@
+---
+"nestjs-doctor": patch
+---
+
+The schema sidebar and the diagram now mark a column the same way.
+
+The diagram gained key, link and index glyphs on columns, but the sidebar tree
+still only told a primary key apart from everything else, so the same column
+could be plain in the list and marked in the diagram. `Journey.name` is indexed,
+and only one of the two views said so.
+
+The sidebar now classifies a column exactly as the diagram does, and its indexes
+group counts a plainly indexed column rather than only a unique one, which is why
+that group was often missing. An indexed column also picks up an `idx` tag beside
+`null`, `gen` and `uniq`.

--- a/.changeset/schema-sidebar-reveal-and-icon-tips.md
+++ b/.changeset/schema-sidebar-reveal-and-icon-tips.md
@@ -1,0 +1,13 @@
+---
+"nestjs-doctor": patch
+---
+
+A synced table now sits at the top of the list, and the list's glyphs explain
+themselves.
+
+Revealing a table scrolled it only far enough to be visible, so it could land
+anywhere on screen with unrelated tables above it. It is now put directly under
+the sticky header, so the table you picked reads first and its columns follow.
+
+The key, link and index glyphs in the list say what they mean on hover, on the
+column rows and on the keys, foreign keys and indexes entries.

--- a/.changeset/schema-toolbar-and-column-icons.md
+++ b/.changeset/schema-toolbar-and-column-icons.md
@@ -1,0 +1,19 @@
+---
+"nestjs-doctor": patch
+---
+
+The schema diagram's zoom bar joins the other controls on one row, every control
+explains itself on hover, and columns are marked with what they are.
+
+The zoom bar sat on its own line below the toolbar. It is now part of the same
+row, so the diagram controls read as one group.
+
+Each control had a bare label like "Expand tables", which says what it is called
+but not what it does. They now carry a name and a short line of explanation,
+shown in a tooltip styled like the rest of the report rather than the browser's
+own.
+
+A table's columns were an undifferentiated list. A primary key, a foreign key and
+an indexed or unique column now each carry their own glyph, matching the icons
+already used in the sidebar tree. Foreign keys are matched from the entity's
+relations, by the property name or that name with an Id suffix.

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -196,13 +196,27 @@ for (let i = 0; i < lines.length; i++) {
             <path d="M11 11l2.5-3L16 11"/>
           </svg>
         </button>
+        <button class="st-btn has-tip" id="schema-sidebar-collapse" aria-label="Hide the table list" data-tip="Hide list \u00b7 give the diagram the whole width">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="9 3 4 8 9 13"/><line x1="13" y1="3" x2="13" y2="13"/>
+          </svg>
+        </button>
       </div>
+      <label class="schema-sync has-tip" data-tip="Sync \u00b7 the list follows the table you pick in the diagram">
+        <input type="checkbox" id="schema-sync-sidebar" checked>
+        <span>Sync with diagram</span>
+      </label>
       <div class="schema-disclaimer">Schema inferred from source code — may not reflect the actual database.</div>
     </div>
     <div id="schema-entity-list"></div>
   </div>
   <div id="schema-main">
     <div id="schema-canvas-wrap">
+      <button class="st-btn has-tip" id="schema-sidebar-show" aria-label="Show the table list" data-tip="Show list \u00b7 bring the table list back">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="7 3 12 8 7 13"/><line x1="3" y1="3" x2="3" y2="13"/>
+        </svg>
+      </button>
       <div id="schema-empty-state">
         <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -233,6 +233,22 @@ for (let i = 0; i < lines.length; i++) {
             <polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="14" y1="10" x2="21" y2="3"/><line x1="3" y1="21" x2="10" y2="14"/>
           </svg>
         </button>
+        <button class="st-btn schema-diagram-btn" id="schema-toggle-cols" title="Show every column">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="10" x2="20" y2="10"/>
+            <line x1="4" y1="14" x2="20" y2="14"/><line x1="4" y1="18" x2="20" y2="18"/>
+          </svg>
+        </button>
+      </div>
+      <div id="schema-zoombar">
+        <button class="st-btn schema-zoom-btn" id="schema-zoom-out" title="Zoom out">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        </button>
+        <input type="range" id="schema-zoom-range" min="5" max="300" step="1" value="100" title="Zoom">
+        <button class="st-btn schema-zoom-btn" id="schema-zoom-in" title="Zoom in">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        </button>
+        <button class="schema-zoom-value" id="schema-zoom-value" title="Fit to view">100%</button>
       </div>
       <canvas id="schema-canvas"></canvas>
       <div id="schema-tooltip" class="schema-tooltip" style="display:none"></div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -209,8 +209,15 @@ for (let i = 0; i < lines.length; i++) {
           <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
         </svg>
         <p>Select an entity from the sidebar to explore its schema</p>
+        <button class="st-btn schema-empty-action" id="schema-show-all">Show all tables</button>
       </div>
       <div id="schema-toolbar">
+        <button class="st-btn schema-diagram-btn" id="schema-toggle-view" title="Show all tables">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
+            <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
+          </svg>
+        </button>
         <button class="st-btn schema-diagram-btn" id="schema-recenter" title="Re-center diagram">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -230,11 +230,11 @@ for (let i = 0; i < lines.length; i++) {
         <button class="st-btn schema-zoom-btn has-tip" id="schema-zoom-out" aria-label="Zoom out" data-tip="Zoom out">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
         </button>
-        <input type="range" id="schema-zoom-range" min="5" max="300" step="1" value="100" aria-label="Zoom">
+        <input type="range" id="schema-zoom-range" min="5" max="500" step="1" value="100" aria-label="Zoom">
         <button class="st-btn schema-zoom-btn has-tip" id="schema-zoom-in" aria-label="Zoom in" data-tip="Zoom in">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
         </button>
-        <button class="schema-zoom-value has-tip" id="schema-zoom-value" aria-label="Fit to view" data-tip="Fit \u00b7 size the diagram to the window">100%</button>
+        <button class="schema-zoom-value has-tip" id="schema-zoom-value" aria-label="100% \u00b7 fit to view" data-tip="Fit \u00b7 size the diagram to the window">100%</button>
       </div>
         <button class="st-btn schema-diagram-btn has-tip" id="schema-toggle-view" aria-label="Show all tables" data-tip="All tables \u00b7 lay out the whole schema at once">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -184,13 +184,13 @@ for (let i = 0; i < lines.length; i++) {
         <span class="schema-sidebar-title" id="schema-sidebar-title">Tables</span>
         <span class="schema-entity-count" id="schema-entity-count"></span>
         <span style="flex:1"></span>
-        <button class="st-btn" id="schema-expand-all" title="Expand all">
+        <button class="st-btn has-tip" id="schema-expand-all" aria-label="Expand all" data-tip="Expand all \u00b7 open every table in the list">
           <svg viewBox="0 0 17 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <line x1="1" y1="3" x2="8" y2="3"/><line x1="1" y1="7" x2="8" y2="7"/><line x1="1" y1="11" x2="8" y2="11"/>
             <path d="M11 5l2.5 3L16 5"/>
           </svg>
         </button>
-        <button class="st-btn" id="schema-collapse-all" title="Collapse all">
+        <button class="st-btn has-tip" id="schema-collapse-all" aria-label="Collapse all" data-tip="Collapse all \u00b7 close every table in the list">
           <svg viewBox="0 0 17 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <line x1="1" y1="3" x2="8" y2="3"/><line x1="1" y1="7" x2="8" y2="7"/><line x1="1" y1="11" x2="8" y2="11"/>
             <path d="M11 11l2.5-3L16 11"/>
@@ -212,43 +212,43 @@ for (let i = 0; i < lines.length; i++) {
         <button class="st-btn schema-empty-action" id="schema-show-all">Show all tables</button>
       </div>
       <div id="schema-toolbar">
-        <button class="st-btn schema-diagram-btn" id="schema-toggle-view" title="Show all tables">
+      <div id="schema-zoombar">
+        <button class="st-btn schema-zoom-btn has-tip" id="schema-zoom-out" aria-label="Zoom out" data-tip="Zoom out">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        </button>
+        <input type="range" id="schema-zoom-range" min="5" max="300" step="1" value="100" aria-label="Zoom">
+        <button class="st-btn schema-zoom-btn has-tip" id="schema-zoom-in" aria-label="Zoom in" data-tip="Zoom in">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        </button>
+        <button class="schema-zoom-value has-tip" id="schema-zoom-value" aria-label="Fit to view" data-tip="Fit \u00b7 size the diagram to the window">100%</button>
+      </div>
+        <button class="st-btn schema-diagram-btn has-tip" id="schema-toggle-view" aria-label="Show all tables" data-tip="All tables \u00b7 lay out the whole schema at once">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
             <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
           </svg>
         </button>
-        <button class="st-btn schema-diagram-btn" id="schema-recenter" title="Re-center diagram">
+        <button class="st-btn schema-diagram-btn has-tip" id="schema-recenter" aria-label="Re-center diagram" data-tip="Re-center \u00b7 bring the diagram back into view">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/>
           </svg>
         </button>
-        <button class="st-btn schema-diagram-btn" id="schema-expand-tables" title="Expand tables">
+        <button class="st-btn schema-diagram-btn has-tip" id="schema-expand-tables" aria-label="Expand tables" data-tip="Expand \u00b7 show the columns inside each table">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/>
           </svg>
         </button>
-        <button class="st-btn schema-diagram-btn" id="schema-minimize-tables" title="Minimize tables">
+        <button class="st-btn schema-diagram-btn has-tip" id="schema-minimize-tables" aria-label="Minimize tables" data-tip="Minimize \u00b7 collapse tables to names only">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="14" y1="10" x2="21" y2="3"/><line x1="3" y1="21" x2="10" y2="14"/>
           </svg>
         </button>
-        <button class="st-btn schema-diagram-btn" id="schema-toggle-cols" title="Show every column">
+        <button class="st-btn schema-diagram-btn has-tip" id="schema-toggle-cols" aria-label="Show every column" data-tip="Every column \u00b7 stop cutting the list at seven">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="10" x2="20" y2="10"/>
             <line x1="4" y1="14" x2="20" y2="14"/><line x1="4" y1="18" x2="20" y2="18"/>
           </svg>
         </button>
-      </div>
-      <div id="schema-zoombar">
-        <button class="st-btn schema-zoom-btn" id="schema-zoom-out" title="Zoom out">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
-        </button>
-        <input type="range" id="schema-zoom-range" min="5" max="300" step="1" value="100" title="Zoom">
-        <button class="st-btn schema-zoom-btn" id="schema-zoom-in" title="Zoom in">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-        </button>
-        <button class="schema-zoom-value" id="schema-zoom-value" title="Fit to view">100%</button>
       </div>
       <canvas id="schema-canvas"></canvas>
       <div id="schema-tooltip" class="schema-tooltip" style="display:none"></div>

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -1830,6 +1830,8 @@ var sAllNodes = [];
 var sAllNodeMap = {};
 var sFocusedMode = false;
 var sShowCols = null;
+// Lowest zoom the wheel allows. Fitting a big overview can need less than this.
+var sMinZoom = 0.2;
 
 // Schema tooltip element
 var sTooltipEl = null;
@@ -2110,45 +2112,175 @@ function sPolylineMidpoint(points) {
   return { x: points[points.length - 1].x, y: points[points.length - 1].y };
 }
 
-// dagre layout computation
-function sComputeDagreLayout() {
-  if (typeof dagre === "undefined") {
-    // Fallback: simple grid layout
-    var cols = Math.max(1, Math.ceil(Math.sqrt(sNodes.length)));
-    for (var i = 0; i < sNodes.length; i++) {
-      sNodes[i].x = 300 + (i % cols) * 250;
-      sNodes[i].y = 200 + Math.floor(i / cols) * 120;
+/** Groups nodes into connected components using the relation edges. */
+function sComputeComponents(nodes) {
+  var index = {};
+  var parent = [];
+  for (var i = 0; i < nodes.length; i++) {
+    index[nodes[i].name] = i;
+    parent.push(i);
+  }
+  function find(a) {
+    while (parent[a] !== a) {
+      parent[a] = parent[parent[a]];
+      a = parent[a];
     }
-    sRouteAllEdges();
-    return;
+    return a;
   }
-
-  var g = new dagre.graphlib.Graph();
-  g.setGraph({ rankdir: "LR", nodesep: 60, ranksep: 120, marginx: 40, marginy: 40 });
-  g.setDefaultEdgeLabel(function() { return {}; });
-
-  for (var i = 0; i < sNodes.length; i++) {
-    g.setNode(sNodes[i].name, { width: sNodes[i].w, height: sNodes[i].h });
-  }
-
-  var seenEdge = {};
   for (var i = 0; i < schema.relations.length; i++) {
     var rel = schema.relations[i];
     if (rel.fromEntity === rel.toEntity) continue;
-    if (!sNodeMap[rel.fromEntity] || !sNodeMap[rel.toEntity]) continue;
-    var ek = sEdgeKey(rel.fromEntity, rel.toEntity);
+    var a = index[rel.fromEntity];
+    var b = index[rel.toEntity];
+    if (a === undefined || b === undefined) continue;
+    var ra = find(a), rb = find(b);
+    if (ra !== rb) parent[rb] = ra;
+  }
+  var groups = {};
+  for (var i = 0; i < nodes.length; i++) {
+    var root = find(i);
+    if (!groups[root]) groups[root] = [];
+    groups[root].push(nodes[i]);
+  }
+  var out = [];
+  for (var key in groups) {
+    if (Object.prototype.hasOwnProperty.call(groups, key)) out.push(groups[key]);
+  }
+  return out;
+}
+
+/** Lays one component out with dagre, positioned from its own origin. */
+function sLayoutComponent(nodes) {
+  var i;
+  if (nodes.length === 1 || typeof dagre === "undefined") {
+    var cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+    var cellW = 0, cellH = 0;
+    for (i = 0; i < nodes.length; i++) {
+      if (nodes[i].w > cellW) cellW = nodes[i].w;
+      if (nodes[i].h > cellH) cellH = nodes[i].h;
+    }
+    var rows = Math.ceil(nodes.length / cols);
+    for (i = 0; i < nodes.length; i++) {
+      nodes[i].x = (i % cols) * (cellW + 60) + cellW / 2;
+      nodes[i].y = Math.floor(i / cols) * (cellH + 60) + cellH / 2;
+    }
+    return {
+      w: cols * cellW + (cols - 1) * 60,
+      h: rows * cellH + (rows - 1) * 60
+    };
+  }
+
+  var g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir: "LR", nodesep: 60, ranksep: 120, marginx: 0, marginy: 0 });
+  g.setDefaultEdgeLabel(function() { return {}; });
+
+  var present = {};
+  for (i = 0; i < nodes.length; i++) {
+    present[nodes[i].name] = true;
+    g.setNode(nodes[i].name, { width: nodes[i].w, height: nodes[i].h });
+  }
+
+  var seenEdge = {};
+  for (i = 0; i < schema.relations.length; i++) {
+    var edge = schema.relations[i];
+    if (edge.fromEntity === edge.toEntity) continue;
+    if (!present[edge.fromEntity] || !present[edge.toEntity]) continue;
+    var ek = sEdgeKey(edge.fromEntity, edge.toEntity);
     if (seenEdge[ek]) continue;
     seenEdge[ek] = true;
-    g.setEdge(rel.fromEntity, rel.toEntity);
+    g.setEdge(edge.fromEntity, edge.toEntity);
   }
 
   dagre.layout(g);
 
-  for (var i = 0; i < sNodes.length; i++) {
-    var laid = g.node(sNodes[i].name);
-    if (laid) {
-      sNodes[i].x = laid.x;
-      sNodes[i].y = laid.y;
+  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (i = 0; i < nodes.length; i++) {
+    var laid = g.node(nodes[i].name);
+    if (!laid) continue;
+    nodes[i].x = laid.x;
+    nodes[i].y = laid.y;
+    minX = Math.min(minX, laid.x - nodes[i].w / 2);
+    maxX = Math.max(maxX, laid.x + nodes[i].w / 2);
+    minY = Math.min(minY, laid.y - nodes[i].h / 2);
+    maxY = Math.max(maxY, laid.y + nodes[i].h / 2);
+  }
+  if (minX === Infinity) return { w: 0, h: 0 };
+  for (i = 0; i < nodes.length; i++) {
+    nodes[i].x -= minX;
+    nodes[i].y -= minY;
+  }
+  return { w: maxX - minX, h: maxY - minY };
+}
+
+/** Packs unrelated tables into a compact grid instead of one long rank. */
+function sLayoutIsolatedBlock(nodes, gutter) {
+  var cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+  var cellW = 0, cellH = 0;
+  for (var i = 0; i < nodes.length; i++) {
+    if (nodes[i].w > cellW) cellW = nodes[i].w;
+    if (nodes[i].h > cellH) cellH = nodes[i].h;
+  }
+  var rows = Math.ceil(nodes.length / cols);
+  for (var j = 0; j < nodes.length; j++) {
+    nodes[j].x = (j % cols) * (cellW + gutter) + cellW / 2;
+    nodes[j].y = Math.floor(j / cols) * (cellH + gutter) + cellH / 2;
+  }
+  return {
+    w: cols * cellW + (cols - 1) * gutter,
+    h: rows * cellH + (rows - 1) * gutter
+  };
+}
+
+/** Shelf-packs component boxes into a roughly square area. */
+function sPackBoxes(boxes, targetW, gutter) {
+  var x = 0, y = 0, shelfH = 0;
+  for (var i = 0; i < boxes.length; i++) {
+    var box = boxes[i];
+    if (x > 0 && x + box.w > targetW) {
+      x = 0;
+      y += shelfH + gutter;
+      shelfH = 0;
+    }
+    box.ox = x;
+    box.oy = y;
+    x += box.w + gutter;
+    if (box.h > shelfH) shelfH = box.h;
+  }
+}
+
+function sComputeOverviewLayout() {
+  var GUTTER = 80;
+  var components = sComputeComponents(sNodes);
+  var boxes = [];
+  var isolated = [];
+  var i;
+
+  for (i = 0; i < components.length; i++) {
+    if (components[i].length === 1) {
+      isolated.push(components[i][0]);
+      continue;
+    }
+    var size = sLayoutComponent(components[i]);
+    boxes.push({ nodes: components[i], w: size.w, h: size.h });
+  }
+
+  boxes.sort(function(a, b) { return b.h - a.h || b.w - a.w; });
+
+  if (isolated.length > 0) {
+    var isoSize = sLayoutIsolatedBlock(isolated, 28);
+    boxes.push({ nodes: isolated, w: isoSize.w, h: isoSize.h });
+  }
+
+  var area = 0;
+  for (i = 0; i < boxes.length; i++) area += boxes[i].w * boxes[i].h;
+  var targetW = Math.max(900, Math.sqrt(area) * 1.6);
+  sPackBoxes(boxes, targetW, GUTTER);
+
+  for (i = 0; i < boxes.length; i++) {
+    var placed = boxes[i];
+    for (var j = 0; j < placed.nodes.length; j++) {
+      placed.nodes[j].x += placed.ox;
+      placed.nodes[j].y += placed.oy;
     }
   }
 
@@ -2221,6 +2353,37 @@ function sComputeStarLayout(centerName) {
   }
 }
 
+/**
+ * Truncation depends only on the fixed box width and font, never on zoom, so
+ * every label is measured once here instead of on every frame.
+ */
+function sCacheNodeLabels(nodes) {
+  if (!sCtx) return;
+  var BOX_W = 180;
+  var maxNameW = BOX_W - 20 - 8;
+  var maxMetaW = BOX_W - 16;
+  function clip(text, maxW) {
+    if (sCtx.measureText(text).width <= maxW) return text;
+    var out = text;
+    while (sCtx.measureText(out).width > maxW && out.length > 3) {
+      out = out.slice(0, -1);
+    }
+    return out + "\\u2026";
+  }
+  for (var i = 0; i < nodes.length; i++) {
+    var n = nodes[i];
+    sCtx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+    n.nameStr = clip(n.name, maxNameW);
+    sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+    n.metaStr = clip(n.entity.columns.length + " cols  \\u00b7  " + n.sizeLabel, maxMetaW);
+    sCtx.font = "10px monospace";
+    n.colTypes = [];
+    for (var c = 0; c < n.entity.columns.length; c++) {
+      n.colTypes.push(clip(n.entity.columns[c].type, 60));
+    }
+  }
+}
+
 function sSetVisibleSubset(entityName) {
   if (!sFocusedMode) return;
 
@@ -2281,8 +2444,10 @@ function sCenterCamera() {
 
   var padW = sW * 0.85;
   var padH = sH * 0.85;
-  sZoom = Math.min(1.5, Math.min(padW / (graphW || 1), padH / (graphH || 1)));
-  sZoom = Math.max(0.2, sZoom);
+  var fit = Math.min(1.5, Math.min(padW / (graphW || 1), padH / (graphH || 1)));
+  // A wide overview has to shrink past the normal floor to fit on screen.
+  sMinZoom = Math.min(0.2, fit);
+  sZoom = Math.max(sMinZoom, fit);
   sCamX = sW / 2 - cx;
   sCamY = sH / 2 - cy;
 }
@@ -2362,13 +2527,15 @@ function schemaDraw() {
     }
 
     // Cardinality label at polyline midpoint
-    var mid = sPolylineMidpoint(points);
-    var labelStr = sRelLabel(rel.type);
-    sCtx.font = (10 / sZoom) + "px monospace";
-    sCtx.textAlign = "center";
-    sCtx.textBaseline = "bottom";
-    sCtx.fillStyle = isHovered ? "#ffffff" : "#666";
-    sCtx.fillText(labelStr, mid.x, mid.y - 4 / sZoom);
+    if (sZoom >= 0.35) {
+      var mid = sPolylineMidpoint(points);
+      var labelStr = sRelLabel(rel.type);
+      sCtx.font = (10 / sZoom) + "px monospace";
+      sCtx.textAlign = "center";
+      sCtx.textBaseline = "bottom";
+      sCtx.fillStyle = isHovered ? "#ffffff" : "#666";
+      sCtx.fillText(labelStr, mid.x, mid.y - 4 / sZoom);
+    }
   }
   sCtx.globalAlpha = 1;
 
@@ -2450,21 +2617,18 @@ function schemaDraw() {
     sCtx.fillStyle = "#ea2845";
     sCtx.fillRect(iconX, iconY, iconSize, iconSize);
 
-    // Entity name (after icon)
-    sCtx.fillStyle = "#e0e0e0";
-    sCtx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
-    sCtx.textAlign = "left";
-    sCtx.textBaseline = "middle";
-    var nameStr = n.name;
-    var nameStartX = iconX + iconSize + 6;
-    var maxNameW = BOX_W - (nameStartX - x) - 8;
-    while (sCtx.measureText(nameStr).width > maxNameW && nameStr.length > 3) {
-      nameStr = nameStr.slice(0, -1);
+    // Entity name (after icon). Below this zoom the glyphs are sub-pixel mush.
+    if (sZoom >= 0.15) {
+      sCtx.fillStyle = "#e0e0e0";
+      sCtx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+      sCtx.textAlign = "left";
+      sCtx.textBaseline = "middle";
+      sCtx.fillText(n.nameStr || n.name, iconX + iconSize + 6, y + HDR_H / 2);
     }
-    if (nameStr !== n.name) nameStr += "\\u2026";
-    sCtx.fillText(nameStr, nameStartX, y + HDR_H / 2);
 
-    if (showCols) {
+    // Body text is skipped below this zoom, where a row is about one pixel tall.
+    var showBodyText = sZoom >= 0.35;
+    if (showCols && showBodyText) {
       // Draw column rows below header
       var colY = y + HDR_H;
       for (var c = 0; c < visibleColCount; c++) {
@@ -2479,12 +2643,7 @@ function schemaDraw() {
         sCtx.fillStyle = "#3b82f6";
         sCtx.font = "10px monospace";
         sCtx.textAlign = "right";
-        var typeStr = col.type;
-        while (sCtx.measureText(typeStr).width > 60 && typeStr.length > 3) {
-          typeStr = typeStr.slice(0, -1);
-        }
-        if (typeStr !== col.type) typeStr += "\\u2026";
-        sCtx.fillText(typeStr, x + BOX_W - 10, colY + COL_ROW_H / 2);
+        sCtx.fillText(n.colTypes ? n.colTypes[c] : col.type, x + BOX_W - 10, colY + COL_ROW_H / 2);
         colY += COL_ROW_H;
       }
       // "+N more" indicator
@@ -2494,19 +2653,11 @@ function schemaDraw() {
         sCtx.textAlign = "left";
         sCtx.fillText("+" + (cols.length - MAX_VISIBLE_COLS) + " more", x + 10, colY + COL_ROW_H / 2);
       }
-    } else {
+    } else if (!showCols && showBodyText) {
       // Meta line: "N cols · ~X KB"
       sCtx.fillStyle = "#666";
       sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
-      var metaStr = n.entity.columns.length + " cols  \\u00b7  " + n.sizeLabel;
-      var metaFull = metaStr;
-      var metaX = x + 8;
-      var maxMetaW = BOX_W - 16;
-      while (sCtx.measureText(metaStr).width > maxMetaW && metaStr.length > 3) {
-        metaStr = metaStr.slice(0, -1);
-      }
-      if (metaStr.length < metaFull.length) metaStr += "\\u2026";
-      sCtx.fillText(metaStr, metaX, y + HDR_H + (BOX_H - HDR_H) / 2);
+      sCtx.fillText(n.metaStr || "", x + 8, y + HDR_H + (BOX_H - HDR_H) / 2);
     }
   }
   sCtx.globalAlpha = 1;
@@ -2649,6 +2800,8 @@ function renderSchema() {
   for (var i = 0; i < sAllNodes.length; i++) {
     sAllNodeMap[sAllNodes[i].name] = sAllNodes[i];
   }
+  sCacheNodeLabels(sAllNodes);
+  // Starting mode only. The toolbar toggle switches it from here on.
   sFocusedMode = schema.entities.length > 7;
 
   // Set count badge
@@ -2911,6 +3064,53 @@ function renderSchema() {
     }
   }
 
+  var viewToggleBtn = document.getElementById("schema-toggle-view");
+
+  function sSyncViewToggle() {
+    if (!viewToggleBtn) return;
+    viewToggleBtn.classList.toggle("active", !sFocusedMode);
+    viewToggleBtn.title = sFocusedMode ? "Show all tables" : "Focus one table";
+  }
+
+  function sShowAllTables() {
+    sFocusedMode = false;
+    var emptyState = document.getElementById("schema-empty-state");
+    if (emptyState) emptyState.style.display = "none";
+    sCanvas.style.display = "block";
+    sNodes = sAllNodes.slice();
+    sNodeMap = {};
+    for (var i = 0; i < sNodes.length; i++) {
+      sNodeMap[sNodes[i].name] = sNodes[i];
+    }
+    sRecalcNodeSizes();
+    sComputeOverviewLayout();
+    sCenterCamera();
+    sSyncViewToggle();
+    sScheduleRedraw();
+  }
+
+  function sFocusOneTable() {
+    sFocusedMode = true;
+    sSetVisibleSubset(sSelectedEntity);
+    sSyncViewToggle();
+    sScheduleRedraw();
+  }
+
+  if (viewToggleBtn) {
+    viewToggleBtn.addEventListener("click", function() {
+      if (sFocusedMode) {
+        sShowAllTables();
+      } else {
+        sFocusOneTable();
+      }
+    });
+  }
+
+  var showAllBtn = document.getElementById("schema-show-all");
+  if (showAllBtn) {
+    showAllBtn.addEventListener("click", sShowAllTables);
+  }
+
   var recenterBtn = document.getElementById("schema-recenter");
   if (recenterBtn) {
     recenterBtn.addEventListener("click", function() {
@@ -2927,8 +3127,7 @@ function renderSchema() {
       if (sFocusedMode && sSelectedEntity) {
         sSetVisibleSubset(sSelectedEntity);
       } else {
-        sRouteAllEdges();
-        if (typeof dagre !== "undefined") sComputeDagreLayout();
+        sComputeOverviewLayout();
         sCenterCamera();
         sScheduleRedraw();
       }
@@ -2943,8 +3142,7 @@ function renderSchema() {
       if (sFocusedMode && sSelectedEntity) {
         sSetVisibleSubset(sSelectedEntity);
       } else {
-        sRouteAllEdges();
-        if (typeof dagre !== "undefined") sComputeDagreLayout();
+        sComputeOverviewLayout();
         sCenterCamera();
         sScheduleRedraw();
       }
@@ -2958,6 +3156,7 @@ function renderSchema() {
   });
 
   // Layout initialization
+  sSyncViewToggle();
   if (sFocusedMode) {
     var emptyState = document.getElementById("schema-empty-state");
     if (emptyState) emptyState.style.display = "flex";
@@ -2967,7 +3166,7 @@ function renderSchema() {
     sEdgeRoutes = {};
     sEdgeKeys = [];
   } else {
-    sComputeDagreLayout();
+    sComputeOverviewLayout();
     sCenterCamera();
   }
 
@@ -3073,7 +3272,7 @@ function renderSchema() {
   sCanvas.addEventListener("wheel", function(e) {
     e.preventDefault();
     var factor = e.deltaY > 0 ? 0.92 : 1.08;
-    sZoom = Math.max(0.2, Math.min(5, sZoom * factor));
+    sZoom = Math.max(sMinZoom, Math.min(5, sZoom * factor));
     sScheduleRedraw();
   }, { passive: false });
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2376,6 +2376,73 @@ function sComputeStarLayout(centerName) {
 /** Columns drawn per table before the "+N more" line, unless all are shown. */
 var S_DEFAULT_MAX_COLS = 7;
 
+var S_PK_COLOR = "#ea2845";
+var S_FK_COLOR = "#8b5cf6";
+var S_IDX_COLOR = "#f59e0b";
+
+/**
+ * A relation names the property, so the column holding the key is either that
+ * name or that name with an Id suffix.
+ */
+function sForeignKeyColumns(entity) {
+  var names = {};
+  for (var i = 0; i < entity.relations.length; i++) {
+    var prop = entity.relations[i].propertyName;
+    if (!prop) continue;
+    names[prop.toLowerCase()] = true;
+    names[prop.toLowerCase() + "id"] = true;
+  }
+  return names;
+}
+
+function sColumnKind(column, foreignKeys) {
+  if (column.isPrimary) return "pk";
+  if (foreignKeys[column.name.toLowerCase()]) return "fk";
+  if (column.isUnique || column.hasIndex) return "idx";
+  return null;
+}
+
+/** Draws the key, link or index glyph that marks what a column is. */
+function sDrawColumnIcon(ctx, kind, cx, cy) {
+  ctx.save();
+  ctx.lineWidth = 1.1;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  if (kind === "pk") {
+    ctx.strokeStyle = S_PK_COLOR;
+    ctx.beginPath();
+    ctx.arc(cx - 2, cy, 2.1, 0, Math.PI * 2);
+    ctx.moveTo(cx + 0.1, cy);
+    ctx.lineTo(cx + 4, cy);
+    ctx.moveTo(cx + 2.4, cy);
+    ctx.lineTo(cx + 2.4, cy + 1.8);
+    ctx.moveTo(cx + 4, cy);
+    ctx.lineTo(cx + 4, cy + 1.8);
+    ctx.stroke();
+  } else if (kind === "fk") {
+    ctx.strokeStyle = S_FK_COLOR;
+    ctx.beginPath();
+    ctx.arc(cx - 2.4, cy, 2, 0, Math.PI * 2);
+    ctx.moveTo(cx - 0.4, cy);
+    ctx.lineTo(cx + 4, cy);
+    ctx.moveTo(cx + 2.2, cy - 1.7);
+    ctx.lineTo(cx + 4, cy);
+    ctx.lineTo(cx + 2.2, cy + 1.7);
+    ctx.stroke();
+  } else if (kind === "idx") {
+    ctx.strokeStyle = S_IDX_COLOR;
+    ctx.beginPath();
+    ctx.moveTo(cx - 4, cy - 2.4);
+    ctx.lineTo(cx + 4, cy - 2.4);
+    ctx.moveTo(cx - 4, cy);
+    ctx.lineTo(cx + 1.6, cy);
+    ctx.moveTo(cx - 4, cy + 2.4);
+    ctx.lineTo(cx - 0.6, cy + 2.4);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
 function sVisibleColCount(node, showCols) {
   if (!showCols) return 0;
   var total = node.entity.columns.length;
@@ -2426,6 +2493,15 @@ function sCacheNodeLabels(nodes) {
     n.colTypes = [];
     for (var c = 0; c < n.entity.columns.length; c++) {
       n.colTypes.push(clip(n.entity.columns[c].type, 60));
+    }
+    // The icon column narrows the space a name can occupy.
+    var foreignKeys = sForeignKeyColumns(n.entity);
+    sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+    n.colNames = [];
+    n.colKinds = [];
+    for (var k = 0; k < n.entity.columns.length; k++) {
+      n.colNames.push(clip(n.entity.columns[k].name, 83));
+      n.colKinds.push(sColumnKind(n.entity.columns[k], foreignKeys));
     }
   }
 }
@@ -2679,12 +2755,16 @@ function schemaDraw() {
       var colY = y + HDR_H;
       for (var c = 0; c < visibleColCount; c++) {
         var col = cols[c];
-        // Column name (left-aligned)
-        sCtx.fillStyle = "#ccc";
+        // Key, link or index glyph, then the column name beside it
+        var kind = n.colKinds ? n.colKinds[c] : null;
+        if (kind) {
+          sDrawColumnIcon(sCtx, kind, x + 13, colY + COL_ROW_H / 2);
+        }
+        sCtx.fillStyle = kind === "pk" ? "#e0e0e0" : "#ccc";
         sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
         sCtx.textAlign = "left";
         sCtx.textBaseline = "middle";
-        sCtx.fillText(col.name, x + 10, colY + COL_ROW_H / 2);
+        sCtx.fillText(n.colNames ? n.colNames[c] : col.name, x + 21, colY + COL_ROW_H / 2);
         // Column type (right-aligned, dimmer)
         sCtx.fillStyle = "#3b82f6";
         sCtx.font = "10px monospace";
@@ -3108,7 +3188,9 @@ function renderSchema() {
   function sSyncViewToggle() {
     if (!viewToggleBtn) return;
     viewToggleBtn.classList.toggle("active", !sFocusedMode);
-    viewToggleBtn.title = sFocusedMode ? "Show all tables" : "Focus one table";
+    viewToggleBtn.setAttribute("data-tip", sFocusedMode
+      ? "All tables \u00b7 lay out the whole schema at once"
+      : "Focus \u00b7 show one table and what it relates to");
   }
 
   function sShowAllTables() {
@@ -3178,9 +3260,9 @@ function renderSchema() {
       sShowAllCols = !sShowAllCols;
       if (sShowAllCols) sShowCols = true;
       toggleColsBtn.classList.toggle("active", sShowAllCols);
-      toggleColsBtn.title = sShowAllCols
-        ? "Show the first " + S_DEFAULT_MAX_COLS + " columns"
-        : "Show every column";
+      toggleColsBtn.setAttribute("data-tip", sShowAllCols
+        ? "First " + S_DEFAULT_MAX_COLS + " \u00b7 go back to a short column list"
+        : "Every column \u00b7 stop cutting the list at seven");
       sRelayoutForSizeChange();
     });
   }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2448,6 +2448,9 @@ function sCenterCamera() {
   // A wide overview has to shrink past the normal floor to fit on screen.
   sMinZoom = Math.min(0.2, fit);
   sZoom = Math.max(sMinZoom, fit);
+  // Fitting everything is pointless when it shrinks the columns out of sight.
+  var showingCols = sShowCols !== null ? sShowCols : sNodes.length <= 5;
+  if (showingCols && sZoom < 0.35) sZoom = 0.35;
   sCamX = sW / 2 - cx;
   sCamY = sH / 2 - cy;
 }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2983,9 +2983,14 @@ function renderSchema() {
       var colGroupId = entityId + "-cols";
       sidebarHtml += sBuildTreeRow(2, colGroupId, ICON_FOLDER_CLOSED, '<span class="st-group-name">columns</span>', '<span class="st-count">' + entity.columns.length + '</span>', "", "");
       sidebarHtml += '<div class="st-children" id="st-' + colGroupId + '">';
+      var entityForeignKeys = sForeignKeyColumns(entity);
       for (var c = 0; c < entity.columns.length; c++) {
         var col = entity.columns[c];
-        var colIcon = col.isPrimary ? ICON_KEY : ICON_COLUMN;
+        var colKind = sColumnKind(col, entityForeignKeys);
+        var colIcon = colKind === "pk" ? ICON_KEY
+          : colKind === "fk" ? ICON_FK
+          : colKind === "idx" ? ICON_INDEX
+          : ICON_COLUMN;
         var colExtra = '<span class="st-col-type">' + escHtml(col.type) + '</span>';
         if (col.defaultValue) {
           colExtra += '<span class="st-col-default">= ' + escHtml(col.defaultValue) + '</span>';
@@ -2994,6 +2999,7 @@ function renderSchema() {
         if (col.isNullable) colTags.push("null");
         if (col.isGenerated) colTags.push("gen");
         if (col.isUnique && !col.isPrimary) colTags.push("uniq");
+        if (col.hasIndex && !(col.isPrimary || col.isUnique)) colTags.push("idx");
         if (colTags.length > 0) {
           colExtra += '<span class="st-col-tags">' + colTags.join(" \\u00B7 ") + '</span>';
         }
@@ -3035,7 +3041,8 @@ function renderSchema() {
     // Indexes group (unique non-PK columns)
     var indexes = [];
     for (var c = 0; c < entity.columns.length; c++) {
-      if (entity.columns[c].isUnique && !entity.columns[c].isPrimary) indexes.push(entity.columns[c]);
+      var idxCol = entity.columns[c];
+      if (!idxCol.isPrimary && (idxCol.isUnique || idxCol.hasIndex)) indexes.push(idxCol);
     }
     if (indexes.length > 0) {
       var idxGroupId = entityId + "-idx";

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -1837,6 +1837,7 @@ var sAllNodes = [];
 var sAllNodeMap = {};
 var sFocusedMode = false;
 var sShowCols = null;
+var sShowAllCols = false;
 // Lowest zoom the wheel allows. Fitting a big overview can need less than this.
 var sMinZoom = 0.2;
 
@@ -1851,6 +1852,18 @@ function sScheduleRedraw() {
     sSchemaDirty = true;
     requestAnimationFrame(function() { sSchemaDirty = false; schemaDraw(); });
   }
+}
+
+var sLastZoomUi = null;
+/** Keeps the zoom bar in step with the camera, whatever changed it. */
+function sSyncZoomUi() {
+  var pct = Math.round(sZoom * 100);
+  if (pct === sLastZoomUi) return;
+  sLastZoomUi = pct;
+  var range = document.getElementById("schema-zoom-range");
+  var label = document.getElementById("schema-zoom-value");
+  if (range) range.value = String(Math.max(5, Math.min(300, pct)));
+  if (label) label.textContent = pct + "%";
 }
 
 function sScreenToWorld(sx, sy) {
@@ -2360,6 +2373,32 @@ function sComputeStarLayout(centerName) {
   }
 }
 
+/** Columns drawn per table before the "+N more" line, unless all are shown. */
+var S_DEFAULT_MAX_COLS = 7;
+
+function sVisibleColCount(node, showCols) {
+  if (!showCols) return 0;
+  var total = node.entity.columns.length;
+  return sShowAllCols ? total : Math.min(total, S_DEFAULT_MAX_COLS);
+}
+
+function sNodeHeight(node, showCols) {
+  if (!showCols) return 52;
+  var visible = sVisibleColCount(node, showCols);
+  var hidden = node.entity.columns.length - visible;
+  return 24 + visible * 16 + (hidden > 0 ? 16 : 0) + 8;
+}
+
+/** Single source of truth for box size, used by both layout and drawing. */
+function sApplyNodeSizes(nodes) {
+  var showCols = sShowCols !== null ? sShowCols : nodes.length <= 5;
+  for (var i = 0; i < nodes.length; i++) {
+    nodes[i].w = 180;
+    nodes[i].h = sNodeHeight(nodes[i], showCols);
+  }
+  return showCols;
+}
+
 /**
  * Truncation depends only on the fixed box width and font, never on zoom, so
  * every label is measured once here instead of on every frame.
@@ -2419,14 +2458,7 @@ function sSetVisibleSubset(entityName) {
     }
   }
 
-  var showCols = sShowCols !== null ? sShowCols : sNodes.length <= 5;
-  for (var i = 0; i < sNodes.length; i++) {
-    var cols = sNodes[i].entity.columns;
-    var visCount = showCols ? Math.min(cols.length, 7) : 0;
-    var hasMore = showCols && cols.length > 7;
-    sNodes[i].h = showCols ? 24 + visCount * 16 + (hasMore ? 16 : 0) + 8 : 52;
-    sNodes[i].w = 180;
-  }
+  sApplyNodeSizes(sNodes);
 
   sComputeStarLayout(entityName);
   sRouteAllEdges();
@@ -2487,6 +2519,7 @@ function sRoundRect(ctx, x, y, w, h, r) {
 
 // Drawing
 function schemaDraw() {
+  sSyncZoomUi();
   if (sNodes.length === 0) return;
   sCtx.save();
   sCtx.clearRect(0, 0, sW, sH);
@@ -2562,19 +2595,14 @@ function schemaDraw() {
   var R = 6;
   var HDR_H = 24;
   var COL_ROW_H = 16;
-  var MAX_VISIBLE_COLS = 7;
-  var showCols = sShowCols !== null ? sShowCols : sNodes.length <= 5;
+  var showCols = sApplyNodeSizes(sNodes);
 
   for (var i = 0; i < sNodes.length; i++) {
     var n = sNodes[i];
     var cols = n.entity.columns;
-    var visibleColCount = showCols ? Math.min(cols.length, MAX_VISIBLE_COLS) : 0;
-    var hasMore = showCols && cols.length > MAX_VISIBLE_COLS;
-    var BOX_H = showCols
-      ? HDR_H + visibleColCount * COL_ROW_H + (hasMore ? COL_ROW_H : 0) + 8
-      : 52;
-    n.w = BOX_W;
-    n.h = BOX_H;
+    var visibleColCount = sVisibleColCount(n, showCols);
+    var hasMore = cols.length > visibleColCount;
+    var BOX_H = n.h;
 
     var x = n.x - BOX_W / 2;
     var y = n.y - BOX_H / 2;
@@ -2669,7 +2697,7 @@ function schemaDraw() {
         sCtx.fillStyle = "#666";
         sCtx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
         sCtx.textAlign = "left";
-        sCtx.fillText("+" + (cols.length - MAX_VISIBLE_COLS) + " more", x + 10, colY + COL_ROW_H / 2);
+        sCtx.fillText("+" + (cols.length - visibleColCount) + " more", x + 10, colY + COL_ROW_H / 2);
       }
     } else if (!showCols && showBodyText) {
       // Meta line: "N cols · ~X KB"
@@ -3072,14 +3100,7 @@ function renderSchema() {
 
   // Diagram control buttons
   function sRecalcNodeSizes() {
-    var showCols = sShowCols !== null ? sShowCols : sNodes.length <= 5;
-    for (var i = 0; i < sNodes.length; i++) {
-      var cols = sNodes[i].entity.columns;
-      var visCount = showCols ? Math.min(cols.length, 7) : 0;
-      var hasMore = showCols && cols.length > 7;
-      sNodes[i].h = showCols ? 24 + visCount * 16 + (hasMore ? 16 : 0) + 8 : 52;
-      sNodes[i].w = 180;
-    }
+    sApplyNodeSizes(sNodes);
   }
 
   var viewToggleBtn = document.getElementById("schema-toggle-view");
@@ -3135,6 +3156,61 @@ function renderSchema() {
   if (recenterBtn) {
     recenterBtn.addEventListener("click", function() {
       sCenterCamera();
+      sScheduleRedraw();
+    });
+  }
+
+  // Relayout after a size change so the taller boxes do not overlap.
+  function sRelayoutForSizeChange() {
+    sRecalcNodeSizes();
+    if (sFocusedMode && sSelectedEntity) {
+      sSetVisibleSubset(sSelectedEntity);
+    } else if (!sFocusedMode) {
+      sComputeOverviewLayout();
+      sCenterCamera();
+      sScheduleRedraw();
+    }
+  }
+
+  var toggleColsBtn = document.getElementById("schema-toggle-cols");
+  if (toggleColsBtn) {
+    toggleColsBtn.addEventListener("click", function() {
+      sShowAllCols = !sShowAllCols;
+      if (sShowAllCols) sShowCols = true;
+      toggleColsBtn.classList.toggle("active", sShowAllCols);
+      toggleColsBtn.title = sShowAllCols
+        ? "Show the first " + S_DEFAULT_MAX_COLS + " columns"
+        : "Show every column";
+      sRelayoutForSizeChange();
+    });
+  }
+
+  var zoomRange = document.getElementById("schema-zoom-range");
+  var zoomInBtn = document.getElementById("schema-zoom-in");
+  var zoomOutBtn = document.getElementById("schema-zoom-out");
+  var zoomValueBtn = document.getElementById("schema-zoom-value");
+
+  function sSetZoom(next) {
+    sZoom = Math.max(Math.min(sMinZoom, 0.05), Math.min(5, next));
+    sSyncZoomUi();
+    sScheduleRedraw();
+  }
+
+  if (zoomRange) {
+    zoomRange.addEventListener("input", function() {
+      sSetZoom(Number(zoomRange.value) / 100);
+    });
+  }
+  if (zoomInBtn) {
+    zoomInBtn.addEventListener("click", function() { sSetZoom(sZoom * 1.2); });
+  }
+  if (zoomOutBtn) {
+    zoomOutBtn.addEventListener("click", function() { sSetZoom(sZoom / 1.2); });
+  }
+  if (zoomValueBtn) {
+    zoomValueBtn.addEventListener("click", function() {
+      sCenterCamera();
+      sSyncZoomUi();
       sScheduleRedraw();
     });
   }
@@ -3272,6 +3348,15 @@ function renderSchema() {
       sSyncSidebarHighlight(sSelectedEntity);
       if (sFocusedMode) {
         sSetVisibleSubset(sSelectedEntity);
+      } else {
+        sScheduleRedraw();
+      }
+    } else if (sPanning && !sDragMoved && sSelectedEntity) {
+      // A click on empty canvas clears the selection.
+      sSelectedEntity = null;
+      sSyncSidebarHighlight(null);
+      if (sFocusedMode) {
+        sSetVisibleSubset(null);
       } else {
         sScheduleRedraw();
       }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2958,7 +2958,7 @@ function renderSchema() {
   var ICON_INDEX = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--cat-performance)" stroke-width="1.2"><line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="8" x2="10" y2="8"/><line x1="3" y1="12" x2="7" y2="12"/></svg>';
 
   // Tree row builder
-  function sBuildTreeRow(depth, toggleId, icon, labelHtml, extra, classes, dataAttrs) {
+  function sBuildTreeRow(depth, toggleId, icon, labelHtml, extra, classes, dataAttrs, iconTip) {
     var h = '<div class="st-row' + (classes ? " " + classes : "") + '"' + (dataAttrs || "") + '>';
     for (var d = 0; d < depth; d++) h += '<span class="st-indent"></span>';
     if (toggleId) {
@@ -2966,12 +2966,18 @@ function renderSchema() {
     } else {
       h += '<span class="st-indent"></span>';
     }
-    h += '<span class="st-icon">' + icon + '</span>';
+    h += iconTip
+      ? '<span class="st-icon has-tip" data-tip="' + escHtml(iconTip) + '">' + icon + '</span>'
+      : '<span class="st-icon">' + icon + '</span>';
     h += '<span class="st-label">' + labelHtml + '</span>';
     if (extra) h += extra;
     h += '</div>';
     return h;
   }
+
+  var TIP_PK = "Primary key \u00b7 identifies the row";
+  var TIP_FK = "Foreign key \u00b7 points at another table";
+  var TIP_IDX = "Indexed \u00b7 unique or carries an index";
 
   // Build sidebar tree
   var sidebarHtml = "";
@@ -3011,7 +3017,11 @@ function renderSchema() {
         if (colTags.length > 0) {
           colExtra += '<span class="st-col-tags">' + colTags.join(" \\u00B7 ") + '</span>';
         }
-        sidebarHtml += sBuildTreeRow(3, null, colIcon, escHtml(col.name), colExtra, "", "");
+        var colTip = colKind === "pk" ? TIP_PK
+          : colKind === "fk" ? TIP_FK
+          : colKind === "idx" ? TIP_IDX
+          : "";
+        sidebarHtml += sBuildTreeRow(3, null, colIcon, escHtml(col.name), colExtra, "", "", colTip);
       }
       sidebarHtml += '</div>';
     }
@@ -3028,7 +3038,7 @@ function renderSchema() {
       var pkColNames = [];
       for (var p = 0; p < pks.length; p++) { pkColNames.push(pks[p].name); }
       var pkLabel = escHtml((entity.tableName || entity.name).toLowerCase() + '_pkey');
-      sidebarHtml += sBuildTreeRow(3, null, ICON_KEY, pkLabel, '<span class="st-col-type">(' + escHtml(pkColNames.join(", ")) + ')</span>', "", "");
+      sidebarHtml += sBuildTreeRow(3, null, ICON_KEY, pkLabel, '<span class="st-col-type">(' + escHtml(pkColNames.join(", ")) + ')</span>', "", "", TIP_PK);
       sidebarHtml += '</div>';
     }
 
@@ -3041,7 +3051,7 @@ function renderSchema() {
         var rel = entity.relations[r];
         var relLabel = sRelLabel(rel.type);
         var fkName = escHtml((entity.tableName || entity.name).toLowerCase() + '_' + rel.propertyName + '_fkey');
-        sidebarHtml += sBuildTreeRow(3, null, ICON_FK, fkName, '<span class="st-col-type">(' + escHtml(rel.propertyName) + ')</span>' + '<span class="st-rel-type">' + relLabel + '</span>', "", "");
+        sidebarHtml += sBuildTreeRow(3, null, ICON_FK, fkName, '<span class="st-col-type">(' + escHtml(rel.propertyName) + ')</span>' + '<span class="st-rel-type">' + relLabel + '</span>', "", "", TIP_FK);
       }
       sidebarHtml += '</div>';
     }
@@ -3057,7 +3067,7 @@ function renderSchema() {
       sidebarHtml += sBuildTreeRow(2, idxGroupId, ICON_FOLDER_CLOSED, '<span class="st-group-name">indexes</span>', '<span class="st-count">' + indexes.length + '</span>', "", "");
       sidebarHtml += '<div class="st-children" id="st-' + idxGroupId + '">';
       for (var x = 0; x < indexes.length; x++) {
-        sidebarHtml += sBuildTreeRow(3, null, ICON_INDEX, escHtml(indexes[x].name), '<span class="st-col-type">' + escHtml(indexes[x].type) + '</span>', "", "");
+        sidebarHtml += sBuildTreeRow(3, null, ICON_INDEX, escHtml(indexes[x].name), '<span class="st-col-type">' + escHtml(indexes[x].type) + '</span>', "", "", TIP_IDX);
       }
       sidebarHtml += '</div>';
     }
@@ -3205,7 +3215,14 @@ function renderSchema() {
         }
       }
     }
-    row.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    // Put the table at the top of the list, just under the sticky header, so
+    // its own columns are what follows it.
+    var panel = document.getElementById("schema-sidebar");
+    if (!panel) return;
+    var sticky = panel.querySelector(".schema-sidebar-sticky");
+    var stickyH = sticky ? sticky.getBoundingClientRect().height : 0;
+    var delta = row.getBoundingClientRect().top - panel.getBoundingClientRect().top - stickyH;
+    panel.scrollTop = panel.scrollTop + delta;
   }
 
   /** Mirrors the diagram's selection into the list, when asked to. */

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -1838,6 +1838,8 @@ var sAllNodeMap = {};
 var sFocusedMode = false;
 var sShowCols = null;
 var sShowAllCols = false;
+// When on, picking a table in the diagram drives the list beside it.
+var sSyncSidebar = true;
 // Lowest zoom the wheel allows. Fitting a big overview can need less than this.
 var sMinZoom = 0.2;
 
@@ -2861,8 +2863,14 @@ function sHideRelBadge() {
 // Canvas resize for schema
 function sResize() {
   var container = sCanvas.parentElement;
+  var prevW = sW, prevH = sH;
   sW = container.clientWidth;
   sH = container.clientHeight;
+  // Keep whatever was in the middle of the viewport in the middle of it.
+  if (prevW && prevH) {
+    sCamX += (sW - prevW) / 2;
+    sCamY += (sH - prevH) / 2;
+  }
   sCanvas.width = sW * sDpr;
   sCanvas.height = sH * sDpr;
   sCanvas.style.width = sW + "px";
@@ -3117,7 +3125,7 @@ function renderSchema() {
 
     // Always select clicked entity (never deselect on close)
     sSelectedEntity = entityName;
-    sSyncSidebarHighlight(sSelectedEntity);
+    if (sSyncSidebar) sSyncSidebarHighlight(sSelectedEntity);
 
     // Toggle entity subtree open/closed (skip if arrow already handled it)
     if (!toggleAlreadyHandled) {
@@ -3147,6 +3155,94 @@ function renderSchema() {
   var collapseAllBtn = document.getElementById("schema-collapse-all");
   var entityListEl = document.getElementById("schema-entity-list");
 
+  /** Closes every table, leaving the root list itself open. */
+  function sCollapseTree() {
+    if (!entityListEl) return;
+    var children = entityListEl.querySelectorAll(".st-children");
+    for (var i = 0; i < children.length; i++) {
+      var isRoot = children[i].id && children[i].id.indexOf("st-root-") === 0;
+      if (isRoot) continue;
+      children[i].classList.remove("st-open");
+    }
+    var toggles = entityListEl.querySelectorAll(".st-toggle");
+    for (var j = 0; j < toggles.length; j++) {
+      var owned = document.getElementById("st-" + toggles[j].dataset.toggle);
+      var open = owned ? owned.classList.contains("st-open") : false;
+      toggles[j].textContent = open ? "\\u25BE" : "\\u25B8";
+    }
+    var entityRows = entityListEl.querySelectorAll(".st-row[data-entity]");
+    for (var k = 0; k < entityRows.length; k++) {
+      var ico = entityRows[k].querySelector(".st-icon");
+      if (ico) ico.innerHTML = ICON_TABLE;
+    }
+  }
+
+  /** Opens one table and its columns, and scrolls the list to it. */
+  function sRevealEntity(name) {
+    if (!entityListEl) return;
+    var rows = entityListEl.querySelectorAll(".st-row[data-entity]");
+    var row = null;
+    for (var i = 0; i < rows.length; i++) {
+      if (rows[i].dataset.entity === name) { row = rows[i]; break; }
+    }
+    if (!row) return;
+    var toggle = row.querySelector(".st-toggle");
+    var subtree = toggle ? document.getElementById("st-" + toggle.dataset.toggle) : null;
+    if (subtree) {
+      subtree.classList.add("st-open");
+      toggle.textContent = "\\u25BE";
+      var icon = row.querySelector(".st-icon");
+      if (icon) icon.innerHTML = ICON_TABLE_OPEN;
+      var groupRow = subtree.querySelector(".st-row");
+      var groupToggle = groupRow ? groupRow.querySelector(".st-toggle") : null;
+      if (groupToggle) {
+        var group = document.getElementById("st-" + groupToggle.dataset.toggle);
+        if (group) {
+          group.classList.add("st-open");
+          groupToggle.textContent = "\\u25BE";
+          var groupIcon = groupRow.querySelector(".st-icon");
+          if (groupIcon) groupIcon.innerHTML = ICON_FOLDER_OPEN;
+        }
+      }
+    }
+    row.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }
+
+  /** Mirrors the diagram's selection into the list, when asked to. */
+  function sReflectSelection() {
+    if (!sSyncSidebar) return;
+    sSyncSidebarHighlight(sSelectedEntity);
+    if (sSelectedEntity) {
+      sRevealEntity(sSelectedEntity);
+    } else {
+      sCollapseTree();
+    }
+  }
+
+  var syncBox = document.getElementById("schema-sync-sidebar");
+  if (syncBox) {
+    sSyncSidebar = syncBox.checked;
+    syncBox.addEventListener("change", function() {
+      sSyncSidebar = syncBox.checked;
+      if (sSyncSidebar) sReflectSelection();
+    });
+  }
+
+  var sidebarCollapseBtn = document.getElementById("schema-sidebar-collapse");
+  var sidebarShowBtn = document.getElementById("schema-sidebar-show");
+  var schemaTab = document.getElementById("tab-schema");
+  function sSetSidebarCollapsed(collapsed) {
+    if (!schemaTab) return;
+    schemaTab.classList.toggle("sidebar-collapsed", collapsed);
+    sResize();
+  }
+  if (sidebarCollapseBtn) {
+    sidebarCollapseBtn.addEventListener("click", function() { sSetSidebarCollapsed(true); });
+  }
+  if (sidebarShowBtn) {
+    sidebarShowBtn.addEventListener("click", function() { sSetSidebarCollapsed(false); });
+  }
+
   if (expandAllBtn && entityListEl) {
     expandAllBtn.addEventListener("click", function() {
       var children = entityListEl.querySelectorAll(".st-children");
@@ -3166,23 +3262,7 @@ function renderSchema() {
   }
 
   if (collapseAllBtn && entityListEl) {
-    collapseAllBtn.addEventListener("click", function() {
-      var children = entityListEl.querySelectorAll(".st-children");
-      for (var i = 0; i < children.length; i++) {
-        // Keep root-level groups open so entity list stays visible
-        if (children[i].id && children[i].id.indexOf("st-root-") === 0) continue;
-        children[i].classList.remove("st-open");
-      }
-      var toggles = entityListEl.querySelectorAll(".st-toggle");
-      for (var j = 0; j < toggles.length; j++) {
-        toggles[j].textContent = "\\u25B8";
-      }
-      var entityRows = entityListEl.querySelectorAll(".st-row[data-entity]");
-      for (var k = 0; k < entityRows.length; k++) {
-        var ico = entityRows[k].querySelector(".st-icon");
-        if (ico) ico.innerHTML = ICON_TABLE;
-      }
-    });
+    collapseAllBtn.addEventListener("click", sCollapseTree);
   }
 
   // Diagram control buttons
@@ -3434,7 +3514,7 @@ function renderSchema() {
   sCanvas.addEventListener("mouseup", function() {
     if (sDragging && !sDragMoved) {
       sSelectedEntity = sSelectedEntity === sDragging.name ? null : sDragging.name;
-      sSyncSidebarHighlight(sSelectedEntity);
+      sReflectSelection();
       if (sFocusedMode) {
         sSetVisibleSubset(sSelectedEntity);
       } else {
@@ -3443,7 +3523,7 @@ function renderSchema() {
     } else if (sPanning && !sDragMoved && sSelectedEntity) {
       // A click on empty canvas clears the selection.
       sSelectedEntity = null;
-      sSyncSidebarHighlight(null);
+      sReflectSelection();
       if (sFocusedMode) {
         sSetVisibleSubset(null);
       } else {

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -325,8 +325,15 @@ canvas.addEventListener("click", (e) => {
 
 canvas.addEventListener("wheel", (e) => {
   e.preventDefault();
-  const factor = e.deltaY > 0 ? 0.92 : 1.08;
-  zoom = Math.max(0.1, Math.min(5, zoom * factor));
+  // A trackpad pinch arrives as a wheel event with ctrlKey set. Everything
+  // else is a two-finger scroll, which pans.
+  if (e.ctrlKey || e.metaKey) {
+    const factor = e.deltaY > 0 ? 0.92 : 1.08;
+    zoom = Math.max(0.1, Math.min(5, zoom * factor));
+  } else {
+    camX -= e.deltaX / zoom;
+    camY -= e.deltaY / zoom;
+  }
 }, { passive: false });
 
 document.getElementById("close-detail").addEventListener("click", () => {
@@ -3284,8 +3291,17 @@ function renderSchema() {
 
   sCanvas.addEventListener("wheel", function(e) {
     e.preventDefault();
-    var factor = e.deltaY > 0 ? 0.92 : 1.08;
-    sZoom = Math.max(sMinZoom, Math.min(5, sZoom * factor));
+    // A trackpad pinch arrives as a wheel event with ctrlKey set. Everything
+    // else is a two-finger scroll, which pans.
+    if (e.ctrlKey || e.metaKey) {
+      var factor = e.deltaY > 0 ? 0.92 : 1.08;
+      sZoom = Math.max(sMinZoom, Math.min(5, sZoom * factor));
+    } else {
+      sCamX -= e.deltaX / sZoom;
+      sCamY -= e.deltaY / sZoom;
+      sHideTooltip();
+      sHideRelBadge();
+    }
     sScheduleRedraw();
   }, { passive: false });
 
@@ -4008,6 +4024,15 @@ function renderEndpoints() {
 
   epCanvas.addEventListener("wheel", function(e) {
     e.preventDefault();
+    // A trackpad pinch arrives as a wheel event with ctrlKey set. Everything
+    // else is a two-finger scroll, which pans.
+    if (!(e.ctrlKey || e.metaKey)) {
+      epCamX -= e.deltaX / epZoom;
+      epCamY -= e.deltaY / epZoom;
+      epHideTooltip();
+      epScheduleRedraw();
+      return;
+    }
     var zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;
     var newZoom = epZoom * zoomFactor;
     newZoom = Math.max(0.2, Math.min(3, newZoom));

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -325,8 +325,7 @@ canvas.addEventListener("click", (e) => {
 
 canvas.addEventListener("wheel", (e) => {
   e.preventDefault();
-  // A trackpad pinch arrives as a wheel event with ctrlKey set. Everything
-  // else is a two-finger scroll, which pans.
+  // ctrlKey or metaKey means a pinch, which zooms; anything else pans.
   if (e.ctrlKey || e.metaKey) {
     const factor = e.deltaY > 0 ? 0.92 : 1.08;
     zoom = Math.max(0.1, Math.min(5, zoom * factor));
@@ -1840,7 +1839,7 @@ var sShowCols = null;
 var sShowAllCols = false;
 // When on, picking a table in the diagram drives the list beside it.
 var sSyncSidebar = true;
-// Lowest zoom the wheel allows. Fitting a big overview can need less than this.
+// The fit zoom of the current layout.
 var sMinZoom = 0.2;
 
 // Schema tooltip element
@@ -1856,6 +1855,11 @@ function sScheduleRedraw() {
   }
 }
 
+/** Lowest zoom either control allows, low enough to fit a large diagram. */
+function sZoomFloor() {
+  return Math.min(sMinZoom, 0.05);
+}
+
 var sLastZoomUi = null;
 /** Keeps the zoom bar in step with the camera, whatever changed it. */
 function sSyncZoomUi() {
@@ -1864,8 +1868,11 @@ function sSyncZoomUi() {
   sLastZoomUi = pct;
   var range = document.getElementById("schema-zoom-range");
   var label = document.getElementById("schema-zoom-value");
-  if (range) range.value = String(Math.max(5, Math.min(300, pct)));
-  if (label) label.textContent = pct + "%";
+  if (range) range.value = String(Math.max(5, Math.min(500, pct)));
+  if (label) {
+    label.textContent = pct + "%";
+    label.setAttribute("aria-label", pct + "% \\u00b7 fit to view");
+  }
 }
 
 function sScreenToWorld(sx, sy) {
@@ -2171,7 +2178,7 @@ function sComputeComponents(nodes) {
   return out;
 }
 
-/** Lays one component out with dagre, positioned from its own origin. */
+/** Positions one component from its own origin, with dagre or a grid. */
 function sLayoutComponent(nodes) {
   var i;
   if (nodes.length === 1 || typeof dagre === "undefined") {
@@ -2382,24 +2389,25 @@ var S_PK_COLOR = "#ea2845";
 var S_FK_COLOR = "#8b5cf6";
 var S_IDX_COLOR = "#f59e0b";
 
-/**
- * A relation names the property, so the column holding the key is either that
- * name or that name with an Id suffix.
- */
+/** Names a relation's property and that property with an Id suffix. */
+function sKeyName(text) {
+  return String(text).toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 function sForeignKeyColumns(entity) {
-  var names = {};
+  var names = Object.create(null);
   for (var i = 0; i < entity.relations.length; i++) {
     var prop = entity.relations[i].propertyName;
     if (!prop) continue;
-    names[prop.toLowerCase()] = true;
-    names[prop.toLowerCase() + "id"] = true;
+    names[sKeyName(prop)] = true;
+    names[sKeyName(prop) + "id"] = true;
   }
   return names;
 }
 
 function sColumnKind(column, foreignKeys) {
   if (column.isPrimary) return "pk";
-  if (foreignKeys[column.name.toLowerCase()]) return "fk";
+  if (foreignKeys[sKeyName(column.name)]) return "fk";
   if (column.isUnique || column.hasIndex) return "idx";
   return null;
 }
@@ -2458,9 +2466,15 @@ function sNodeHeight(node, showCols) {
   return 24 + visible * 16 + (hidden > 0 ? 16 : 0) + 8;
 }
 
+/** The overview shows columns; a focused star shows them for a small set. */
+function sColumnsShown(count) {
+  if (sShowCols !== null) return sShowCols;
+  return !sFocusedMode || count <= 5;
+}
+
 /** Single source of truth for box size, used by both layout and drawing. */
 function sApplyNodeSizes(nodes) {
-  var showCols = sShowCols !== null ? sShowCols : nodes.length <= 5;
+  var showCols = sColumnsShown(nodes.length);
   for (var i = 0; i < nodes.length; i++) {
     nodes[i].w = 180;
     nodes[i].h = sNodeHeight(nodes[i], showCols);
@@ -2496,7 +2510,6 @@ function sCacheNodeLabels(nodes) {
     for (var c = 0; c < n.entity.columns.length; c++) {
       n.colTypes.push(clip(n.entity.columns[c].type, 60));
     }
-    // The icon column narrows the space a name can occupy.
     var foreignKeys = sForeignKeyColumns(n.entity);
     sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
     n.colNames = [];
@@ -2562,15 +2575,14 @@ function sCenterCamera() {
   var padW = sW * 0.85;
   var padH = sH * 0.85;
   var fit = Math.min(1.5, Math.min(padW / (graphW || 1), padH / (graphH || 1)));
-  // A wide overview has to shrink past the normal floor to fit on screen.
+  // Records the fit so the controls can zoom out this far.
   sMinZoom = Math.min(0.2, fit);
   sZoom = Math.max(sMinZoom, fit);
-  // Column text is 11px in world units, so anything under this renders too
-  // small to read. Better to stop fitting and let the user pan.
-  var showingCols = sShowCols !== null ? sShowCols : sNodes.length <= 5;
+  // Stops the fit at the zoom where 11px column text is still legible.
+  var showingCols = sColumnsShown(sNodes.length);
   if (showingCols && sZoom < 0.75) {
     sZoom = 0.75;
-    // Too big to fit, so start at the top left rather than mid-diagram.
+    // Anchors the top left of the diagram instead of centring it.
     var pad = 40;
     sCamX = (pad - sW / 2) / sZoom + sW / 2 - minX;
     sCamY = (pad - sH / 2) / sZoom + sH / 2 - minY;
@@ -2975,9 +2987,9 @@ function renderSchema() {
     return h;
   }
 
-  var TIP_PK = "Primary key \u00b7 identifies the row";
-  var TIP_FK = "Foreign key \u00b7 points at another table";
-  var TIP_IDX = "Indexed \u00b7 unique or carries an index";
+  var TIP_PK = "Primary key \\u00b7 identifies the row";
+  var TIP_FK = "Foreign key \\u00b7 points at another table";
+  var TIP_IDX = "Indexed \\u00b7 unique or carries an index";
 
   // Build sidebar tree
   var sidebarHtml = "";
@@ -3292,9 +3304,11 @@ function renderSchema() {
   function sSyncViewToggle() {
     if (!viewToggleBtn) return;
     viewToggleBtn.classList.toggle("active", !sFocusedMode);
+    viewToggleBtn.setAttribute("aria-pressed", String(!sFocusedMode));
+    viewToggleBtn.setAttribute("aria-label", sFocusedMode ? "Show all tables" : "Focus one table");
     viewToggleBtn.setAttribute("data-tip", sFocusedMode
-      ? "All tables \u00b7 lay out the whole schema at once"
-      : "Focus \u00b7 show one table and what it relates to");
+      ? "All tables \\u00b7 lay out the whole schema at once"
+      : "Focus \\u00b7 show one table and what it relates to");
   }
 
   function sShowAllTables() {
@@ -3307,8 +3321,6 @@ function renderSchema() {
     for (var i = 0; i < sNodes.length; i++) {
       sNodeMap[sNodes[i].name] = sNodes[i];
     }
-    // Show columns unless the user has already chosen otherwise.
-    if (sShowCols === null) sShowCols = true;
     sRecalcNodeSizes();
     sComputeOverviewLayout();
     sCenterCamera();
@@ -3364,9 +3376,13 @@ function renderSchema() {
       sShowAllCols = !sShowAllCols;
       if (sShowAllCols) sShowCols = true;
       toggleColsBtn.classList.toggle("active", sShowAllCols);
+      toggleColsBtn.setAttribute("aria-pressed", String(sShowAllCols));
+      toggleColsBtn.setAttribute("aria-label", sShowAllCols
+        ? "Show the first " + S_DEFAULT_MAX_COLS + " columns"
+        : "Show every column");
       toggleColsBtn.setAttribute("data-tip", sShowAllCols
-        ? "First " + S_DEFAULT_MAX_COLS + " \u00b7 go back to a short column list"
-        : "Every column \u00b7 stop cutting the list at seven");
+        ? "First " + S_DEFAULT_MAX_COLS + " \\u00b7 go back to a short column list"
+        : "Every column \\u00b7 stop cutting the list at seven");
       sRelayoutForSizeChange();
     });
   }
@@ -3377,7 +3393,7 @@ function renderSchema() {
   var zoomValueBtn = document.getElementById("schema-zoom-value");
 
   function sSetZoom(next) {
-    sZoom = Math.max(Math.min(sMinZoom, 0.05), Math.min(5, next));
+    sZoom = Math.max(sZoomFloor(), Math.min(5, next));
     sSyncZoomUi();
     sScheduleRedraw();
   }
@@ -3448,6 +3464,7 @@ function renderSchema() {
     sEdgeRoutes = {};
     sEdgeKeys = [];
   } else {
+    sApplyNodeSizes(sNodes);
     sComputeOverviewLayout();
     sCenterCamera();
   }
@@ -3562,11 +3579,10 @@ function renderSchema() {
 
   sCanvas.addEventListener("wheel", function(e) {
     e.preventDefault();
-    // A trackpad pinch arrives as a wheel event with ctrlKey set. Everything
-    // else is a two-finger scroll, which pans.
+    // ctrlKey or metaKey means a pinch, which zooms; anything else pans.
     if (e.ctrlKey || e.metaKey) {
       var factor = e.deltaY > 0 ? 0.92 : 1.08;
-      sZoom = Math.max(sMinZoom, Math.min(5, sZoom * factor));
+      sZoom = Math.max(sZoomFloor(), Math.min(5, sZoom * factor));
     } else {
       sCamX -= e.deltaX / sZoom;
       sCamY -= e.deltaY / sZoom;
@@ -4295,8 +4311,7 @@ function renderEndpoints() {
 
   epCanvas.addEventListener("wheel", function(e) {
     e.preventDefault();
-    // A trackpad pinch arrives as a wheel event with ctrlKey set. Everything
-    // else is a two-finger scroll, which pans.
+    // ctrlKey or metaKey means a pinch, which zooms; anything else pans.
     if (!(e.ctrlKey || e.metaKey)) {
       epCamX -= e.deltaX / epZoom;
       epCamY -= e.deltaY / epZoom;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2448,9 +2448,17 @@ function sCenterCamera() {
   // A wide overview has to shrink past the normal floor to fit on screen.
   sMinZoom = Math.min(0.2, fit);
   sZoom = Math.max(sMinZoom, fit);
-  // Fitting everything is pointless when it shrinks the columns out of sight.
+  // Column text is 11px in world units, so anything under this renders too
+  // small to read. Better to stop fitting and let the user pan.
   var showingCols = sShowCols !== null ? sShowCols : sNodes.length <= 5;
-  if (showingCols && sZoom < 0.35) sZoom = 0.35;
+  if (showingCols && sZoom < 0.75) {
+    sZoom = 0.75;
+    // Too big to fit, so start at the top left rather than mid-diagram.
+    var pad = 40;
+    sCamX = (pad - sW / 2) / sZoom + sW / 2 - minX;
+    sCamY = (pad - sH / 2) / sZoom + sH / 2 - minY;
+    return;
+  }
   sCamX = sW / 2 - cx;
   sCamY = sH / 2 - cy;
 }
@@ -3085,6 +3093,8 @@ function renderSchema() {
     for (var i = 0; i < sNodes.length; i++) {
       sNodeMap[sNodes[i].name] = sNodes[i];
     }
+    // Show columns unless the user has already chosen otherwise.
+    if (sShowCols === null) sShowCols = true;
     sRecalcNodeSizes();
     sComputeOverviewLayout();
     sCenterCamera();

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -878,6 +878,8 @@ canvas:active { cursor: grabbing; }
 #schema-sidebar .has-tip:hover::after {
   white-space: normal; width: max-content; max-width: 240px;
 }
+/* An icon sits near the left edge, so its tip has to open rightwards. */
+.st-icon.has-tip:hover::after { left: 0; right: auto; top: calc(100% + 2px); }
 .schema-diagram-btn {
   width: 28px; height: 28px; justify-content: center;
   background: rgba(50,50,50,0.9);

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -841,8 +841,19 @@ canvas:active { cursor: grabbing; }
 #schema-canvas:active { cursor: grabbing; }
 #schema-toolbar {
   position: absolute; top: 12px; right: 12px; z-index: 10;
-  display: flex; gap: 4px;
+  display: flex; align-items: center; gap: 4px;
 }
+.has-tip { position: relative; }
+.has-tip:hover::after {
+  content: attr(data-tip);
+  position: absolute; top: calc(100% + 6px); right: 0; z-index: 40;
+  white-space: nowrap; pointer-events: none;
+  background: #1a1a1a; border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 4px; padding: 4px 8px;
+  font-size: 11px; font-family: var(--font); color: var(--text);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+.schema-sidebar-header .has-tip:hover::after { right: auto; left: 0; }
 .schema-diagram-btn {
   width: 28px; height: 28px; justify-content: center;
   background: rgba(50,50,50,0.9);
@@ -861,9 +872,8 @@ canvas:active { cursor: grabbing; }
   color: #fff;
 }
 #schema-zoombar {
-  position: absolute; top: 48px; right: 12px; z-index: 10;
   display: flex; align-items: center; gap: 6px;
-  padding: 4px 8px; border-radius: 6px;
+  height: 28px; padding: 0 8px; border-radius: 6px;
   background: rgba(50,50,50,0.9);
   backdrop-filter: blur(4px);
   border: 1px solid rgba(255,255,255,0.22);

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -783,7 +783,7 @@ canvas:active { cursor: grabbing; }
 }
 #schema-entity-list { padding: 4px 0; }
 .st-row {
-  display: flex; align-items: center; padding: 3px 0; cursor: pointer;
+  display: flex; align-items: center; padding: 3px 12px 3px 0; cursor: pointer;
   line-height: 20px; font-size: 12px; white-space: nowrap;
 }
 .st-row:hover { background: rgba(255,255,255,0.04); }
@@ -798,31 +798,31 @@ canvas:active { cursor: grabbing; }
   align-items: center; justify-content: center; margin-right: 4px;
 }
 .st-icon svg { width: 14px; height: 14px; }
-.st-label { flex: 1; overflow: hidden; text-overflow: ellipsis; color: var(--text); }
+.st-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; color: var(--text); }
 .st-entity-name { font-weight: 600; color: var(--white); }
 .st-group-name { color: var(--text-muted); font-weight: 500; }
 .st-count {
-  font-size: 10px; color: var(--text-dim); margin-left: 6px; margin-right: 8px;
-  opacity: 0.7;
+  font-size: 10px; color: var(--text-dim); margin-left: 6px;
+  opacity: 0.7; flex-shrink: 0;
 }
 .st-col-type {
   font-size: 11px; color: var(--cat-correctness); font-family: monospace;
-  margin-left: 6px; margin-right: 8px;
+  margin-left: 6px; flex-shrink: 0;
 }
 .st-rel-type {
   font-size: 9px; font-weight: 600; color: var(--cat-architecture);
   background: rgba(139,92,246,0.1); padding: 1px 5px; border-radius: 3px;
-  margin-left: 6px; margin-right: 8px; font-family: monospace;
+  margin-left: 6px; font-family: monospace; flex-shrink: 0;
 }
 .st-col-default {
   font-size: 10px; color: var(--text-dim); margin-left: 4px;
   font-family: monospace; max-width: 120px;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  display: inline-block; vertical-align: middle;
+  display: inline-block; vertical-align: middle; flex-shrink: 0;
 }
 .st-col-tags {
   font-size: 9px; color: var(--cat-architecture);
-  margin-left: 6px; opacity: 0.7;
+  margin-left: 6px; opacity: 0.7; flex-shrink: 0;
 }
 .st-children { display: none; }
 .st-open { display: block; }
@@ -843,6 +843,28 @@ canvas:active { cursor: grabbing; }
   position: absolute; top: 12px; right: 12px; z-index: 10;
   display: flex; align-items: center; gap: 4px;
 }
+#tab-schema.sidebar-collapsed #schema-sidebar { display: none; }
+#schema-sidebar-show { display: none; }
+#tab-schema.sidebar-collapsed #schema-sidebar-show {
+  display: flex; position: absolute; top: 12px; left: 12px; z-index: 10;
+  width: 28px; height: 28px; justify-content: center;
+  background: rgba(50,50,50,0.9);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255,255,255,0.22);
+  color: rgba(255,255,255,0.7);
+}
+#tab-schema.sidebar-collapsed #schema-sidebar-show:hover {
+  background: rgba(70,70,70,0.95); color: #fff;
+}
+#schema-sidebar-show:hover::after { left: 0; right: auto; }
+.schema-sync {
+  display: flex; align-items: center; gap: 6px;
+  padding: 10px 16px; cursor: pointer;
+  font-size: 11px; color: var(--text-dim); user-select: none;
+}
+.schema-sync:hover { color: var(--text); }
+.schema-sync input { accent-color: var(--nest-red); cursor: pointer; margin: 0; }
+.schema-sync:hover::after { left: 16px; right: auto; }
 .has-tip { position: relative; }
 .has-tip:hover::after {
   content: attr(data-tip);
@@ -853,7 +875,9 @@ canvas:active { cursor: grabbing; }
   font-size: 11px; font-family: var(--font); color: var(--text);
   box-shadow: 0 4px 12px rgba(0,0,0,0.5);
 }
-.schema-sidebar-header .has-tip:hover::after { right: auto; left: 0; }
+#schema-sidebar .has-tip:hover::after {
+  white-space: normal; width: max-content; max-width: 240px;
+}
 .schema-diagram-btn {
   width: 28px; height: 28px; justify-content: center;
   background: rgba(50,50,50,0.9);

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -856,7 +856,7 @@ canvas:active { cursor: grabbing; }
 #tab-schema.sidebar-collapsed #schema-sidebar-show:hover {
   background: rgba(70,70,70,0.95); color: #fff;
 }
-#schema-sidebar-show:hover::after { left: 0; right: auto; }
+#schema-sidebar-show:is(:hover, :focus-visible)::after { left: 0; right: auto; }
 .schema-sync {
   display: flex; align-items: center; gap: 6px;
   padding: 10px 16px; cursor: pointer;
@@ -864,9 +864,9 @@ canvas:active { cursor: grabbing; }
 }
 .schema-sync:hover { color: var(--text); }
 .schema-sync input { accent-color: var(--nest-red); cursor: pointer; margin: 0; }
-.schema-sync:hover::after { left: 16px; right: auto; }
+.schema-sync:is(:hover, :focus-visible)::after { left: 16px; right: auto; }
 .has-tip { position: relative; }
-.has-tip:hover::after {
+.has-tip:is(:hover, :focus-visible)::after {
   content: attr(data-tip);
   position: absolute; top: calc(100% + 6px); right: 0; z-index: 40;
   white-space: nowrap; pointer-events: none;
@@ -875,11 +875,11 @@ canvas:active { cursor: grabbing; }
   font-size: 11px; font-family: var(--font); color: var(--text);
   box-shadow: 0 4px 12px rgba(0,0,0,0.5);
 }
-#schema-sidebar .has-tip:hover::after {
+#schema-sidebar .has-tip:is(:hover, :focus-visible)::after {
   white-space: normal; width: max-content; max-width: 240px;
 }
 /* An icon sits near the left edge, so its tip has to open rightwards. */
-.st-icon.has-tip:hover::after { left: 0; right: auto; top: calc(100% + 2px); }
+.st-icon.has-tip:is(:hover, :focus-visible)::after { left: 0; right: auto; top: calc(100% + 2px); }
 .schema-diagram-btn {
   width: 28px; height: 28px; justify-content: center;
   background: rgba(50,50,50,0.9);

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -860,6 +860,40 @@ canvas:active { cursor: grabbing; }
   border-color: rgba(234,40,69,0.7);
   color: #fff;
 }
+#schema-zoombar {
+  position: absolute; top: 48px; right: 12px; z-index: 10;
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 8px; border-radius: 6px;
+  background: rgba(50,50,50,0.9);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255,255,255,0.22);
+}
+.schema-zoom-btn {
+  width: 20px; height: 20px; justify-content: center; padding: 0;
+  background: none; border: none; color: rgba(255,255,255,0.7);
+}
+.schema-zoom-btn:hover { background: rgba(255,255,255,0.12); color: #fff; }
+.schema-zoom-btn svg { width: 14px; height: 14px; }
+#schema-zoom-range {
+  -webkit-appearance: none; appearance: none;
+  width: 110px; height: 3px; border-radius: 2px;
+  background: rgba(255,255,255,0.25); outline: none; cursor: pointer;
+}
+#schema-zoom-range::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 11px; height: 11px; border-radius: 50%;
+  background: var(--nest-red); cursor: pointer;
+}
+#schema-zoom-range::-moz-range-thumb {
+  width: 11px; height: 11px; border: none; border-radius: 50%;
+  background: var(--nest-red); cursor: pointer;
+}
+.schema-zoom-value {
+  min-width: 38px; text-align: right; cursor: pointer;
+  font-size: 11px; font-family: var(--font); color: rgba(255,255,255,0.7);
+  background: none; border: none; padding: 0;
+}
+.schema-zoom-value:hover { color: #fff; }
 .schema-tooltip {
   position: absolute; z-index: 20; pointer-events: none;
   background: #1a1a1a; border: 1px solid rgba(255,255,255,0.12);

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -855,6 +855,11 @@ canvas:active { cursor: grabbing; }
   border-color: rgba(255,255,255,0.35);
   color: #fff;
 }
+.schema-diagram-btn.active {
+  background: rgba(234,40,69,0.22);
+  border-color: rgba(234,40,69,0.7);
+  color: #fff;
+}
 .schema-tooltip {
   position: absolute; z-index: 20; pointer-events: none;
   background: #1a1a1a; border: 1px solid rgba(255,255,255,0.12);
@@ -889,6 +894,11 @@ canvas:active { cursor: grabbing; }
   color: var(--text-muted); gap: 12px; text-align: center; z-index: 5;
 }
 #schema-empty-state p { font-size: 14px; color: var(--text-dim); margin: 0; }
+.schema-empty-action {
+  padding: 6px 14px; font-size: 12px; font-family: var(--font);
+  color: var(--text); border-color: rgba(255,255,255,0.18);
+}
+.schema-empty-action:hover { color: var(--white); }
 
 /* ── Schema diagnostics panel ── */
 #schema-diag-panel {

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+	getReportScripts,
+	type ReportScriptData,
+} from "../../src/report/ui/scripts.js";
+
+const EMPTY: ReportScriptData = {
+	diagnosticsJson: "[]",
+	elapsedMsJson: "0",
+	endpointsJson: '{"endpoints":[]}',
+	examplesJson: "[]",
+	fileSourcesJson: "{}",
+	graphJson: '{"modules":[],"edges":[]}',
+	projectJson: "{}",
+	providersJson: "[]",
+	schemaJson: "null",
+	sourceLinesJson: "{}",
+	summaryJson: "{}",
+};
+
+interface Node {
+	h: number;
+	name: string;
+	w: number;
+	x: number;
+	y: number;
+}
+
+interface Relation {
+	fromEntity: string;
+	toEntity: string;
+}
+
+function edgeKey(from: string, to: string): string {
+	return from < to ? `${from}|${to}` : `${to}|${from}`;
+}
+
+/** Fake dagre that ranks nodes along a diagonal, enough to exercise packing. */
+const fakeDagre = {
+	graphlib: {
+		Graph: class {
+			private readonly nodes = new Map<
+				string,
+				{ width: number; height: number; x: number; y: number }
+			>();
+			private order = 0;
+			setGraph() {
+				return this;
+			}
+			setDefaultEdgeLabel() {
+				return this;
+			}
+			setNode(id: string, value: { width: number; height: number }) {
+				this.order += 1;
+				this.nodes.set(id, {
+					...value,
+					x: this.order * 400,
+					y: this.order * 200,
+				});
+			}
+			setEdge() {
+				return this;
+			}
+			node(id: string) {
+				return this.nodes.get(id);
+			}
+		},
+	},
+	layout() {
+		// Positions are assigned in setNode.
+	},
+};
+
+/**
+ * Pulls the layout functions out of the emitted script and runs them against a
+ * synthetic schema. The report has no DOM harness, so this executes the real
+ * emitted source rather than a copy.
+ */
+function runOverviewLayout(
+	relations: Relation[],
+	nodes: Node[],
+	dagreImpl: unknown
+): void {
+	const scripts = getReportScripts(EMPTY);
+	const start = scripts.indexOf("function sComputeComponents");
+	const end = scripts.indexOf("function sComputeStarLayout");
+	if (start < 0 || end <= start) {
+		throw new Error("layout functions not found in the emitted report script");
+	}
+
+	const factory = new Function(
+		"schema",
+		"sNodes",
+		"sEdgeKey",
+		"sRouteAllEdges",
+		"dagre",
+		`${scripts.slice(start, end)}\nreturn sComputeOverviewLayout;`
+	);
+	factory(
+		{ relations },
+		nodes,
+		edgeKey,
+		() => {
+			// Edge routing is not under test.
+		},
+		dagreImpl
+	)();
+}
+
+function overlaps(a: Node, b: Node): boolean {
+	return (
+		Math.abs(a.x - b.x) < (a.w + b.w) / 2 &&
+		Math.abs(a.y - b.y) < (a.h + b.h) / 2
+	);
+}
+
+function findOverlap(nodes: Node[]): string | null {
+	for (let i = 0; i < nodes.length; i++) {
+		for (let j = i + 1; j < nodes.length; j++) {
+			if (overlaps(nodes[i], nodes[j])) {
+				return `${nodes[i].name} overlaps ${nodes[j].name}`;
+			}
+		}
+	}
+	return null;
+}
+
+/** Mirrors a real 34-entity schema: 18 components, 12 of them unrelated. */
+function buildSchema(): { nodes: Node[]; relations: Relation[] } {
+	const nodes: Node[] = [];
+	const relations: Relation[] = [];
+	const add = (name: string) => {
+		nodes.push({ name, x: 0, y: 0, w: 180, h: 52 });
+	};
+
+	const componentSizes = [7, 6, 3, 2, 2, 2];
+	componentSizes.forEach((size, index) => {
+		for (let i = 0; i < size; i++) {
+			add(`c${index}_${i}`);
+			if (i > 0) {
+				relations.push({
+					fromEntity: `c${index}_0`,
+					toEntity: `c${index}_${i}`,
+				});
+			}
+		}
+	});
+	for (let i = 0; i < 12; i++) {
+		add(`isolated${i}`);
+	}
+	return { nodes, relations };
+}
+
+describe("schema overview layout", () => {
+	it("separates every table when dagre is available", () => {
+		const { nodes, relations } = buildSchema();
+		runOverviewLayout(relations, nodes, fakeDagre);
+
+		expect(nodes).toHaveLength(34);
+		expect(findOverlap(nodes)).toBeNull();
+	});
+
+	it("still separates every table with no dagre on the page", () => {
+		const { nodes, relations } = buildSchema();
+		runOverviewLayout(relations, nodes, undefined);
+
+		expect(findOverlap(nodes)).toBeNull();
+	});
+
+	it("groups unrelated tables instead of stringing them out", () => {
+		const { nodes, relations } = buildSchema();
+		runOverviewLayout(relations, nodes, fakeDagre);
+
+		const isolated = nodes.filter((n) => n.name.startsWith("isolated"));
+		const rows = new Set(isolated.map((n) => n.y));
+		const columns = new Set(isolated.map((n) => n.x));
+		expect(rows.size).toBeGreaterThan(1);
+		expect(columns.size).toBeGreaterThan(1);
+	});
+
+	it("keeps a single connected schema in one block", () => {
+		const nodes: Node[] = [
+			{ name: "a", x: 0, y: 0, w: 180, h: 52 },
+			{ name: "b", x: 0, y: 0, w: 180, h: 52 },
+			{ name: "c", x: 0, y: 0, w: 180, h: 52 },
+		];
+		const relations: Relation[] = [
+			{ fromEntity: "a", toEntity: "b" },
+			{ fromEntity: "b", toEntity: "c" },
+		];
+		runOverviewLayout(relations, nodes, fakeDagre);
+
+		expect(findOverlap(nodes)).toBeNull();
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -178,6 +178,33 @@ describe("schema overview layout", () => {
 		expect(columns.size).toBeGreaterThan(1);
 	});
 
+	it("sizes a table to every column only when all columns are shown", () => {
+		const scripts = getReportScripts(EMPTY);
+		const start = scripts.indexOf("var S_DEFAULT_MAX_COLS");
+		const end = scripts.indexOf("function sCacheNodeLabels");
+		if (start < 0 || end <= start) {
+			throw new Error("sizing helpers not found in the emitted report script");
+		}
+		const factory = new Function(
+			"sShowAllCols",
+			"sShowCols",
+			`${scripts.slice(start, end)}\nreturn { sNodeHeight: sNodeHeight, sVisibleColCount: sVisibleColCount };`
+		);
+		const wide = {
+			entity: { columns: new Array(24).fill({ type: "String" }) },
+		};
+
+		const capped = factory(false, true);
+		const all = factory(true, true);
+
+		expect(capped.sVisibleColCount(wide, true)).toBe(7);
+		expect(all.sVisibleColCount(wide, true)).toBe(24);
+		// Header, one row per column, the "+N more" row only while capped.
+		expect(capped.sNodeHeight(wide, true)).toBe(24 + 7 * 16 + 16 + 8);
+		expect(all.sNodeHeight(wide, true)).toBe(24 + 24 * 16 + 8);
+		expect(all.sNodeHeight(wide, false)).toBe(52);
+	});
+
 	it("keeps a single connected schema in one block", () => {
 		const nodes: Node[] = [
 			{ name: "a", x: 0, y: 0, w: 180, h: 52 },


### PR DESCRIPTION
## 1. Context

The HTML report's Relational Schema tab draws tables on a canvas beside a tree of
the same tables. One line at render time decided how much of the schema you were
allowed to see:

```js
sFocusedMode = schema.entities.length > 7;   // scripts.ts
```

It was computed once and never revisited, and there was no control to change it.

## 2. Problem

Above seven tables you could only ever see one table plus its direct neighbours.
The all-tables layout already existed and was unreachable, so on a real 34-table
schema you landed on an empty canvas reading "Select an entity from the sidebar"
and stayed there.

Just exposing the existing layout was not enough. Measured on that schema:

| | |
|---|---|
| tables | 34 |
| relations | 36 |
| tables with **no** relation at all | **12** (35%) |
| connected components | **18**, sized 7, 6, 3, 2, 2, 2 and twelve singletons |

Dagre puts every unconnected node in rank 0, so those twelve would have stacked
into one tall column, which is most of the diagram.

## 3. Possible flows

| Flow | Before | After |
|---|---|---|
| schema of 7 tables or fewer | all tables, no control | all tables, plus the controls; laid out per component |
| schema over 7 tables | one table and its neighbours, no way out | a control switches to every table |
| clicking a table | select, dim the rest | unchanged, and the list follows |
| clicking empty canvas | pans only | also clears the selection |
| trackpad two-finger scroll | zoomed | pans |
| trackpad pinch | zoomed | unchanged |
| a table with more than 7 columns | "+N more", no way to see them | a control shows every column |
| the table list | always taking 340px | can be hidden |
| modules and endpoints diagrams | wheel zoomed | wheel pans, pinch zooms |
| LSP | untouched | untouched |

## 4. Solution

The mode is state the reader owns: a toolbar toggle plus a **Show all tables**
button on the empty state, which is where a large schema lands. The starting mode
is unchanged. The layout is not: a schema that is one connected component lands
where it used to, and one that is several no longer strings its unrelated tables
down a single rank.

Tables are laid out per connected component and the components are shelf-packed
into a roughly square area, with unrelated tables gathered into their own grid
block instead of one long rank.

Fitting a large diagram meant letting the camera go below the old hard `0.2`
zoom floor, but not so far that the text becomes unreadable: when columns are
showing, the fit stops at the point they are still legible and the diagram is
panned instead, anchored at its top left.

Alongside that: a zoom bar in the same row as the other controls, a control to
show every column rather than the first seven, and a table list that can be
hidden and that follows the diagram through a **Sync with diagram** checkbox.
Both views classify a column the same way, with a key, link or index glyph.

What I did not do: change the starting mode for a large schema, or bundle dagre
so the layout survives offline.

Two things here are deliberate changes rather than fixes. The wheel now pans and
ctrl or command with the wheel zooms, which is what drawing tools do and what
makes a trackpad usable, but it is a change for mouse users. That applies to all
three diagrams in the report, not only this one, since one handler would
otherwise behave unlike the rest.

## 5. Before vs after

| | Before | After |
|---|---|---|
| tables visible on a 34-table schema | 1 plus neighbours | **all 34** |
| overlapping tables in that view | n/a | **0** |
| overlapping tables with every column shown | n/a | **0** |
| lowest zoom the camera could reach | 0.2 | as low as the graph needs (0.037 measured) |
| columns visible per table | 7 | 7, or every one |
| columns classified the same in list and diagram | 34 of 369 | **369 of 369** |
| `measureText` calls per frame | one per name and per column | **0**, cached at layout |
| schema of 7 tables or fewer *(unchanged)* | all tables | all tables |
| the modules and endpoints diagrams | wheel zoomed | wheel pans |

## 6. Example

Generated from a private 44-project Nx workspace, `nestjs-doctor . --report`,
then read off the live canvas:

```
before   sFocusedMode = true, canvas hidden, "Select an entity from the sidebar"

after    34 nodes drawn, 0 overlapping pairs
         graph 1184 x 1136, fits at zoom 0.50
         with every column shown: tallest table 416px, still 0 overlapping pairs
         column marks: 34 primary keys, 18 foreign keys, 58 indexed, 259 plain
```

Layout is covered by tests that run the emitted script itself and assert no two
tables overlap, with and without dagre on the page. They were checked against a
deliberately broken packing, which fails them with `c0_0 overlaps c1_0`.
