### PR TITLE
feat(report): make the modules graph readable

### DIFF
--- a/.changeset/modules-graph-readability.md
+++ b/.changeset/modules-graph-readability.md
@@ -26,6 +26,10 @@ The tab also gains the zoom bar and re-center control the schema diagram has,
 a hover tooltip with the full module name, and focusing a module now brings it
 and its neighbours into view rather than only dimming everything else.
 
+A graph too wide to fit and still be read opens at a readable zoom instead,
+anchored at the top so the root module is where you start, and is panned from
+there. A graph that fits legibly still opens whole.
+
 One caveat: dagre is loaded from a CDN, so a report opened without network access
 falls back to a plain grid per group and loses the top-down ordering. The old
 simulation ran offline. That tradeoff already applied to the schema diagram.

--- a/.changeset/modules-graph-readability.md
+++ b/.changeset/modules-graph-readability.md
@@ -14,8 +14,8 @@ Each connected group is now laid out top down, so a module sits above what it
 imports, and the groups are packed together. Modules with no import links are
 gathered into one labelled block under the rest, rather than scattered. The
 simulation, its constants and the per-frame animation loop are gone; dragging a
-module still moves it, and the layout no longer changes shape when the project
-filter is touched.
+module still moves it. Filtering to a project and back reproduces the same
+layout, where the old code re-scrambled it with random jitter every time.
 
 Boxes are capped at 220px with the module name on its own line, so a long project
 prefix can no longer push it out of view. The old code measured a short count

--- a/.changeset/modules-graph-readability.md
+++ b/.changeset/modules-graph-readability.md
@@ -22,4 +22,10 @@ prefix can no longer push it out of view. The old code measured a short count
 string while drawing a longer one, so boxes were sized for text narrower than
 what went into them.
 
-The tab also gains the zoom bar and re-center control the schema diagram has.
+The tab also gains the zoom bar and re-center control the schema diagram has,
+a hover tooltip with the full module name, and focusing a module now brings it
+and its neighbours into view rather than only dimming everything else.
+
+One caveat: dagre is loaded from a CDN, so a report opened without network access
+falls back to a plain grid per group and loses the top-down ordering. The old
+simulation ran offline. That tradeoff already applied to the schema diagram.

--- a/.changeset/modules-graph-readability.md
+++ b/.changeset/modules-graph-readability.md
@@ -1,0 +1,25 @@
+---
+"nestjs-doctor": patch
+---
+
+The report's modules graph is laid out instead of simulated, so it can be read.
+
+The tab ran a force simulation over nodes seeded on a circle of radius 248 while
+the boxes were up to 407px wide, so they could not avoid piling up. On a
+66-module workspace that left **221 overlapping pairs**, with **98% of modules**
+covering another one. There was little for a simulation to reveal in the first
+place: 19 import edges across 47 groups, 29 of them a single module.
+
+Each connected group is now laid out top down, so a module sits above what it
+imports, and the groups are packed together. Modules with no import links are
+gathered into one labelled block under the rest, rather than scattered. The
+simulation, its constants and the per-frame animation loop are gone; dragging a
+module still moves it, and the layout no longer changes shape when the project
+filter is touched.
+
+Boxes are capped at 220px with the module name on its own line, so a long project
+prefix can no longer push it out of view. The old code measured a short count
+string while drawing a longer one, so boxes were sized for text narrower than
+what went into them.
+
+The tab also gains the zoom bar and re-center control the schema diagram has.

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -347,7 +347,6 @@ for (let i = 0; i < lines.length; i++) {
     </button>
   </div>
   <button id="focus-btn">Unfocus</button>
-  <div id="modules-tooltip" class="schema-tooltip" style="display:none"></div>
 </div>
 
 <!-- ── Sidebar (Graph tab) ── -->
@@ -385,6 +384,8 @@ for (let i = 0; i < lines.length; i++) {
   <div class="filepath" id="detail-path"></div>
   <div id="detail-sections"></div>
 </div>
+
+<div id="modules-tooltip" class="schema-tooltip" style="display:none"></div>
 
 <div id="focus-hint">Focused view — click empty space or press Esc to exit</div>`;
 }

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -347,6 +347,7 @@ for (let i = 0; i < lines.length; i++) {
     </button>
   </div>
   <button id="focus-btn">Unfocus</button>
+  <div id="modules-tooltip" class="schema-tooltip" style="display:none"></div>
 </div>
 
 <!-- ── Sidebar (Graph tab) ── -->

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -329,6 +329,23 @@ for (let i = 0; i < lines.length; i++) {
 <!-- ── Tab: Modules Graph ── -->
 <div class="tab-content" id="tab-modules">
   <canvas id="graph"></canvas>
+  <div id="modules-toolbar">
+    <div id="modules-zoombar">
+      <button class="st-btn schema-zoom-btn has-tip" id="modules-zoom-out" aria-label="Zoom out" data-tip="Zoom out">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      </button>
+      <input type="range" id="modules-zoom-range" min="5" max="500" step="1" value="100" aria-label="Zoom">
+      <button class="st-btn schema-zoom-btn has-tip" id="modules-zoom-in" aria-label="Zoom in" data-tip="Zoom in">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      </button>
+      <button class="schema-zoom-value has-tip" id="modules-zoom-value" aria-label="100% \u00b7 fit to view" data-tip="Fit \u00b7 size the graph to the window">100%</button>
+    </div>
+    <button class="st-btn schema-diagram-btn has-tip" id="modules-recenter" aria-label="Re-center graph" data-tip="Re-center \u00b7 bring the graph back into view">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/>
+      </svg>
+    </button>
+  </div>
   <button id="focus-btn">Unfocus</button>
 </div>
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -483,17 +483,17 @@ document.getElementById("close-detail").addEventListener("click", () => {
 });
 
 document.getElementById("focus-btn").addEventListener("click", () => {
-  exitFocus();
   document.getElementById("detail").style.display = "none";
   selectedNode = null;
+  exitFocus();
   scheduleGraphDraw();
 });
 
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && focusNode) {
-    exitFocus();
     document.getElementById("detail").style.display = "none";
     selectedNode = null;
+    exitFocus();
   }
 });
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -170,6 +170,7 @@ let W, H;
 // The graph is laid out after the nodes exist; resize does nothing before that.
 let graphReady = false;
 function resize() {
+  const sameSize = W === window.innerWidth - 340 && H === window.innerHeight - 96;
   W = window.innerWidth - 340;
   H = window.innerHeight - 96;
   canvas.width = W * dpr;
@@ -178,7 +179,8 @@ function resize() {
   canvas.style.height = H + "px";
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   if (graphReady) {
-    centerGraph();
+    // Only a real size change refits; switching tabs keeps the reader's view.
+    if (!sameSize) centerGraph();
     scheduleGraphDraw();
   }
 }
@@ -247,9 +249,9 @@ function layoutModules() {
 
   // The unconnected modules get their own row under everything else, so the
   // heading above them has somewhere to sit.
-  // With nothing connected there is no contrast to draw, so no heading either.
+  const anyConnected = boxes.length > 0;
   let isolatedBox = null;
-  if (isolated.length > 0 && boxes.length > 0) {
+  if (isolated.length > 0) {
     isolated.sort((a, b) => (a.project || "").localeCompare(b.project || "") || a.name.localeCompare(b.name));
     const size = sLayoutIsolatedBlock(isolated, 28);
     let below = 0;
@@ -262,8 +264,9 @@ function layoutModules() {
     for (const n of b.nodes) { n.x += b.ox; n.y += b.oy; }
   }
 
+  // With nothing connected there is no contrast to draw, so no heading either.
   isolatedHeading = null;
-  if (isolatedBox) {
+  if (isolatedBox && anyConnected) {
     let top = Infinity, left = Infinity;
     for (const n of isolatedBox.nodes) {
       top = Math.min(top, n.y - n.h / 2);
@@ -371,6 +374,7 @@ function exitFocus() {
   focusSet = null;
   document.getElementById("focus-btn").classList.remove("visible");
   document.getElementById("focus-hint").style.display = "none";
+  scheduleGraphDraw();
 }
 
 function screenToWorld(sx, sy) {
@@ -402,6 +406,7 @@ canvas.addEventListener("mousemove", (e) => {
     camX += (e.clientX - panStart.x) / zoom;
     camY += (e.clientY - panStart.y) / zoom;
     panStart = { x: e.clientX, y: e.clientY };
+    scheduleGraphDraw();
   }
 });
 
@@ -433,22 +438,26 @@ canvas.addEventListener("wheel", (e) => {
   if (e.ctrlKey || e.metaKey) {
     const factor = e.deltaY > 0 ? 0.92 : 1.08;
     zoom = Math.max(0.1, Math.min(5, zoom * factor));
+    syncModulesZoomUi();
   } else {
     camX -= e.deltaX / zoom;
     camY -= e.deltaY / zoom;
   }
+  scheduleGraphDraw();
 }, { passive: false });
 
 document.getElementById("close-detail").addEventListener("click", () => {
   document.getElementById("detail").style.display = "none";
   selectedNode = null;
   exitFocus();
+  scheduleGraphDraw();
 });
 
 document.getElementById("focus-btn").addEventListener("click", () => {
   exitFocus();
   document.getElementById("detail").style.display = "none";
   selectedNode = null;
+  scheduleGraphDraw();
 });
 
 document.addEventListener("keydown", (e) => {

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -213,6 +213,7 @@ const nodes = graph.modules.map((m) => ({ ...m, x: 0, y: 0, w: 0, h: 36 }));
 const nodeMap = new Map();
 for (const n of nodes) nodeMap.set(n.name, n);
 
+let isolatedHeading = null;
 let graphDirty = false;
 function scheduleGraphDraw() {
   if (graphDirty) return;
@@ -239,17 +240,41 @@ function layoutModules() {
   }
   boxes.sort((a, b) => b.h - a.h || b.w - a.w);
 
-  if (isolated.length > 0) {
-    isolated.sort((a, b) => (a.project || "").localeCompare(b.project || "") || a.name.localeCompare(b.name));
-    const size = sLayoutIsolatedBlock(isolated, 28);
-    boxes.push({ nodes: isolated, w: size.w, h: size.h });
-  }
-
   let area = 0;
   for (const b of boxes) area += b.w * b.h;
-  sPackBoxes(boxes, Math.max(900, Math.sqrt(area) * 1.7), GUTTER);
+  const targetW = Math.max(900, Math.sqrt(area) * 1.7);
+  sPackBoxes(boxes, targetW, GUTTER);
+
+  // The unconnected modules get their own row under everything else, so the
+  // heading above them has somewhere to sit.
+  // With nothing connected there is no contrast to draw, so no heading either.
+  let isolatedBox = null;
+  if (isolated.length > 0 && boxes.length > 0) {
+    isolated.sort((a, b) => (a.project || "").localeCompare(b.project || "") || a.name.localeCompare(b.name));
+    const size = sLayoutIsolatedBlock(isolated, 28);
+    let below = 0;
+    for (const b of boxes) below = Math.max(below, b.oy + b.h);
+    isolatedBox = { nodes: isolated, w: size.w, h: size.h, ox: 0, oy: below + GUTTER };
+    boxes.push(isolatedBox);
+  }
+
   for (const b of boxes) {
     for (const n of b.nodes) { n.x += b.ox; n.y += b.oy; }
+  }
+
+  isolatedHeading = null;
+  if (isolatedBox) {
+    let top = Infinity, left = Infinity;
+    for (const n of isolatedBox.nodes) {
+      top = Math.min(top, n.y - n.h / 2);
+      left = Math.min(left, n.x - n.w / 2);
+    }
+    const many = isolatedBox.nodes.length !== 1;
+    isolatedHeading = {
+      x: left,
+      y: top - 16,
+      text: isolatedBox.nodes.length + (many ? " modules" : " module") + " with no import links"
+    };
   }
 }
 
@@ -546,6 +571,7 @@ function getEdgeEndpoints(a, b) {
 }
 
 function draw() {
+  syncModulesZoomUi();
   ctx.save();
   ctx.clearRect(0, 0, W, H);
   ctx.translate(W / 2, H / 2);
@@ -626,9 +652,51 @@ function draw() {
     ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
     ctx.fillText(n.subStr || "", n.x, n.y + 10);
   }
+  if (isolatedHeading && !focusNode) {
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = "#666";
+    ctx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "alphabetic";
+    ctx.fillText(isolatedHeading.text, isolatedHeading.x, isolatedHeading.y);
+  }
   ctx.globalAlpha = 1;
   ctx.restore();
 }
+
+// ── Modules toolbar ──
+let modulesZoomUi = null;
+function syncModulesZoomUi() {
+  const pct = Math.round(zoom * 100);
+  if (pct === modulesZoomUi) return;
+  modulesZoomUi = pct;
+  const range = document.getElementById("modules-zoom-range");
+  const label = document.getElementById("modules-zoom-value");
+  if (range) range.value = String(Math.max(5, Math.min(500, pct)));
+  if (label) {
+    label.textContent = pct + "%";
+    label.setAttribute("aria-label", pct + "% \u00b7 fit to view");
+  }
+}
+
+function setModulesZoom(next) {
+  zoom = Math.max(0.05, Math.min(5, next));
+  syncModulesZoomUi();
+  scheduleGraphDraw();
+}
+
+const modulesZoomRange = document.getElementById("modules-zoom-range");
+if (modulesZoomRange) {
+  modulesZoomRange.addEventListener("input", () => setModulesZoom(Number(modulesZoomRange.value) / 100));
+}
+const modulesZoomIn = document.getElementById("modules-zoom-in");
+if (modulesZoomIn) modulesZoomIn.addEventListener("click", () => setModulesZoom(zoom * 1.2));
+const modulesZoomOut = document.getElementById("modules-zoom-out");
+if (modulesZoomOut) modulesZoomOut.addEventListener("click", () => setModulesZoom(zoom / 1.2));
+const modulesFit = document.getElementById("modules-zoom-value");
+if (modulesFit) modulesFit.addEventListener("click", () => { centerGraph(); syncModulesZoomUi(); scheduleGraphDraw(); });
+const modulesRecenter = document.getElementById("modules-recenter");
+if (modulesRecenter) modulesRecenter.addEventListener("click", () => { centerGraph(); syncModulesZoomUi(); scheduleGraphDraw(); });
 
 relayoutGraph();
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -299,7 +299,14 @@ function centerGraph(subset) {
     : 0;
   const usableW = covered > W / 2 ? W : W - covered;
   const fit = Math.min(1.2, Math.min((usableW * 0.9) / (maxX - minX || 1), (H * 0.9) / (maxY - minY || 1)));
-  zoom = Math.max(0.05, fit);
+  zoom = fit < FIT_TOO_SMALL ? READABLE_ZOOM : fit;
+  if (fit < FIT_TOO_SMALL) {
+    // Start at the top of the hierarchy, centred, and pan down from there.
+    const pad = 40;
+    camX = (usableW / 2 - W / 2) / zoom + W / 2 - (minX + maxX) / 2;
+    camY = (pad - H / 2) / zoom + H / 2 - minY;
+    return;
+  }
   camX = (usableW / 2 - W / 2) / zoom + W / 2 - (minX + maxX) / 2;
   camY = H / 2 - (minY + maxY) / 2;
 }
@@ -314,6 +321,10 @@ function relayoutGraph() {
 
 ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
 const NODE_MAX_W = 220;
+// Below this a fit is too small to read, so the graph is shown readable and
+// panned instead. Above it, fitting everything still says more than zooming in.
+const FIT_TOO_SMALL = 0.4;
+const READABLE_ZOOM = 0.55;
 
 function clipToWidth(text, maxW) {
   if (ctx.measureText(text).width <= maxW) return text;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -668,7 +668,6 @@ function draw() {
 
 // ── Hover tooltip ──
 const modulesTooltip = document.getElementById("modules-tooltip");
-let hoveredNode = null;
 
 function showModuleTooltip(n, sx, sy) {
   if (!modulesTooltip) return;
@@ -681,8 +680,11 @@ function showModuleTooltip(n, sx, sy) {
     '<ul class="tt-cols"><li><span class="col-name">imports</span><span>' + imports +
     '</span></li><li><span class="col-name">exports</span><span>' + exports + "</span></li></ul>";
   modulesTooltip.style.display = "block";
-  modulesTooltip.style.left = sx + 16 + "px";
-  modulesTooltip.style.top = sy - 10 + "px";
+  const box = modulesTooltip.getBoundingClientRect();
+  const left = Math.min(sx + 16, Math.max(0, W - box.width - 8));
+  const top = Math.min(Math.max(0, sy - 10), Math.max(0, H - box.height - 8));
+  modulesTooltip.style.left = left + "px";
+  modulesTooltip.style.top = top + "px";
 }
 
 function hideModuleTooltip() {
@@ -706,17 +708,15 @@ canvas.addEventListener("mousemove", (e) => {
       break;
     }
   }
-  canvas.style.cursor = hit ? "pointer" : "grab";
+  canvas.style.cursor = hit ? "pointer" : "";
   if (hit) {
     showModuleTooltip(hit, sx, sy);
   } else {
     hideModuleTooltip();
   }
-  if (hit !== hoveredNode) hoveredNode = hit;
 });
 
 canvas.addEventListener("mouseleave", () => {
-  hoveredNode = null;
   hideModuleTooltip();
 });
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2308,7 +2308,7 @@ function sPolylineMidpoint(points) {
 
 /** Groups nodes into connected components using the given edges. */
 function sComputeComponents(nodes, edges, fromKey, toKey) {
-  var index = {};
+  var index = Object.create(null);
   var parent = [];
   for (var i = 0; i < nodes.length; i++) {
     index[nodes[i].name] = i;
@@ -2330,16 +2330,14 @@ function sComputeComponents(nodes, edges, fromKey, toKey) {
     var ra = find(a), rb = find(b);
     if (ra !== rb) parent[rb] = ra;
   }
-  var groups = {};
+  var groups = Object.create(null);
   for (var i = 0; i < nodes.length; i++) {
     var root = find(i);
     if (!groups[root]) groups[root] = [];
     groups[root].push(nodes[i]);
   }
   var out = [];
-  for (var key in groups) {
-    if (Object.prototype.hasOwnProperty.call(groups, key)) out.push(groups[key]);
-  }
+  for (var key in groups) out.push(groups[key]);
   return out;
 }
 
@@ -2368,13 +2366,13 @@ function sLayoutComponent(nodes, edges, fromKey, toKey, rankdir) {
   g.setGraph({ rankdir: rankdir || "LR", nodesep: 60, ranksep: 120, marginx: 0, marginy: 0 });
   g.setDefaultEdgeLabel(function() { return {}; });
 
-  var present = {};
+  var present = Object.create(null);
   for (i = 0; i < nodes.length; i++) {
     present[nodes[i].name] = true;
     g.setNode(nodes[i].name, { width: nodes[i].w, height: nodes[i].h });
   }
 
-  var seenEdge = {};
+  var seenEdge = Object.create(null);
   for (i = 0; i < edges.length; i++) {
     var edge = edges[i];
     if (edge[fromKey] === edge[toKey]) continue;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -179,7 +179,7 @@ function resize() {
   canvas.style.height = H + "px";
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   if (graphReady) {
-    // Only a real size change refits; switching tabs keeps the reader's view.
+    // Refit only when the canvas actually changed size.
     if (!sameSize) centerGraph();
     scheduleGraphDraw();
   }
@@ -209,7 +209,7 @@ for (const m of graph.modules) {
   if (m.name === "AppModule") rootModules.add(m.name);
 }
 
-// ── Create nodes with physics ──
+// ── Nodes ──
 const nodes = graph.modules.map((m) => ({ ...m, x: 0, y: 0, w: 0, h: 36 }));
 
 const nodeMap = new Map();
@@ -247,8 +247,7 @@ function layoutModules() {
   const targetW = Math.max(900, Math.sqrt(area) * 1.7);
   sPackBoxes(boxes, targetW, GUTTER);
 
-  // The unconnected modules get their own row under everything else, so the
-  // heading above them has somewhere to sit.
+  // The unconnected modules take their own row under everything else.
   const anyConnected = boxes.length > 0;
   let isolatedBox = null;
   if (isolated.length > 0) {
@@ -264,14 +263,12 @@ function layoutModules() {
     for (const n of b.nodes) { n.x += b.ox; n.y += b.oy; }
   }
 
-  // With nothing connected there is no contrast to draw, so no heading either.
+  // Headed only when there is something connected to contrast against.
   isolatedHeading = null;
-  if (isolatedBox && anyConnected) {
-    let top = Infinity, left = Infinity;
-    for (const n of isolatedBox.nodes) {
-      top = Math.min(top, n.y - n.h / 2);
-      left = Math.min(left, n.x - n.w / 2);
-    }
+  if (isolatedBox && anyConnected && activeProject === "all") {
+    let top = Infinity;
+    for (const n of isolatedBox.nodes) top = Math.min(top, n.y - n.h / 2);
+    const left = isolatedBox.ox;
     const many = isolatedBox.nodes.length !== 1;
     isolatedHeading = {
       x: left,
@@ -316,10 +313,7 @@ function clipToWidth(text, maxW) {
   return out + "\u2026";
 }
 
-/**
- * The module name goes on its own line so the project prefix cannot crowd it
- * out; the project moves to the second line, where colour already hints at it.
- */
+/** Sizes each box and caches its two lines: module name, then project. */
 function remeasureNodes() {
   const room = NODE_MAX_W - 24;
   for (const n of nodes) {
@@ -341,7 +335,6 @@ function remeasureNodes() {
     n.w = Math.min(Math.max(lw, sw) + 24, NODE_MAX_W);
   }
 }
-remeasureNodes();
 
 // ── Camera & interaction state ──
 let camX = 0, camY = 0, zoom = 1;
@@ -385,6 +378,7 @@ canvas.addEventListener("mousedown", (e) => {
   const rect = canvas.getBoundingClientRect();
   const pos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
   for (const n of nodes) {
+    if (!isNodeVisible(n)) continue;
     if (pos.x >= n.x - n.w / 2 && pos.x <= n.x + n.w / 2 && pos.y >= n.y - n.h / 2 && pos.y <= n.y + n.h / 2) {
       dragging = n;
       scheduleGraphDraw();
@@ -437,7 +431,7 @@ canvas.addEventListener("wheel", (e) => {
   // ctrlKey or metaKey means a pinch, which zooms; anything else pans.
   if (e.ctrlKey || e.metaKey) {
     const factor = e.deltaY > 0 ? 0.92 : 1.08;
-    zoom = Math.max(0.1, Math.min(5, zoom * factor));
+    zoom = Math.max(0.05, Math.min(5, zoom * factor));
     syncModulesZoomUi();
   } else {
     camX -= e.deltaX / zoom;
@@ -527,7 +521,6 @@ function showDetail(n) {
   enterFocus(n);
 }
 
-// ── Physics simulation ──
 
 function drawArrow(fromX, fromY, toX, toY, color, dashed) {
   const dx = toX - fromX;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -282,7 +282,7 @@ function layoutModules() {
   }
 }
 
-/** Fits the given nodes, or the whole visible graph, into the viewport. */
+/** Fits nodes into the part of the canvas the detail panel leaves free. */
 function centerGraph(subset) {
   const visible = subset && subset.length > 0 ? subset : nodes.filter(isNodeVisible);
   if (visible.length === 0) return;
@@ -297,7 +297,7 @@ function centerGraph(subset) {
   const covered = panel && getComputedStyle(panel).display !== "none"
     ? panel.getBoundingClientRect().width
     : 0;
-  const usableW = Math.max(120, W - covered);
+  const usableW = covered > W / 2 ? W : W - covered;
   const fit = Math.min(1.2, Math.min((usableW * 0.9) / (maxX - minX || 1), (H * 0.9) / (maxY - minY || 1)));
   zoom = Math.max(0.05, fit);
   camX = (usableW / 2 - W / 2) / zoom + W / 2 - (minX + maxX) / 2;
@@ -499,12 +499,12 @@ document.addEventListener("keydown", (e) => {
 
 document.getElementById("project-filter").addEventListener("change", (e) => {
   activeProject = e.target.value;
-  relayoutGraph();
-  if (focusNode) exitFocus();
   if (selectedNode && !isNodeVisible(selectedNode)) {
     document.getElementById("detail").style.display = "none";
     selectedNode = null;
   }
+  if (focusNode) exitFocus();
+  relayoutGraph();
 });
 
 function showDetail(n) {

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -165,13 +165,10 @@ function getDisplayName(n) {
 const canvas = document.getElementById("graph");
 const ctx = canvas.getContext("2d");
 const dpr = window.devicePixelRatio || 1;
-let simulationHeat = 1;
-
-function wakeSimulation(heat = 1) {
-  simulationHeat = Math.max(simulationHeat, heat);
-}
 
 let W, H;
+// The graph is laid out after the nodes exist; resize does nothing before that.
+let graphReady = false;
 function resize() {
   W = window.innerWidth - 340;
   H = window.innerHeight - 96;
@@ -180,7 +177,10 @@ function resize() {
   canvas.style.width = W + "px";
   canvas.style.height = H + "px";
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-  wakeSimulation(0.4);
+  if (graphReady) {
+    centerGraph();
+    scheduleGraphDraw();
+  }
 }
 resize();
 window.addEventListener("resize", resize);
@@ -208,29 +208,109 @@ for (const m of graph.modules) {
 }
 
 // ── Create nodes with physics ──
-const nodes = graph.modules.map((m, i) => {
-  const angle = (2 * Math.PI * i) / graph.modules.length;
-  const radius = Math.min(W, H) * 0.3;
-  return {
-    ...m,
-    x: W / 2 + Math.cos(angle) * radius,
-    y: H / 2 + Math.sin(angle) * radius,
-    vx: 0, vy: 0,
-    w: 0, h: 36,
-  };
-});
+const nodes = graph.modules.map((m) => ({ ...m, x: 0, y: 0, w: 0, h: 36 }));
 
 const nodeMap = new Map();
 for (const n of nodes) nodeMap.set(n.name, n);
 
+let graphDirty = false;
+function scheduleGraphDraw() {
+  if (graphDirty) return;
+  graphDirty = true;
+  requestAnimationFrame(() => { graphDirty = false; draw(); });
+}
+
+/**
+ * Lays each connected group out top down and packs the groups together, with
+ * modules that import nothing and are imported by nothing in one block.
+ */
+function layoutModules() {
+  const GUTTER = 90;
+  const visible = nodes.filter(isNodeVisible);
+  if (visible.length === 0) return;
+  const components = sComputeComponents(visible, graph.edges, "from", "to");
+  const boxes = [];
+  const isolated = [];
+
+  for (const comp of components) {
+    if (comp.length === 1) { isolated.push(comp[0]); continue; }
+    const size = sLayoutComponent(comp, graph.edges, "from", "to", "TB");
+    boxes.push({ nodes: comp, w: size.w, h: size.h });
+  }
+  boxes.sort((a, b) => b.h - a.h || b.w - a.w);
+
+  if (isolated.length > 0) {
+    isolated.sort((a, b) => (a.project || "").localeCompare(b.project || "") || a.name.localeCompare(b.name));
+    const size = sLayoutIsolatedBlock(isolated, 28);
+    boxes.push({ nodes: isolated, w: size.w, h: size.h });
+  }
+
+  let area = 0;
+  for (const b of boxes) area += b.w * b.h;
+  sPackBoxes(boxes, Math.max(900, Math.sqrt(area) * 1.7), GUTTER);
+  for (const b of boxes) {
+    for (const n of b.nodes) { n.x += b.ox; n.y += b.oy; }
+  }
+}
+
+/** Fits the laid-out graph into the viewport. */
+function centerGraph() {
+  const visible = nodes.filter(isNodeVisible);
+  if (visible.length === 0) return;
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const n of visible) {
+    minX = Math.min(minX, n.x - n.w / 2);
+    maxX = Math.max(maxX, n.x + n.w / 2);
+    minY = Math.min(minY, n.y - n.h / 2);
+    maxY = Math.max(maxY, n.y + n.h / 2);
+  }
+  const fit = Math.min(1.2, Math.min((W * 0.9) / (maxX - minX || 1), (H * 0.9) / (maxY - minY || 1)));
+  zoom = Math.max(0.05, fit);
+  camX = W / 2 - (minX + maxX) / 2;
+  camY = H / 2 - (minY + maxY) / 2;
+}
+
+function relayoutGraph() {
+  remeasureNodes();
+  layoutModules();
+  centerGraph();
+  graphReady = true;
+  scheduleGraphDraw();
+}
+
 ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
+const NODE_MAX_W = 220;
+
+function clipToWidth(text, maxW) {
+  if (ctx.measureText(text).width <= maxW) return text;
+  let out = text;
+  while (out.length > 3 && ctx.measureText(out).width > maxW) out = out.slice(0, -1);
+  return out + "\u2026";
+}
+
+/**
+ * The module name goes on its own line so the project prefix cannot crowd it
+ * out; the project moves to the second line, where colour already hints at it.
+ */
 function remeasureNodes() {
+  const room = NODE_MAX_W - 24;
   for (const n of nodes) {
-    const label = getDisplayName(n);
-    const sub = (n.providers.length || 0) + "p " + (n.controllers.length || 0) + "c";
-    const lw = ctx.measureText(label).width;
-    const sw = ctx.measureText(sub).width;
-    n.w = Math.max(lw, sw) + 24;
+    const shown = getDisplayName(n);
+    const cut = shown.lastIndexOf("/");
+    const moduleName = cut === -1 ? shown : shown.slice(cut + 1);
+    const counts = n.providers.length + "p " + n.controllers.length + "c";
+    const project = cut === -1 ? "" : shown.slice(0, cut);
+
+    ctx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+    n.labelStr = clipToWidth(moduleName, room);
+    const lw = Math.min(ctx.measureText(moduleName).width, room);
+
+    ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+    const sub = project ? project + " \u00b7 " + counts : counts;
+    n.subStr = clipToWidth(sub, room);
+    const sw = Math.min(ctx.measureText(sub).width, room);
+
+    n.w = Math.min(Math.max(lw, sw) + 24, NODE_MAX_W);
   }
 }
 remeasureNodes();
@@ -278,7 +358,7 @@ canvas.addEventListener("mousedown", (e) => {
   for (const n of nodes) {
     if (pos.x >= n.x - n.w / 2 && pos.x <= n.x + n.w / 2 && pos.y >= n.y - n.h / 2 && pos.y <= n.y + n.h / 2) {
       dragging = n;
-      wakeSimulation(0.35);
+      scheduleGraphDraw();
       return;
     }
   }
@@ -292,8 +372,7 @@ canvas.addEventListener("mousemove", (e) => {
     const pos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
     dragging.x = pos.x;
     dragging.y = pos.y;
-    dragging.vx = 0;
-    dragging.vy = 0;
+    scheduleGraphDraw();
   } else if (panning) {
     camX += (e.clientX - panStart.x) / zoom;
     camY += (e.clientY - panStart.y) / zoom;
@@ -305,7 +384,7 @@ canvas.addEventListener("mouseup", () => {
   if (dragging && !panning) {
     showDetail(dragging);
   }
-  wakeSimulation(0.25);
+  scheduleGraphDraw();
   dragging = null;
   panning = false;
 });
@@ -355,12 +434,7 @@ document.addEventListener("keydown", (e) => {
 
 document.getElementById("project-filter").addEventListener("change", (e) => {
   activeProject = e.target.value;
-  remeasureNodes();
-  for (const n of nodes) {
-    n.vx = (Math.random() - 0.5) * 0.8;
-    n.vy = (Math.random() - 0.5) * 0.8;
-  }
-  wakeSimulation();
+  relayoutGraph();
   if (focusNode) exitFocus();
   if (selectedNode && !isNodeVisible(selectedNode)) {
     document.getElementById("detail").style.display = "none";
@@ -420,73 +494,6 @@ function showDetail(n) {
 }
 
 // ── Physics simulation ──
-const REPULSION = 2400;
-const SPRING_LENGTH = 180;
-const SPRING_K = 0.0035;
-const DAMPING = 0.8;
-const CENTER_PULL = 0.00035;
-const HEAT_DECAY = 0.985;
-const HEAT_SLEEP_THRESHOLD = 0.02;
-const SPEED_SLEEP_THRESHOLD = 0.03;
-
-function simulate() {
-  if (simulationHeat <= 0 && !dragging && !panning) {
-    return;
-  }
-
-  const forceScale = Math.max(simulationHeat, HEAT_SLEEP_THRESHOLD);
-
-  for (const a of nodes) {
-    if (!isNodeVisible(a)) continue;
-    for (const b of nodes) {
-      if (a === b || !isNodeVisible(b)) continue;
-      let dx = a.x - b.x;
-      let dy = a.y - b.y;
-      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
-      const force = (REPULSION * forceScale) / (dist * dist);
-      a.vx += (dx / dist) * force;
-      a.vy += (dy / dist) * force;
-    }
-    a.vx += (W / 2 - a.x) * CENTER_PULL * forceScale;
-    a.vy += (H / 2 - a.y) * CENTER_PULL * forceScale;
-  }
-  for (const edge of graph.edges) {
-    const a = nodeMap.get(edge.from);
-    const b = nodeMap.get(edge.to);
-    if (!a || !b) continue;
-    if (!isNodeVisible(a) || !isNodeVisible(b)) continue;
-    const dx = b.x - a.x;
-    const dy = b.y - a.y;
-    const dist = Math.sqrt(dx * dx + dy * dy) || 1;
-    const force = (dist - SPRING_LENGTH) * SPRING_K * forceScale;
-    const fx = (dx / dist) * force;
-    const fy = (dy / dist) * force;
-    a.vx += fx; a.vy += fy;
-    b.vx -= fx; b.vy -= fy;
-  }
-
-  let maxSpeed = 0;
-  for (const n of nodes) {
-    if (n === dragging || !isNodeVisible(n)) continue;
-    n.vx *= DAMPING;
-    n.vy *= DAMPING;
-    n.x += n.vx;
-    n.y += n.vy;
-    const speed = Math.abs(n.vx) + Math.abs(n.vy);
-    if (speed > maxSpeed) maxSpeed = speed;
-  }
-
-  if (!dragging && !panning) {
-    simulationHeat *= HEAT_DECAY;
-    if (simulationHeat < HEAT_SLEEP_THRESHOLD && maxSpeed < SPEED_SLEEP_THRESHOLD) {
-      simulationHeat = 0;
-      for (const n of nodes) {
-        n.vx = 0;
-        n.vy = 0;
-      }
-    }
-  }
-}
 
 function drawArrow(fromX, fromY, toX, toY, color, dashed) {
   const dx = toX - fromX;
@@ -610,28 +617,20 @@ function draw() {
     ctx.lineWidth = isSelected ? 2 : 1;
     ctx.stroke();
 
-    const displayName = getDisplayName(n);
     ctx.fillStyle = "#fff";
     ctx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
-    ctx.fillText(displayName, n.x, n.y - 5);
+    ctx.fillText(n.labelStr || getDisplayName(n), n.x, n.y - 5);
     ctx.fillStyle = "#888";
     ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
-    ctx.fillText(n.providers.length + " providers, " + n.controllers.length + " controllers", n.x, n.y + 10);
+    ctx.fillText(n.subStr || "", n.x, n.y + 10);
   }
   ctx.globalAlpha = 1;
   ctx.restore();
 }
 
-function loop() {
-  if (activeTab === "modules") {
-    simulate();
-    draw();
-  }
-  requestAnimationFrame(loop);
-}
-loop();
+relayoutGraph();
 
 // ── Diagnosis Tab rendering ──
 const SEV_ORDER = { error: 0, warning: 1, info: 2 };
@@ -1466,7 +1465,6 @@ function renderLab() {
     }
   });
 
-
   function showPgFile(filePath) {
     const findings = currentPgFileMap[filePath];
     if (!findings) return;
@@ -2141,8 +2139,8 @@ function sPolylineMidpoint(points) {
   return { x: points[points.length - 1].x, y: points[points.length - 1].y };
 }
 
-/** Groups nodes into connected components using the relation edges. */
-function sComputeComponents(nodes) {
+/** Groups nodes into connected components using the given edges. */
+function sComputeComponents(nodes, edges, fromKey, toKey) {
   var index = {};
   var parent = [];
   for (var i = 0; i < nodes.length; i++) {
@@ -2156,11 +2154,11 @@ function sComputeComponents(nodes) {
     }
     return a;
   }
-  for (var i = 0; i < schema.relations.length; i++) {
-    var rel = schema.relations[i];
-    if (rel.fromEntity === rel.toEntity) continue;
-    var a = index[rel.fromEntity];
-    var b = index[rel.toEntity];
+  for (var i = 0; i < edges.length; i++) {
+    var rel = edges[i];
+    if (rel[fromKey] === rel[toKey]) continue;
+    var a = index[rel[fromKey]];
+    var b = index[rel[toKey]];
     if (a === undefined || b === undefined) continue;
     var ra = find(a), rb = find(b);
     if (ra !== rb) parent[rb] = ra;
@@ -2179,7 +2177,7 @@ function sComputeComponents(nodes) {
 }
 
 /** Positions one component from its own origin, with dagre or a grid. */
-function sLayoutComponent(nodes) {
+function sLayoutComponent(nodes, edges, fromKey, toKey, rankdir) {
   var i;
   if (nodes.length === 1 || typeof dagre === "undefined") {
     var cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
@@ -2200,7 +2198,7 @@ function sLayoutComponent(nodes) {
   }
 
   var g = new dagre.graphlib.Graph();
-  g.setGraph({ rankdir: "LR", nodesep: 60, ranksep: 120, marginx: 0, marginy: 0 });
+  g.setGraph({ rankdir: rankdir || "LR", nodesep: 60, ranksep: 120, marginx: 0, marginy: 0 });
   g.setDefaultEdgeLabel(function() { return {}; });
 
   var present = {};
@@ -2210,14 +2208,14 @@ function sLayoutComponent(nodes) {
   }
 
   var seenEdge = {};
-  for (i = 0; i < schema.relations.length; i++) {
-    var edge = schema.relations[i];
-    if (edge.fromEntity === edge.toEntity) continue;
-    if (!present[edge.fromEntity] || !present[edge.toEntity]) continue;
-    var ek = sEdgeKey(edge.fromEntity, edge.toEntity);
+  for (i = 0; i < edges.length; i++) {
+    var edge = edges[i];
+    if (edge[fromKey] === edge[toKey]) continue;
+    if (!present[edge[fromKey]] || !present[edge[toKey]]) continue;
+    var ek = sEdgeKey(edge[fromKey], edge[toKey]);
     if (seenEdge[ek]) continue;
     seenEdge[ek] = true;
-    g.setEdge(edge.fromEntity, edge.toEntity);
+    g.setEdge(edge[fromKey], edge[toKey]);
   }
 
   dagre.layout(g);
@@ -2279,7 +2277,7 @@ function sPackBoxes(boxes, targetW, gutter) {
 
 function sComputeOverviewLayout() {
   var GUTTER = 80;
-  var components = sComputeComponents(sNodes);
+  var components = sComputeComponents(sNodes, schema.relations, "fromEntity", "toEntity");
   var boxes = [];
   var isolated = [];
   var i;
@@ -2289,7 +2287,7 @@ function sComputeOverviewLayout() {
       isolated.push(components[i][0]);
       continue;
     }
-    var size = sLayoutComponent(components[i]);
+    var size = sLayoutComponent(components[i], schema.relations, "fromEntity", "toEntity", "LR");
     boxes.push({ nodes: components[i], w: size.w, h: size.h });
   }
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -170,7 +170,7 @@ let W, H;
 // The graph is laid out after the nodes exist; resize does nothing before that.
 let graphReady = false;
 function resize() {
-  const sameSize = W === window.innerWidth - 340 && H === window.innerHeight - 96;
+  const prevW = W, prevH = H;
   W = window.innerWidth - 340;
   H = window.innerHeight - 96;
   canvas.width = W * dpr;
@@ -179,8 +179,11 @@ function resize() {
   canvas.style.height = H + "px";
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   if (graphReady) {
-    // Refit only when the canvas actually changed size.
-    if (!sameSize) centerGraph();
+    // Hold whatever was in the middle of the viewport in the middle of it.
+    if (prevW && prevH) {
+      camX += (W - prevW) / 2;
+      camY += (H - prevH) / 2;
+    }
     scheduleGraphDraw();
   }
 }
@@ -278,9 +281,9 @@ function layoutModules() {
   }
 }
 
-/** Fits the laid-out graph into the viewport. */
-function centerGraph() {
-  const visible = nodes.filter(isNodeVisible);
+/** Fits the given nodes, or the whole visible graph, into the viewport. */
+function centerGraph(subset) {
+  const visible = subset && subset.length > 0 ? subset : nodes.filter(isNodeVisible);
   if (visible.length === 0) return;
   let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
   for (const n of visible) {
@@ -360,6 +363,9 @@ function enterFocus(n) {
   focusSet = getRelatedNames(n.name);
   document.getElementById("focus-btn").classList.add("visible");
   document.getElementById("focus-hint").style.display = "block";
+  centerGraph(nodes.filter((m) => isNodeVisible(m) && focusSet.has(m.name)));
+  syncModulesZoomUi();
+  scheduleGraphDraw();
 }
 
 function exitFocus() {
@@ -367,6 +373,8 @@ function exitFocus() {
   focusSet = null;
   document.getElementById("focus-btn").classList.remove("visible");
   document.getElementById("focus-hint").style.display = "none";
+  centerGraph();
+  syncModulesZoomUi();
   scheduleGraphDraw();
 }
 
@@ -649,10 +657,10 @@ function draw() {
     ctx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
-    ctx.fillText(n.labelStr || getDisplayName(n), n.x, n.y - 5);
+    ctx.fillText(n.labelStr, n.x, n.y - 5);
     ctx.fillStyle = "#888";
     ctx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
-    ctx.fillText(n.subStr || "", n.x, n.y + 10);
+    ctx.fillText(n.subStr, n.x, n.y + 10);
   }
   if (isolatedHeading && !focusNode) {
     ctx.globalAlpha = 1;
@@ -668,9 +676,18 @@ function draw() {
 
 // ── Hover tooltip ──
 const modulesTooltip = document.getElementById("modules-tooltip");
+let tooltipFor = null;
 
 function showModuleTooltip(n, sx, sy) {
   if (!modulesTooltip) return;
+  if (tooltipFor !== n) {
+    tooltipFor = n;
+    fillModuleTooltip(n);
+  }
+  placeModuleTooltip(sx, sy);
+}
+
+function fillModuleTooltip(n) {
   const imports = n.imports.length;
   const exports = n.exports.length;
   modulesTooltip.innerHTML =
@@ -680,14 +697,19 @@ function showModuleTooltip(n, sx, sy) {
     '<ul class="tt-cols"><li><span class="col-name">imports</span><span>' + imports +
     '</span></li><li><span class="col-name">exports</span><span>' + exports + "</span></li></ul>";
   modulesTooltip.style.display = "block";
+}
+
+/** Places the tooltip in viewport coordinates, kept on screen. */
+function placeModuleTooltip(clientX, clientY) {
   const box = modulesTooltip.getBoundingClientRect();
-  const left = Math.min(sx + 16, Math.max(0, W - box.width - 8));
-  const top = Math.min(Math.max(0, sy - 10), Math.max(0, H - box.height - 8));
+  const left = Math.min(clientX + 16, Math.max(0, window.innerWidth - box.width - 8));
+  const top = Math.min(Math.max(0, clientY - 10), Math.max(0, window.innerHeight - box.height - 8));
   modulesTooltip.style.left = left + "px";
   modulesTooltip.style.top = top + "px";
 }
 
 function hideModuleTooltip() {
+  tooltipFor = null;
   if (modulesTooltip) modulesTooltip.style.display = "none";
 }
 
@@ -697,9 +719,7 @@ canvas.addEventListener("mousemove", (e) => {
     return;
   }
   const rect = canvas.getBoundingClientRect();
-  const sx = e.clientX - rect.left;
-  const sy = e.clientY - rect.top;
-  const pos = screenToWorld(sx, sy);
+  const pos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
   let hit = null;
   for (const n of nodes) {
     if (!isNodeVisible(n)) continue;
@@ -710,7 +730,7 @@ canvas.addEventListener("mousemove", (e) => {
   }
   canvas.style.cursor = hit ? "pointer" : "";
   if (hit) {
-    showModuleTooltip(hit, sx, sy);
+    showModuleTooltip(hit, e.clientX, e.clientY);
   } else {
     hideModuleTooltip();
   }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -673,6 +673,60 @@ function draw() {
   ctx.restore();
 }
 
+// ── Hover tooltip ──
+const modulesTooltip = document.getElementById("modules-tooltip");
+let hoveredNode = null;
+
+function showModuleTooltip(n, sx, sy) {
+  if (!modulesTooltip) return;
+  const imports = n.imports.length;
+  const exports = n.exports.length;
+  modulesTooltip.innerHTML =
+    '<div class="tt-name">' + escHtml(n.name) + "</div>" +
+    '<div class="tt-table">' + n.providers.length + " providers \u00b7 " +
+    n.controllers.length + " controllers</div>" +
+    '<ul class="tt-cols"><li><span class="col-name">imports</span><span>' + imports +
+    '</span></li><li><span class="col-name">exports</span><span>' + exports + "</span></li></ul>";
+  modulesTooltip.style.display = "block";
+  modulesTooltip.style.left = sx + 16 + "px";
+  modulesTooltip.style.top = sy - 10 + "px";
+}
+
+function hideModuleTooltip() {
+  if (modulesTooltip) modulesTooltip.style.display = "none";
+}
+
+canvas.addEventListener("mousemove", (e) => {
+  if (dragging || panning) {
+    hideModuleTooltip();
+    return;
+  }
+  const rect = canvas.getBoundingClientRect();
+  const sx = e.clientX - rect.left;
+  const sy = e.clientY - rect.top;
+  const pos = screenToWorld(sx, sy);
+  let hit = null;
+  for (const n of nodes) {
+    if (!isNodeVisible(n)) continue;
+    if (Math.abs(pos.x - n.x) <= n.w / 2 && Math.abs(pos.y - n.y) <= n.h / 2) {
+      hit = n;
+      break;
+    }
+  }
+  canvas.style.cursor = hit ? "pointer" : "grab";
+  if (hit) {
+    showModuleTooltip(hit, sx, sy);
+  } else {
+    hideModuleTooltip();
+  }
+  if (hit !== hoveredNode) hoveredNode = hit;
+});
+
+canvas.addEventListener("mouseleave", () => {
+  hoveredNode = null;
+  hideModuleTooltip();
+});
+
 // ── Modules toolbar ──
 let modulesZoomUi = null;
 function syncModulesZoomUi() {

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -428,6 +428,15 @@ canvas.addEventListener("mouseup", () => {
   panning = false;
 });
 
+// A release outside the canvas never reaches it, which would leave a node stuck
+// to the pointer.
+window.addEventListener("mouseup", () => {
+  if (!(dragging || panning)) return;
+  dragging = null;
+  panning = false;
+  scheduleGraphDraw();
+});
+
 canvas.addEventListener("click", (e) => {
   if (clickHandled) {
     clickHandled = false;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -103,7 +103,7 @@ function switchTab(name) {
   if (name !== "modules") {
     document.getElementById("detail").style.display = "none";
     selectedNode = null;
-    exitFocus();
+    if (focusNode) exitFocus();
   }
 
   if (name === "diagnosis" && !diagnosisRendered) { renderDiagnosis(); diagnosisRendered = true; }
@@ -167,7 +167,7 @@ const ctx = canvas.getContext("2d");
 const dpr = window.devicePixelRatio || 1;
 
 let W, H;
-// The graph is laid out after the nodes exist; resize does nothing before that.
+// True once the nodes have been laid out at least once.
 let graphReady = false;
 function resize() {
   const prevW = W, prevH = H;
@@ -266,7 +266,7 @@ function layoutModules() {
     for (const n of b.nodes) { n.x += b.ox; n.y += b.oy; }
   }
 
-  // Headed only when there is something connected to contrast against.
+  // The heading needs a connected group to contrast against.
   isolatedHeading = null;
   if (isolatedBox && anyConnected && activeProject === "all") {
     let top = Infinity;
@@ -343,6 +343,8 @@ function remeasureNodes() {
 let camX = 0, camY = 0, zoom = 1;
 let dragging = null;
 let panning = false;
+let pointerMoved = false;
+let clickHandled = false;
 let panStart = { x: 0, y: 0 };
 let selectedNode = null;
 let focusNode = null;
@@ -383,6 +385,8 @@ function screenToWorld(sx, sy) {
 }
 
 canvas.addEventListener("mousedown", (e) => {
+  pointerMoved = false;
+  clickHandled = false;
   const rect = canvas.getBoundingClientRect();
   const pos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
   for (const n of nodes) {
@@ -399,12 +403,14 @@ canvas.addEventListener("mousedown", (e) => {
 
 canvas.addEventListener("mousemove", (e) => {
   if (dragging) {
+    pointerMoved = true;
     const rect = canvas.getBoundingClientRect();
     const pos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
     dragging.x = pos.x;
     dragging.y = pos.y;
     scheduleGraphDraw();
   } else if (panning) {
+    pointerMoved = true;
     camX += (e.clientX - panStart.x) / zoom;
     camY += (e.clientY - panStart.y) / zoom;
     panStart = { x: e.clientX, y: e.clientY };
@@ -413,8 +419,9 @@ canvas.addEventListener("mousemove", (e) => {
 });
 
 canvas.addEventListener("mouseup", () => {
-  if (dragging && !panning) {
+  if (dragging && !panning && !pointerMoved) {
     showDetail(dragging);
+    clickHandled = true;
   }
   scheduleGraphDraw();
   dragging = null;
@@ -422,6 +429,11 @@ canvas.addEventListener("mouseup", () => {
 });
 
 canvas.addEventListener("click", (e) => {
+  if (clickHandled) {
+    clickHandled = false;
+    return;
+  }
+  if (pointerMoved) return;
   const rect = canvas.getBoundingClientRect();
   const pos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
   for (const n of nodes) {
@@ -463,8 +475,10 @@ document.getElementById("focus-btn").addEventListener("click", () => {
 });
 
 document.addEventListener("keydown", (e) => {
-  if (e.key === "Escape") {
-    if (focusNode) exitFocus();
+  if (e.key === "Escape" && focusNode) {
+    exitFocus();
+    document.getElementById("detail").style.display = "none";
+    selectedNode = null;
   }
 });
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -103,6 +103,7 @@ function switchTab(name) {
   if (name !== "modules") {
     document.getElementById("detail").style.display = "none";
     selectedNode = null;
+    hideModuleTooltip();
     if (focusNode) exitFocus();
   }
 
@@ -232,6 +233,7 @@ function scheduleGraphDraw() {
  */
 function layoutModules() {
   const GUTTER = 90;
+  isolatedHeading = null;
   const visible = nodes.filter(isNodeVisible);
   if (visible.length === 0) return;
   const components = sComputeComponents(visible, graph.edges, "from", "to");
@@ -266,8 +268,7 @@ function layoutModules() {
     for (const n of b.nodes) { n.x += b.ox; n.y += b.oy; }
   }
 
-  // The heading needs a connected group to contrast against.
-  isolatedHeading = null;
+  // A heading only reads against a connected group, and only for the whole graph.
   if (isolatedBox && anyConnected && activeProject === "all") {
     let top = Infinity;
     for (const n of isolatedBox.nodes) top = Math.min(top, n.y - n.h / 2);
@@ -292,9 +293,14 @@ function centerGraph(subset) {
     minY = Math.min(minY, n.y - n.h / 2);
     maxY = Math.max(maxY, n.y + n.h / 2);
   }
-  const fit = Math.min(1.2, Math.min((W * 0.9) / (maxX - minX || 1), (H * 0.9) / (maxY - minY || 1)));
+  const panel = document.getElementById("detail");
+  const covered = panel && getComputedStyle(panel).display !== "none"
+    ? panel.getBoundingClientRect().width
+    : 0;
+  const usableW = Math.max(120, W - covered);
+  const fit = Math.min(1.2, Math.min((usableW * 0.9) / (maxX - minX || 1), (H * 0.9) / (maxY - minY || 1)));
   zoom = Math.max(0.05, fit);
-  camX = W / 2 - (minX + maxX) / 2;
+  camX = (usableW / 2 - W / 2) / zoom + W / 2 - (minX + maxX) / 2;
   camY = H / 2 - (minY + maxY) / 2;
 }
 
@@ -428,8 +434,7 @@ canvas.addEventListener("mouseup", () => {
   panning = false;
 });
 
-// A release outside the canvas never reaches it, which would leave a node stuck
-// to the pointer.
+// Catches the release when it lands outside the canvas.
 window.addEventListener("mouseup", () => {
   if (!(dragging || panning)) return;
   dragging = null;
@@ -466,6 +471,7 @@ canvas.addEventListener("wheel", (e) => {
     camX -= e.deltaX / zoom;
     camY -= e.deltaY / zoom;
   }
+  hideModuleTooltip();
   scheduleGraphDraw();
 }, { passive: false });
 
@@ -780,6 +786,7 @@ function syncModulesZoomUi() {
 
 function setModulesZoom(next) {
   zoom = Math.max(0.05, Math.min(5, next));
+  hideModuleTooltip();
   syncModulesZoomUi();
   scheduleGraphDraw();
 }

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -860,6 +860,10 @@ canvas:active { cursor: grabbing; }
   width: 11px; height: 11px; border-radius: 50%;
   background: var(--nest-red); cursor: pointer;
 }
+#modules-zoom-range::-moz-range-thumb {
+  width: 11px; height: 11px; border: none; border-radius: 50%;
+  background: var(--nest-red); cursor: pointer;
+}
 #schema-toolbar {
   position: absolute; top: 12px; right: 12px; z-index: 10;
   display: flex; align-items: center; gap: 4px;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -839,7 +839,7 @@ canvas:active { cursor: grabbing; }
   cursor: grab; display: block;
 }
 #schema-canvas:active { cursor: grabbing; }
-#modules-tooltip { position: absolute; z-index: 20; }
+#modules-tooltip { position: fixed; z-index: 25; }
 /* Left, because the detail panel is fixed over the right edge. */
 #modules-toolbar {
   position: absolute; top: 12px; left: 12px; z-index: 10;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -839,6 +839,7 @@ canvas:active { cursor: grabbing; }
   cursor: grab; display: block;
 }
 #schema-canvas:active { cursor: grabbing; }
+#modules-tooltip { position: absolute; z-index: 20; }
 #modules-toolbar {
   position: absolute; top: 12px; right: 12px; z-index: 10;
   display: flex; align-items: center; gap: 4px;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -840,7 +840,6 @@ canvas:active { cursor: grabbing; }
 }
 #schema-canvas:active { cursor: grabbing; }
 #modules-tooltip { position: fixed; z-index: 25; }
-/* Left, because the detail panel is fixed over the right edge. */
 #modules-toolbar {
   position: absolute; top: 12px; left: 12px; z-index: 10;
   display: flex; align-items: center; gap: 4px;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -839,6 +839,27 @@ canvas:active { cursor: grabbing; }
   cursor: grab; display: block;
 }
 #schema-canvas:active { cursor: grabbing; }
+#modules-toolbar {
+  position: absolute; top: 12px; right: 12px; z-index: 10;
+  display: flex; align-items: center; gap: 4px;
+}
+#modules-zoombar {
+  display: flex; align-items: center; gap: 6px;
+  height: 28px; padding: 0 8px; border-radius: 6px;
+  background: rgba(50,50,50,0.9);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255,255,255,0.22);
+}
+#modules-zoom-range {
+  -webkit-appearance: none; appearance: none;
+  width: 110px; height: 3px; border-radius: 2px;
+  background: rgba(255,255,255,0.25); outline: none; cursor: pointer;
+}
+#modules-zoom-range::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 11px; height: 11px; border-radius: 50%;
+  background: var(--nest-red); cursor: pointer;
+}
 #schema-toolbar {
   position: absolute; top: 12px; right: 12px; z-index: 10;
   display: flex; align-items: center; gap: 4px;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -840,8 +840,9 @@ canvas:active { cursor: grabbing; }
 }
 #schema-canvas:active { cursor: grabbing; }
 #modules-tooltip { position: absolute; z-index: 20; }
+/* Left, because the detail panel is fixed over the right edge. */
 #modules-toolbar {
-  position: absolute; top: 12px; right: 12px; z-index: 10;
+  position: absolute; top: 12px; left: 12px; z-index: 10;
   display: flex; align-items: center; gap: 4px;
 }
 #modules-zoombar {

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -353,7 +353,7 @@ describe("modules graph layout", () => {
 	) {
 		const scripts = getReportScripts(EMPTY);
 		const start = scripts.indexOf("function layoutModules()");
-		const end = scripts.indexOf("/** Fits the given nodes");
+		const end = scripts.indexOf("function centerGraph");
 		const helperStart = scripts.indexOf("function sComputeComponents");
 		const helperEnd = scripts.indexOf("function sComputeStarLayout");
 		if (start < 0 || end <= start || helperStart < 0) {

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -335,3 +335,133 @@ describe("schema overview layout", () => {
 		expect(findOverlap(nodes)).toBeNull();
 	});
 });
+
+describe("modules graph layout", () => {
+	interface ModuleNode {
+		h: number;
+		name: string;
+		project?: string;
+		w: number;
+		x: number;
+		y: number;
+	}
+
+	function loadLayout(
+		moduleNodes: ModuleNode[],
+		edges: { from: string; to: string }[],
+		activeProject = "all"
+	) {
+		const scripts = getReportScripts(EMPTY);
+		const start = scripts.indexOf("function layoutModules()");
+		const end = scripts.indexOf("/** Fits the given nodes");
+		const helperStart = scripts.indexOf("function sComputeComponents");
+		const helperEnd = scripts.indexOf("function sComputeStarLayout");
+		if (start < 0 || end <= start || helperStart < 0) {
+			throw new Error(
+				"layout functions not found in the emitted report script"
+			);
+		}
+		const factory = new Function(
+			"nodes",
+			"graph",
+			"activeProject",
+			"sEdgeKey",
+			"dagre",
+			`${scripts.slice(helperStart, helperEnd)}
+			 let isolatedHeading = null;
+			 function isNodeVisible(n) {
+			   return activeProject === "all" || n.project === activeProject;
+			 }
+			 ${scripts.slice(start, end)}
+			 return { layoutModules: layoutModules, heading: () => isolatedHeading };`
+		);
+		return factory(moduleNodes, { edges }, activeProject, edgeKey, fakeDagre);
+	}
+
+	function build(connected: number, alone: number): ModuleNode[] {
+		const out: ModuleNode[] = [];
+		for (let i = 0; i < connected; i++) {
+			out.push({
+				h: 36,
+				name: `linked${i}`,
+				project: "app",
+				w: 180,
+				x: 0,
+				y: 0,
+			});
+		}
+		for (let i = 0; i < alone; i++) {
+			out.push({
+				h: 36,
+				name: `alone${i}`,
+				project: "lib",
+				w: 180,
+				x: 0,
+				y: 0,
+			});
+		}
+		return out;
+	}
+
+	it("puts the unconnected modules below the connected ones", () => {
+		const moduleNodes = build(4, 5);
+		const edges = [
+			{ from: "linked0", to: "linked1" },
+			{ from: "linked1", to: "linked2" },
+			{ from: "linked2", to: "linked3" },
+		];
+		const api = loadLayout(moduleNodes, edges);
+
+		api.layoutModules();
+
+		const linked = moduleNodes.filter((n) => n.name.startsWith("linked"));
+		const alone = moduleNodes.filter((n) => n.name.startsWith("alone"));
+		expect(findOverlap(moduleNodes)).toBeNull();
+		expect(Math.min(...alone.map((n) => n.y))).toBeGreaterThan(
+			Math.max(...linked.map((n) => n.y))
+		);
+		expect(api.heading()).toEqual(
+			expect.objectContaining({ text: "5 modules with no import links" })
+		);
+	});
+
+	it("says module once when only one has no links", () => {
+		const moduleNodes = build(2, 1);
+		const api = loadLayout(moduleNodes, [{ from: "linked0", to: "linked1" }]);
+
+		api.layoutModules();
+
+		expect(api.heading().text).toBe("1 module with no import links");
+	});
+
+	it("lays out a graph with no edges at all, without a heading", () => {
+		const moduleNodes = build(0, 4);
+		const api = loadLayout(moduleNodes, []);
+
+		api.layoutModules();
+
+		expect(api.heading()).toBeNull();
+		expect(findOverlap(moduleNodes)).toBeNull();
+		// Every module was positioned rather than left stacked on the origin.
+		expect(new Set(moduleNodes.map((n) => `${n.x},${n.y}`)).size).toBe(4);
+	});
+
+	it("drops the heading while a project filter narrows the edges", () => {
+		const moduleNodes = build(3, 2);
+		const api = loadLayout(
+			moduleNodes,
+			[{ from: "linked0", to: "linked1" }],
+			"lib"
+		);
+
+		api.layoutModules();
+
+		expect(api.heading()).toBeNull();
+	});
+
+	it("does nothing when there are no modules", () => {
+		const api = loadLayout([], []);
+
+		expect(() => api.layoutModules()).not.toThrow();
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -205,6 +205,38 @@ describe("schema overview layout", () => {
 		expect(all.sNodeHeight(wide, false)).toBe(52);
 	});
 
+	it("groups by whatever edge shape it is handed", () => {
+		// The module graph uses from/to, the schema uses fromEntity/toEntity.
+		const scripts = getReportScripts(EMPTY);
+		const start = scripts.indexOf("function sComputeComponents");
+		const end = scripts.indexOf("function sComputeStarLayout");
+		if (start < 0 || end <= start) {
+			throw new Error(
+				"layout functions not found in the emitted report script"
+			);
+		}
+		const factory = new Function(
+			"sEdgeKey",
+			`${scripts.slice(start, end)}\nreturn sComputeComponents;`
+		);
+		const computeComponents = factory(edgeKey);
+		const nodes = [
+			{ name: "a", x: 0, y: 0, w: 180, h: 52 },
+			{ name: "b", x: 0, y: 0, w: 180, h: 52 },
+			{ name: "c", x: 0, y: 0, w: 180, h: 52 },
+		];
+
+		const grouped = computeComponents(
+			nodes,
+			[{ from: "a", to: "b" }],
+			"from",
+			"to"
+		);
+
+		expect(grouped).toHaveLength(2);
+		expect(grouped.map((g: Node[]) => g.length).sort()).toEqual([1, 2]);
+	});
+
 	it("keeps a single connected schema in one block", () => {
 		const nodes: Node[] = [
 			{ name: "a", x: 0, y: 0, w: 180, h: 52 },

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -459,6 +459,25 @@ describe("modules graph layout", () => {
 		expect(api.heading()).toBeNull();
 	});
 
+	it("survives a module named after an Object member", () => {
+		const moduleNodes: ModuleNode[] = [
+			{ h: 36, name: "toString", project: "app", w: 180, x: 0, y: 0 },
+			{ h: 36, name: "constructor", project: "app", w: 180, x: 0, y: 0 },
+			{ h: 36, name: "AppModule", project: "app", w: 180, x: 0, y: 0 },
+		];
+		const api = loadLayout(moduleNodes, [
+			{ from: "AppModule", to: "toString" },
+			// An edge naming something that is not a module at all.
+			{ from: "AppModule", to: "valueOf" },
+		]);
+
+		expect(() => api.layoutModules()).not.toThrow();
+		expect(findOverlap(moduleNodes)).toBeNull();
+		expect(
+			moduleNodes.every((n) => Number.isFinite(n.x) && Number.isFinite(n.y))
+		).toBe(true);
+	});
+
 	it("does nothing when there are no modules", () => {
 		const api = loadLayout([], []);
 

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -205,6 +205,89 @@ describe("schema overview layout", () => {
 		expect(all.sNodeHeight(wide, false)).toBe(52);
 	});
 
+	it("separates module-shaped nodes, connected and not", () => {
+		// Mirrors what the modules graph does: dagre per group, top down, with the
+		// unconnected ones packed into a block.
+		const scripts = getReportScripts(EMPTY);
+		const start = scripts.indexOf("function sComputeComponents");
+		const end = scripts.indexOf("function sComputeStarLayout");
+		if (start < 0 || end <= start) {
+			throw new Error(
+				"layout functions not found in the emitted report script"
+			);
+		}
+		const factory = new Function(
+			"sEdgeKey",
+			"dagre",
+			`${scripts.slice(start, end)}\nreturn { sComputeComponents, sLayoutComponent, sLayoutIsolatedBlock, sPackBoxes };`
+		);
+		const api = factory(edgeKey, fakeDagre);
+
+		const nodes: Node[] = [];
+		const relations: Relation[] = [];
+		for (let i = 0; i < 6; i++) {
+			nodes.push({ name: `linked${i}`, x: 0, y: 0, w: 180, h: 36 });
+			if (i > 0) {
+				relations.push({ fromEntity: "linked0", toEntity: `linked${i}` });
+			}
+		}
+		for (let i = 0; i < 9; i++) {
+			nodes.push({ name: `alone${i}`, x: 0, y: 0, w: 180, h: 36 });
+		}
+		const edges = relations.map((r) => ({
+			from: r.fromEntity,
+			to: r.toEntity,
+		}));
+
+		const groups = api.sComputeComponents(nodes, edges, "from", "to");
+		const boxes: {
+			h: number;
+			nodes: Node[];
+			ox?: number;
+			oy?: number;
+			w: number;
+		}[] = [];
+		const alone: Node[] = [];
+		for (const group of groups) {
+			if (group.length === 1) {
+				alone.push(group[0]);
+				continue;
+			}
+			const size = api.sLayoutComponent(group, edges, "from", "to", "TB");
+			boxes.push({ h: size.h, nodes: group, w: size.w });
+		}
+		api.sPackBoxes(boxes, 900, 90);
+		let below = 0;
+		for (const box of boxes) {
+			below = Math.max(below, (box.oy ?? 0) + box.h);
+		}
+		const aloneSize = api.sLayoutIsolatedBlock(alone, 28);
+		boxes.push({
+			h: aloneSize.h,
+			nodes: alone,
+			ox: 0,
+			oy: below + 90,
+			w: aloneSize.w,
+		});
+		for (const box of boxes) {
+			for (const node of box.nodes) {
+				node.x += box.ox ?? 0;
+				node.y += box.oy ?? 0;
+			}
+		}
+
+		expect(alone).toHaveLength(9);
+		expect(findOverlap(nodes)).toBeNull();
+		// The unconnected block sits under everything it was packed beneath.
+		const lowestLinked = Math.max(
+			...nodes.filter((n) => n.name.startsWith("linked")).map((n) => n.y)
+		);
+		const highestAlone = Math.min(
+			...nodes.filter((n) => n.name.startsWith("alone")).map((n) => n.y)
+		);
+		expect(highestAlone).toBeGreaterThan(lowestLinked);
+	});
+
 	it("groups by whatever edge shape it is handed", () => {
 		// The module graph uses from/to, the schema uses fromEntity/toEntity.
 		const scripts = getReportScripts(EMPTY);


### PR DESCRIPTION
## 1. Context

The report's Modules Graph tab draws every Nest module on a canvas. Positions came
from a force simulation: nodes were seeded on a circle of radius `min(W,H) * 0.3`
and then pushed apart by repulsion and pulled together by springs, redrawn every
frame from a `requestAnimationFrame` loop.

## 2. Problem

The boxes are wider than the circle they are seeded on, so they cannot avoid
piling up. Measured on a 66-module Nx workspace:

| | |
|---|---|
| modules | 66 |
| node box width | up to **407px** (median 193) |
| seed circle radius | **248** |
| **overlapping pairs** | **221** |
| **modules covering another one** | **98%** |

There is also very little for a simulation to reveal. The same workspace has
**19 import edges across 47 groups, 29 of which are a single module**, and the
largest group is 3 nodes. A layout tuned to expose topology spends the whole
canvas on a graph that has almost none.

On a 16-module project with 30 real edges it does settle, but into a ring with
the edges crossing the middle and the root module on the right, so it still
answers neither "what depends on what" nor "what is orphaned".

## 3. Possible flows

| Flow | Before | After |
|---|---|---|
| monorepo, 66 modules | 221 overlapping pairs | **0**, all on screen |
| single project, 16 modules, 30 edges | settles into a ring | top-down layers, root above its imports |
| single-module project | one box, arbitrary position | one box, no heading |
| modules with no import links | scattered through the pile | one labelled block under the rest |
| project filter | re-scrambled the layout with random jitter | re-lays out the visible set; all -> project -> all reproduces exactly |
| dragging a node | fought the simulation | moves and stays |
| schema and endpoints tabs | untouched | untouched |

## 4. Solution

Each connected group is laid out top down with dagre, so a module sits above what
it imports, and the groups are shelf-packed. Modules with no import links are
gathered into one block below everything, under a heading that counts them.

This is the layout the schema tab already uses. Rather than write it twice, its
three helpers now take the edge list and the property names that hold the
endpoints, so both tabs share one implementation.

The simulation, its constants and the animation loop are deleted. Dragging still
moves a module, exactly as it does on the schema tab.

Boxes are capped at 220px with the module name on its own line and the project
below it, because a long project prefix was truncating away the part that
identifies the module. The old code measured a short `"4p 5c"` string while
drawing `"4 providers, 5 controllers"`, so boxes were sized for text narrower than
what went into them.

What I did not do: group spatially by project. 44 projects across 66 modules is
about 1.5 modules each, so it would be 40-odd containers holding one box, and
project is already carried by the colour legend and the filter.

## 5. Before vs after

| | Before | After |
|---|---|---|
| overlapping pairs, 66 modules | 221 | **0** |
| modules covering another | 98% | **0%** |
| labels truncated | most, at 407px wide | **1 of 66** |
| whole graph visible at load | no, zoom stayed at 1 | yes, fits |
| layout for the same input | varies, random jitter on filter | reproducible |
| per-frame work | O(n²) repulsion, forever | none once drawn |
| schema tab *(unchanged)* | — | — |

## 6. Example

`nestjs-doctor . --report` on the 66-module workspace, read off the live canvas:

```
before   221 overlapping pairs, 98% of nodes covering another, zoom 1.0
         graph 439x439 world units with boxes up to 407 wide

after    0 overlapping pairs, fits at zoom 0.58
         graph 1557x1102, boxes capped at 220
         "29 modules with no import links" block beneath the rest
```

A caveat worth recording: 19 edges for 66 modules is suspiciously sparse and is
probably issue #119, where the module graph keys by class name so the many
`AppModule`s collide. The layout is right either way and gets better on its own
once that is fixed.

Not fixed here, both pre-existing on main and both in the schema diagram, which
this diff otherwise leaves alone: it releases a drag by listening on its own
canvas, so letting go outside leaves an entity stuck to the pointer; and its
pinch-zoom neither refreshes its zoom readout nor hides its tooltip. The camera,
tooltip and zoom-bar layer is now duplicated between the two tabs while the
layout helpers are shared, which is the obvious next thing to pull together.
