### PR TITLE
feat(report): endpoints tab overview mode with auth shields and diagnostics

### DIFF
--- a/.changeset/endpoints-overview-ui.md
+++ b/.changeset/endpoints-overview-ui.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": minor
+---
+
+The report's endpoints tab now opens on an API-surface overview: module clusters, controller boxes, per-endpoint auth shields and diagnostic counts, with search and a problems drawer. The per-endpoint dependency tree remains as drill-down with fixed click/zoom/camera interactions, a truncation banner, and a legend.

--- a/.changeset/endpoints-overview-ui.md
+++ b/.changeset/endpoints-overview-ui.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": minor
 ---
 
-The report's endpoints tab now opens on an API-surface overview: module clusters, controller boxes, per-endpoint auth shields and diagnostic counts, with search and a problems drawer. The per-endpoint dependency tree remains as drill-down with fixed click/zoom/camera interactions, a truncation banner, and a legend.
+The report's endpoints tab now opens on an API-surface overview: module clusters, controller boxes, per-endpoint auth shields and diagnostic counts, with search and a problems drawer. The per-endpoint dependency tree remains as drill-down with fixed click/zoom/camera interactions, a truncation banner, and a legend, and now opens collapsed to the handler's direct calls with per-node expand/collapse and expand-all/collapse-all controls.

--- a/docs/superpowers/plans/2026-07-30-endpoints-overview-ui.md
+++ b/docs/superpowers/plans/2026-07-30-endpoints-overview-ui.md
@@ -1,0 +1,125 @@
+# Endpoints Overview UI (PR 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The endpoints tab opens on an API-surface overview (module clusters → controller boxes → endpoint rows with method chip, path, auth shield, diagnostic dot) and drills down into the existing per-endpoint tree, whose broken interactions get fixed.
+
+**Architecture:** Data joins happen in Node (`prepareReportData`) where they are unit-testable; the report canvas code in `src/report/ui/scripts.ts` (a template string emitting browser JS) gains an overview mode mirroring schema mode's proven patterns (`sComputeOverviewLayout` family, PR #220), and the focused tree keeps its renderer with interaction fixes. Spec: `docs/superpowers/specs/2026-07-30-endpoints-overview-design.md` (PR 2 section). PR 1 (branch `feat/endpoint-auth-metadata`, this branch's parent) added `EndpointNode.auth` / `.module` / `.project`.
+
+**Tech Stack:** TypeScript, hand-rolled 2D canvas in emitted JS, dagre only where already used, vitest.
+
+## Global Constraints
+
+- Fully deterministic; no AI, no network beyond the existing dagre CDN load.
+- Degrade wider, never narrower: an endpoint with failed attribution appears under "(no module)"; unknown auth renders as `unknown`, never as public or guarded.
+- Endpoint identity everywhere: `filePath` + `line` + `httpMethod` + `routePath` (spec amended after PR 1 — `filePath`+`line` alone is NOT unique). In the UI, select endpoints by their index in `endpoints.endpoints`; never by `controllerClass`+`handlerMethod`.
+- The auth shield for GraphQL endpoints (`httpMethod` `QUERY`/`MUTATION`/`SUBSCRIPTION`) must not use `auth.globalGuard` — render their state without the global-guard qualifier.
+- Diagnostic joins gate on `isCodeDiagnostic` (`SchemaDiagnostic` has no line — CLAUDE.md invariant). Compare `filePath` strings as-is; never re-resolve with `node:path`.
+- Comments what-only ≤2 lines. No `Co-Authored-By`/`Claude-Session` trailers. Conventional Commits. Never `--no-verify`.
+- Mirror schema mode's existing patterns and names (prefix `ep` where schema uses `s`); do not restructure `scripts.ts` beyond the endpoints section.
+
+---
+
+### Task 1: Endpoint diagnostic counts in report data
+
+**Files:**
+- Create: `packages/nestjs-doctor/src/report/formatters/endpoint-diagnostics.ts`
+- Modify: `packages/nestjs-doctor/src/report/formatters/report-data.ts` (add `endpointDiagnosticsJson`), `packages/nestjs-doctor/src/report/ui/scripts.ts:1-30` (declare `const endpointDiagnostics = ...` in `getReportScripts` and add the field to `ReportScriptData`)
+- Test: `packages/nestjs-doctor/tests/unit/endpoint-diagnostics.test.ts`
+
+**Interfaces:**
+- Consumes: `EndpointNode` (with `line`, `endLine`, `filePath`, `httpMethod`, `routePath`), `Diagnostic` + `isCodeDiagnostic` from `src/common/diagnostic.ts`.
+- Produces:
+
+```ts
+export interface EndpointDiagnosticCounts {
+	/** Keyed by endpoint index in endpoints.endpoints, as a string. */
+	perEndpoint: Record<string, { error: number; warning: number; info: number }>;
+	/** Diagnostics in a scanned file that fall outside every handler range. Keyed by filePath. */
+	perFile: Record<string, { error: number; warning: number; info: number }>;
+}
+
+export function computeEndpointDiagnostics(
+	endpoints: EndpointNode[],
+	diagnostics: Diagnostic[]
+): EndpointDiagnosticCounts
+```
+
+Rules: a code diagnostic joins every endpoint whose `filePath` matches exactly and whose range `line..endLine` contains `diagnostic.line` (a handler emitting two endpoints counts it on both rows — same underlying issue, both rows must show it). A code diagnostic whose file contains at least one endpoint but matches no range goes to `perFile`. Diagnostics in files with no endpoints are ignored (other tabs own them). Schema diagnostics never join.
+
+- [ ] **Step 1: Write the failing test** — cases: (a) diagnostic on a handler line → counted on that endpoint index; (b) same handler emitting GET+POST endpoints → counted on both indices; (c) diagnostic in a controller file outside every handler → `perFile` only; (d) schema diagnostic (no `line`) in input → ignored, no crash; (e) diagnostic in a file with no endpoints → nowhere; (f) severities bucketed correctly. Build `EndpointNode[]` fixtures as plain object literals (no ts-morph needed) and diagnostics as plain literals matching `CodeDiagnostic`/`SchemaDiagnostic` shapes — read `src/common/diagnostic.ts` first for exact required fields.
+- [ ] **Step 2: Run** `pnpm --filter nestjs-doctor exec vitest run tests/unit/endpoint-diagnostics.test.ts` — FAIL (module not found).
+- [ ] **Step 3: Implement** `computeEndpointDiagnostics` (two passes: index endpoints by filePath, then bucket each code diagnostic). Wire into `prepareReportData`: `endpointDiagnosticsJson = safeJsonForScript(JSON.stringify(computeEndpointDiagnostics(result.endpoints?.endpoints ?? [], result.diagnostics)))`; add `const endpointDiagnostics = ${data.endpointDiagnosticsJson};` beside the other consts in `getReportScripts`.
+- [ ] **Step 4: Run** the new test + full package suite — PASS.
+- [ ] **Step 5: Commit** `feat(report): compute per-endpoint diagnostic counts for the endpoints tab`
+
+---
+
+### Task 2: Sidebar regroup, search, index-based selection, method chips
+
+**Files:**
+- Modify: `packages/nestjs-doctor/src/report/ui/scripts.ts` — `renderEndpoints()` sidebar build (~`:4131-4249`), `METHOD_COLORS` (~`:4156`), endpoint selection (~`:4209-4241`); `packages/nestjs-doctor/src/report/ui/html.ts:298-307` (search input); `packages/nestjs-doctor/src/report/ui/styles.ts` (chip/shield/dot styles)
+- Test: none runnable for DOM string-building; correctness lands in Task 5's visual verification. Keep changes mechanical.
+
+**Interfaces:**
+- Consumes: `endpoints.endpoints[i].module` / `.project` / `.auth` (PR 1), `endpointDiagnostics` (Task 1).
+- Produces: sidebar grouped `module → controller → endpoint`; every endpoint row carries `data-ep-index="<i>"`; selection and the canvas build key off that index (`epSelectedIndex`). Helper `epAuthShield(ep)` returning `{glyph, cls, label}` reused by Task 3.
+
+Requirements:
+- Group order: modules sorted alphabetically, `"(no module)"` last; monorepo: group label is the prefixed module (`api/CatsModule`) as stored.
+- Row: method chip + `routePath` + auth shield + diagnostic dot. Shield: `guarded` ✓ green, `declared-public` ○ blue, `unguarded` ⚠ amber, `unknown` ? grey; tooltip lists `auth.guardNames` when present; append "global guard registered" only when `auth.globalGuard` AND the endpoint is not GraphQL (`QUERY`/`MUTATION`/`SUBSCRIPTION`). Dot: highest severity colours it (error `var(--error)`, warning amber, info blue), text = total count; absent when zero.
+- `METHOD_COLORS`: add distinct entries for `ALL`, `HEAD`, `OPTIONS`, `QUERY`, `MUTATION`, `SUBSCRIPTION` (GraphQL entries visually distinct from REST — e.g. purple family). No silent GET fallback: unknown methods get a neutral grey chip.
+- Search `<input id="endpoints-search">` in the sticky header: case-insensitive substring filter over `routePath`, `controllerClass`, `handlerMethod`, module; hides non-matching rows and empties groups; filters, not highlights.
+- Selection: replace the `controllerClass`+`handlerMethod` first-match lookup with the row's `data-ep-index`. Fix the dead controller-row toggle: clicking anywhere on a controller header toggles its group (today only the caret `.st-toggle` works, ~`:4193-4206`).
+- [ ] Steps: implement → `pnpm --filter nestjs-doctor test && pnpm typecheck` (report emit must still typecheck/build) → commit `feat(report): regroup endpoints sidebar by module with search, auth shields, index selection`
+
+---
+
+### Task 3: Overview canvas mode (new default) + problems drawer
+
+**Files:**
+- Modify: `packages/nestjs-doctor/src/report/ui/scripts.ts` (endpoints section), `html.ts:284-327` (toolbar toggle button, drawer container, remove empty-state as entry state), `styles.ts`
+- Test: `packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts`
+
+**Interfaces:**
+- Consumes: `epAuthShield` (Task 2), `endpointDiagnostics` (Task 1).
+- Produces: `epMode: "overview" | "focused"` (initial `"overview"`); pure layout fn `epComputeOverviewLayout(groups, boxWidth)` emitted between marker comments `// ep-overview-layout-start` / `// ep-overview-layout-end` so the test can extract it exactly the way `tests/unit/report-schema-layout.test.ts:79-108` extracts schema's (read that file first and copy its `new Function` technique).
+
+Requirements:
+- Overview draws controller boxes grouped under module cluster headers. Box: header = controller class name; rows = endpoints (method chip, truncated path, shield glyph, dot) at fixed row height; box width fixed (320px), height = header + rows (cap visible rows at 12 with a `+N more` final row — mirror schema's `sVisibleColCount` idea). Layout: within a module, boxes shelf-packed left-to-right wrapping at a target width derived from total area (mirror `sPackBoxes` `:2264-2278` math); modules stacked vertically with a cluster header line. No edges. No dagre dependency for overview (pure arithmetic — works offline).
+- Label truncation precomputed once per box (mirror `sCacheNodeLabels` `:2489-2522`), never inside the draw loop.
+- Auto-fit camera on entry and on tab re-entry when in overview (mirror `sCenterCamera` `:2560-2594` incl. min-zoom recording). Zoom/pan: same wheel/drag handlers as focused mode, shared.
+- Click an endpoint row → `epMode = "focused"`, select that index, existing tree renders; toolbar gains a view-toggle button mirroring `#schema-toggle-view` (`:3337-3345`) with `aria-pressed`, plus back-to-overview. Keep the recenter button working in both modes.
+- Problems drawer (schema parity — mirror `#schema-problems` markup `html.ts:271-280` and logic `scripts.ts:3598-3667`): lists code diagnostics joined to endpoints (from `endpointDiagnostics` indices; resolve rule/message/severity from the `diagnostics` array), plus per-file rollup rows labelled with the file name. Click → focused mode on that endpoint + code panel at the diagnostic line. Drawer header carries the scope caveat verbatim: "Counts reflect this report's diagnostics; a narrowed scan scope reports fewer, not cleaner."
+- Layout test asserts: no box overlap within and across module clusters; module grouping preserved; `+N more` row math; determinism (two runs identical). Use a synthetic 30-endpoint/8-controller/3-module fixture.
+- [ ] Steps: extract-technique study → failing layout test → implement layout pure fn → implement draw/interactions/drawer → full suite → commit `feat(report): endpoints overview mode with module clusters and problems drawer`
+
+---
+
+### Task 4: Focused-mode interaction fixes
+
+**Files:**
+- Modify: `packages/nestjs-doctor/src/report/ui/scripts.ts` (focused-mode handlers ~`:4244-4406`, `epResize` `:4046-4061`, `epCenterCamera` `:3819-3842`), `html.ts` (zoom toolbar, legend, truncation banner containers), `styles.ts` (code panel side, banner, legend)
+
+**Interfaces:** consumes `epMode`/`epSelectedIndex` (Task 3). No new exports.
+
+Requirements, each independently verifiable:
+1. **Click-vs-drag:** a drag starts only after >4px cumulative movement from mousedown; store grab offset (`epDragging = {node, dx, dy}`) so the node moves relative to grab point instead of teleporting its centre to the cursor (today ~`:4251-4271` sets `epDragging.x = pos.x`). Below threshold, mouseup is a click → code panel opens.
+2. **Zoom toolbar** in `#endpoints-toolbar`: −/+/% readout + fit, mirroring schema's (`html.ts:229-238`, handlers `:3401-3418`); one `epZoomFloor()` replaces the mismatched clamps (`[0.3,1.5]` in `epCenterCamera` vs `[0.2,3]` on wheel `:4324`).
+3. **Camera preserved:** `epResize` shifts camera by half the size delta (mirror `sResize` `:2876-2898`) instead of unconditionally re-centring; tab re-entry keeps the camera in focused mode.
+4. **Truncation banner:** when the selected endpoint has `truncated`, show a dismissible banner over the canvas: "Trace truncated at 5000 nodes — the tree below is incomplete."
+5. **Legend** (small fixed overlay, both modes, toggle button in toolbar): type colours (11 entries from `EP_TYPE_COLORS` `:3687-3699`), `#N` = call order, dashed amber = conditional call, `↱` = drawn at another call site; overview adds shield/dot meanings.
+6. **Code panel** anchors right (`right:0`, sidebar stays usable, ~`styles.ts:1086-1092`); tooltip z-index no longer draws over it.
+- [ ] Steps: implement → `pnpm --filter nestjs-doctor test && pnpm typecheck && pnpm build` → commit `fix(report): endpoints focused-mode interactions — click threshold, zoom toolbar, camera, banner, legend`
+
+---
+
+### Task 5: Changeset, verification, visual QA
+
+**Files:**
+- Create: `.changeset/endpoints-overview-ui.md` (`"nestjs-doctor": minor` — "The report's endpoints tab now opens on an API-surface overview: module clusters, controller boxes, per-endpoint auth shields and diagnostic counts, with search and a problems drawer. The per-endpoint dependency tree remains as drill-down with fixed click/zoom/camera interactions, a truncation banner, and a legend.")
+
+Steps:
+- [ ] `pnpm check && pnpm typecheck && pnpm test && pnpm build`
+- [ ] Generate reports from `packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns` and `tests/fixtures/drizzle-app` (`node packages/nestjs-doctor/dist/cli/index.mjs <fixture> --report <scratch>/r.html` — verify flag shape via `--help`), serve over localhost (file:// is blocked by the browser extension), and visually verify in Chrome: overview default + auto-fit, shields match fixture guards, dots match diagnostics, search filters, row click drills down, code panel opens on plain click, zoom toolbar, truncation banner absent (fixtures are small), legend, GraphQL rows show no global-guard qualifier. Screenshot each state.
+- [ ] Commit `chore: changeset for endpoints overview UI`

--- a/docs/superpowers/specs/2026-07-30-endpoint-flow-view-design.md
+++ b/docs/superpowers/specs/2026-07-30-endpoint-flow-view-design.md
@@ -1,0 +1,49 @@
+# Endpoint flow view: sequence semantics + canonical flow JSON
+
+Date: 2026-07-30. Status: approved direction; implementation is a separate PR after the endpoints overview UI ships.
+
+## Problem
+
+The per-endpoint tree shows *who is called*, but caller-side control flow (conditional throws, branch alternatives, loops) and dataflow (which variable a call produces and who consumes it) are either invisible or, when naively attached to callee boxes, misattributed. Concrete case: `const x = await svc.access(...); if (!x) throw new HttpException(FORBIDDEN); return svc.deleteAccess(...)` must never render the throw inside `AccessService`.
+
+Interim fix (shipped in the overview-UI PR): guard-throws render as caller-owned "break" steps in tree order; call boxes show `→ assignedTo`; tooltips carry condition text, branch kind, iteration context, and the callee signature (labeled as a signature, never as call arguments).
+
+## Decision framework (in priority order)
+
+1. Semantic fidelity — every fact renders on the code location where it happens (hard gate).
+2. Deterministic derivability from existing static extraction; no AI at runtime.
+3. Reading cost — seconds to grasp; degrades from 2 to 50 calls.
+4. Layout stability — insertion of a call must not reflow unrelated elements.
+5. Implementation locality.
+6. Diffability — phase 3 compares endpoint behaviour across revisions.
+
+## Decision
+
+A per-endpoint **flow view** using UML sequence-diagram semantics rendered in the existing vertical canvas (not a lifeline-per-participant layout initially — the caller column + call rows we already have, upgraded with frames):
+
+- **`break` frames** for guard-throws (caller-owned; "everything below happens only if we didn't break"). Fed by `guardThrow` (`conditionText`, `className`, `message`, `callSiteLine`).
+- **`alt`/`opt` frames** for branch groups — mutually exclusive branches finally get spatial encoding. Fed by `branchGroupId`, `branchKind`, `conditionText`.
+- **`loop`/`par` frames** for iteration context. Fed by `iterationKind`/`iterationLabel` (`par` for `Promise.all`).
+- **Labeled call/return edges**: call edge labeled with the callee signature; dashed return edge labeled with `assignedTo` (PlantUML `return` convention).
+- **Hover def-use highlighting** (Flowistry-style): hovering a variable highlights its producing return edge and every consumer (argument expressions, frame guards), fading the rest. Fed by `assignedTo` matched statically against `conditionText`/`stepStatements`/parameter expressions. No permanent dataflow edges — PDG-style dual-edge graphs are unreadable at this granularity.
+- 1-D vertical layout: inserting a call inserts a row; nothing else moves. This is the property that makes diagram diffing viable (precedents: AppMap `sequence-diagram-diff` diffs serialized sequence models red/green; SciTools Understand ships Compare Control Flow Graph).
+
+## Canonical flow JSON
+
+Each endpoint's flow serializes to a canonical, deterministic JSON model (calls in order, frames with guards, produced/consumed variables, throws). This artifact is:
+
+- the render input for the flow view,
+- the diff substrate for phase 3 (API changelog): structural diff of two flow models → added/removed/changed steps painted green/red on the same renderer,
+- machine-readable output agents can consume.
+
+Determinism is the moat: LLM diagram generators produce different output on identical input, so their diffs are noise. Ours diff cleanly because same code → same model, byte for byte.
+
+## Non-goals
+
+- Lifeline-per-service layout (revisit only if the caller-column form proves insufficient).
+- Rendering permanent data-dependence edges.
+- Any runtime/trace collection (AppMap's approach) — static only.
+
+## Evidence base (research 2026-07-30)
+
+UML combined fragments put guards on the lifeline that evaluates them — the notation was designed to prevent exactly our misattribution; `break` is the standard operator for guard-throws (uml-diagrams.org, PlantUML/Mermaid implementations). AppMap demonstrates sequence-model diffing for PRs; Understand demonstrates CFG comparison. Flowistry demonstrates slice highlighting beating drawn dataflow edges. Comprehension studies (Scanniello et al.) find sequence diagrams aid dynamic-behaviour comprehension with diagram *size* as the dominant cost — supporting collapse-by-default over notation maximalism.

--- a/docs/superpowers/specs/2026-07-30-endpoints-overview-design.md
+++ b/docs/superpowers/specs/2026-07-30-endpoints-overview-design.md
@@ -66,6 +66,7 @@ Caveat shown in the UI: counts follow the report's diagnostics as scoped; zero d
 
 ### Focused mode (existing tree, kept as drill-down)
 
+- The tree opens collapsed to the handler's direct calls; each node with children carries an expand chip.
 - Fix click-vs-drag: movement threshold (~4px) before a drag starts, and preserve the grab offset (today any 1px move cancels the click and teleports the node's centre to the cursor — the code panel is effectively unreachable).
 - Truncation banner when `truncated` is set.
 - Legend: `#N` = call order, dashed amber = conditional, colours = provider type.

--- a/packages/nestjs-doctor/src/report/formatters/endpoint-diagnostics.ts
+++ b/packages/nestjs-doctor/src/report/formatters/endpoint-diagnostics.ts
@@ -1,0 +1,65 @@
+import { type Diagnostic, isCodeDiagnostic } from "../../common/diagnostic.js";
+import type { EndpointNode } from "../../common/endpoint.js";
+
+export interface EndpointDiagnosticCounts {
+	/** Keyed by endpoint index in endpoints.endpoints, as a string. */
+	perEndpoint: Record<string, { error: number; warning: number; info: number }>;
+	/** Diagnostics in a scanned file that fall outside every handler range. Keyed by filePath. */
+	perFile: Record<string, { error: number; warning: number; info: number }>;
+}
+
+function emptyBucket() {
+	return { error: 0, warning: 0, info: 0 };
+}
+
+/** Joins code diagnostics to endpoints by filePath and line range, bucketing counts by severity. */
+export function computeEndpointDiagnostics(
+	endpoints: EndpointNode[],
+	diagnostics: Diagnostic[]
+): EndpointDiagnosticCounts {
+	const perEndpoint: EndpointDiagnosticCounts["perEndpoint"] = {};
+	const perFile: EndpointDiagnosticCounts["perFile"] = {};
+
+	const endpointsByFile = new Map<string, number[]>();
+	for (const [index, endpoint] of endpoints.entries()) {
+		const indices = endpointsByFile.get(endpoint.filePath);
+		if (indices) {
+			indices.push(index);
+		} else {
+			endpointsByFile.set(endpoint.filePath, [index]);
+		}
+	}
+
+	for (const diagnostic of diagnostics) {
+		if (!isCodeDiagnostic(diagnostic)) {
+			continue;
+		}
+		const indices = endpointsByFile.get(diagnostic.filePath);
+		if (!indices) {
+			continue;
+		}
+
+		let matched = false;
+		for (const index of indices) {
+			const endpoint = endpoints[index];
+			if (
+				diagnostic.line >= endpoint.line &&
+				diagnostic.line <= endpoint.endLine
+			) {
+				matched = true;
+				const key = String(index);
+				const bucket = perEndpoint[key] ?? emptyBucket();
+				bucket[diagnostic.severity]++;
+				perEndpoint[key] = bucket;
+			}
+		}
+
+		if (!matched) {
+			const bucket = perFile[diagnostic.filePath] ?? emptyBucket();
+			bucket[diagnostic.severity]++;
+			perFile[diagnostic.filePath] = bucket;
+		}
+	}
+
+	return { perEndpoint, perFile };
+}

--- a/packages/nestjs-doctor/src/report/formatters/report-data.ts
+++ b/packages/nestjs-doctor/src/report/formatters/report-data.ts
@@ -4,6 +4,7 @@ import type { ModuleGraph } from "../../engine/graph/module-graph.js";
 import type { ProviderInfo } from "../../engine/graph/type-resolver.js";
 import { getRuleExamples } from "../data/examples.js";
 import type { ReportScriptData } from "../ui/scripts.js";
+import { computeEndpointDiagnostics } from "./endpoint-diagnostics.js";
 import { serializeModuleGraph } from "./module-serializer.js";
 
 function safeJsonForScript(json: string): string {
@@ -90,6 +91,14 @@ export function prepareReportData(
 	const endpointsJson = safeJsonForScript(
 		JSON.stringify(result.endpoints ?? { endpoints: [] })
 	);
+	const endpointDiagnosticsJson = safeJsonForScript(
+		JSON.stringify(
+			computeEndpointDiagnostics(
+				result.endpoints?.endpoints ?? [],
+				result.diagnostics
+			)
+		)
+	);
 
 	return {
 		graphJson,
@@ -103,5 +112,6 @@ export function prepareReportData(
 		providersJson,
 		schemaJson,
 		endpointsJson,
+		endpointDiagnosticsJson,
 	};
 }

--- a/packages/nestjs-doctor/src/report/ui/codemirror.ts
+++ b/packages/nestjs-doctor/src/report/ui/codemirror.ts
@@ -41,17 +41,18 @@ function escHtml(s) {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
-function makeHighlightPlugin(targetLines) {
-  const lineDeco = Decoration.line({ attributes: { class: "cm-highlighted-line" } });
+// entries: [{ line, cls }] — one line decoration per entry, any number of classes per line.
+function makeLineDecoPlugin(entries) {
   return ViewPlugin.fromClass(class {
     constructor(view) {
       this.decorations = this.buildDecos(view);
     }
     buildDecos(view) {
       const builder = [];
-      for (const tl of targetLines) {
-        if (tl >= 1 && tl <= view.state.doc.lines) {
-          builder.push(lineDeco.range(view.state.doc.line(tl).from));
+      for (const en of entries) {
+        if (en.line >= 1 && en.line <= view.state.doc.lines) {
+          const deco = Decoration.line({ attributes: { class: en.cls } });
+          builder.push(deco.range(view.state.doc.line(en.line).from));
         }
       }
       return Decoration.set(builder, true);
@@ -104,7 +105,12 @@ window.createCodeViewer = function(container, code, options) {
   const firstLineNumber = options.firstLineNumber || 1;
   const showLineNumbers = options.lineNumbers !== false;
   const highlightLine = options.highlightLine || 0;
+  // highlightLines: neutral "here's the definition/call site" marker (blue-grey).
+  // diagnosticLines: severity-red marker, reserved for diagnostic navigation.
   const highlightLines = options.highlightLines || (highlightLine > 0 ? [highlightLine] : []);
+  const diagnosticLines = options.diagnosticLines || [];
+  const tintRangeStart = options.tintRangeStart || 0;
+  const tintRangeEnd = options.tintRangeEnd || 0;
   const lineMetadata = options.lineMetadata || null;
 
   const extensions = [
@@ -128,6 +134,13 @@ window.createCodeViewer = function(container, code, options) {
         borderLeft: "3px solid #ea2845",
         cursor: "pointer",
       },
+      ".cm-neutral-line": {
+        background: "rgba(59,130,246,0.10) !important",
+        borderLeft: "2px solid #3b82f6",
+      },
+      ".cm-range-tint": {
+        background: "rgba(59,130,246,0.05)",
+      },
     }),
   ];
 
@@ -135,8 +148,16 @@ window.createCodeViewer = function(container, code, options) {
     extensions.push(lineNumbers({ formatNumber: (n) => String(n + firstLineNumber - 1) }));
   }
 
-  if (highlightLines.length > 0) {
-    extensions.push(makeHighlightPlugin(highlightLines));
+  const lineDecoEntries = [];
+  if (tintRangeEnd > tintRangeStart) {
+    for (let l = tintRangeStart; l <= tintRangeEnd; l++) {
+      lineDecoEntries.push({ line: l, cls: "cm-range-tint" });
+    }
+  }
+  for (const dl of diagnosticLines) lineDecoEntries.push({ line: dl, cls: "cm-highlighted-line" });
+  for (const hl of highlightLines) lineDecoEntries.push({ line: hl, cls: "cm-neutral-line" });
+  if (lineDecoEntries.length > 0) {
+    extensions.push(makeLineDecoPlugin(lineDecoEntries));
   }
 
   if (lineMetadata) {
@@ -152,8 +173,9 @@ window.createCodeViewer = function(container, code, options) {
 
   viewerInstances.set(key, view);
 
-  if (highlightLines.length > 0 && !options.skipScrollIntoView) {
-    const firstHL = highlightLines[0];
+  const scrollTargetLines = highlightLines.length > 0 ? highlightLines : diagnosticLines;
+  if (scrollTargetLines.length > 0 && !options.skipScrollIntoView) {
+    const firstHL = scrollTargetLines[0];
     requestAnimationFrame(() => {
       if (firstHL >= 1 && firstHL <= view.state.doc.lines) {
         const line = view.state.doc.line(firstHL);

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -315,7 +315,7 @@ for (let i = 0; i < lines.length; i++) {
           <button class="st-btn schema-zoom-btn has-tip" id="endpoints-zoom-out" aria-label="Zoom out" data-tip="Zoom out">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
           </button>
-          <input type="range" id="endpoints-zoom-range" min="5" max="500" step="1" value="100" aria-label="Zoom">
+          <input type="range" id="endpoints-zoom-range" min="5" max="300" step="1" value="100" aria-label="Zoom">
           <button class="st-btn schema-zoom-btn has-tip" id="endpoints-zoom-in" aria-label="Zoom in" data-tip="Zoom in">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
           </button>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -302,6 +302,9 @@ for (let i = 0; i < lines.length; i++) {
         <span class="schema-entity-count" id="endpoints-count"></span>
         <span style="flex:1"></span>
       </div>
+      <div class="endpoints-sidebar-search">
+        <input type="text" id="endpoints-search" placeholder="Filter by route, controller, handler, module…" spellcheck="false">
+      </div>
     </div>
     <div id="endpoints-list"></div>
   </div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -310,14 +310,14 @@ for (let i = 0; i < lines.length; i++) {
   </div>
   <div id="endpoints-main">
     <div id="endpoints-canvas-wrap">
-      <div id="endpoints-empty-state">
-        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
-        </svg>
-        <p>Select an endpoint from the sidebar to view its dependency graph</p>
-      </div>
       <div id="endpoints-toolbar">
-        <button class="st-btn schema-diagram-btn" id="endpoints-recenter" title="Re-center diagram">
+        <button class="st-btn schema-diagram-btn has-tip active" id="endpoints-toggle-view" aria-label="Focus one endpoint" aria-pressed="true" data-tip="Focus · show one endpoint and its call graph">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
+            <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
+          </svg>
+        </button>
+        <button class="st-btn schema-diagram-btn has-tip" id="endpoints-recenter" aria-label="Re-center diagram" data-tip="Re-center · bring the diagram back into view">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/>
           </svg>
@@ -325,6 +325,17 @@ for (let i = 0; i < lines.length; i++) {
       </div>
       <canvas id="endpoints-canvas"></canvas>
       <div id="endpoints-tooltip" class="schema-tooltip" style="display:none"></div>
+    </div>
+    <div id="endpoints-diag-panel">
+      <div id="endpoints-diag-header">
+        <svg class="schema-diag-chevron" id="endpoints-diag-chevron" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="schema-diag-title">Problems</span>
+        <span class="schema-diag-count" id="endpoints-diag-count">0</span>
+      </div>
+      <div class="ep-diag-caveat">Counts reflect this report's diagnostics; a narrowed scan scope reports fewer, not cleaner.</div>
+      <div id="endpoints-diag-body" style="display:none">
+        <div id="endpoints-diag-list"></div>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -376,6 +376,9 @@ for (let i = 0; i < lines.length; i++) {
         <div class="ep-legend-row"><span class="ep-legend-order">#N</span> Call order</div>
         <div class="ep-legend-row"><span class="ep-legend-swatch ep-legend-dashed"></span> Conditional call</div>
         <div class="ep-legend-row"><span class="ep-legend-glyph">&#8625;</span> Calls drawn at another call site</div>
+        <div class="ep-legend-row"><span class="ep-legend-glyph" style="color:#f59e0b">&#9888;</span> Guard-throw strip — fetch checked, then thrown</div>
+        <div class="ep-legend-row"><span class="ep-legend-glyph" style="color:#f87171">&#9888;</span> Throw message (on THROW nodes)</div>
+        <div class="ep-legend-row"><span class="ep-legend-glyph">&#8635;</span> Iteration chip, e.g. &#8635; map — called inside a loop/callback</div>
         <div id="endpoints-legend-overview" style="display:none">
           <div class="ep-legend-divider"></div>
           <div class="ep-legend-row"><span class="ep-legend-glyph ep-auth-guarded">&#10003;</span> Guarded</div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -376,8 +376,9 @@ for (let i = 0; i < lines.length; i++) {
         <div class="ep-legend-row"><span class="ep-legend-order">#N</span> Call order</div>
         <div class="ep-legend-row"><span class="ep-legend-swatch ep-legend-dashed"></span> Conditional call</div>
         <div class="ep-legend-row"><span class="ep-legend-glyph">&#8625;</span> Calls drawn at another call site</div>
-        <div class="ep-legend-row"><span class="ep-legend-glyph" style="color:#f59e0b">&#9888;</span> Guard-throw strip — fetch checked, then thrown</div>
+        <div class="ep-legend-row"><span class="ep-legend-swatch ep-legend-break"></span> Break step — caller checks a result and may throw; handler stops here</div>
         <div class="ep-legend-row"><span class="ep-legend-glyph" style="color:#f87171">&#9888;</span> Throw message (on THROW nodes)</div>
+        <div class="ep-legend-row"><span class="ep-legend-glyph">&#8594;</span> variable — return value assigned to</div>
         <div class="ep-legend-row"><span class="ep-legend-glyph">&#8635;</span> Iteration chip, e.g. &#8635; map — called inside a loop/callback</div>
         <div id="endpoints-legend-overview" style="display:none">
           <div class="ep-legend-divider"></div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -374,6 +374,7 @@ for (let i = 0; i < lines.length; i++) {
       <div id="endpoints-diag-header">
         <svg class="schema-diag-chevron" id="endpoints-diag-chevron" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <span class="schema-diag-title">Problems</span>
+        <span class="ep-diag-scope" id="endpoints-diag-scope"></span>
         <span class="schema-diag-count" id="endpoints-diag-count">0</span>
       </div>
       <div class="ep-diag-caveat">Counts reflect this report's diagnostics; a narrowed scan scope reports fewer, not cleaner.</div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -343,7 +343,7 @@ for (let i = 0; i < lines.length; i++) {
         <div id="endpoints-legend-types"></div>
         <div class="ep-legend-row"><span class="ep-legend-order">#N</span> Call order</div>
         <div class="ep-legend-row"><span class="ep-legend-swatch ep-legend-dashed"></span> Conditional call</div>
-        <div class="ep-legend-row"><span class="ep-legend-glyph">&#8631;</span> Calls drawn at another call site</div>
+        <div class="ep-legend-row"><span class="ep-legend-glyph">&#8625;</span> Calls drawn at another call site</div>
         <div id="endpoints-legend-overview" style="display:none">
           <div class="ep-legend-divider"></div>
           <div class="ep-legend-row"><span class="ep-legend-glyph ep-auth-guarded">&#10003;</span> Guarded</div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -301,6 +301,23 @@ for (let i = 0; i < lines.length; i++) {
         <span class="schema-sidebar-title">Endpoints</span>
         <span class="schema-entity-count" id="endpoints-count"></span>
         <span style="flex:1"></span>
+        <button class="st-btn has-tip" id="endpoints-sidebar-expand-all" aria-label="Expand all" data-tip="Expand all · open every group in the list">
+          <svg viewBox="0 0 17 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="1" y1="3" x2="8" y2="3"/><line x1="1" y1="7" x2="8" y2="7"/><line x1="1" y1="11" x2="8" y2="11"/>
+            <path d="M11 5l2.5 3L16 5"/>
+          </svg>
+        </button>
+        <button class="st-btn has-tip" id="endpoints-sidebar-collapse-all" aria-label="Collapse all" data-tip="Collapse all · close every group in the list">
+          <svg viewBox="0 0 17 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="1" y1="3" x2="8" y2="3"/><line x1="1" y1="7" x2="8" y2="7"/><line x1="1" y1="11" x2="8" y2="11"/>
+            <path d="M11 11l2.5-3L16 11"/>
+          </svg>
+        </button>
+        <button class="st-btn has-tip" id="endpoints-sidebar-collapse" aria-label="Hide the endpoint list" data-tip="Hide list · give the diagram the whole width">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="9 3 4 8 9 13"/><line x1="13" y1="3" x2="13" y2="13"/>
+          </svg>
+        </button>
       </div>
       <div class="endpoints-sidebar-search">
         <input type="text" id="endpoints-search" placeholder="Filter by route, controller, handler, module…" spellcheck="false">
@@ -310,6 +327,11 @@ for (let i = 0; i < lines.length; i++) {
   </div>
   <div id="endpoints-main">
     <div id="endpoints-canvas-wrap">
+      <button class="st-btn has-tip" id="endpoints-sidebar-show" aria-label="Show the endpoint list" data-tip="Show list · bring the endpoint list back">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="7 3 12 8 7 13"/><line x1="3" y1="3" x2="3" y2="13"/>
+        </svg>
+      </button>
       <div id="endpoints-toolbar">
         <div id="endpoints-zoombar">
           <button class="st-btn schema-zoom-btn has-tip" id="endpoints-zoom-out" aria-label="Zoom out" data-tip="Zoom out">

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -332,6 +332,16 @@ for (let i = 0; i < lines.length; i++) {
             <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
           </svg>
         </button>
+        <button class="st-btn schema-diagram-btn has-tip" id="endpoints-expand-all" aria-label="Expand all calls" data-tip="Expand all · show the full call tree" style="display:none">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/>
+          </svg>
+        </button>
+        <button class="st-btn schema-diagram-btn has-tip" id="endpoints-collapse-all" aria-label="Collapse all calls" data-tip="Collapse all · back to the root node only" style="display:none">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="14" y1="10" x2="21" y2="3"/><line x1="3" y1="21" x2="10" y2="14"/>
+          </svg>
+        </button>
         <button class="st-btn schema-diagram-btn has-tip" id="endpoints-recenter" aria-label="Re-center diagram" data-tip="Re-center · bring the diagram back into view">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -311,6 +311,21 @@ for (let i = 0; i < lines.length; i++) {
   <div id="endpoints-main">
     <div id="endpoints-canvas-wrap">
       <div id="endpoints-toolbar">
+        <div id="endpoints-zoombar">
+          <button class="st-btn schema-zoom-btn has-tip" id="endpoints-zoom-out" aria-label="Zoom out" data-tip="Zoom out">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          </button>
+          <input type="range" id="endpoints-zoom-range" min="5" max="500" step="1" value="100" aria-label="Zoom">
+          <button class="st-btn schema-zoom-btn has-tip" id="endpoints-zoom-in" aria-label="Zoom in" data-tip="Zoom in">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          </button>
+          <button class="schema-zoom-value has-tip" id="endpoints-zoom-value" aria-label="100% · fit to view" data-tip="Fit · size the diagram to the window">100%</button>
+        </div>
+        <button class="st-btn schema-diagram-btn has-tip" id="endpoints-legend-toggle" aria-label="Show legend" aria-pressed="false" data-tip="Legend · what the colors and glyphs mean">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="9"/><line x1="12" y1="11" x2="12" y2="16"/><circle cx="12" cy="7.5" r="0.75" fill="currentColor" stroke="none"/>
+          </svg>
+        </button>
         <button class="st-btn schema-diagram-btn has-tip active" id="endpoints-toggle-view" aria-label="Focus one endpoint" aria-pressed="true" data-tip="Focus · show one endpoint and its call graph">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
@@ -322,6 +337,25 @@ for (let i = 0; i < lines.length; i++) {
             <circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/>
           </svg>
         </button>
+      </div>
+      <div id="endpoints-legend" style="display:none">
+        <div class="ep-legend-title">Legend</div>
+        <div id="endpoints-legend-types"></div>
+        <div class="ep-legend-row"><span class="ep-legend-order">#N</span> Call order</div>
+        <div class="ep-legend-row"><span class="ep-legend-swatch ep-legend-dashed"></span> Conditional call</div>
+        <div class="ep-legend-row"><span class="ep-legend-glyph">&#8631;</span> Calls drawn at another call site</div>
+        <div id="endpoints-legend-overview" style="display:none">
+          <div class="ep-legend-divider"></div>
+          <div class="ep-legend-row"><span class="ep-legend-glyph ep-auth-guarded">&#10003;</span> Guarded</div>
+          <div class="ep-legend-row"><span class="ep-legend-glyph ep-auth-public">&#9675;</span> Declared public</div>
+          <div class="ep-legend-row"><span class="ep-legend-glyph ep-auth-unguarded">&#9888;</span> Unguarded</div>
+          <div class="ep-legend-row"><span class="ep-legend-glyph ep-auth-unknown">?</span> Unknown auth</div>
+          <div class="ep-legend-row"><span class="ep-legend-swatch" style="background:#ef4444;border-radius:50%"></span> Has diagnostics (red/amber/blue = error/warning/info)</div>
+        </div>
+      </div>
+      <div id="endpoints-truncated-banner" style="display:none">
+        <span>Trace truncated at 5000 nodes — the tree below is incomplete.</span>
+        <button id="endpoints-truncated-dismiss" aria-label="Dismiss">&times;</button>
       </div>
       <canvas id="endpoints-canvas"></canvas>
       <div id="endpoints-tooltip" class="schema-tooltip" style="display:none"></div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -377,6 +377,7 @@ for (let i = 0; i < lines.length; i++) {
         <div class="ep-legend-row"><span class="ep-legend-swatch ep-legend-dashed"></span> Conditional call</div>
         <div class="ep-legend-row"><span class="ep-legend-glyph">&#8625;</span> Calls drawn at another call site</div>
         <div class="ep-legend-row"><span class="ep-legend-swatch ep-legend-break"></span> Break step — caller checks a result and may throw; handler stops here</div>
+        <div class="ep-legend-row"><span class="ep-legend-swatch ep-legend-value-edge"></span> Value flows from a call's result into a check</div>
         <div class="ep-legend-row"><span class="ep-legend-glyph" style="color:#f87171">&#9888;</span> Throw message (on THROW nodes)</div>
         <div class="ep-legend-row"><span class="ep-legend-glyph">&#8594;</span> variable — return value assigned to</div>
         <div class="ep-legend-row"><span class="ep-legend-glyph">&#8635;</span> Iteration chip, e.g. &#8635; map — called inside a loop/callback</div>

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3724,6 +3724,7 @@ var epDragMoved = false;
 var epDragStartX = 0, epDragStartY = 0;
 var EP_DRAG_THRESHOLD_PX = 4;
 var epHoveredNode = null;
+var epHoveredEdge = null;
 var epNodes = [];
 var epEdges = [];
 var epTooltipEl = null;
@@ -4197,6 +4198,51 @@ function epHitTest(wx, wy) {
   return null;
 }
 
+/**
+ * The polyline points one edge is drawn along — shared by the draw loop and the
+ * hit-test below so they can never drift apart. Value edges connect same-rank
+ * siblings, so they anchor to the near box SIDES at box-center height instead of
+ * the parent/child top-bottom anchors every other edge uses — otherwise a value
+ * edge lands on exactly the same point as the structural edge into the same box
+ * and its arrowhead is indistinguishable from (or hidden behind) that one's.
+ */
+function epEdgePoints(fromN, toN, kind) {
+  if (kind === "value") {
+    var toIsRight = toN.x >= fromN.x;
+    var vfx = toIsRight ? fromN.x + fromN.w / 2 : fromN.x - fromN.w / 2;
+    var vtx = toIsRight ? toN.x - toN.w / 2 : toN.x + toN.w / 2;
+    return [{ x: vfx, y: fromN.y }, { x: vtx, y: toN.y }];
+  }
+  var fx = fromN.x;
+  var fy = fromN.y + fromN.h / 2;
+  var tx = toN.x;
+  var ty = toN.y - toN.h / 2;
+  if (Math.abs(fx - tx) > 2) {
+    var midY = fy + (ty - fy) / 2;
+    return [{ x: fx, y: fy }, { x: fx, y: midY }, { x: tx, y: midY }, { x: tx, y: ty }];
+  }
+  return [{ x: fx, y: fy }, { x: tx, y: ty }];
+}
+
+/** Nearest edge to a point, within a small on-screen threshold — lets overlapping lines be told apart by hovering one. */
+function epHitTestEdge(wx, wy) {
+  var threshold = 6 / epZoom;
+  var nodeById = {};
+  for (var i = 0; i < epNodes.length; i++) nodeById[epNodes[i].id] = epNodes[i];
+  for (var i = 0; i < epEdges.length; i++) {
+    var fromN = nodeById[epEdges[i].from];
+    var toN = nodeById[epEdges[i].to];
+    if (!fromN || !toN || !fromN.visible || !toN.visible) continue;
+    var pts = epEdgePoints(fromN, toN, epEdges[i].kind);
+    for (var p = 0; p < pts.length - 1; p++) {
+      if (sPointToSegmentDist(wx, wy, pts[p].x, pts[p].y, pts[p + 1].x, pts[p + 1].y) < threshold) {
+        return epEdges[i];
+      }
+    }
+  }
+  return null;
+}
+
 function epRoundRect(ctx, x, y, w, h, r) {
   ctx.beginPath();
   ctx.moveTo(x + r, y);
@@ -4559,6 +4605,81 @@ function epDraw() {
   }
 }
 
+/**
+ * One edge's line, arrowhead, and (for value edges) label. The arrowhead is always
+ * solid — drawn after the dash pattern is reset — so it reads as an arrow instead of
+ * dissolving into the line's own dots/dashes. A hovered edge overrides color/width/
+ * dash with a white glow so it stands out from whatever else it overlaps.
+ */
+function epDrawOneEdge(edge, fromN, toN, isHovered) {
+  var pts = epEdgePoints(fromN, toN, edge.kind);
+  var isValueEdge = edge.kind === "value";
+  var baseColor = isValueEdge
+    ? EP_VALUE_EDGE_COLOR
+    : (edge.conditional ? "rgba(245, 158, 11, 0.6)" : "#555");
+  var edgeColor = isHovered ? "#ffffff" : baseColor;
+  var edgeLineW = (isHovered ? 2.5 : (isValueEdge ? 1 : 1.5)) / epZoom;
+
+  if (isHovered) {
+    epCtx.save();
+    epCtx.shadowColor = "#ffffff";
+    epCtx.shadowBlur = 8;
+  } else if (isValueEdge) {
+    epCtx.setLineDash([2 / epZoom, 3 / epZoom]);
+  } else if (edge.conditional) {
+    epCtx.setLineDash([6 / epZoom, 4 / epZoom]);
+  }
+
+  epCtx.beginPath();
+  epCtx.moveTo(pts[0].x, pts[0].y);
+  for (var p = 1; p < pts.length; p++) epCtx.lineTo(pts[p].x, pts[p].y);
+  epCtx.strokeStyle = edgeColor;
+  epCtx.lineWidth = edgeLineW;
+  epCtx.stroke();
+  epCtx.setLineDash([]);
+
+  // Arrow — solid regardless of the line's own dash style (drawn after the reset
+  // above), oriented along the final segment's own direction of travel rather than
+  // assumed-vertical. For every existing top-down edge that final segment is still
+  // vertical, so this draws the exact same chevron as before; for a value edge's
+  // horizontal side-to-side approach it correctly points sideways instead of down.
+  var tip = pts[pts.length - 1];
+  var prev = pts[pts.length - 2];
+  var dx = tip.x - prev.x;
+  var dy = tip.y - prev.y;
+  var dlen = Math.sqrt(dx * dx + dy * dy) || 1;
+  dx /= dlen;
+  dy /= dlen;
+  var px = -dy;
+  var py = dx;
+  var arrowSize = 5 / epZoom;
+  var backX = tip.x - dx * arrowSize;
+  var backY = tip.y - dy * arrowSize;
+  epCtx.beginPath();
+  epCtx.moveTo(backX + px * arrowSize, backY + py * arrowSize);
+  epCtx.lineTo(tip.x, tip.y);
+  epCtx.lineTo(backX - px * arrowSize, backY - py * arrowSize);
+  epCtx.strokeStyle = edgeColor;
+  epCtx.lineWidth = edgeLineW;
+  epCtx.stroke();
+
+  if (isHovered) epCtx.restore();
+
+  // Label the value edge with the producer's assigned variable, at the midpoint of
+  // its (usually horizontal, same-rank) middle segment.
+  if (isValueEdge && fromN.assignedTo) {
+    var segStart = pts.length === 4 ? 1 : 0;
+    var labelX = (pts[segStart].x + pts[segStart + 1].x) / 2;
+    var labelY = (pts[segStart].y + pts[segStart + 1].y) / 2;
+    epCtx.font = "9px monospace";
+    epCtx.fillStyle = isHovered ? "#ffffff" : EP_VALUE_EDGE_COLOR;
+    epCtx.textAlign = "center";
+    epCtx.textBaseline = "bottom";
+    epCtx.fillText(fromN.assignedTo, labelX, labelY - 2 / epZoom);
+    epCtx.textAlign = "left";
+  }
+}
+
 function epDrawFocusedGraph() {
   epCtx.save();
   epCtx.clearRect(0, 0, epW, epH);
@@ -4577,67 +4698,21 @@ function epDrawFocusedGraph() {
   for (var i = 0; i < epNodes.length; i++) nodeById[epNodes[i].id] = epNodes[i];
 
   // Draw edges — only between visible nodes; a collapsed node's whole subtree drops out here.
+  // The hovered edge (if any) is skipped here and redrawn last, on top of every other edge,
+  // so it stays easy to tell apart when several lines overlap.
   for (var i = 0; i < epEdges.length; i++) {
-    var fromN = nodeById[epEdges[i].from];
-    var toN = nodeById[epEdges[i].to];
+    var edge = epEdges[i];
+    if (edge === epHoveredEdge) continue;
+    var fromN = nodeById[edge.from];
+    var toN = nodeById[edge.to];
     if (!fromN || !toN || !fromN.visible || !toN.visible) continue;
-
-    var fx = fromN.x;
-    var fy = fromN.y + fromN.h / 2;
-    var tx = toN.x;
-    var ty = toN.y - toN.h / 2;
-
-    // Value edges (a guarded call's return value flowing into its break step) draw
-    // thinner and dotted in a muted blue, distinct from the amber conditional dash.
-    var isValueEdge = epEdges[i].kind === "value";
-    var edgeColor = isValueEdge
-      ? EP_VALUE_EDGE_COLOR
-      : (epEdges[i].conditional ? "rgba(245, 158, 11, 0.6)" : "#555");
-    var edgeLineW = isValueEdge ? 1 / epZoom : 1.5 / epZoom;
-    if (isValueEdge) {
-      epCtx.setLineDash([2 / epZoom, 3 / epZoom]);
-    } else if (epEdges[i].conditional) {
-      epCtx.setLineDash([6 / epZoom, 4 / epZoom]);
-    }
-
-    epCtx.beginPath();
-    epCtx.moveTo(fx, fy);
-    // L-shaped edge if not aligned
-    var bent = Math.abs(fx - tx) > 2;
-    var midY = fy;
-    if (bent) {
-      midY = fy + (ty - fy) / 2;
-      epCtx.lineTo(fx, midY);
-      epCtx.lineTo(tx, midY);
-    }
-    epCtx.lineTo(tx, ty);
-    epCtx.strokeStyle = edgeColor;
-    epCtx.lineWidth = edgeLineW;
-    epCtx.stroke();
-
-    // Arrow
-    var arrowSize = 5 / epZoom;
-    epCtx.beginPath();
-    epCtx.moveTo(tx - arrowSize, ty - arrowSize);
-    epCtx.lineTo(tx, ty);
-    epCtx.lineTo(tx + arrowSize, ty - arrowSize);
-    epCtx.strokeStyle = edgeColor;
-    epCtx.lineWidth = edgeLineW;
-    epCtx.stroke();
-
-    epCtx.setLineDash([]);
-
-    // Label the value edge with the producer's assigned variable, at the midpoint
-    // of its (usually horizontal, same-rank) segment.
-    if (isValueEdge && fromN.assignedTo) {
-      var labelX = bent ? (fx + tx) / 2 : fx;
-      var labelY = bent ? midY : (fy + ty) / 2;
-      epCtx.font = "9px monospace";
-      epCtx.fillStyle = EP_VALUE_EDGE_COLOR;
-      epCtx.textAlign = "center";
-      epCtx.textBaseline = "bottom";
-      epCtx.fillText(fromN.assignedTo, labelX, labelY - 2 / epZoom);
-      epCtx.textAlign = "left";
+    epDrawOneEdge(edge, fromN, toN, false);
+  }
+  if (epHoveredEdge) {
+    var hFromN = nodeById[epHoveredEdge.from];
+    var hToN = nodeById[epHoveredEdge.to];
+    if (hFromN && hToN && hFromN.visible && hToN.visible) {
+      epDrawOneEdge(epHoveredEdge, hFromN, hToN, true);
     }
   }
 
@@ -5462,6 +5537,13 @@ function renderEndpoints() {
       } else if (hit) {
         epShowTooltip(hit, sx, sy);
       }
+
+      // Edge hover only when no node is under the cursor — a node's own hover wins.
+      var hitEdge = hit ? null : epHitTestEdge(pos.x, pos.y);
+      if (hitEdge !== epHoveredEdge) {
+        epHoveredEdge = hitEdge;
+        epScheduleRedraw();
+      }
     }
   });
 
@@ -5491,6 +5573,7 @@ function renderEndpoints() {
     epDragging = null;
     epPanning = false;
     epHoveredNode = null;
+    epHoveredEdge = null;
     epOvHoveredRow = null;
     epOvHitRowPending = null;
     epHideTooltip();

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -4224,6 +4224,11 @@ function epComputeTreeVisibility(nodes, edges) {
   var i;
   for (i = 0; i < edges.length; i++) {
     var e = edges[i];
+    // Value edges aren't tree structure — they're an extra annotation between
+    // siblings, not a parent/child relationship. Counting them here would inflate
+    // childCount (and the "N direct calls" tooltip that reads it) and give a
+    // childless guarded call a spurious expand chip.
+    if (e.kind === "value") continue;
     if (!childrenOf[e.from]) childrenOf[e.from] = [];
     childrenOf[e.from].push(e.to);
     hasParent[e.to] = true;
@@ -4412,6 +4417,7 @@ function epBuildGraph(ep) {
 }
 // ep-build-graph-end
 
+// ep-layout-start
 /** Lays out visible nodes only — collapsed subtrees don't take up graph space. */
 function epLayout() {
   var visible = [];
@@ -4433,6 +4439,10 @@ function epLayout() {
     }
     for (var j = 0; j < epEdges.length; j++) {
       var e = epEdges[j];
+      // Value edges aren't tree structure — feeding them to dagre adds a rank
+      // constraint that pushes the break step below its guarded call instead of
+      // beside it.
+      if (e.kind === "value") continue;
       if (byId[e.from] && byId[e.to]) g.setEdge(e.from, e.to);
     }
 
@@ -4453,6 +4463,7 @@ function epLayout() {
     }
   }
 }
+// ep-layout-end
 
 function epCenterCamera() {
   if (epNodes.length === 0) return;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3679,12 +3679,16 @@ var epCanvas, epCtx, epDpr, epW, epH;
 var epCamX = 0, epCamY = 0, epZoom = 1, epMinZoom = 0.2;
 var epDragging = null, epPanning = false, epPanStart = {x: 0, y: 0};
 var epDragMoved = false;
+var epDragStartX = 0, epDragStartY = 0;
+var EP_DRAG_THRESHOLD_PX = 4;
 var epHoveredNode = null;
 var epNodes = [];
 var epEdges = [];
 var epTooltipEl = null;
 var epDirty = false;
 var epSelectedIndex = -1;
+var epLastZoomUi = null;
+var epBannerDismissedIndex = -1;
 
 /** "overview" (default) shows module clusters; "focused" shows one endpoint's call graph. */
 var epMode = "overview";
@@ -3694,6 +3698,26 @@ var epOvHitRowPending = null;
 
 function epZoomFloor() {
   return Math.min(epMinZoom, 0.05);
+}
+
+/** Keeps the zoom bar in step with the camera, whatever changed it. */
+function epSyncZoomUi() {
+  var pct = Math.round(epZoom * 100);
+  if (pct === epLastZoomUi) return;
+  epLastZoomUi = pct;
+  var range = document.getElementById("endpoints-zoom-range");
+  var label = document.getElementById("endpoints-zoom-value");
+  if (range) range.value = String(Math.max(5, Math.min(500, pct)));
+  if (label) {
+    label.textContent = pct + "%";
+    label.setAttribute("aria-label", pct + "% \\u00b7 fit to view");
+  }
+}
+
+function epSetZoom(next) {
+  epZoom = Math.max(epZoomFloor(), Math.min(3, next));
+  epSyncZoomUi();
+  epScheduleRedraw();
 }
 
 // Auth shield for one endpoint. Reused by the endpoints overview canvas.
@@ -4066,6 +4090,17 @@ var EP_TYPE_COLORS = {
   unknown: "#666"
 };
 
+/** Builds the type-color rows of the endpoints legend straight from EP_TYPE_COLORS. */
+function epBuildLegendTypesHtml() {
+  var html = "";
+  for (var type in EP_TYPE_COLORS) {
+    if (!Object.prototype.hasOwnProperty.call(EP_TYPE_COLORS, type)) continue;
+    html += '<div class="ep-legend-row"><span class="ep-legend-swatch" style="background:' +
+      EP_TYPE_COLORS[type] + '"></span>' + escHtml(type) + '</div>';
+  }
+  return html;
+}
+
 function epScheduleRedraw() {
   if (!epDirty) {
     epDirty = true;
@@ -4202,8 +4237,10 @@ function epCenterCamera() {
   var pad = 60;
   var scaleX = (epW - pad * 2) / (graphW || 1);
   var scaleY = (epH - pad * 2) / (graphH || 1);
-  epZoom = Math.min(scaleX, scaleY, 1.5);
-  epZoom = Math.max(epZoom, 0.3);
+  var fit = Math.min(scaleX, scaleY, 1.5);
+  // Records the fit so the zoom floor can zoom out this far, same as overview.
+  epMinZoom = Math.min(0.2, fit);
+  epZoom = Math.max(epMinZoom, fit);
 
   epCamX = epW / 2 - cx;
   epCamY = epH / 2 - cy;
@@ -4211,6 +4248,7 @@ function epCenterCamera() {
 
 function epDraw() {
   if (!epCtx) return;
+  epSyncZoomUi();
   if (epMode === "overview") {
     epDrawOverview();
   } else {
@@ -4423,17 +4461,21 @@ function epResize() {
   if (!epCanvas) return;
   var container = epCanvas.parentElement;
   if (!container) return;
+  var prevW = epW, prevH = epH;
   epW = container.clientWidth;
   epH = container.clientHeight;
+  // Focused mode keeps whatever was centred in view instead of re-fitting the graph.
+  if (epMode === "focused" && prevW && prevH) {
+    epCamX += (epW - prevW) / 2;
+    epCamY += (epH - prevH) / 2;
+  }
   epCanvas.width = epW * epDpr;
   epCanvas.height = epH * epDpr;
   epCanvas.style.width = epW + "px";
   epCanvas.style.height = epH + "px";
   epCtx.setTransform(epDpr, 0, 0, epDpr, 0, 0);
-  if (epMode === "overview") {
-    if (epOverviewGroups.length > 0) epCenterOverviewCamera();
-  } else if (epNodes.length > 0) {
-    epCenterCamera();
+  if (epMode === "overview" && epOverviewGroups.length > 0) {
+    epCenterOverviewCamera();
   }
   epScheduleRedraw();
 }
@@ -4527,12 +4569,28 @@ function epSyncViewToggle() {
     : "All endpoints \\u00b7 back to the module overview");
 }
 
+/** Shows the truncation banner for a focused endpoint whose trace hit the node cap, unless dismissed for it. */
+function epSyncTruncatedBanner(ep) {
+  var banner = document.getElementById("endpoints-truncated-banner");
+  if (!banner) return;
+  var show = !!(ep && ep.truncated) && epSelectedIndex !== epBannerDismissedIndex;
+  banner.style.display = show ? "flex" : "none";
+}
+
+/** The legend's auth-shield and diagnostic-dot entries only apply to overview mode. */
+function epSyncLegendMode() {
+  var section = document.getElementById("endpoints-legend-overview");
+  if (section) section.style.display = epMode === "overview" ? "block" : "none";
+}
+
 function epShowOverview() {
   epMode = "overview";
   epHideCodePanel();
   epHideTooltip();
   epCanvas.style.display = "block";
   epSyncViewToggle();
+  epSyncLegendMode();
+  epSyncTruncatedBanner(null);
   epResize();
 }
 
@@ -4546,7 +4604,13 @@ function epShowFocused(index) {
   epBuildGraph(found);
   epLayout();
   epSyncViewToggle();
+  epSyncLegendMode();
+  epSyncTruncatedBanner(found);
   epResize();
+  // A new endpoint has a different graph, so fit it — epResize alone only
+  // preserves the camera across container resizes, not endpoint changes.
+  epCenterCamera();
+  epScheduleRedraw();
 }
 
 function renderEndpoints() {
@@ -4739,7 +4803,11 @@ function renderEndpoints() {
 
     var hit = epHitTest(pos.x, pos.y);
     if (hit) {
-      epDragging = hit;
+      // Grab offset, not the node's centre — so a drag moves the node
+      // relative to where it was grabbed instead of snapping it to the cursor.
+      epDragging = { node: hit, dx: pos.x - hit.x, dy: pos.y - hit.y };
+      epDragStartX = e.clientX;
+      epDragStartY = e.clientY;
       epHideTooltip();
     } else {
       epPanning = true;
@@ -4776,11 +4844,19 @@ function renderEndpoints() {
     }
 
     if (epDragging) {
-      epDragMoved = true;
-      epDragging.x = pos.x;
-      epDragging.y = pos.y;
-      epScheduleRedraw();
-      epHideTooltip();
+      if (!epDragMoved) {
+        var ddx = e.clientX - epDragStartX;
+        var ddy = e.clientY - epDragStartY;
+        if (ddx * ddx + ddy * ddy > EP_DRAG_THRESHOLD_PX * EP_DRAG_THRESHOLD_PX) {
+          epDragMoved = true;
+        }
+      }
+      if (epDragMoved) {
+        epDragging.node.x = pos.x - epDragging.dx;
+        epDragging.node.y = pos.y - epDragging.dy;
+        epScheduleRedraw();
+        epHideTooltip();
+      }
     } else if (epPanning) {
       epDragMoved = true;
       epCamX += (e.clientX - epPanStart.x) / epZoom;
@@ -4817,7 +4893,7 @@ function renderEndpoints() {
 
     var clickedNode = epDragging;
     if (!epDragMoved && clickedNode) {
-      epShowCodePanel(clickedNode);
+      epShowCodePanel(clickedNode.node);
     }
     epDragging = null;
     epPanning = false;
@@ -4861,6 +4937,53 @@ function renderEndpoints() {
     epHideTooltip();
     epScheduleRedraw();
   }, { passive: false });
+
+  // Zoom toolbar: mirrors the schema tab's -/+/% readout + click-to-fit, both modes.
+  var epZoomRange = document.getElementById("endpoints-zoom-range");
+  var epZoomInBtn = document.getElementById("endpoints-zoom-in");
+  var epZoomOutBtn = document.getElementById("endpoints-zoom-out");
+  var epZoomValueBtn = document.getElementById("endpoints-zoom-value");
+  if (epZoomRange) {
+    epZoomRange.addEventListener("input", function() {
+      epSetZoom(Number(epZoomRange.value) / 100);
+    });
+  }
+  if (epZoomInBtn) {
+    epZoomInBtn.addEventListener("click", function() { epSetZoom(epZoom * 1.2); });
+  }
+  if (epZoomOutBtn) {
+    epZoomOutBtn.addEventListener("click", function() { epSetZoom(epZoom / 1.2); });
+  }
+  if (epZoomValueBtn) {
+    epZoomValueBtn.addEventListener("click", function() {
+      if (epMode === "overview") { epCenterOverviewCamera(); } else { epCenterCamera(); }
+      epSyncZoomUi();
+      epScheduleRedraw();
+    });
+  }
+
+  // Legend: type-color rows are built once here; overview-only rows toggle via epSyncLegendMode.
+  var epLegendTypesEl = document.getElementById("endpoints-legend-types");
+  if (epLegendTypesEl) epLegendTypesEl.innerHTML = epBuildLegendTypesHtml();
+  var legendToggleBtn = document.getElementById("endpoints-legend-toggle");
+  var legendPanel = document.getElementById("endpoints-legend");
+  if (legendToggleBtn && legendPanel) {
+    legendToggleBtn.addEventListener("click", function() {
+      var showing = legendPanel.style.display !== "none";
+      legendPanel.style.display = showing ? "none" : "block";
+      legendToggleBtn.classList.toggle("active", !showing);
+      legendToggleBtn.setAttribute("aria-pressed", String(!showing));
+    });
+  }
+
+  // Truncation banner dismiss — stays dismissed only for the endpoint it was shown for.
+  var truncatedDismissBtn = document.getElementById("endpoints-truncated-dismiss");
+  if (truncatedDismissBtn) {
+    truncatedDismissBtn.addEventListener("click", function() {
+      epBannerDismissedIndex = epSelectedIndex;
+      epSyncTruncatedBanner(endpoints.endpoints[epSelectedIndex]);
+    });
+  }
 
   // Recenter button — auto-fits whichever mode is active.
   var recenterBtn = document.getElementById("endpoints-recenter");
@@ -4912,7 +5035,9 @@ function renderEndpoints() {
     });
     document.addEventListener("mousemove", function(e) {
       if (!epResizing) return;
-      var w = epStartW + (e.clientX - epStartX);
+      // Panel is right-anchored, so its resize handle sits on the left edge:
+      // dragging left (negative clientX delta) grows the panel.
+      var w = epStartW + (epStartX - e.clientX);
       if (w < 300) w = 300;
       if (w > window.innerWidth * 0.8) w = window.innerWidth * 0.8;
       epCodePanel.style.width = w + "px";

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -1,6 +1,7 @@
 export interface ReportScriptData {
 	diagnosticsJson: string;
 	elapsedMsJson: string;
+	endpointDiagnosticsJson: string;
 	endpointsJson: string;
 	examplesJson: string;
 	fileSourcesJson: string;
@@ -25,6 +26,7 @@ const fileSources = ${data.fileSourcesJson};
 const providers = ${data.providersJson};
 const schema = ${data.schemaJson};
 const endpoints = ${data.endpointsJson};
+const endpointDiagnostics = ${data.endpointDiagnosticsJson};
 const isMonorepo = Object.keys(fileSources).length === 0;
 
 // ── Score helpers ──

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3731,6 +3731,9 @@ var epDirty = false;
 var epSelectedIndex = -1;
 var epLastZoomUi = null;
 var epBannerDismissedIndex = -1;
+// Set once the problems drawer is wired up in renderEndpoints(); epShowFocused/epShowOverview
+// call it with the selected index (or null for overview) to keep the drawer in scope.
+var epDiagPanelRender = null;
 var EP_CHIP_W = 34, EP_CHIP_H = 15;
 var EP_NODE_HDR_H = 22;
 
@@ -4813,6 +4816,7 @@ function epShowOverview() {
   epSyncLegendMode();
   epSyncFocusedToolbar();
   epSyncTruncatedBanner(null);
+  if (epDiagPanelRender) epDiagPanelRender(null);
   epResize();
 }
 
@@ -4829,6 +4833,7 @@ function epShowFocused(index) {
   epSyncLegendMode();
   epSyncFocusedToolbar();
   epSyncTruncatedBanner(found);
+  if (epDiagPanelRender) epDiagPanelRender(index);
   epResize();
   // A new endpoint has a different graph, so fit it — epResize alone only
   // preserves the camera across container resizes, not endpoint changes.
@@ -5325,11 +5330,12 @@ function renderEndpoints() {
   // ── Endpoint diagnostics drawer ──
   var epDiagCountEl = document.getElementById("endpoints-diag-count");
   var epDiagHeaderEl = document.getElementById("endpoints-diag-header");
+  var epDiagScopeEl = document.getElementById("endpoints-diag-scope");
   var epDiagBodyEl = document.getElementById("endpoints-diag-body");
   var epDiagListEl = document.getElementById("endpoints-diag-list");
   var epDiagChevronEl = document.getElementById("endpoints-diag-chevron");
 
-  if (epDiagCountEl && epDiagHeaderEl && epDiagBodyEl && epDiagListEl && epDiagChevronEl) {
+  if (epDiagCountEl && epDiagHeaderEl && epDiagScopeEl && epDiagBodyEl && epDiagListEl && epDiagChevronEl) {
     var epEndpointsByFile = {};
     for (var fi = 0; fi < endpoints.endpoints.length; fi++) {
       var fep = endpoints.endpoints[fi];
@@ -5338,6 +5344,7 @@ function renderEndpoints() {
     }
 
     // Joins diagnostics to endpoints by filePath + line range, mirroring endpoint-diagnostics.ts.
+    // Computed once — epRenderDiagPanel below just filters/aggregates this on every mode switch.
     var epDiagRows = [];
     for (var di = 0; di < diagnostics.length; di++) {
       var d = diagnostics[di];
@@ -5352,53 +5359,88 @@ function renderEndpoints() {
       }
     }
 
-    var epSumCounts = function(c) { return c.error + c.warning + c.info; };
-    var epFileKeys = Object.keys(endpointDiagnostics.perFile);
-    var epEndpointKeys = Object.keys(endpointDiagnostics.perEndpoint);
-    var epDiagTotal = 0;
-    for (var pek = 0; pek < epEndpointKeys.length; pek++) {
-      epDiagTotal += epSumCounts(endpointDiagnostics.perEndpoint[epEndpointKeys[pek]]);
-    }
-    for (var pfk = 0; pfk < epFileKeys.length; pfk++) {
-      epDiagTotal += epSumCounts(endpointDiagnostics.perFile[epFileKeys[pfk]]);
+    var epSumCounts = function(c) { return c ? c.error + c.warning + c.info : 0; };
+
+    function epDiagRowHtml(row) {
+      var rd = row.diagnostic;
+      var rep = endpoints.endpoints[row.epIndex];
+      var sevColor = rd.severity === "error" ? "var(--sev-error)" : rd.severity === "warning" ? "var(--sev-warning)" : "var(--sev-info)";
+      return '<div class="sd-item">' +
+        '<span class="sev-dot" style="background:' + sevColor + '"></span>' +
+        '<span class="sd-rule">' + escHtml(rd.rule) + '</span>' +
+        '<span class="sd-entity" data-ep-index="' + row.epIndex + '" data-line="' + rd.line + '">' + escHtml(rep.controllerClass + "." + rep.handlerMethod) + '</span>' +
+        '<span class="sd-msg">' + escHtml(rd.message) + '</span>' +
+        '</div>';
     }
 
-    epDiagCountEl.textContent = epDiagTotal + (epDiagTotal === 1 ? " issue" : " issues");
-    if (epDiagTotal > 0) epDiagCountEl.classList.add("has-issues");
+    function epFileRollupHtml(filePath) {
+      var counts = endpointDiagnostics.perFile[filePath];
+      var frTotal = epSumCounts(counts);
+      var frColor = counts.error > 0 ? "var(--sev-error)" : (counts.warning > 0 ? "var(--sev-warning)" : "var(--sev-info)");
+      var frParts = [];
+      if (counts.error > 0) frParts.push(counts.error + " error" + (counts.error !== 1 ? "s" : ""));
+      if (counts.warning > 0) frParts.push(counts.warning + " warning" + (counts.warning !== 1 ? "s" : ""));
+      if (counts.info > 0) frParts.push(counts.info + " info");
+      return '<div class="sd-item">' +
+        '<span class="sev-dot" style="background:' + frColor + '"></span>' +
+        '<span class="sd-entity">' + escHtml(epRelPath(filePath)) + '</span>' +
+        '<span class="sd-msg">' + frTotal + (frTotal === 1 ? " issue" : " issues") + ' outside any handler \\u00b7 ' + escHtml(frParts.join(", ")) + '</span>' +
+        '</div>';
+    }
 
-    if (epDiagTotal === 0) {
-      epDiagListEl.innerHTML = '<div class="sd-empty">No endpoint issues found</div>';
-    } else {
+    /**
+     * Renders the drawer badge/title/list. scopeIndex null scopes to the whole project
+     * (overview); a number scopes to just that endpoint's joined rows — no per-file
+     * "outside any handler" rollup, since those aren't attributable to one endpoint.
+     */
+    function epRenderDiagPanel(scopeIndex) {
+      var scoped = typeof scopeIndex === "number";
+      var total;
+
+      if (scoped) {
+        total = epSumCounts(endpointDiagnostics.perEndpoint[String(scopeIndex)]);
+      } else {
+        var epFileKeys = Object.keys(endpointDiagnostics.perFile);
+        var epEndpointKeys = Object.keys(endpointDiagnostics.perEndpoint);
+        total = 0;
+        for (var pek = 0; pek < epEndpointKeys.length; pek++) {
+          total += epSumCounts(endpointDiagnostics.perEndpoint[epEndpointKeys[pek]]);
+        }
+        for (var pfk = 0; pfk < epFileKeys.length; pfk++) {
+          total += epSumCounts(endpointDiagnostics.perFile[epFileKeys[pfk]]);
+        }
+      }
+
+      if (scoped) {
+        var scopedEp = endpoints.endpoints[scopeIndex];
+        epDiagScopeEl.textContent = "\\u00b7 " + (scopedEp.httpMethod || "").toUpperCase() + " " + (scopedEp.routePath || "/");
+      } else {
+        epDiagScopeEl.textContent = "";
+      }
+
+      epDiagCountEl.textContent = total + (total === 1 ? " issue" : " issues");
+      epDiagCountEl.classList.toggle("has-issues", total > 0);
+
+      if (total === 0) {
+        epDiagListEl.innerHTML = '<div class="sd-empty">' + (scoped ? "No issues for this endpoint" : "No endpoint issues found") + '</div>';
+        return;
+      }
+
       var epDiagHtml = "";
       for (var ri = 0; ri < epDiagRows.length; ri++) {
-        var row = epDiagRows[ri];
-        var rd = row.diagnostic;
-        var rep = endpoints.endpoints[row.epIndex];
-        var sevColor = rd.severity === "error" ? "var(--sev-error)" : rd.severity === "warning" ? "var(--sev-warning)" : "var(--sev-info)";
-        epDiagHtml += '<div class="sd-item">';
-        epDiagHtml += '<span class="sev-dot" style="background:' + sevColor + '"></span>';
-        epDiagHtml += '<span class="sd-rule">' + escHtml(rd.rule) + '</span>';
-        epDiagHtml += '<span class="sd-entity" data-ep-index="' + row.epIndex + '" data-line="' + rd.line + '">' + escHtml(rep.controllerClass + "." + rep.handlerMethod) + '</span>';
-        epDiagHtml += '<span class="sd-msg">' + escHtml(rd.message) + '</span>';
-        epDiagHtml += '</div>';
+        if (scoped && epDiagRows[ri].epIndex !== scopeIndex) continue;
+        epDiagHtml += epDiagRowHtml(epDiagRows[ri]);
       }
-      for (var rj = 0; rj < epFileKeys.length; rj++) {
-        var filePath = epFileKeys[rj];
-        var counts = endpointDiagnostics.perFile[filePath];
-        var frTotal = epSumCounts(counts);
-        var frColor = counts.error > 0 ? "var(--sev-error)" : (counts.warning > 0 ? "var(--sev-warning)" : "var(--sev-info)");
-        var frParts = [];
-        if (counts.error > 0) frParts.push(counts.error + " error" + (counts.error !== 1 ? "s" : ""));
-        if (counts.warning > 0) frParts.push(counts.warning + " warning" + (counts.warning !== 1 ? "s" : ""));
-        if (counts.info > 0) frParts.push(counts.info + " info");
-        epDiagHtml += '<div class="sd-item">';
-        epDiagHtml += '<span class="sev-dot" style="background:' + frColor + '"></span>';
-        epDiagHtml += '<span class="sd-entity">' + escHtml(epRelPath(filePath)) + '</span>';
-        epDiagHtml += '<span class="sd-msg">' + frTotal + (frTotal === 1 ? " issue" : " issues") + ' outside any handler \\u00b7 ' + escHtml(frParts.join(", ")) + '</span>';
-        epDiagHtml += '</div>';
+      if (!scoped) {
+        var rollupFileKeys = Object.keys(endpointDiagnostics.perFile);
+        for (var rj = 0; rj < rollupFileKeys.length; rj++) {
+          epDiagHtml += epFileRollupHtml(rollupFileKeys[rj]);
+        }
       }
       epDiagListEl.innerHTML = epDiagHtml;
     }
+
+    epDiagPanelRender = epRenderDiagPanel;
 
     epDiagHeaderEl.addEventListener("click", function() {
       var isOpen = epDiagBodyEl.style.display !== "none";

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3923,6 +3923,7 @@ function epBuildOverviewGroups() {
   return groups;
 }
 
+// ep-build-graph-start
 function epClipText(text, maxW) {
   if (!epCtx || epCtx.measureText(text).width <= maxW) return text;
   var out = text;
@@ -4321,7 +4322,6 @@ function epBuildGraph(ep) {
     type: "controller",
     methodName: ep.handlerMethod,
     conditional: false,
-    order: -1,
     totalMethods: 1,
     filePath: ep.filePath,
     line: ep.line,
@@ -4331,8 +4331,15 @@ function epBuildGraph(ep) {
   };
   epNodes.push(rootNode);
 
-  // Walk dependency tree — each dep is a MethodDependencyNode (one method per node)
+  // Walk dependency tree — each dep is a MethodDependencyNode (one method per node).
+  // #N badges are assigned here with a counter local to this one call — i.e. per
+  // sibling group, the same level the engine already sorted deps into — rather than
+  // sorted globally across the whole tree. The engine's order field is scoped to a
+  // single method body and resets per call, so a global sort by it interleaves levels
+  // (a call's own nested children can outrank its next sibling). Per-level numbering
+  // stays contiguous and stable under expand/collapse.
   function walkDeps(parentNode, deps) {
+    var seq = 0;
     for (var i = 0; i < deps.length; i++) {
       var dep = deps[i];
       var n = {
@@ -4343,13 +4350,12 @@ function epBuildGraph(ep) {
         conditional: dep.conditional,
         conditionText: dep.conditionText,
         branchKind: dep.branchKind,
-        order: dep.order,
+        displayOrder: seq++,
         totalMethods: dep.totalMethods,
         filePath: dep.filePath,
         line: dep.line,
         endLine: dep.endLine,
         expandedElsewhere: dep.expandedElsewhere,
-        guardThrow: dep.guardThrow,
         throwMessage: dep.throwMessage,
         iterationKind: dep.iterationKind,
         iterationLabel: dep.iterationLabel,
@@ -4364,8 +4370,7 @@ function epBuildGraph(ep) {
 
       // Guard-throw belongs to the caller, not the callee: synthesize a break-step leaf
       // right after the guarded call, same parent, so the tree reads check-then-throw at
-      // the call site. Fractional order sorts it directly after dep in the flat #N sequence
-      // without needing a reserved integer gap.
+      // the call site.
       if (dep.guardThrow) {
         var bn = {
           id: nodeId++,
@@ -4373,7 +4378,7 @@ function epBuildGraph(ep) {
           className: parentNode.className,
           methodName: null,
           conditional: false,
-          order: dep.order + 0.5,
+          displayOrder: seq++,
           filePath: parentNode.filePath,
           line: dep.guardThrow.callSiteLine,
           endLine: dep.guardThrow.callSiteLine,
@@ -4395,18 +4400,9 @@ function epBuildGraph(ep) {
 
   walkDeps(rootNode, ep.dependencies);
 
-  // Contiguous #N badges in engine-order sequence. The raw order field skips slots a
-  // merged guard-throw consumed (e.g. 0, 2), which would otherwise show as #1 -> #3.
-  // Computed once here so display order stays stable while nodes expand/collapse.
-  var ordered = [];
-  for (var oi = 0; oi < epNodes.length; oi++) {
-    if (epNodes[oi].order >= 0) ordered.push(epNodes[oi]);
-  }
-  ordered.sort(function(a, b) { return a.order - b.order; });
-  for (var di = 0; di < ordered.length; di++) ordered[di].displayOrder = di;
-
   epComputeTreeVisibility(epNodes, epEdges);
 }
+// ep-build-graph-end
 
 /** Lays out visible nodes only — collapsed subtrees don't take up graph space. */
 function epLayout() {
@@ -4888,11 +4884,16 @@ function epResize() {
 }
 
 /** Joins parameter names into a call-args string, e.g. "id, userId". */
-function epFormatParams(params) {
+/** Formats a method's declared parameters as "name: type" pairs — a signature, never a call. */
+function epFormatSignature(node) {
+  var params = node.parameters;
   if (!params || params.length === 0) return "";
-  var names = [];
-  for (var i = 0; i < params.length; i++) names.push(params[i].name);
-  return names.join(", ");
+  var parts = [];
+  for (var i = 0; i < params.length; i++) {
+    var p = params[i];
+    parts.push(p.type ? p.name + ": " + p.type : p.name);
+  }
+  return node.methodName + "(" + parts.join(", ") + ")";
 }
 
 function epShowTooltip(node, screenX, screenY) {
@@ -4913,8 +4914,11 @@ function epShowTooltip(node, screenX, screenY) {
     var methodHtml = "";
     if (node.methodName) {
       var mColor = node.conditional ? "#f59e0b" : "#ccc";
-      var callText = node.methodName + "(" + epFormatParams(node.parameters) + ")";
-      methodHtml = '<div style="font-family:monospace;font-size:11px;color:' + mColor + ';margin-top:4px">.' + escHtml(callText) + '</div>';
+      methodHtml = '<div style="font-family:monospace;font-size:11px;color:' + mColor + ';margin-top:4px">.' + escHtml(node.methodName) + '()</div>';
+    }
+    var signatureLabel = "";
+    if (node.parameters && node.parameters.length > 0) {
+      signatureLabel = '<div style="font-size:9px;color:#888;margin-top:4px">signature: ' + escHtml(epFormatSignature(node)) + '</div>';
     }
     var assignedLabel = "";
     if (node.assignedTo) {
@@ -4946,7 +4950,7 @@ function epShowTooltip(node, screenX, screenY) {
     }
     epTooltipEl.innerHTML = '<div class="tt-name">' + escHtml(node.className) + '</div>' +
       '<div class="tt-table" style="color:' + color + '">' + escHtml(node.type) + '</div>' +
-      methodHtml + assignedLabel + condLabel + throwMsgLabel + iterLabel + repeatLabel + childLabel;
+      methodHtml + signatureLabel + assignedLabel + condLabel + throwMsgLabel + iterLabel + repeatLabel + childLabel;
     epTooltipEl.style.display = "block";
   }
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -5011,6 +5011,50 @@ function renderEndpoints() {
     epShowFocused(epIndex);
   });
 
+  // Sidebar expand-all / collapse-all / hide — mirrors schema's sCollapseTree and the
+  // schema-sidebar-collapse/schema-sidebar-show pair, scoped to the endpoints tree.
+  /** Closes every module/controller group in the sidebar tree. */
+  function epCollapseSidebarTree() {
+    var children = sidebarEl.querySelectorAll(".st-children");
+    for (var i = 0; i < children.length; i++) {
+      children[i].classList.remove("st-open");
+    }
+    var toggles = sidebarEl.querySelectorAll(".st-toggle");
+    for (var j = 0; j < toggles.length; j++) {
+      toggles[j].textContent = "\\u25B8";
+    }
+  }
+
+  var epSidebarExpandAllBtn = document.getElementById("endpoints-sidebar-expand-all");
+  if (epSidebarExpandAllBtn) {
+    epSidebarExpandAllBtn.addEventListener("click", function() {
+      var children = sidebarEl.querySelectorAll(".st-children");
+      for (var i = 0; i < children.length; i++) children[i].classList.add("st-open");
+      var toggles = sidebarEl.querySelectorAll(".st-toggle");
+      for (var j = 0; j < toggles.length; j++) toggles[j].textContent = "\\u25BE";
+    });
+  }
+
+  var epSidebarCollapseAllBtn = document.getElementById("endpoints-sidebar-collapse-all");
+  if (epSidebarCollapseAllBtn) {
+    epSidebarCollapseAllBtn.addEventListener("click", epCollapseSidebarTree);
+  }
+
+  var epSidebarCollapseBtn = document.getElementById("endpoints-sidebar-collapse");
+  var epSidebarShowBtn = document.getElementById("endpoints-sidebar-show");
+  var endpointsTabEl = document.getElementById("tab-endpoints");
+  function epSetSidebarCollapsed(collapsed) {
+    if (!endpointsTabEl) return;
+    endpointsTabEl.classList.toggle("sidebar-collapsed", collapsed);
+    epResize();
+  }
+  if (epSidebarCollapseBtn) {
+    epSidebarCollapseBtn.addEventListener("click", function() { epSetSidebarCollapsed(true); });
+  }
+  if (epSidebarShowBtn) {
+    epSidebarShowBtn.addEventListener("click", function() { epSetSidebarCollapsed(false); });
+  }
+
   // Canvas interactions. Overview and focused mode share panning and zoom;
   // only hit-testing and the click result differ.
   epCanvas.addEventListener("mousedown", function(e) {

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3684,7 +3684,29 @@ var epNodes = [];
 var epEdges = [];
 var epTooltipEl = null;
 var epDirty = false;
-var epSelectedEndpoint = null;
+var epSelectedIndex = -1;
+
+// Auth shield for one endpoint. Reused by the endpoints overview canvas.
+function epAuthShield(ep) {
+  var auth = ep.auth;
+  var state = auth ? auth.state : "unknown";
+  var SHIELD_INFO = {
+    guarded: { glyph: "\\u2713", cls: "ep-auth-guarded", text: "Guarded" },
+    "declared-public": { glyph: "\\u25CB", cls: "ep-auth-public", text: "Declared public" },
+    unguarded: { glyph: "\\u26A0", cls: "ep-auth-unguarded", text: "Unguarded" },
+    unknown: { glyph: "?", cls: "ep-auth-unknown", text: "Unknown" }
+  };
+  var info = SHIELD_INFO[state] || SHIELD_INFO.unknown;
+  var labelParts = [info.text];
+  if (auth && auth.guardNames && auth.guardNames.length > 0) {
+    labelParts.push("guards: " + auth.guardNames.join(", "));
+  }
+  var isGraphQL = ep.httpMethod === "QUERY" || ep.httpMethod === "MUTATION" || ep.httpMethod === "SUBSCRIPTION";
+  if (auth && auth.globalGuard && !isGraphQL) {
+    labelParts.push("global guard registered");
+  }
+  return { glyph: info.glyph, cls: info.cls, label: labelParts.join(" \\u00b7 ") };
+}
 
 var EP_TYPE_COLORS = {
   controller: "#ea2845",
@@ -4139,90 +4161,186 @@ function renderEndpoints() {
   epCtx = epCanvas.getContext("2d");
   epDpr = window.devicePixelRatio || 1;
 
-  // Group endpoints by controller
-  var controllers = {};
-  var controllerOrder = [];
+  var NO_MODULE_LABEL = "(no module)";
+
+  // Group endpoints by module, then controller. Module labels are used as stored.
+  var moduleGroups = {};
+  var moduleOrder = [];
   for (var i = 0; i < endpoints.endpoints.length; i++) {
     var ep = endpoints.endpoints[i];
-    if (!controllers[ep.controllerClass]) {
-      controllers[ep.controllerClass] = [];
-      controllerOrder.push(ep.controllerClass);
+    var moduleLabel = ep.module ? ep.module : NO_MODULE_LABEL;
+    if (!moduleGroups[moduleLabel]) {
+      moduleGroups[moduleLabel] = { controllers: {}, controllerOrder: [], count: 0 };
+      moduleOrder.push(moduleLabel);
     }
-    controllers[ep.controllerClass].push(ep);
+    var moduleGroup = moduleGroups[moduleLabel];
+    moduleGroup.count++;
+    if (!moduleGroup.controllers[ep.controllerClass]) {
+      moduleGroup.controllers[ep.controllerClass] = [];
+      moduleGroup.controllerOrder.push(ep.controllerClass);
+    }
+    moduleGroup.controllers[ep.controllerClass].push(i);
   }
+
+  // Alphabetical by module; "(no module)" always sorts last.
+  var sortedModules = moduleOrder.slice().sort(function(a, b) {
+    if (a === NO_MODULE_LABEL) return b === NO_MODULE_LABEL ? 0 : 1;
+    if (b === NO_MODULE_LABEL) return -1;
+    return a < b ? -1 : (a > b ? 1 : 0);
+  });
 
   // Set count
   document.getElementById("endpoints-count").textContent = endpoints.endpoints.length;
 
-  // HTTP method badge colors
+  // HTTP method badge colors. GraphQL entries are visually distinct from REST.
+  // No fallback to GET: an unrecognized method gets a neutral grey chip.
   var METHOD_COLORS = {
     GET: "ep-method-get",
     POST: "ep-method-post",
     PUT: "ep-method-put",
     PATCH: "ep-method-patch",
-    DELETE: "ep-method-delete"
+    DELETE: "ep-method-delete",
+    ALL: "ep-method-all",
+    HEAD: "ep-method-head",
+    OPTIONS: "ep-method-options",
+    QUERY: "ep-method-query",
+    MUTATION: "ep-method-mutation",
+    SUBSCRIPTION: "ep-method-subscription"
   };
 
-  // Build sidebar
-  var html = "";
-  for (var c = 0; c < controllerOrder.length; c++) {
-    var ctrlName = controllerOrder[c];
-    var ctrlEndpoints = controllers[ctrlName];
-    var ctrlId = "ep-ctrl-" + c;
-    html += '<div class="st-row" data-toggle="' + ctrlId + '">';
-    html += '<span class="st-toggle" data-toggle="' + ctrlId + '">\\u25BE</span>';
-    html += '<span class="st-icon"><svg viewBox="0 0 16 16" fill="none" stroke="var(--nest-red)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="2"/><line x1="5" y1="6" x2="11" y2="6"/><line x1="5" y1="10" x2="9" y2="10"/></svg></span>';
-    html += '<span class="st-label"><span class="st-entity-name">' + escHtml(ctrlName) + '</span></span>';
-    html += '<span class="st-count">' + ctrlEndpoints.length + '</span>';
-    html += '</div>';
-    html += '<div class="st-children st-open" id="st-' + ctrlId + '">';
+  // Diagnostic count badge for one endpoint index, colored by highest severity present.
+  function epDiagBadgeHtml(index) {
+    var counts = endpointDiagnostics.perEndpoint[String(index)];
+    if (!counts) return "";
+    var total = counts.error + counts.warning + counts.info;
+    if (total === 0) return "";
+    var color = counts.error > 0 ? "var(--sev-error)" : (counts.warning > 0 ? "var(--sev-warning)" : "var(--sev-info)");
+    var parts = [];
+    if (counts.error > 0) parts.push(counts.error + " error" + (counts.error !== 1 ? "s" : ""));
+    if (counts.warning > 0) parts.push(counts.warning + " warning" + (counts.warning !== 1 ? "s" : ""));
+    if (counts.info > 0) parts.push(counts.info + " info");
+    return '<span class="ep-diag-badge" title="' + escHtml(parts.join(", ")) + '"><span class="ep-diag-dot" style="background:' + color + '"></span>' + total + '</span>';
+  }
 
-    for (var e = 0; e < ctrlEndpoints.length; e++) {
-      var ep = ctrlEndpoints[e];
-      var method = (ep.httpMethod || "GET").toUpperCase();
-      var badgeClass = METHOD_COLORS[method] || "ep-method-get";
-      html += '<div class="st-row ep-endpoint-row" data-ep-ctrl="' + escHtml(ctrlName) + '" data-ep-handler="' + escHtml(ep.handlerMethod) + '">';
-      html += '<span class="st-indent"></span><span class="st-indent"></span>';
-      html += '<span class="ep-method-badge ' + badgeClass + '">' + escHtml(method) + '</span>';
-      html += '<span class="st-label">' + escHtml(ep.routePath || "/") + '</span>';
-      html += '</div>';
-    }
+  // Build sidebar: module → controller → endpoint
+  var html = "";
+  for (var m = 0; m < sortedModules.length; m++) {
+    var moduleLabel = sortedModules[m];
+    var moduleGroup = moduleGroups[moduleLabel];
+    var modId = "ep-mod-" + m;
+    html += '<div class="st-row ep-module-row" data-toggle="' + modId + '">';
+    html += '<span class="st-toggle" data-toggle="' + modId + '">\\u25BE</span>';
+    html += '<span class="st-icon"><svg viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" stroke-width="1.2"><path d="M2 4.5h4l1.5-1.5H14v2H4L2 13V4.5z"/><path d="M4 7h11l-2 6H2z"/></svg></span>';
+    html += '<span class="st-label"><span class="st-group-name">' + escHtml(moduleLabel) + '</span></span>';
+    html += '<span class="st-count">' + moduleGroup.count + '</span>';
     html += '</div>';
+    html += '<div class="st-children st-open" id="st-' + modId + '">';
+
+    for (var c = 0; c < moduleGroup.controllerOrder.length; c++) {
+      var ctrlName = moduleGroup.controllerOrder[c];
+      var ctrlIndices = moduleGroup.controllers[ctrlName];
+      var ctrlId = modId + "-ctrl-" + c;
+      html += '<div class="st-row ep-ctrl-row" data-toggle="' + ctrlId + '">';
+      html += '<span class="st-indent"></span>';
+      html += '<span class="st-toggle" data-toggle="' + ctrlId + '">\\u25BE</span>';
+      html += '<span class="st-icon"><svg viewBox="0 0 16 16" fill="none" stroke="var(--nest-red)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="2"/><line x1="5" y1="6" x2="11" y2="6"/><line x1="5" y1="10" x2="9" y2="10"/></svg></span>';
+      html += '<span class="st-label"><span class="st-entity-name">' + escHtml(ctrlName) + '</span></span>';
+      html += '<span class="st-count">' + ctrlIndices.length + '</span>';
+      html += '</div>';
+      html += '<div class="st-children st-open" id="st-' + ctrlId + '">';
+
+      for (var e = 0; e < ctrlIndices.length; e++) {
+        var epIndex = ctrlIndices[e];
+        var endpoint = endpoints.endpoints[epIndex];
+        var method = (endpoint.httpMethod || "GET").toUpperCase();
+        var badgeClass = METHOD_COLORS[method] || "ep-method-unknown";
+        var shield = epAuthShield(endpoint);
+        html += '<div class="st-row ep-endpoint-row" data-ep-index="' + epIndex + '">';
+        html += '<span class="st-indent"></span><span class="st-indent"></span>';
+        html += '<span class="ep-method-badge ' + badgeClass + '">' + escHtml(method) + '</span>';
+        html += '<span class="st-label">' + escHtml(endpoint.routePath || "/") + '</span>';
+        html += '<span class="ep-auth-shield ' + shield.cls + '" title="' + escHtml(shield.label) + '">' + shield.glyph + '</span>';
+        html += epDiagBadgeHtml(epIndex);
+        html += '</div>';
+      }
+      html += '</div>'; // close controller children
+    }
+    html += '</div>'; // close module children
   }
   sidebarEl.innerHTML = html;
 
+  // Search filter: case-insensitive substring over routePath, controllerClass,
+  // handlerMethod, module. Hides non-matching rows and empties groups.
+  var searchInput = document.getElementById("endpoints-search");
+  if (searchInput) {
+    searchInput.addEventListener("input", function() {
+      var q = searchInput.value.trim().toLowerCase();
+      var endpointRows = sidebarEl.querySelectorAll(".ep-endpoint-row");
+      for (var r = 0; r < endpointRows.length; r++) {
+        var row = endpointRows[r];
+        var rowIndex = Number(row.dataset.epIndex);
+        var rowEp = endpoints.endpoints[rowIndex];
+        var haystack = (
+          (rowEp.routePath || "") + " " +
+          (rowEp.controllerClass || "") + " " +
+          (rowEp.handlerMethod || "") + " " +
+          (rowEp.module || "")
+        ).toLowerCase();
+        row.style.display = (q === "" || haystack.indexOf(q) !== -1) ? "" : "none";
+      }
+
+      var ctrlRows = sidebarEl.querySelectorAll(".ep-ctrl-row");
+      for (var r2 = 0; r2 < ctrlRows.length; r2++) {
+        var ctrlRow = ctrlRows[r2];
+        var ctrlChildren = document.getElementById("st-" + ctrlRow.dataset.toggle);
+        var anyEndpointVisible = false;
+        if (ctrlChildren) {
+          var childEndpointRows = ctrlChildren.querySelectorAll(".ep-endpoint-row");
+          for (var k = 0; k < childEndpointRows.length; k++) {
+            if (childEndpointRows[k].style.display !== "none") { anyEndpointVisible = true; break; }
+          }
+        }
+        ctrlRow.style.display = anyEndpointVisible ? "" : "none";
+      }
+
+      var modRows = sidebarEl.querySelectorAll(".ep-module-row");
+      for (var r3 = 0; r3 < modRows.length; r3++) {
+        var modRow = modRows[r3];
+        var modChildren = document.getElementById("st-" + modRow.dataset.toggle);
+        var anyCtrlVisible = false;
+        if (modChildren) {
+          var childCtrlRows = modChildren.querySelectorAll(".ep-ctrl-row");
+          for (var k2 = 0; k2 < childCtrlRows.length; k2++) {
+            if (childCtrlRows[k2].style.display !== "none") { anyCtrlVisible = true; break; }
+          }
+        }
+        modRow.style.display = anyCtrlVisible ? "" : "none";
+      }
+    });
+  }
+
   // Sidebar click handlers
   sidebarEl.addEventListener("click", function(e) {
-    // Toggle handling
-    var toggleEl = e.target.closest(".st-toggle");
-    if (toggleEl) {
-      var toggleId = toggleEl.dataset.toggle;
-      var childDiv = document.getElementById("st-" + toggleId);
-      if (childDiv) {
-        var isOpen = childDiv.classList.toggle("st-open");
-        toggleEl.textContent = isOpen ? "\\u25BE" : "\\u25B8";
+    // Clicking anywhere on a module or controller header row toggles its group.
+    var groupRow = e.target.closest(".ep-module-row, .ep-ctrl-row");
+    if (groupRow) {
+      var rowToggle = groupRow.querySelector(".st-toggle");
+      if (rowToggle) {
+        var childDiv = document.getElementById("st-" + rowToggle.dataset.toggle);
+        if (childDiv) {
+          var isOpen = childDiv.classList.toggle("st-open");
+          rowToggle.textContent = isOpen ? "\\u25BE" : "\\u25B8";
+        }
       }
-      // If not an endpoint row, stop
-      var row = e.target.closest(".ep-endpoint-row");
-      if (!row) return;
+      return;
     }
 
-    // Endpoint selection
+    // Endpoint selection, keyed by index into endpoints.endpoints.
     var epRow = e.target.closest(".ep-endpoint-row");
     if (!epRow) return;
-    var ctrlName = epRow.dataset.epCtrl;
-    var handlerName = epRow.dataset.epHandler;
-
-    // Find matching endpoint
-    var found = null;
-    for (var i = 0; i < endpoints.endpoints.length; i++) {
-      var ep = endpoints.endpoints[i];
-      if (ep.controllerClass === ctrlName && ep.handlerMethod === handlerName) {
-        found = ep;
-        break;
-      }
-    }
-    if (!found) return;
+    var epIndex = Number(epRow.dataset.epIndex);
+    if (!(epIndex >= 0 && epIndex < endpoints.endpoints.length)) return;
+    var found = endpoints.endpoints[epIndex];
 
     // Highlight selected
     var allRows = sidebarEl.querySelectorAll(".ep-endpoint-row");
@@ -4230,7 +4348,7 @@ function renderEndpoints() {
       allRows[i].classList.toggle("st-selected", allRows[i] === epRow);
     }
 
-    epSelectedEndpoint = found;
+    epSelectedIndex = epIndex;
 
     // Build graph and render
     var emptyState = document.getElementById("endpoints-empty-state");

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -5079,9 +5079,7 @@ function renderEndpoints() {
       epEndpointsByFile[fep.filePath].push(fi);
     }
 
-    // Re-joins diagnostics to endpoints by filePath and line range — the same
-    // rule report-data.ts used to build endpointDiagnostics.perEndpoint — so
-    // each row can show the rule and message the counts summarize.
+    // Joins diagnostics to endpoints by filePath + line range, mirroring endpoint-diagnostics.ts.
     var epDiagRows = [];
     for (var di = 0; di < diagnostics.length; di++) {
       var d = diagnostics[di];

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -844,7 +844,7 @@ function renderDiagnosis() {
         codeEl.appendChild(wrapDiv);
         if (window.createCodeViewer) {
           window.createCodeViewer(wrapDiv, codeText, {
-            highlightLines: hlLines,
+            diagnosticLines: hlLines,
             lineMetadata: lineMetadata,
             firstLineNumber: firstLineNum,
             skipScrollIntoView: sg > 0,
@@ -895,7 +895,7 @@ function renderDiagnosis() {
         codeEl.appendChild(wrapDiv);
         if (window.createCodeViewer) {
           window.createCodeViewer(wrapDiv, codeText, {
-            highlightLines: hlLines,
+            diagnosticLines: hlLines,
             lineMetadata: lineMetadata,
             firstLineNumber: firstLineNum,
           });
@@ -1574,7 +1574,7 @@ function renderLab() {
         pgFileCode.appendChild(wrapDiv);
         if (window.createCodeViewer) {
           window.createCodeViewer(wrapDiv, codeText, {
-            highlightLines: hlLines,
+            diagnosticLines: hlLines,
             lineMetadata: lineMetadata,
             firstLineNumber: firstLineNum,
             skipScrollIntoView: sg > 0,
@@ -3675,6 +3675,41 @@ function renderSchema() {
 
 // ── Endpoints tab: Canvas-based dependency graph ──
 
+var epProjectRoot = null;
+
+/** Longest common directory prefix of every known source path — display-only project root. */
+function epComputeProjectRoot() {
+  var keys = Object.keys(fileSources);
+  if (keys.length === 0) {
+    keys = [];
+    for (var i = 0; i < endpoints.endpoints.length; i++) keys.push(endpoints.endpoints[i].filePath);
+  }
+  if (keys.length === 0) return "";
+  var parts = keys[0].split("/");
+  for (var k = 1; k < keys.length && parts.length > 0; k++) {
+    var otherParts = keys[k].split("/");
+    var j = 0;
+    while (j < parts.length && j < otherParts.length && parts[j] === otherParts[j]) j++;
+    parts = parts.slice(0, j);
+  }
+  return parts.join("/");
+}
+
+/**
+ * Display-only: strips the project root off an absolute path for the endpoints tab's
+ * UI. Every internal join/lookup keeps using the raw absolute filePath untouched.
+ */
+function epRelPath(filePath) {
+  if (!filePath) return filePath || "";
+  if (epProjectRoot === null) epProjectRoot = epComputeProjectRoot();
+  if (epProjectRoot && filePath.indexOf(epProjectRoot) === 0) {
+    var rest = filePath.slice(epProjectRoot.length);
+    while (rest.charAt(0) === "/") rest = rest.slice(1);
+    return rest;
+  }
+  return filePath;
+}
+
 var epCanvas, epCtx, epDpr, epW, epH;
 var epCamX = 0, epCamY = 0, epZoom = 1, epMinZoom = 0.2;
 var epDragging = null, epPanning = false, epPanStart = {x: 0, y: 0};
@@ -4219,6 +4254,7 @@ function epBuildGraph(ep) {
     totalMethods: 1,
     filePath: ep.filePath,
     line: ep.line,
+    endLine: ep.endLine,
     expanded: true,
     x: 0, y: 0, w: 180, h: 60
   };
@@ -4238,6 +4274,7 @@ function epBuildGraph(ep) {
         totalMethods: dep.totalMethods,
         filePath: dep.filePath,
         line: dep.line,
+        endLine: dep.endLine,
         expandedElsewhere: dep.expandedElsewhere,
         expanded: false,
         x: 0, y: 0, w: 180, h: 60
@@ -4679,21 +4716,32 @@ function epHideTooltip() {
   if (epTooltipEl) epTooltipEl.style.display = "none";
 }
 
-function epShowCodePanel(node) {
+// isDiagnostic: true for the problems-drawer jump, which marks the flagged line in
+// severity red; false/omitted for a plain node click, which uses the neutral highlight.
+function epShowCodePanel(node, isDiagnostic) {
   var panel = document.getElementById("ep-code-panel");
   if (!panel) return;
   document.getElementById("ep-code-panel-class").textContent = node.className;
   var methodText = node.methodName ? "." + node.methodName + "()" : "";
   document.getElementById("ep-code-panel-method").textContent = methodText;
-  document.getElementById("ep-code-panel-path").textContent = node.filePath || "";
+  document.getElementById("ep-code-panel-path").textContent = epRelPath(node.filePath);
   var bodyEl = document.getElementById("ep-code-panel-body");
   bodyEl.innerHTML = "";
   var code = node.filePath ? fileSources[node.filePath] : null;
   if (!code) {
     bodyEl.innerHTML = '<div class="ep-code-no-source">Source code not available</div>';
   } else if (window.createCodeViewer) {
-    var highlightLines = node.line > 0 ? [node.line] : [];
-    window.createCodeViewer(bodyEl, code, { highlightLines: highlightLines, firstLineNumber: 1 });
+    var viewerOptions = { firstLineNumber: 1 };
+    if (isDiagnostic) {
+      viewerOptions.diagnosticLines = node.line > 0 ? [node.line] : [];
+    } else {
+      viewerOptions.highlightLines = node.line > 0 ? [node.line] : [];
+    }
+    if (node.endLine > node.line) {
+      viewerOptions.tintRangeStart = node.line;
+      viewerOptions.tintRangeEnd = node.endLine;
+    }
+    window.createCodeViewer(bodyEl, code, viewerOptions);
   } else {
     bodyEl.innerHTML = '<div class="ep-code-no-source">Code viewer not available</div>';
   }
@@ -5070,6 +5118,9 @@ function renderEndpoints() {
     var clickedNode = epDragging;
     if (!epDragMoved && clickedNode) {
       epShowCodePanel(clickedNode.node);
+    } else if (!epDragMoved && !clickedNode && epPanning) {
+      // Sub-threshold click hit neither a node nor a chip — empty canvas, close the panel.
+      epHideCodePanel();
     }
     epDragging = null;
     epPanning = false;
@@ -5221,9 +5272,9 @@ function renderEndpoints() {
     });
     document.addEventListener("mousemove", function(e) {
       if (!epResizing) return;
-      // Panel is right-anchored, so its resize handle sits on the left edge:
-      // dragging left (negative clientX delta) grows the panel.
-      var w = epStartW + (epStartX - e.clientX);
+      // Panel is left-anchored, so its resize handle sits on the right edge:
+      // dragging right grows the panel.
+      var w = epStartW + (e.clientX - epStartX);
       if (w < 300) w = 300;
       if (w > window.innerWidth * 0.8) w = window.innerWidth * 0.8;
       epCodePanel.style.width = w + "px";
@@ -5321,7 +5372,7 @@ function renderEndpoints() {
         if (counts.info > 0) frParts.push(counts.info + " info");
         epDiagHtml += '<div class="sd-item">';
         epDiagHtml += '<span class="sev-dot" style="background:' + frColor + '"></span>';
-        epDiagHtml += '<span class="sd-entity">' + escHtml(filePath.split("/").pop()) + '</span>';
+        epDiagHtml += '<span class="sd-entity">' + escHtml(epRelPath(filePath)) + '</span>';
         epDiagHtml += '<span class="sd-msg">' + frTotal + (frTotal === 1 ? " issue" : " issues") + ' outside any handler \\u00b7 ' + escHtml(frParts.join(", ")) + '</span>';
         epDiagHtml += '</div>';
       }
@@ -5347,8 +5398,9 @@ function renderEndpoints() {
         className: targetEp.controllerClass,
         methodName: targetEp.handlerMethod,
         filePath: targetEp.filePath,
-        line: line
-      });
+        line: line,
+        endLine: targetEp.endLine
+      }, true);
     });
   }
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -4140,6 +4140,7 @@ function epScreenToWorld(sx, sy) {
 function epHitTest(wx, wy) {
   for (var i = epNodes.length - 1; i >= 0; i--) {
     var n = epNodes[i];
+    if (!n.visible) continue;
     if (wx >= n.x - n.w / 2 && wx <= n.x + n.w / 2 &&
         wy >= n.y - n.h / 2 && wy <= n.y + n.h / 2) return n;
   }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -4679,7 +4679,7 @@ function renderEndpoints() {
     if (counts.error > 0) parts.push(counts.error + " error" + (counts.error !== 1 ? "s" : ""));
     if (counts.warning > 0) parts.push(counts.warning + " warning" + (counts.warning !== 1 ? "s" : ""));
     if (counts.info > 0) parts.push(counts.info + " info");
-    return '<span class="ep-diag-badge" title="' + escHtml(parts.join(", ")) + '"><span class="ep-diag-dot" style="background:' + color + '"></span>' + total + '</span>';
+    return '<span class="ep-diag-badge has-tip" data-tip="' + escHtml(parts.join(", ")) + '"><span class="ep-diag-dot" style="background:' + color + '"></span>' + total + '</span>';
   }
 
   // Build sidebar: module → controller → endpoint
@@ -4719,7 +4719,7 @@ function renderEndpoints() {
         html += '<span class="st-indent"></span><span class="st-indent"></span>';
         html += '<span class="ep-method-badge ' + badgeClass + '">' + escHtml(method) + '</span>';
         html += '<span class="st-label">' + escHtml(endpoint.routePath || "/") + '</span>';
-        html += '<span class="ep-auth-shield ' + shield.cls + '" title="' + escHtml(shield.label) + '">' + shield.glyph + '</span>';
+        html += '<span class="ep-auth-shield ' + shield.cls + ' has-tip" data-tip="' + escHtml(shield.label) + '">' + shield.glyph + '</span>';
         html += epDiagBadgeHtml(epIndex);
         html += '</div>';
       }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -4680,16 +4680,16 @@ function epDrawOneEdge(edge, fromN, toN, isHovered) {
 
   if (isHovered) epCtx.restore();
 
-  // Value-edge label: the producer's assigned variable, centred over the horizontal
-  // run, just above the first leg (pts[0]..pts[1] is horizontal on every path shape).
+  // Value-edge label: the producer's assigned variable, drawn above the row in the
+  // inter-rank band — the sibling gap is narrower than the text and nodes paint over edges.
   if (isValueEdge && fromN.assignedTo) {
-    var labelX = (pts[0].x + pts[pts.length - 1].x) / 2;
-    var labelY = Math.min(pts[0].y, pts[1].y);
+    var labelX = (fromN.x + toN.x) / 2;
+    var labelY = Math.min(fromN.y - fromN.h / 2, toN.y - toN.h / 2) - 4 / epZoom;
     epCtx.font = "9px monospace";
     epCtx.fillStyle = EP_VALUE_EDGE_COLOR;
     epCtx.textAlign = "center";
     epCtx.textBaseline = "bottom";
-    epCtx.fillText(fromN.assignedTo, labelX, labelY - 2 / epZoom);
+    epCtx.fillText(fromN.assignedTo, labelX, labelY);
     epCtx.textAlign = "left";
   }
 }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -4158,6 +4158,10 @@ var EP_TYPE_COLORS = {
   unknown: "#666"
 };
 
+// Muted blue-grey for value edges (a call's return value flowing into a break-step
+// check) — distinct from the amber conditional dash and the solid grey structural edge.
+var EP_VALUE_EDGE_COLOR = "#5b9bd5";
+
 /** Builds the type-color rows of the endpoints legend straight from EP_TYPE_COLORS. */
 function epBuildLegendTypesHtml() {
   var html = "";
@@ -4390,6 +4394,10 @@ function epBuildGraph(ep) {
         epBuildBreakNodeExtras(bn);
         epNodes.push(bn);
         epEdges.push({ from: parentNode.id, to: bn.id, conditional: false });
+
+        // Value edge: the guarded call's own return value flows into this check —
+        // additional to (not instead of) the structural caller-to-break-step edge above.
+        epEdges.push({ from: n.id, to: bn.id, kind: "value" });
       }
 
       if (dep.dependencies && dep.dependencies.length > 0) {
@@ -4568,22 +4576,32 @@ function epDrawFocusedGraph() {
     var tx = toN.x;
     var ty = toN.y - toN.h / 2;
 
-    var edgeColor = epEdges[i].conditional ? "rgba(245, 158, 11, 0.6)" : "#555";
-    if (epEdges[i].conditional) {
+    // Value edges (a guarded call's return value flowing into its break step) draw
+    // thinner and dotted in a muted blue, distinct from the amber conditional dash.
+    var isValueEdge = epEdges[i].kind === "value";
+    var edgeColor = isValueEdge
+      ? EP_VALUE_EDGE_COLOR
+      : (epEdges[i].conditional ? "rgba(245, 158, 11, 0.6)" : "#555");
+    var edgeLineW = isValueEdge ? 1 / epZoom : 1.5 / epZoom;
+    if (isValueEdge) {
+      epCtx.setLineDash([2 / epZoom, 3 / epZoom]);
+    } else if (epEdges[i].conditional) {
       epCtx.setLineDash([6 / epZoom, 4 / epZoom]);
     }
 
     epCtx.beginPath();
     epCtx.moveTo(fx, fy);
     // L-shaped edge if not aligned
-    if (Math.abs(fx - tx) > 2) {
-      var midY = fy + (ty - fy) / 2;
+    var bent = Math.abs(fx - tx) > 2;
+    var midY = fy;
+    if (bent) {
+      midY = fy + (ty - fy) / 2;
       epCtx.lineTo(fx, midY);
       epCtx.lineTo(tx, midY);
     }
     epCtx.lineTo(tx, ty);
     epCtx.strokeStyle = edgeColor;
-    epCtx.lineWidth = 1.5 / epZoom;
+    epCtx.lineWidth = edgeLineW;
     epCtx.stroke();
 
     // Arrow
@@ -4593,10 +4611,23 @@ function epDrawFocusedGraph() {
     epCtx.lineTo(tx, ty);
     epCtx.lineTo(tx + arrowSize, ty - arrowSize);
     epCtx.strokeStyle = edgeColor;
-    epCtx.lineWidth = 1.5 / epZoom;
+    epCtx.lineWidth = edgeLineW;
     epCtx.stroke();
 
     epCtx.setLineDash([]);
+
+    // Label the value edge with the producer's assigned variable, at the midpoint
+    // of its (usually horizontal, same-rank) segment.
+    if (isValueEdge && fromN.assignedTo) {
+      var labelX = bent ? (fx + tx) / 2 : fx;
+      var labelY = bent ? midY : (fy + ty) / 2;
+      epCtx.font = "9px monospace";
+      epCtx.fillStyle = EP_VALUE_EDGE_COLOR;
+      epCtx.textAlign = "center";
+      epCtx.textBaseline = "bottom";
+      epCtx.fillText(fromN.assignedTo, labelX, labelY - 2 / epZoom);
+      epCtx.textAlign = "left";
+    }
   }
 
   // Draw nodes — collapsed-away nodes carry stale coordinates from their last layout, so skip them.

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3676,7 +3676,7 @@ function renderSchema() {
 // ── Endpoints tab: Canvas-based dependency graph ──
 
 var epCanvas, epCtx, epDpr, epW, epH;
-var epCamX = 0, epCamY = 0, epZoom = 1;
+var epCamX = 0, epCamY = 0, epZoom = 1, epMinZoom = 0.2;
 var epDragging = null, epPanning = false, epPanStart = {x: 0, y: 0};
 var epDragMoved = false;
 var epHoveredNode = null;
@@ -3685,6 +3685,12 @@ var epEdges = [];
 var epTooltipEl = null;
 var epDirty = false;
 var epSelectedIndex = -1;
+
+/** "overview" (default) shows module clusters; "focused" shows one endpoint's call graph. */
+var epMode = "overview";
+var epOverviewGroups = [];
+var epOvHoveredRow = null;
+var epOvHitRowPending = null;
 
 // Auth shield for one endpoint. Reused by the endpoints overview canvas.
 function epAuthShield(ep) {
@@ -3706,6 +3712,335 @@ function epAuthShield(ep) {
     labelParts.push("global guard registered");
   }
   return { glyph: info.glyph, cls: info.cls, label: labelParts.join(" \\u00b7 ") };
+}
+
+// ── Endpoints tab: Overview mode (module clusters of controller boxes) ──
+
+var EP_BOX_W = 320;
+var EP_ROW_H = 22;
+var EP_BOX_HEADER_H = 30;
+var EP_BOX_PAD_BOTTOM = 8;
+var EP_MAX_VISIBLE_ROWS = 12;
+var EP_NO_MODULE_LABEL = "(no module)";
+
+function epRowCount(count) {
+  return Math.min(count, EP_MAX_VISIBLE_ROWS);
+}
+
+/** Header, one row per visible endpoint, plus a "+N more" row past the cap. */
+function epBoxHeight(count) {
+  var visible = epRowCount(count);
+  var hidden = count - visible;
+  return EP_BOX_HEADER_H + visible * EP_ROW_H + (hidden > 0 ? EP_ROW_H : 0) + EP_BOX_PAD_BOTTOM;
+}
+
+// ep-overview-layout-start
+/** Shelf-packs same-width boxes left to right, wrapping at targetW. */
+function epPackOverviewBoxes(boxes, targetW, gutter) {
+  var x = 0, y = 0, shelfH = 0;
+  for (var i = 0; i < boxes.length; i++) {
+    var box = boxes[i];
+    if (x > 0 && x + box.w > targetW) {
+      x = 0;
+      y += shelfH + gutter;
+      shelfH = 0;
+    }
+    box.ox = x;
+    box.oy = y;
+    x += box.w + gutter;
+    if (box.h > shelfH) shelfH = box.h;
+  }
+  return y + shelfH;
+}
+
+/** Packs each module's controller boxes into a shelf, then stacks modules vertically. */
+function epComputeOverviewLayout(groups, boxWidth) {
+  var GUTTER = 32;
+  var MODULE_HEADER_H = 28;
+  var MODULE_GAP = 56;
+  var top = 0;
+  for (var g = 0; g < groups.length; g++) {
+    var group = groups[g];
+    var boxes = group.boxes;
+    var area = 0;
+    for (var i = 0; i < boxes.length; i++) area += boxes[i].w * boxes[i].h;
+    var targetW = Math.max(boxWidth * 3, Math.sqrt(area) * 1.6);
+    var packH = epPackOverviewBoxes(boxes, targetW, GUTTER);
+    group.headerY = top;
+    var contentTop = top + MODULE_HEADER_H;
+    for (var j = 0; j < boxes.length; j++) {
+      boxes[j].x = boxes[j].ox + boxes[j].w / 2;
+      boxes[j].y = contentTop + boxes[j].oy + boxes[j].h / 2;
+    }
+    group.w = targetW;
+    group.h = MODULE_HEADER_H + packH;
+    top += group.h + MODULE_GAP;
+  }
+}
+// ep-overview-layout-end
+
+/** Groups endpoint indices by module, then controller; "(no module)" always sorts last. */
+function epGroupEndpointsByModule() {
+  var moduleGroups = {};
+  var moduleOrder = [];
+  for (var i = 0; i < endpoints.endpoints.length; i++) {
+    var ep = endpoints.endpoints[i];
+    var moduleLabel = ep.module ? ep.module : EP_NO_MODULE_LABEL;
+    if (!moduleGroups[moduleLabel]) {
+      moduleGroups[moduleLabel] = { controllers: {}, controllerOrder: [], count: 0 };
+      moduleOrder.push(moduleLabel);
+    }
+    var moduleGroup = moduleGroups[moduleLabel];
+    moduleGroup.count++;
+    if (!moduleGroup.controllers[ep.controllerClass]) {
+      moduleGroup.controllers[ep.controllerClass] = [];
+      moduleGroup.controllerOrder.push(ep.controllerClass);
+    }
+    moduleGroup.controllers[ep.controllerClass].push(i);
+  }
+  var sortedModules = moduleOrder.slice().sort(function(a, b) {
+    if (a === EP_NO_MODULE_LABEL) return b === EP_NO_MODULE_LABEL ? 0 : 1;
+    if (b === EP_NO_MODULE_LABEL) return -1;
+    return a < b ? -1 : (a > b ? 1 : 0);
+  });
+  return { moduleGroups: moduleGroups, sortedModules: sortedModules };
+}
+
+function epBuildOverviewGroups() {
+  var grouping = epGroupEndpointsByModule();
+  var groups = [];
+  for (var m = 0; m < grouping.sortedModules.length; m++) {
+    var label = grouping.sortedModules[m];
+    var moduleGroup = grouping.moduleGroups[label];
+    var boxes = [];
+    for (var c = 0; c < moduleGroup.controllerOrder.length; c++) {
+      var ctrlName = moduleGroup.controllerOrder[c];
+      var indices = moduleGroup.controllers[ctrlName];
+      boxes.push({
+        controllerClass: ctrlName,
+        endpointIndices: indices,
+        w: EP_BOX_W,
+        h: epBoxHeight(indices.length)
+      });
+    }
+    groups.push({ label: label, boxes: boxes });
+  }
+  return groups;
+}
+
+function epClipText(text, maxW) {
+  if (!epCtx || epCtx.measureText(text).width <= maxW) return text;
+  var out = text;
+  while (epCtx.measureText(out).width > maxW && out.length > 3) {
+    out = out.slice(0, -1);
+  }
+  return out + "\\u2026";
+}
+
+/** Truncation depends only on the fixed box width and font, so it is cached once here. */
+function epCacheOverviewLabels(groups) {
+  if (!epCtx) return;
+  for (var g = 0; g < groups.length; g++) {
+    var boxes = groups[g].boxes;
+    for (var i = 0; i < boxes.length; i++) {
+      var box = boxes[i];
+      epCtx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+      box.nameStr = epClipText(box.controllerClass, box.w - 20);
+      var visible = epRowCount(box.endpointIndices.length);
+      var pathMaxW = box.w - 10 - 44 - 24 - 16;
+      box.pathStrs = [];
+      box.shields = [];
+      box.chipWidths = [];
+      for (var r = 0; r < visible; r++) {
+        var rowEp = endpoints.endpoints[box.endpointIndices[r]];
+        epCtx.font = "11px monospace";
+        box.pathStrs.push(epClipText(rowEp.routePath || "/", pathMaxW));
+        box.shields.push(epAuthShield(rowEp));
+        epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
+        var chipMethod = (rowEp.httpMethod || "GET").toUpperCase();
+        box.chipWidths.push(Math.max(30, epCtx.measureText(chipMethod).width + 8));
+      }
+    }
+  }
+}
+
+function epRebuildOverview() {
+  epOverviewGroups = epBuildOverviewGroups();
+  epComputeOverviewLayout(epOverviewGroups, EP_BOX_W);
+  epCacheOverviewLabels(epOverviewGroups);
+}
+
+function epCenterOverviewCamera() {
+  if (epOverviewGroups.length === 0) return;
+  var minX = 0, maxX = 0, minY = Infinity, maxY = -Infinity;
+  for (var g = 0; g < epOverviewGroups.length; g++) {
+    var group = epOverviewGroups[g];
+    if (group.w > maxX) maxX = group.w;
+    if (group.headerY < minY) minY = group.headerY;
+    if (group.headerY + group.h > maxY) maxY = group.headerY + group.h;
+  }
+  var graphW = maxX - minX;
+  var graphH = maxY - minY;
+  var cx = (minX + maxX) / 2;
+  var cy = (minY + maxY) / 2;
+
+  var padW = epW * 0.9;
+  var padH = epH * 0.85;
+  var fit = Math.min(1.5, Math.min(padW / (graphW || 1), padH / (graphH || 1)));
+  // Records the fit so the recenter/wheel floor can zoom out this far.
+  epMinZoom = Math.min(0.2, fit);
+  epZoom = Math.max(epMinZoom, fit);
+  epCamX = epW / 2 - cx;
+  epCamY = epH / 2 - cy;
+}
+
+function epOvHitTestRow(wx, wy) {
+  for (var g = 0; g < epOverviewGroups.length; g++) {
+    var boxes = epOverviewGroups[g].boxes;
+    for (var b = 0; b < boxes.length; b++) {
+      var box = boxes[b];
+      var x0 = box.x - box.w / 2;
+      var y0 = box.y - box.h / 2;
+      if (wx < x0 || wx > x0 + box.w || wy < y0 || wy > y0 + box.h) continue;
+      var visible = epRowCount(box.endpointIndices.length);
+      var rowTop = y0 + EP_BOX_HEADER_H;
+      for (var r = 0; r < visible; r++) {
+        if (wy >= rowTop && wy < rowTop + EP_ROW_H) {
+          return { epIndex: box.endpointIndices[r] };
+        }
+        rowTop += EP_ROW_H;
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+var EP_METHOD_HEX = {
+  GET: "#3b82f6", POST: "#10b981", PUT: "#f59e0b", PATCH: "#f59e0b",
+  DELETE: "#ef4444", ALL: "#06b6d4", HEAD: "#64748b", OPTIONS: "#94a3b8",
+  QUERY: "#8b5cf6", MUTATION: "#a855f7", SUBSCRIPTION: "#c026d3"
+};
+var EP_SHIELD_HEX = {
+  "ep-auth-guarded": "#4ade80",
+  "ep-auth-public": "#3b82f6",
+  "ep-auth-unguarded": "#f59e0b",
+  "ep-auth-unknown": "#666"
+};
+
+function epDrawOverviewRow(box, rowIndex, boxX, rowTop) {
+  var epIndex = box.endpointIndices[rowIndex];
+  var rowEp = endpoints.endpoints[epIndex];
+  var method = (rowEp.httpMethod || "GET").toUpperCase();
+  var color = EP_METHOD_HEX[method] || "#888";
+  var isHovered = epOvHoveredRow && epOvHoveredRow.epIndex === epIndex;
+
+  if (isHovered) {
+    epCtx.fillStyle = "rgba(255,255,255,0.06)";
+    epCtx.fillRect(boxX + 1, rowTop, box.w - 2, EP_ROW_H);
+  }
+
+  var cy = rowTop + EP_ROW_H / 2;
+  var cx = boxX + 10;
+
+  epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
+  var chipW = box.chipWidths[rowIndex];
+  epRoundRect(epCtx, cx, cy - 7, chipW, 14, 3);
+  epCtx.fillStyle = color;
+  epCtx.globalAlpha = 0.18;
+  epCtx.fill();
+  epCtx.globalAlpha = 1;
+  epCtx.fillStyle = color;
+  epCtx.textAlign = "left";
+  epCtx.textBaseline = "middle";
+  epCtx.fillText(method, cx + 4, cy);
+
+  epCtx.font = "11px monospace";
+  epCtx.fillStyle = "#ccc";
+  epCtx.fillText(box.pathStrs[rowIndex], cx + chipW + 8, cy);
+
+  var shield = box.shields[rowIndex];
+  var rightEdge = boxX + box.w - 10;
+  epCtx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+  epCtx.fillStyle = EP_SHIELD_HEX[shield.cls] || "#666";
+  epCtx.textAlign = "right";
+  epCtx.fillText(shield.glyph, rightEdge, cy);
+
+  var counts = endpointDiagnostics.perEndpoint[String(epIndex)];
+  if (counts) {
+    var total = counts.error + counts.warning + counts.info;
+    if (total > 0) {
+      var dotColor = counts.error > 0 ? "#ef4444" : (counts.warning > 0 ? "#f59e0b" : "#3b82f6");
+      epCtx.beginPath();
+      epCtx.arc(rightEdge - 18, cy, 3, 0, Math.PI * 2);
+      epCtx.fillStyle = dotColor;
+      epCtx.fill();
+    }
+  }
+}
+
+function epDrawOverviewBox(box) {
+  var x = box.x - box.w / 2;
+  var y = box.y - box.h / 2;
+
+  epRoundRect(epCtx, x, y, box.w, box.h, 6);
+  epCtx.fillStyle = "#151515";
+  epCtx.fill();
+  epCtx.strokeStyle = "rgba(255,255,255,0.08)";
+  epCtx.lineWidth = 1;
+  epCtx.stroke();
+
+  epCtx.fillStyle = "#e0e0e0";
+  epCtx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+  epCtx.textAlign = "left";
+  epCtx.textBaseline = "middle";
+  epCtx.fillText(box.nameStr, x + 10, y + EP_BOX_HEADER_H / 2);
+
+  epCtx.beginPath();
+  epCtx.moveTo(x + 1, y + EP_BOX_HEADER_H);
+  epCtx.lineTo(x + box.w - 1, y + EP_BOX_HEADER_H);
+  epCtx.strokeStyle = "rgba(255,255,255,0.06)";
+  epCtx.lineWidth = 1;
+  epCtx.stroke();
+
+  var rowTop = y + EP_BOX_HEADER_H;
+  var visible = epRowCount(box.endpointIndices.length);
+  for (var r = 0; r < visible; r++) {
+    epDrawOverviewRow(box, r, x, rowTop);
+    rowTop += EP_ROW_H;
+  }
+  var hidden = box.endpointIndices.length - visible;
+  if (hidden > 0) {
+    epCtx.fillStyle = "#888";
+    epCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+    epCtx.textAlign = "left";
+    epCtx.textBaseline = "middle";
+    epCtx.fillText("+" + hidden + " more", x + 10, rowTop + EP_ROW_H / 2);
+  }
+}
+
+function epDrawOverview() {
+  epCtx.clearRect(0, 0, epW, epH);
+  if (epOverviewGroups.length === 0) return;
+  epCtx.save();
+  epCtx.translate(epW / 2, epH / 2);
+  epCtx.scale(epZoom, epZoom);
+  epCtx.translate(-epW / 2 + epCamX, -epH / 2 + epCamY);
+
+  for (var g = 0; g < epOverviewGroups.length; g++) {
+    var group = epOverviewGroups[g];
+    epCtx.font = "bold 13px -apple-system, BlinkMacSystemFont, sans-serif";
+    epCtx.fillStyle = "#e0e0e0";
+    epCtx.textAlign = "left";
+    epCtx.textBaseline = "top";
+    epCtx.fillText(group.label, 0, group.headerY + 6);
+
+    for (var b = 0; b < group.boxes.length; b++) {
+      epDrawOverviewBox(group.boxes[b]);
+    }
+  }
+
+  epCtx.restore();
 }
 
 var EP_TYPE_COLORS = {
@@ -3867,6 +4202,14 @@ function epCenterCamera() {
 
 function epDraw() {
   if (!epCtx) return;
+  if (epMode === "overview") {
+    epDrawOverview();
+  } else {
+    epDrawFocusedGraph();
+  }
+}
+
+function epDrawFocusedGraph() {
   epCtx.save();
   epCtx.clearRect(0, 0, epW, epH);
 
@@ -4078,7 +4421,9 @@ function epResize() {
   epCanvas.style.width = epW + "px";
   epCanvas.style.height = epH + "px";
   epCtx.setTransform(epDpr, 0, 0, epDpr, 0, 0);
-  if (epNodes.length > 0) {
+  if (epMode === "overview") {
+    if (epOverviewGroups.length > 0) epCenterOverviewCamera();
+  } else if (epNodes.length > 0) {
     epCenterCamera();
   }
   epScheduleRedraw();
@@ -4152,6 +4497,49 @@ function epHideCodePanel() {
   if (panel) panel.classList.remove("open");
 }
 
+function epSyncSidebarSelection(epIndex) {
+  var sidebarEl = document.getElementById("endpoints-list");
+  if (!sidebarEl) return;
+  var allRows = sidebarEl.querySelectorAll(".ep-endpoint-row");
+  for (var i = 0; i < allRows.length; i++) {
+    allRows[i].classList.toggle("st-selected", Number(allRows[i].dataset.epIndex) === epIndex);
+  }
+}
+
+function epSyncViewToggle() {
+  var btn = document.getElementById("endpoints-toggle-view");
+  if (!btn) return;
+  var overview = epMode === "overview";
+  btn.classList.toggle("active", overview);
+  btn.setAttribute("aria-pressed", String(overview));
+  btn.setAttribute("aria-label", overview ? "Focus one endpoint" : "Show all endpoints");
+  btn.setAttribute("data-tip", overview
+    ? "Focus \\u00b7 show one endpoint and its call graph"
+    : "All endpoints \\u00b7 back to the module overview");
+}
+
+function epShowOverview() {
+  epMode = "overview";
+  epHideCodePanel();
+  epHideTooltip();
+  epCanvas.style.display = "block";
+  epSyncViewToggle();
+  epResize();
+}
+
+function epShowFocused(index) {
+  var found = endpoints.endpoints[index];
+  if (!found) return;
+  epMode = "focused";
+  epSelectedIndex = index;
+  epSyncSidebarSelection(index);
+  epCanvas.style.display = "block";
+  epBuildGraph(found);
+  epLayout();
+  epSyncViewToggle();
+  epResize();
+}
+
 function renderEndpoints() {
   var sidebarEl = document.getElementById("endpoints-list");
   epCanvas = document.getElementById("endpoints-canvas");
@@ -4161,33 +4549,12 @@ function renderEndpoints() {
   epCtx = epCanvas.getContext("2d");
   epDpr = window.devicePixelRatio || 1;
 
-  var NO_MODULE_LABEL = "(no module)";
+  var NO_MODULE_LABEL = EP_NO_MODULE_LABEL;
 
-  // Group endpoints by module, then controller. Module labels are used as stored.
-  var moduleGroups = {};
-  var moduleOrder = [];
-  for (var i = 0; i < endpoints.endpoints.length; i++) {
-    var ep = endpoints.endpoints[i];
-    var moduleLabel = ep.module ? ep.module : NO_MODULE_LABEL;
-    if (!moduleGroups[moduleLabel]) {
-      moduleGroups[moduleLabel] = { controllers: {}, controllerOrder: [], count: 0 };
-      moduleOrder.push(moduleLabel);
-    }
-    var moduleGroup = moduleGroups[moduleLabel];
-    moduleGroup.count++;
-    if (!moduleGroup.controllers[ep.controllerClass]) {
-      moduleGroup.controllers[ep.controllerClass] = [];
-      moduleGroup.controllerOrder.push(ep.controllerClass);
-    }
-    moduleGroup.controllers[ep.controllerClass].push(i);
-  }
-
-  // Alphabetical by module; "(no module)" always sorts last.
-  var sortedModules = moduleOrder.slice().sort(function(a, b) {
-    if (a === NO_MODULE_LABEL) return b === NO_MODULE_LABEL ? 0 : 1;
-    if (b === NO_MODULE_LABEL) return -1;
-    return a < b ? -1 : (a > b ? 1 : 0);
-  });
+  // Same module -> controller grouping the overview canvas boxes use.
+  var grouping = epGroupEndpointsByModule();
+  var moduleGroups = grouping.moduleGroups;
+  var sortedModules = grouping.sortedModules;
 
   // Set count
   document.getElementById("endpoints-count").textContent = endpoints.endpoints.length;
@@ -4340,34 +4707,28 @@ function renderEndpoints() {
     if (!epRow) return;
     var epIndex = Number(epRow.dataset.epIndex);
     if (!(epIndex >= 0 && epIndex < endpoints.endpoints.length)) return;
-    var found = endpoints.endpoints[epIndex];
-
-    // Highlight selected
-    var allRows = sidebarEl.querySelectorAll(".ep-endpoint-row");
-    for (var i = 0; i < allRows.length; i++) {
-      allRows[i].classList.toggle("st-selected", allRows[i] === epRow);
-    }
-
-    epSelectedIndex = epIndex;
-
-    // Build graph and render
-    var emptyState = document.getElementById("endpoints-empty-state");
-    if (emptyState) emptyState.style.display = "none";
-    epCanvas.style.display = "block";
-
-    epBuildGraph(found);
-    epLayout();
-    epResize();
+    epShowFocused(epIndex);
   });
 
-  // Canvas interactions
+  // Canvas interactions. Overview and focused mode share panning and zoom;
+  // only hit-testing and the click result differ.
   epCanvas.addEventListener("mousedown", function(e) {
     var rect = epCanvas.getBoundingClientRect();
     var sx = e.clientX - rect.left;
     var sy = e.clientY - rect.top;
     var pos = epScreenToWorld(sx, sy);
-    var hit = epHitTest(pos.x, pos.y);
     epDragMoved = false;
+
+    if (epMode === "overview") {
+      epOvHitRowPending = epOvHitTestRow(pos.x, pos.y);
+      if (!epOvHitRowPending) {
+        epPanning = true;
+        epPanStart = { x: e.clientX, y: e.clientY };
+      }
+      return;
+    }
+
+    var hit = epHitTest(pos.x, pos.y);
     if (hit) {
       epDragging = hit;
       epHideTooltip();
@@ -4382,6 +4743,28 @@ function renderEndpoints() {
     var sx = e.clientX - rect.left;
     var sy = e.clientY - rect.top;
     var pos = epScreenToWorld(sx, sy);
+
+    if (epMode === "overview") {
+      if (epPanning) {
+        epDragMoved = true;
+        epCamX += (e.clientX - epPanStart.x) / epZoom;
+        epCamY += (e.clientY - epPanStart.y) / epZoom;
+        epPanStart = { x: e.clientX, y: e.clientY };
+        epScheduleRedraw();
+      } else if (epOvHitRowPending) {
+        epDragMoved = true;
+      } else {
+        var hoverRow = epOvHitTestRow(pos.x, pos.y);
+        var hoverIndex = hoverRow ? hoverRow.epIndex : null;
+        var currentIndex = epOvHoveredRow ? epOvHoveredRow.epIndex : null;
+        if (hoverIndex !== currentIndex) {
+          epOvHoveredRow = hoverRow;
+          epCanvas.style.cursor = hoverRow ? "pointer" : "grab";
+          epScheduleRedraw();
+        }
+      }
+      return;
+    }
 
     if (epDragging) {
       epDragMoved = true;
@@ -4413,6 +4796,16 @@ function renderEndpoints() {
   });
 
   epCanvas.addEventListener("mouseup", function() {
+    if (epMode === "overview") {
+      if (epOvHitRowPending && !epDragMoved) {
+        epShowFocused(epOvHitRowPending.epIndex);
+      }
+      epOvHitRowPending = null;
+      epPanning = false;
+      epDragMoved = false;
+      return;
+    }
+
     var clickedNode = epDragging;
     if (!epDragMoved && clickedNode) {
       epShowCodePanel(clickedNode);
@@ -4425,6 +4818,8 @@ function renderEndpoints() {
     epDragging = null;
     epPanning = false;
     epHoveredNode = null;
+    epOvHoveredRow = null;
+    epOvHitRowPending = null;
     epHideTooltip();
     epScheduleRedraw();
   });
@@ -4458,12 +4853,28 @@ function renderEndpoints() {
     epScheduleRedraw();
   }, { passive: false });
 
-  // Recenter button
+  // Recenter button — auto-fits whichever mode is active.
   var recenterBtn = document.getElementById("endpoints-recenter");
   if (recenterBtn) {
     recenterBtn.addEventListener("click", function() {
-      epCenterCamera();
+      if (epMode === "overview") {
+        epCenterOverviewCamera();
+      } else {
+        epCenterCamera();
+      }
       epScheduleRedraw();
+    });
+  }
+
+  // View toggle: overview <-> focused mode on the currently selected endpoint.
+  var viewToggleBtn = document.getElementById("endpoints-toggle-view");
+  if (viewToggleBtn) {
+    viewToggleBtn.addEventListener("click", function() {
+      if (epMode === "focused") {
+        epShowOverview();
+      } else if (epSelectedIndex >= 0) {
+        epShowFocused(epSelectedIndex);
+      }
     });
   }
 
@@ -4519,10 +4930,113 @@ function renderEndpoints() {
     if (activeTab === "endpoints") epResize();
   });
 
-  // Show empty state initially
-  var emptyState = document.getElementById("endpoints-empty-state");
-  if (emptyState) emptyState.style.display = "flex";
-  epCanvas.style.display = "none";
+  // ── Endpoint diagnostics drawer ──
+  var epDiagCountEl = document.getElementById("endpoints-diag-count");
+  var epDiagHeaderEl = document.getElementById("endpoints-diag-header");
+  var epDiagBodyEl = document.getElementById("endpoints-diag-body");
+  var epDiagListEl = document.getElementById("endpoints-diag-list");
+  var epDiagChevronEl = document.getElementById("endpoints-diag-chevron");
+
+  if (epDiagCountEl && epDiagHeaderEl && epDiagBodyEl && epDiagListEl && epDiagChevronEl) {
+    var epEndpointsByFile = {};
+    for (var fi = 0; fi < endpoints.endpoints.length; fi++) {
+      var fep = endpoints.endpoints[fi];
+      if (!epEndpointsByFile[fep.filePath]) epEndpointsByFile[fep.filePath] = [];
+      epEndpointsByFile[fep.filePath].push(fi);
+    }
+
+    // Re-joins diagnostics to endpoints by filePath and line range — the same
+    // rule report-data.ts used to build endpointDiagnostics.perEndpoint — so
+    // each row can show the rule and message the counts summarize.
+    var epDiagRows = [];
+    for (var di = 0; di < diagnostics.length; di++) {
+      var d = diagnostics[di];
+      if (!("line" in d)) continue;
+      var candidates = epEndpointsByFile[d.filePath];
+      if (!candidates) continue;
+      for (var ci = 0; ci < candidates.length; ci++) {
+        var cep = endpoints.endpoints[candidates[ci]];
+        if (d.line >= cep.line && d.line <= cep.endLine) {
+          epDiagRows.push({ epIndex: candidates[ci], diagnostic: d });
+        }
+      }
+    }
+
+    var epSumCounts = function(c) { return c.error + c.warning + c.info; };
+    var epFileKeys = Object.keys(endpointDiagnostics.perFile);
+    var epEndpointKeys = Object.keys(endpointDiagnostics.perEndpoint);
+    var epDiagTotal = 0;
+    for (var pek = 0; pek < epEndpointKeys.length; pek++) {
+      epDiagTotal += epSumCounts(endpointDiagnostics.perEndpoint[epEndpointKeys[pek]]);
+    }
+    for (var pfk = 0; pfk < epFileKeys.length; pfk++) {
+      epDiagTotal += epSumCounts(endpointDiagnostics.perFile[epFileKeys[pfk]]);
+    }
+
+    epDiagCountEl.textContent = epDiagTotal + (epDiagTotal === 1 ? " issue" : " issues");
+    if (epDiagTotal > 0) epDiagCountEl.classList.add("has-issues");
+
+    if (epDiagTotal === 0) {
+      epDiagListEl.innerHTML = '<div class="sd-empty">No endpoint issues found</div>';
+    } else {
+      var epDiagHtml = "";
+      for (var ri = 0; ri < epDiagRows.length; ri++) {
+        var row = epDiagRows[ri];
+        var rd = row.diagnostic;
+        var rep = endpoints.endpoints[row.epIndex];
+        var sevColor = rd.severity === "error" ? "var(--sev-error)" : rd.severity === "warning" ? "var(--sev-warning)" : "var(--sev-info)";
+        epDiagHtml += '<div class="sd-item">';
+        epDiagHtml += '<span class="sev-dot" style="background:' + sevColor + '"></span>';
+        epDiagHtml += '<span class="sd-rule">' + escHtml(rd.rule) + '</span>';
+        epDiagHtml += '<span class="sd-entity" data-ep-index="' + row.epIndex + '" data-line="' + rd.line + '">' + escHtml(rep.controllerClass + "." + rep.handlerMethod) + '</span>';
+        epDiagHtml += '<span class="sd-msg">' + escHtml(rd.message) + '</span>';
+        epDiagHtml += '</div>';
+      }
+      for (var rj = 0; rj < epFileKeys.length; rj++) {
+        var filePath = epFileKeys[rj];
+        var counts = endpointDiagnostics.perFile[filePath];
+        var frTotal = epSumCounts(counts);
+        var frColor = counts.error > 0 ? "var(--sev-error)" : (counts.warning > 0 ? "var(--sev-warning)" : "var(--sev-info)");
+        var frParts = [];
+        if (counts.error > 0) frParts.push(counts.error + " error" + (counts.error !== 1 ? "s" : ""));
+        if (counts.warning > 0) frParts.push(counts.warning + " warning" + (counts.warning !== 1 ? "s" : ""));
+        if (counts.info > 0) frParts.push(counts.info + " info");
+        epDiagHtml += '<div class="sd-item">';
+        epDiagHtml += '<span class="sev-dot" style="background:' + frColor + '"></span>';
+        epDiagHtml += '<span class="sd-entity">' + escHtml(filePath.split("/").pop()) + '</span>';
+        epDiagHtml += '<span class="sd-msg">' + frTotal + (frTotal === 1 ? " issue" : " issues") + ' outside any handler \\u00b7 ' + escHtml(frParts.join(", ")) + '</span>';
+        epDiagHtml += '</div>';
+      }
+      epDiagListEl.innerHTML = epDiagHtml;
+    }
+
+    epDiagHeaderEl.addEventListener("click", function() {
+      var isOpen = epDiagBodyEl.style.display !== "none";
+      epDiagBodyEl.style.display = isOpen ? "none" : "block";
+      epDiagChevronEl.classList.toggle("open", !isOpen);
+      epResize();
+    });
+
+    epDiagListEl.addEventListener("click", function(e) {
+      var entityEl = e.target.closest(".sd-entity[data-ep-index]");
+      if (!entityEl) return;
+      var idx = Number(entityEl.dataset.epIndex);
+      var line = Number(entityEl.dataset.line);
+      if (!(idx >= 0 && idx < endpoints.endpoints.length)) return;
+      var targetEp = endpoints.endpoints[idx];
+      epShowFocused(idx);
+      epShowCodePanel({
+        className: targetEp.controllerClass,
+        methodName: targetEp.handlerMethod,
+        filePath: targetEp.filePath,
+        line: line
+      });
+    });
+  }
+
+  // Overview is the default entry state; no empty state to show first.
+  epRebuildOverview();
+  epShowOverview();
 }
 
 switchTab("summary");`;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3689,6 +3689,8 @@ var epDirty = false;
 var epSelectedIndex = -1;
 var epLastZoomUi = null;
 var epBannerDismissedIndex = -1;
+var EP_CHIP_W = 34, EP_CHIP_H = 15;
+var EP_NODE_HDR_H = 22;
 
 /** "overview" (default) shows module clusters; "focused" shows one endpoint's call graph. */
 var epMode = "overview";
@@ -4158,12 +4160,54 @@ function epRoundRect(ctx, x, y, w, h, r) {
   ctx.closePath();
 }
 
+// ep-tree-visibility-start
+/**
+ * A node is visible iff every ancestor from the root down has expanded=true;
+ * the root is always visible regardless of its own flag. Also records each
+ * node's childCount (direct children) from edges. Mutates nodes in place;
+ * the caller decides when to re-layout/redraw.
+ */
+function epComputeTreeVisibility(nodes, edges) {
+  var childrenOf = {};
+  var hasParent = {};
+  var i;
+  for (i = 0; i < edges.length; i++) {
+    var e = edges[i];
+    if (!childrenOf[e.from]) childrenOf[e.from] = [];
+    childrenOf[e.from].push(e.to);
+    hasParent[e.to] = true;
+  }
+
+  var byId = {};
+  for (i = 0; i < nodes.length; i++) {
+    byId[nodes[i].id] = nodes[i];
+    nodes[i].visible = false;
+    nodes[i].childCount = childrenOf[nodes[i].id] ? childrenOf[nodes[i].id].length : 0;
+  }
+
+  function walk(nodeId, ancestorsExpanded) {
+    var node = byId[nodeId];
+    if (!node) return;
+    node.visible = ancestorsExpanded;
+    var kids = childrenOf[nodeId] || [];
+    for (var k = 0; k < kids.length; k++) {
+      walk(kids[k], ancestorsExpanded && node.expanded);
+    }
+  }
+
+  for (i = 0; i < nodes.length; i++) {
+    if (!hasParent[nodes[i].id]) walk(nodes[i].id, true);
+  }
+}
+// ep-tree-visibility-end
+
 function epBuildGraph(ep) {
   epNodes = [];
   epEdges = [];
   var nodeId = 0;
 
-  // Root node for the endpoint (controller method)
+  // Root node for the endpoint (controller method). Starts expanded so its
+  // direct calls show by default; every other node starts collapsed.
   var rootNode = {
     id: nodeId++,
     className: ep.controllerClass,
@@ -4174,6 +4218,7 @@ function epBuildGraph(ep) {
     totalMethods: 1,
     filePath: ep.filePath,
     line: ep.line,
+    expanded: true,
     x: 0, y: 0, w: 180, h: 60
   };
   epNodes.push(rootNode);
@@ -4193,6 +4238,7 @@ function epBuildGraph(ep) {
         filePath: dep.filePath,
         line: dep.line,
         expandedElsewhere: dep.expandedElsewhere,
+        expanded: false,
         x: 0, y: 0, w: 180, h: 60
       };
       epNodes.push(n);
@@ -4204,37 +4250,47 @@ function epBuildGraph(ep) {
   }
 
   walkDeps(rootNode, ep.dependencies);
+  epComputeTreeVisibility(epNodes, epEdges);
 }
 
+/** Lays out visible nodes only — collapsed subtrees don't take up graph space. */
 function epLayout() {
-  if (epNodes.length === 0) return;
+  var visible = [];
+  for (var v = 0; v < epNodes.length; v++) {
+    if (epNodes[v].visible) visible.push(epNodes[v]);
+  }
+  if (visible.length === 0) return;
+
+  var byId = {};
+  for (var b = 0; b < visible.length; b++) byId[visible[b].id] = true;
 
   if (typeof dagre !== "undefined") {
     var g = new dagre.graphlib.Graph();
     g.setGraph({ rankdir: "TB", nodesep: 40, ranksep: 80, marginx: 40, marginy: 40 });
     g.setDefaultEdgeLabel(function() { return {}; });
 
-    for (var i = 0; i < epNodes.length; i++) {
-      g.setNode(epNodes[i].id, { width: epNodes[i].w, height: epNodes[i].h });
+    for (var i = 0; i < visible.length; i++) {
+      g.setNode(visible[i].id, { width: visible[i].w, height: visible[i].h });
     }
-    for (var i = 0; i < epEdges.length; i++) {
-      g.setEdge(epEdges[i].from, epEdges[i].to);
+    for (var j = 0; j < epEdges.length; j++) {
+      var e = epEdges[j];
+      if (byId[e.from] && byId[e.to]) g.setEdge(e.from, e.to);
     }
 
     dagre.layout(g);
 
-    for (var i = 0; i < epNodes.length; i++) {
-      var laid = g.node(epNodes[i].id);
+    for (var k = 0; k < visible.length; k++) {
+      var laid = g.node(visible[k].id);
       if (laid) {
-        epNodes[i].x = laid.x;
-        epNodes[i].y = laid.y;
+        visible[k].x = laid.x;
+        visible[k].y = laid.y;
       }
     }
   } else {
     // Fallback: simple vertical layout
-    for (var i = 0; i < epNodes.length; i++) {
-      epNodes[i].x = 300;
-      epNodes[i].y = 60 + i * 100;
+    for (var m = 0; m < visible.length; m++) {
+      visible[m].x = 300;
+      visible[m].y = 60 + m * 100;
     }
   }
 }
@@ -4242,13 +4298,17 @@ function epLayout() {
 function epCenterCamera() {
   if (epNodes.length === 0) return;
   var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  var any = false;
   for (var i = 0; i < epNodes.length; i++) {
     var n = epNodes[i];
+    if (!n.visible) continue;
+    any = true;
     minX = Math.min(minX, n.x - n.w / 2);
     maxX = Math.max(maxX, n.x + n.w / 2);
     minY = Math.min(minY, n.y - n.h / 2);
     maxY = Math.max(maxY, n.y + n.h / 2);
   }
+  if (!any) return;
   var graphW = maxX - minX;
   var graphH = maxY - minY;
   var cx = (minX + maxX) / 2;
@@ -4264,6 +4324,59 @@ function epCenterCamera() {
 
   epCamX = epW / 2 - cx;
   epCamY = epH / 2 - cy;
+}
+
+/** World-space rect for a node's expand chip, top-right of its header. Shared by draw and hit-test. */
+function epNodeChipRect(node) {
+  var x = node.x - node.w / 2;
+  var y = node.y - node.h / 2;
+  return {
+    x: x + node.w - EP_CHIP_W - 6,
+    y: y + (EP_NODE_HDR_H - EP_CHIP_H) / 2,
+    w: EP_CHIP_W,
+    h: EP_CHIP_H
+  };
+}
+
+function epChipHitTest(wx, wy) {
+  for (var i = epNodes.length - 1; i >= 0; i--) {
+    var n = epNodes[i];
+    if (!n.visible || n.childCount === 0) continue;
+    var r = epNodeChipRect(n);
+    if (wx >= r.x && wx <= r.x + r.w && wy >= r.y && wy <= r.y + r.h) return n;
+  }
+  return null;
+}
+
+/** Toggles one node's expansion, re-lays-out the now-different visible set, and
+ * shifts the camera so the toggled node stays under the cursor instead of the
+ * view jumping. */
+function epToggleNode(node) {
+  if (!node || node.childCount === 0) return;
+  var beforeX = node.x, beforeY = node.y;
+  node.expanded = !node.expanded;
+  epComputeTreeVisibility(epNodes, epEdges);
+  epLayout();
+  epCamX += beforeX - node.x;
+  epCamY += beforeY - node.y;
+  epHideTooltip();
+  epScheduleRedraw();
+}
+
+function epExpandAll() {
+  for (var i = 0; i < epNodes.length; i++) epNodes[i].expanded = true;
+  epComputeTreeVisibility(epNodes, epEdges);
+  epLayout();
+  epCenterCamera();
+  epScheduleRedraw();
+}
+
+function epCollapseAll() {
+  for (var i = 0; i < epNodes.length; i++) epNodes[i].expanded = false;
+  epComputeTreeVisibility(epNodes, epEdges);
+  epLayout();
+  epCenterCamera();
+  epScheduleRedraw();
 }
 
 function epDraw() {
@@ -4293,11 +4406,11 @@ function epDrawFocusedGraph() {
   var nodeById = {};
   for (var i = 0; i < epNodes.length; i++) nodeById[epNodes[i].id] = epNodes[i];
 
-  // Draw edges
+  // Draw edges — only between visible nodes; a collapsed node's whole subtree drops out here.
   for (var i = 0; i < epEdges.length; i++) {
     var fromN = nodeById[epEdges[i].from];
     var toN = nodeById[epEdges[i].to];
-    if (!fromN || !toN) continue;
+    if (!fromN || !toN || !fromN.visible || !toN.visible) continue;
 
     var fx = fromN.x;
     var fy = fromN.y + fromN.h / 2;
@@ -4335,12 +4448,13 @@ function epDrawFocusedGraph() {
     epCtx.setLineDash([]);
   }
 
-  // Draw nodes
+  // Draw nodes — collapsed-away nodes carry stale coordinates from their last layout, so skip them.
   var BOX_R = 6;
-  var HDR_H = 22;
+  var HDR_H = EP_NODE_HDR_H;
 
   for (var i = 0; i < epNodes.length; i++) {
     var n = epNodes[i];
+    if (!n.visible) continue;
     var x = n.x - n.w / 2;
     var y = n.y - n.h / 2;
     var color = EP_TYPE_COLORS[n.type] || EP_TYPE_COLORS.unknown;
@@ -4410,12 +4524,30 @@ function epDrawFocusedGraph() {
     epCtx.textBaseline = "middle";
     var nameStr = n.className;
     var nameStartX = x + 8 + dotSize + 6;
-    var maxNameW = n.w - (nameStartX - x) - 8;
+    var chipReserve = n.childCount > 0 ? EP_CHIP_W + 6 : 0;
+    var maxNameW = n.w - (nameStartX - x) - 8 - chipReserve;
     while (epCtx.measureText(nameStr).width > maxNameW && nameStr.length > 3) {
       nameStr = nameStr.slice(0, -1);
     }
     if (nameStr !== n.className) nameStr += "\\u2026";
     epCtx.fillText(nameStr, nameStartX, y + HDR_H / 2);
+
+    // Expand chip — collapsed/expanded state and direct-child count, hit-tested by epChipHitTest.
+    if (n.childCount > 0) {
+      var chip = epNodeChipRect(n);
+      epRoundRect(epCtx, chip.x, chip.y, chip.w, chip.h, 4);
+      epCtx.fillStyle = n.expanded ? "rgba(255,255,255,0.16)" : "rgba(255,255,255,0.09)";
+      epCtx.fill();
+      epCtx.strokeStyle = "rgba(255,255,255,0.25)";
+      epCtx.lineWidth = 1;
+      epCtx.stroke();
+      epCtx.font = "bold 9px -apple-system, BlinkMacSystemFont, sans-serif";
+      epCtx.fillStyle = "#ddd";
+      epCtx.textAlign = "center";
+      epCtx.textBaseline = "middle";
+      epCtx.fillText((n.expanded ? "\\u25BE" : "\\u25B8") + " " + n.childCount, chip.x + chip.w / 2, chip.y + chip.h / 2 + 0.5);
+      epCtx.textAlign = "left";
+    }
 
     // Below header: type badge + order badge + method name
     var infoY = y + HDR_H + 8;
@@ -4516,9 +4648,13 @@ function epShowTooltip(node, screenX, screenY) {
   if (node.expandedElsewhere) {
     repeatLabel = '<div style="font-size:9px;color:#888;margin-top:4px">\u21B1 Calls drawn at another call site</div>';
   }
+  var childLabel = "";
+  if (node.childCount > 0) {
+    childLabel = '<div style="font-size:9px;color:#888;margin-top:4px">' + node.childCount + ' direct call' + (node.childCount === 1 ? "" : "s") + '</div>';
+  }
   epTooltipEl.innerHTML = '<div class="tt-name">' + escHtml(node.className) + '</div>' +
     '<div class="tt-table" style="color:' + color + '">' + escHtml(node.type) + '</div>' +
-    methodHtml + condLabel + repeatLabel;
+    methodHtml + condLabel + repeatLabel + childLabel;
   epTooltipEl.style.display = "block";
 
   var mainRect = epCanvas.parentElement.getBoundingClientRect();
@@ -4603,6 +4739,15 @@ function epSyncLegendMode() {
   if (section) section.style.display = epMode === "overview" ? "block" : "none";
 }
 
+/** Expand-all/collapse-all only make sense once a tree is on screen. */
+function epSyncFocusedToolbar() {
+  var focused = epMode === "focused";
+  var expandBtn = document.getElementById("endpoints-expand-all");
+  var collapseBtn = document.getElementById("endpoints-collapse-all");
+  if (expandBtn) expandBtn.style.display = focused ? "" : "none";
+  if (collapseBtn) collapseBtn.style.display = focused ? "" : "none";
+}
+
 function epShowOverview() {
   epMode = "overview";
   epHideCodePanel();
@@ -4610,6 +4755,7 @@ function epShowOverview() {
   epCanvas.style.display = "block";
   epSyncViewToggle();
   epSyncLegendMode();
+  epSyncFocusedToolbar();
   epSyncTruncatedBanner(null);
   epResize();
 }
@@ -4625,6 +4771,7 @@ function epShowFocused(index) {
   epLayout();
   epSyncViewToggle();
   epSyncLegendMode();
+  epSyncFocusedToolbar();
   epSyncTruncatedBanner(found);
   epResize();
   // A new endpoint has a different graph, so fit it — epResize alone only
@@ -4821,6 +4968,14 @@ function renderEndpoints() {
       return;
     }
 
+    // Chip hits are checked first: toggling expansion is not a drag and never
+    // opens the code panel, so it must win over the node-body hit-test below.
+    var chipHit = epChipHitTest(pos.x, pos.y);
+    if (chipHit) {
+      epToggleNode(chipHit);
+      return;
+    }
+
     var hit = epHitTest(pos.x, pos.y);
     if (hit) {
       // Grab offset, not the node's centre — so a drag moves the node
@@ -5003,6 +5158,16 @@ function renderEndpoints() {
       epBannerDismissedIndex = epSelectedIndex;
       epSyncTruncatedBanner(endpoints.endpoints[epSelectedIndex]);
     });
+  }
+
+  // Expand-all / collapse-all — focused mode only (hidden via epSyncFocusedToolbar elsewhere).
+  var expandAllBtn = document.getElementById("endpoints-expand-all");
+  if (expandAllBtn) {
+    expandAllBtn.addEventListener("click", function() { epExpandAll(); });
+  }
+  var collapseAllBtn = document.getElementById("endpoints-collapse-all");
+  if (collapseAllBtn) {
+    collapseAllBtn.addEventListener("click", function() { epCollapseAll(); });
   }
 
   // Recenter button — auto-fits whichever mode is active.

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3781,28 +3781,48 @@ function epPackOverviewBoxes(boxes, targetW, gutter) {
   return y + shelfH;
 }
 
-/** Packs each module's controller boxes into a shelf, then stacks modules vertically. */
+/**
+ * Packs each module's controller boxes into a shelf sized to its own content,
+ * then shelf-packs the module rectangles themselves onto rows — the same
+ * epPackOverviewBoxes call used at both levels, so a project with hundreds of
+ * one-controller modules fills the canvas instead of stacking into one column.
+ */
 function epComputeOverviewLayout(groups, boxWidth) {
   var GUTTER = 32;
   var MODULE_HEADER_H = 28;
   var MODULE_GAP = 56;
-  var top = 0;
-  for (var g = 0; g < groups.length; g++) {
+  var g, i, j;
+
+  for (g = 0; g < groups.length; g++) {
     var group = groups[g];
     var boxes = group.boxes;
     var area = 0;
-    for (var i = 0; i < boxes.length; i++) area += boxes[i].w * boxes[i].h;
-    var targetW = Math.max(boxWidth * 3, Math.sqrt(area) * 1.6);
-    var packH = epPackOverviewBoxes(boxes, targetW, GUTTER);
-    group.headerY = top;
-    var contentTop = top + MODULE_HEADER_H;
-    for (var j = 0; j < boxes.length; j++) {
-      boxes[j].x = boxes[j].ox + boxes[j].w / 2;
-      boxes[j].y = contentTop + boxes[j].oy + boxes[j].h / 2;
+    for (i = 0; i < boxes.length; i++) area += boxes[i].w * boxes[i].h;
+    var innerTargetW = Math.max(boxWidth * 3, Math.sqrt(area) * 1.6);
+    var packH = epPackOverviewBoxes(boxes, innerTargetW, GUTTER);
+    var contentW = 0;
+    for (j = 0; j < boxes.length; j++) {
+      var right = boxes[j].ox + boxes[j].w;
+      if (right > contentW) contentW = right;
     }
-    group.w = targetW;
+    group.w = contentW;
     group.h = MODULE_HEADER_H + packH;
-    top += group.h + MODULE_GAP;
+  }
+
+  var groupArea = 0;
+  for (g = 0; g < groups.length; g++) groupArea += groups[g].w * groups[g].h;
+  var outerTargetW = Math.max(boxWidth * 3, Math.sqrt(groupArea) * 1.6);
+  epPackOverviewBoxes(groups, outerTargetW, MODULE_GAP);
+
+  for (g = 0; g < groups.length; g++) {
+    var placed = groups[g];
+    placed.headerY = placed.oy;
+    var contentTop = placed.oy + MODULE_HEADER_H;
+    for (j = 0; j < placed.boxes.length; j++) {
+      var pbox = placed.boxes[j];
+      pbox.x = placed.ox + pbox.ox + pbox.w / 2;
+      pbox.y = contentTop + pbox.oy + pbox.h / 2;
+    }
   }
 }
 // ep-overview-layout-end
@@ -4066,7 +4086,7 @@ function epDrawOverview() {
     epCtx.fillStyle = "#e0e0e0";
     epCtx.textAlign = "left";
     epCtx.textBaseline = "top";
-    epCtx.fillText(group.label, 0, group.headerY + 6);
+    epCtx.fillText(group.label, group.ox, group.headerY + 6);
 
     for (var b = 0; b < group.boxes.length; b++) {
       epDrawOverviewBox(group.boxes[b]);

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3685,6 +3685,13 @@ function epComputeProjectRoot() {
     for (var i = 0; i < endpoints.endpoints.length; i++) keys.push(endpoints.endpoints[i].filePath);
   }
   if (keys.length === 0) return "";
+  if (keys.length === 1) {
+    // Nothing to compare against — root is that one file's own directory,
+    // not the file itself (which would make its relative path empty).
+    var onlyParts = keys[0].split("/");
+    onlyParts.pop();
+    return onlyParts.join("/");
+  }
   var parts = keys[0].split("/");
   for (var k = 1; k < keys.length && parts.length > 0; k++) {
     var otherParts = keys[k].split("/");
@@ -5036,6 +5043,10 @@ function renderEndpoints() {
     } else {
       epPanning = true;
       epPanStart = { x: e.clientX, y: e.clientY };
+      // Same fixed gesture origin the dragging branch uses below, so a pan
+      // that never actually moves still reads as a click at mouseup.
+      epDragStartX = e.clientX;
+      epDragStartY = e.clientY;
     }
   });
 
@@ -5082,7 +5093,17 @@ function renderEndpoints() {
         epHideTooltip();
       }
     } else if (epPanning) {
-      epDragMoved = true;
+      // Cumulative distance from the fixed gesture origin, not the unconditional
+      // set this used to do — a single incidental mousemove with near-zero delta
+      // (real jitter, or a synthetic click's own move+down+up sequence) must not
+      // by itself turn a click into a "drag" that skips every click handler below.
+      if (!epDragMoved) {
+        var pdx = e.clientX - epDragStartX;
+        var pdy = e.clientY - epDragStartY;
+        if (pdx * pdx + pdy * pdy > EP_DRAG_THRESHOLD_PX * EP_DRAG_THRESHOLD_PX) {
+          epDragMoved = true;
+        }
+      }
       epCamX += (e.clientX - epPanStart.x) / epZoom;
       epCamY += (e.clientY - epPanStart.y) / epZoom;
       epPanStart = { x: e.clientX, y: e.clientY };

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -4256,7 +4256,7 @@ function epGuardThrowFullText(gt) {
 
 /**
  * Precomputes truncated label text, chip width, and box height for one node's optional
- * content (guard-throw strip, throw message, condition line, iteration chip) — all text
+ * content (dataflow line, throw message, condition line, iteration chip) — all text
  * measurement happens here, once per node, never in the draw loop.
  */
 function epBuildNodeExtras(n) {
@@ -4264,9 +4264,9 @@ function epBuildNodeExtras(n) {
   var extraRows = 0;
   var innerW = n.w - 16;
 
-  if (n.guardThrow) {
-    epCtx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
-    n.guardThrowText = epClipText("⚠ " + epGuardThrowFullText(n.guardThrow), innerW);
+  if (n.assignedTo) {
+    epCtx.font = "9px monospace";
+    n.assignedToText = epClipText("→ " + n.assignedTo, innerW);
     extraRows++;
   }
   if (n.type === "throw" && n.throwMessage) {
@@ -4286,6 +4286,26 @@ function epBuildNodeExtras(n) {
   }
 
   n.h = 60 + extraRows * 14;
+}
+
+/**
+ * Precomputes the two label lines for a break-step node (caller-side guard-throw).
+ * Same text-once-not-in-draw-loop rule as epBuildNodeExtras.
+ */
+function epBuildBreakNodeExtras(n) {
+  if (!epCtx) return;
+  var innerW = n.w - 20;
+  var lines = 0;
+  epCtx.font = "9px monospace";
+  if (n.guardThrow.conditionText) {
+    n.breakLine1Text = epClipText("if (" + n.guardThrow.conditionText + ")", innerW);
+    lines++;
+  }
+  var throwText = "throw " + n.guardThrow.className;
+  if (n.guardThrow.message) throwText += ": " + n.guardThrow.message;
+  n.breakLine2Text = epClipText(throwText, innerW);
+  lines++;
+  n.h = 30 + lines * 14 + 6;
 }
 
 function epBuildGraph(ep) {
@@ -4333,12 +4353,40 @@ function epBuildGraph(ep) {
         throwMessage: dep.throwMessage,
         iterationKind: dep.iterationKind,
         iterationLabel: dep.iterationLabel,
+        assignedTo: dep.assignedTo,
+        parameters: dep.parameters,
         expanded: false,
         x: 0, y: 0, w: 180, h: 60
       };
       epBuildNodeExtras(n);
       epNodes.push(n);
       epEdges.push({ from: parentNode.id, to: n.id, conditional: dep.conditional });
+
+      // Guard-throw belongs to the caller, not the callee: synthesize a break-step leaf
+      // right after the guarded call, same parent, so the tree reads check-then-throw at
+      // the call site. Fractional order sorts it directly after dep in the flat #N sequence
+      // without needing a reserved integer gap.
+      if (dep.guardThrow) {
+        var bn = {
+          id: nodeId++,
+          kind: "break",
+          className: parentNode.className,
+          methodName: null,
+          conditional: false,
+          order: dep.order + 0.5,
+          filePath: parentNode.filePath,
+          line: dep.guardThrow.callSiteLine,
+          endLine: dep.guardThrow.callSiteLine,
+          guardThrow: dep.guardThrow,
+          consumedVar: dep.assignedTo,
+          expanded: false,
+          x: 0, y: 0, w: 180, h: 60
+        };
+        epBuildBreakNodeExtras(bn);
+        epNodes.push(bn);
+        epEdges.push({ from: parentNode.id, to: bn.id, conditional: false });
+      }
+
       if (dep.dependencies && dep.dependencies.length > 0) {
         walkDeps(n, dep.dependencies);
       }
@@ -4567,6 +4615,59 @@ function epDrawFocusedGraph() {
     var color = EP_TYPE_COLORS[n.type] || EP_TYPE_COLORS.unknown;
     var isHovered = (epHoveredNode && epHoveredNode.id === n.id);
 
+    // Break step — caller-owned guard-throw. Its own small draw path: amber border,
+    // controller-red left accent, order badge, two label lines. No header, no chip.
+    if (n.kind === "break") {
+      if (isHovered) {
+        epCtx.save();
+        epCtx.shadowColor = "rgba(255,255,255,0.2)";
+        epCtx.shadowBlur = 10;
+      }
+      epRoundRect(epCtx, x, y, n.w, n.h, BOX_R);
+      epCtx.fillStyle = "#1a1408";
+      epCtx.fill();
+      epCtx.strokeStyle = isHovered ? "#f59e0b" : "rgba(245,158,11,0.6)";
+      epCtx.lineWidth = isHovered ? 2 : 1;
+      epCtx.stroke();
+      if (isHovered) epCtx.restore();
+
+      epCtx.save();
+      epRoundRect(epCtx, x, y, n.w, n.h, BOX_R);
+      epCtx.clip();
+      epCtx.fillStyle = "#ea2845";
+      epCtx.fillRect(x, y, 3, n.h);
+      epCtx.restore();
+
+      if (n.displayOrder !== undefined) {
+        var bOrderLabel = "#" + (n.displayOrder + 1);
+        epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
+        var bOrderW = epCtx.measureText(bOrderLabel).width + 8;
+        epRoundRect(epCtx, x + 10, y + 8, bOrderW, 12, 3);
+        epCtx.fillStyle = "rgba(255,255,255,0.08)";
+        epCtx.fill();
+        epCtx.fillStyle = "#999";
+        epCtx.textAlign = "left";
+        epCtx.textBaseline = "middle";
+        epCtx.fillText(bOrderLabel, x + 14, y + 14);
+      }
+
+      var bY = y + 30;
+      epCtx.textAlign = "left";
+      epCtx.textBaseline = "middle";
+      if (n.breakLine1Text) {
+        epCtx.font = "9px monospace";
+        epCtx.fillStyle = "#f59e0b";
+        epCtx.fillText(n.breakLine1Text, x + 10, bY);
+        bY += 14;
+      }
+      if (n.breakLine2Text) {
+        epCtx.font = "9px monospace";
+        epCtx.fillStyle = "#f87171";
+        epCtx.fillText(n.breakLine2Text, x + 10, bY);
+      }
+      continue;
+    }
+
     var isCond = n.conditional;
     var headerColor = isCond ? "#f59e0b" : color;
 
@@ -4734,16 +4835,16 @@ function epDrawFocusedGraph() {
       epCtx.fillText(mText, x + 8, methodY);
     }
 
-    // Extra rows below whatever content just drew — guard-throw strip, throw message,
+    // Extra rows below whatever content just drew — dataflow line, throw message,
     // condition text. Text is precomputed in epBuildNodeExtras; box height already
     // accounts for however many of these apply, so nothing here measures text.
     var rowY = infoY + (n.methodName ? 18 : 0) + 14;
     epCtx.textAlign = "left";
     epCtx.textBaseline = "middle";
-    if (n.guardThrowText) {
-      epCtx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
-      epCtx.fillStyle = "#f59e0b";
-      epCtx.fillText(n.guardThrowText, x + 8, rowY);
+    if (n.assignedToText) {
+      epCtx.font = "9px monospace";
+      epCtx.fillStyle = "#777";
+      epCtx.fillText(n.assignedToText, x + 8, rowY);
       rowY += 14;
     }
     if (n.throwMsgText) {
@@ -4786,46 +4887,68 @@ function epResize() {
   epScheduleRedraw();
 }
 
+/** Joins parameter names into a call-args string, e.g. "id, userId". */
+function epFormatParams(params) {
+  if (!params || params.length === 0) return "";
+  var names = [];
+  for (var i = 0; i < params.length; i++) names.push(params[i].name);
+  return names.join(", ");
+}
+
 function epShowTooltip(node, screenX, screenY) {
   if (!epTooltipEl) return;
-  var color = EP_TYPE_COLORS[node.type] || EP_TYPE_COLORS.unknown;
-  var methodHtml = "";
-  if (node.methodName) {
-    var mColor = node.conditional ? "#f59e0b" : "#ccc";
-    methodHtml = '<div style="font-family:monospace;font-size:11px;color:' + mColor + ';margin-top:4px">.' + escHtml(node.methodName) + '()</div>';
+
+  if (node.kind === "break") {
+    var gt = node.guardThrow;
+    var breakHtml = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">\u26A0 ' + escHtml(epGuardThrowFullText(gt)) + '</div>' +
+      '<div style="font-size:9px;color:#888;margin-top:4px">Handler stops here when the condition holds.</div>';
+    if (node.consumedVar) {
+      breakHtml += '<div style="font-size:9px;color:#888;margin-top:4px">Checks ' + escHtml(node.consumedVar) + '</div>';
+    }
+    epTooltipEl.innerHTML = '<div class="tt-name">Break step</div>' +
+      '<div class="tt-table" style="color:#f59e0b">caller check</div>' + breakHtml;
+    epTooltipEl.style.display = "block";
+  } else {
+    var color = EP_TYPE_COLORS[node.type] || EP_TYPE_COLORS.unknown;
+    var methodHtml = "";
+    if (node.methodName) {
+      var mColor = node.conditional ? "#f59e0b" : "#ccc";
+      var callText = node.methodName + "(" + epFormatParams(node.parameters) + ")";
+      methodHtml = '<div style="font-family:monospace;font-size:11px;color:' + mColor + ';margin-top:4px">.' + escHtml(callText) + '</div>';
+    }
+    var assignedLabel = "";
+    if (node.assignedTo) {
+      assignedLabel = '<div style="font-size:9px;color:#888;margin-top:4px">\u2192 ' + escHtml(node.assignedTo) + '</div>';
+    }
+    var condLabel = "";
+    if (node.conditional) {
+      var condText = "Conditionally called";
+      if (node.branchKind) condText += " (" + node.branchKind + ")";
+      if (node.conditionText) condText += " \u2014 when " + node.conditionText;
+      condLabel = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">' + escHtml(condText) + '</div>';
+    }
+    var throwMsgLabel = "";
+    if (node.type === "throw" && node.throwMessage) {
+      throwMsgLabel = '<div style="font-size:9px;color:#f87171;margin-top:4px">' + escHtml(node.throwMessage) + '</div>';
+    }
+    var iterLabel = "";
+    if (node.iterationKind) {
+      var iterText = "Called inside " + (node.iterationLabel ? "." + node.iterationLabel + "()" : node.iterationKind);
+      iterLabel = '<div style="font-size:9px;color:#888;margin-top:4px">\u21BB ' + escHtml(iterText) + '</div>';
+    }
+    var repeatLabel = "";
+    if (node.expandedElsewhere) {
+      repeatLabel = '<div style="font-size:9px;color:#888;margin-top:4px">\u21B1 Calls drawn at another call site</div>';
+    }
+    var childLabel = "";
+    if (node.childCount > 0) {
+      childLabel = '<div style="font-size:9px;color:#888;margin-top:4px">' + node.childCount + ' direct call' + (node.childCount === 1 ? "" : "s") + '</div>';
+    }
+    epTooltipEl.innerHTML = '<div class="tt-name">' + escHtml(node.className) + '</div>' +
+      '<div class="tt-table" style="color:' + color + '">' + escHtml(node.type) + '</div>' +
+      methodHtml + assignedLabel + condLabel + throwMsgLabel + iterLabel + repeatLabel + childLabel;
+    epTooltipEl.style.display = "block";
   }
-  var condLabel = "";
-  if (node.conditional) {
-    var condText = "Conditionally called";
-    if (node.branchKind) condText += " (" + node.branchKind + ")";
-    if (node.conditionText) condText += " \u2014 when " + node.conditionText;
-    condLabel = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">' + escHtml(condText) + '</div>';
-  }
-  var guardThrowLabel = "";
-  if (node.guardThrow) {
-    guardThrowLabel = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">\u26A0 ' + escHtml(epGuardThrowFullText(node.guardThrow)) + '</div>';
-  }
-  var throwMsgLabel = "";
-  if (node.type === "throw" && node.throwMessage) {
-    throwMsgLabel = '<div style="font-size:9px;color:#f87171;margin-top:4px">' + escHtml(node.throwMessage) + '</div>';
-  }
-  var iterLabel = "";
-  if (node.iterationKind) {
-    var iterText = "Called inside " + (node.iterationLabel ? "." + node.iterationLabel + "()" : node.iterationKind);
-    iterLabel = '<div style="font-size:9px;color:#888;margin-top:4px">\u21BB ' + escHtml(iterText) + '</div>';
-  }
-  var repeatLabel = "";
-  if (node.expandedElsewhere) {
-    repeatLabel = '<div style="font-size:9px;color:#888;margin-top:4px">\u21B1 Calls drawn at another call site</div>';
-  }
-  var childLabel = "";
-  if (node.childCount > 0) {
-    childLabel = '<div style="font-size:9px;color:#888;margin-top:4px">' + node.childCount + ' direct call' + (node.childCount === 1 ? "" : "s") + '</div>';
-  }
-  epTooltipEl.innerHTML = '<div class="tt-name">' + escHtml(node.className) + '</div>' +
-    '<div class="tt-table" style="color:' + color + '">' + escHtml(node.type) + '</div>' +
-    methodHtml + condLabel + guardThrowLabel + throwMsgLabel + iterLabel + repeatLabel + childLabel;
-  epTooltipEl.style.display = "block";
 
   var mainRect = epCanvas.parentElement.getBoundingClientRect();
   var tx = screenX + 16;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -4247,6 +4247,47 @@ function epComputeTreeVisibility(nodes, edges) {
 }
 // ep-tree-visibility-end
 
+function epGuardThrowFullText(gt) {
+  var s = "Throws " + gt.className;
+  if (gt.conditionText) s += " if " + gt.conditionText;
+  if (gt.message) s += ": " + gt.message;
+  return s;
+}
+
+/**
+ * Precomputes truncated label text, chip width, and box height for one node's optional
+ * content (guard-throw strip, throw message, condition line, iteration chip) — all text
+ * measurement happens here, once per node, never in the draw loop.
+ */
+function epBuildNodeExtras(n) {
+  if (!epCtx) return;
+  var extraRows = 0;
+  var innerW = n.w - 16;
+
+  if (n.guardThrow) {
+    epCtx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+    n.guardThrowText = epClipText("⚠ " + epGuardThrowFullText(n.guardThrow), innerW);
+    extraRows++;
+  }
+  if (n.type === "throw" && n.throwMessage) {
+    epCtx.font = "9px monospace";
+    n.throwMsgText = epClipText(n.throwMessage, innerW);
+    extraRows++;
+  }
+  if (n.conditional && n.conditionText) {
+    epCtx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+    n.conditionLineText = epClipText("when " + n.conditionText, innerW);
+    extraRows++;
+  }
+  if (n.iterationKind) {
+    epCtx.font = "bold 9px -apple-system, BlinkMacSystemFont, sans-serif";
+    n.iterChipText = epClipText("↻ " + (n.iterationLabel || n.iterationKind), 70);
+    n.iterChipW = epCtx.measureText(n.iterChipText).width + 10;
+  }
+
+  n.h = 60 + extraRows * 14;
+}
+
 function epBuildGraph(ep) {
   epNodes = [];
   epEdges = [];
@@ -4280,15 +4321,22 @@ function epBuildGraph(ep) {
         type: dep.type,
         methodName: dep.methodName,
         conditional: dep.conditional,
+        conditionText: dep.conditionText,
+        branchKind: dep.branchKind,
         order: dep.order,
         totalMethods: dep.totalMethods,
         filePath: dep.filePath,
         line: dep.line,
         endLine: dep.endLine,
         expandedElsewhere: dep.expandedElsewhere,
+        guardThrow: dep.guardThrow,
+        throwMessage: dep.throwMessage,
+        iterationKind: dep.iterationKind,
+        iterationLabel: dep.iterationLabel,
         expanded: false,
         x: 0, y: 0, w: 180, h: 60
       };
+      epBuildNodeExtras(n);
       epNodes.push(n);
       epEdges.push({ from: parentNode.id, to: n.id, conditional: dep.conditional });
       if (dep.dependencies && dep.dependencies.length > 0) {
@@ -4298,6 +4346,17 @@ function epBuildGraph(ep) {
   }
 
   walkDeps(rootNode, ep.dependencies);
+
+  // Contiguous #N badges in engine-order sequence. The raw order field skips slots a
+  // merged guard-throw consumed (e.g. 0, 2), which would otherwise show as #1 -> #3.
+  // Computed once here so display order stays stable while nodes expand/collapse.
+  var ordered = [];
+  for (var oi = 0; oi < epNodes.length; oi++) {
+    if (epNodes[oi].order >= 0) ordered.push(epNodes[oi]);
+  }
+  ordered.sort(function(a, b) { return a.order - b.order; });
+  for (var di = 0; di < ordered.length; di++) ordered[di].displayOrder = di;
+
   epComputeTreeVisibility(epNodes, epEdges);
 }
 
@@ -4572,7 +4631,8 @@ function epDrawFocusedGraph() {
     epCtx.textBaseline = "middle";
     var nameStr = n.className;
     var nameStartX = x + 8 + dotSize + 6;
-    var chipReserve = n.childCount > 0 ? EP_CHIP_W + 6 : 0;
+    var iterChipReserve = n.iterationKind ? (n.iterChipW || 30) + 4 : 0;
+    var chipReserve = (n.childCount > 0 ? EP_CHIP_W + 6 : 0) + iterChipReserve;
     var maxNameW = n.w - (nameStartX - x) - 8 - chipReserve;
     while (epCtx.measureText(nameStr).width > maxNameW && nameStr.length > 3) {
       nameStr = nameStr.slice(0, -1);
@@ -4581,6 +4641,7 @@ function epDrawFocusedGraph() {
     epCtx.fillText(nameStr, nameStartX, y + HDR_H / 2);
 
     // Expand chip — collapsed/expanded state and direct-child count, hit-tested by epChipHitTest.
+    var chipLeftEdge = x + n.w - 6;
     if (n.childCount > 0) {
       var chip = epNodeChipRect(n);
       epRoundRect(epCtx, chip.x, chip.y, chip.w, chip.h, 4);
@@ -4594,6 +4655,26 @@ function epDrawFocusedGraph() {
       epCtx.textAlign = "center";
       epCtx.textBaseline = "middle";
       epCtx.fillText((n.expanded ? "\\u25BE" : "\\u25B8") + " " + n.childCount, chip.x + chip.w / 2, chip.y + chip.h / 2 + 0.5);
+      epCtx.textAlign = "left";
+      chipLeftEdge = chip.x - 6;
+    }
+
+    // Iteration chip — sits left of the expand chip when both are present.
+    if (n.iterationKind && n.iterChipText) {
+      var iterW = n.iterChipW || 30;
+      var iterX = chipLeftEdge - iterW;
+      var iterY = y + (HDR_H - EP_CHIP_H) / 2;
+      epRoundRect(epCtx, iterX, iterY, iterW, EP_CHIP_H, 4);
+      epCtx.fillStyle = "rgba(255,255,255,0.09)";
+      epCtx.fill();
+      epCtx.strokeStyle = "rgba(255,255,255,0.2)";
+      epCtx.lineWidth = 1;
+      epCtx.stroke();
+      epCtx.font = "bold 9px -apple-system, BlinkMacSystemFont, sans-serif";
+      epCtx.fillStyle = "#aaa";
+      epCtx.textAlign = "center";
+      epCtx.textBaseline = "middle";
+      epCtx.fillText(n.iterChipText, iterX + iterW / 2, iterY + EP_CHIP_H / 2 + 0.5);
       epCtx.textAlign = "left";
     }
 
@@ -4614,11 +4695,11 @@ function epDrawFocusedGraph() {
     epCtx.textBaseline = "middle";
     epCtx.fillText(typeLabel, x + 13, infoY + 6);
 
-    // Order badge (#N)
+    // Order badge (#N) — displayOrder is the contiguous, gap-free renumbering from epBuildGraph.
     var badgeRight = x + 8 + badgeW;
     var orderW = 0;
-    if (n.order >= 0) {
-      var orderLabel = "#" + (n.order + 1);
+    if (n.displayOrder !== undefined) {
+      var orderLabel = "#" + (n.displayOrder + 1);
       epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
       orderW = epCtx.measureText(orderLabel).width + 8;
       epRoundRect(epCtx, badgeRight + 4, infoY, orderW, 12, 3);
@@ -4651,6 +4732,31 @@ function epDrawFocusedGraph() {
         mText = mText.slice(0, -1);
       }
       epCtx.fillText(mText, x + 8, methodY);
+    }
+
+    // Extra rows below whatever content just drew — guard-throw strip, throw message,
+    // condition text. Text is precomputed in epBuildNodeExtras; box height already
+    // accounts for however many of these apply, so nothing here measures text.
+    var rowY = infoY + (n.methodName ? 18 : 0) + 14;
+    epCtx.textAlign = "left";
+    epCtx.textBaseline = "middle";
+    if (n.guardThrowText) {
+      epCtx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+      epCtx.fillStyle = "#f59e0b";
+      epCtx.fillText(n.guardThrowText, x + 8, rowY);
+      rowY += 14;
+    }
+    if (n.throwMsgText) {
+      epCtx.font = "9px monospace";
+      epCtx.fillStyle = "#f87171";
+      epCtx.fillText(n.throwMsgText, x + 8, rowY);
+      rowY += 14;
+    }
+    if (n.conditionLineText) {
+      epCtx.font = "9px -apple-system, BlinkMacSystemFont, sans-serif";
+      epCtx.fillStyle = "rgba(245,158,11,0.75)";
+      epCtx.fillText(n.conditionLineText, x + 8, rowY);
+      rowY += 14;
     }
   }
 
@@ -4690,7 +4796,23 @@ function epShowTooltip(node, screenX, screenY) {
   }
   var condLabel = "";
   if (node.conditional) {
-    condLabel = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">Conditionally called</div>';
+    var condText = "Conditionally called";
+    if (node.branchKind) condText += " (" + node.branchKind + ")";
+    if (node.conditionText) condText += " \u2014 when " + node.conditionText;
+    condLabel = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">' + escHtml(condText) + '</div>';
+  }
+  var guardThrowLabel = "";
+  if (node.guardThrow) {
+    guardThrowLabel = '<div style="font-size:9px;color:#f59e0b;margin-top:4px">\u26A0 ' + escHtml(epGuardThrowFullText(node.guardThrow)) + '</div>';
+  }
+  var throwMsgLabel = "";
+  if (node.type === "throw" && node.throwMessage) {
+    throwMsgLabel = '<div style="font-size:9px;color:#f87171;margin-top:4px">' + escHtml(node.throwMessage) + '</div>';
+  }
+  var iterLabel = "";
+  if (node.iterationKind) {
+    var iterText = "Called inside " + (node.iterationLabel ? "." + node.iterationLabel + "()" : node.iterationKind);
+    iterLabel = '<div style="font-size:9px;color:#888;margin-top:4px">\u21BB ' + escHtml(iterText) + '</div>';
   }
   var repeatLabel = "";
   if (node.expandedElsewhere) {
@@ -4702,7 +4824,7 @@ function epShowTooltip(node, screenX, screenY) {
   }
   epTooltipEl.innerHTML = '<div class="tt-name">' + escHtml(node.className) + '</div>' +
     '<div class="tt-table" style="color:' + color + '">' + escHtml(node.type) + '</div>' +
-    methodHtml + condLabel + repeatLabel + childLabel;
+    methodHtml + condLabel + guardThrowLabel + throwMsgLabel + iterLabel + repeatLabel + childLabel;
   epTooltipEl.style.display = "block";
 
   var mainRect = epCanvas.parentElement.getBoundingClientRect();

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -3692,6 +3692,10 @@ var epOverviewGroups = [];
 var epOvHoveredRow = null;
 var epOvHitRowPending = null;
 
+function epZoomFloor() {
+  return Math.min(epMinZoom, 0.05);
+}
+
 // Auth shield for one endpoint. Reused by the endpoints overview canvas.
 function epAuthShield(ep) {
   var auth = ep.auth;
@@ -3872,13 +3876,18 @@ function epRebuildOverview() {
 
 function epCenterOverviewCamera() {
   if (epOverviewGroups.length === 0) return;
-  var minX = 0, maxX = 0, minY = Infinity, maxY = -Infinity;
+  var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
   for (var g = 0; g < epOverviewGroups.length; g++) {
     var group = epOverviewGroups[g];
-    if (group.w > maxX) maxX = group.w;
     if (group.headerY < minY) minY = group.headerY;
     if (group.headerY + group.h > maxY) maxY = group.headerY + group.h;
+    for (var b = 0; b < group.boxes.length; b++) {
+      var box = group.boxes[b];
+      if (box.x - box.w / 2 < minX) minX = box.x - box.w / 2;
+      if (box.x + box.w / 2 > maxX) maxX = box.x + box.w / 2;
+    }
   }
+  if (minX === Infinity) { minX = 0; maxX = 0; }
   var graphW = maxX - minX;
   var graphH = maxY - minY;
   var cx = (minX + maxX) / 2;
@@ -4836,7 +4845,7 @@ function renderEndpoints() {
     }
     var zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;
     var newZoom = epZoom * zoomFactor;
-    newZoom = Math.max(0.2, Math.min(3, newZoom));
+    newZoom = Math.max(epZoomFloor(), Math.min(3, newZoom));
 
     var rect = epCanvas.getBoundingClientRect();
     var mx = e.clientX - rect.left;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -4211,7 +4211,14 @@ function epEdgePoints(fromN, toN, kind) {
     var toIsRight = toN.x >= fromN.x;
     var vfx = toIsRight ? fromN.x + fromN.w / 2 : fromN.x - fromN.w / 2;
     var vtx = toIsRight ? toN.x - toN.w / 2 : toN.x + toN.w / 2;
-    return [{ x: vfx, y: fromN.y }, { x: vtx, y: toN.y }];
+    var vfy = fromN.y;
+    var vty = toN.y;
+    // Same-rank boxes can differ in centre Y; route with 90-degree turns, never a diagonal.
+    if (Math.abs(vfy - vty) > 2) {
+      var midX = vfx + (vtx - vfx) / 2;
+      return [{ x: vfx, y: vfy }, { x: midX, y: vfy }, { x: midX, y: vty }, { x: vtx, y: vty }];
+    }
+    return [{ x: vfx, y: vfy }, { x: vtx, y: vty }];
   }
   var fx = fromN.x;
   var fy = fromN.y + fromN.h / 2;
@@ -4367,6 +4374,9 @@ function epBuildBreakNodeExtras(n) {
 function epBuildGraph(ep) {
   epNodes = [];
   epEdges = [];
+  // Node ids restart per graph, so hover refs from the previous graph must not survive.
+  epHoveredNode = null;
+  epHoveredEdge = null;
   var nodeId = 0;
 
   // Root node for the endpoint (controller method). Starts expanded so its
@@ -4608,8 +4618,9 @@ function epDraw() {
 /**
  * One edge's line, arrowhead, and (for value edges) label. The arrowhead is always
  * solid — drawn after the dash pattern is reset — so it reads as an arrow instead of
- * dissolving into the line's own dots/dashes. A hovered edge overrides color/width/
- * dash with a white glow so it stands out from whatever else it overlaps.
+ * dissolving into the line's own dots/dashes. A hovered edge keeps its own color
+ * (never overridden to white) but gets a matching glow, solid stroke, and extra
+ * width so it stands out from whatever else it overlaps.
  */
 function epDrawOneEdge(edge, fromN, toN, isHovered) {
   var pts = epEdgePoints(fromN, toN, edge.kind);
@@ -4617,12 +4628,16 @@ function epDrawOneEdge(edge, fromN, toN, isHovered) {
   var baseColor = isValueEdge
     ? EP_VALUE_EDGE_COLOR
     : (edge.conditional ? "rgba(245, 158, 11, 0.6)" : "#555");
-  var edgeColor = isHovered ? "#ffffff" : baseColor;
+  // A plain structural edge is grey — a grey glow on a grey line barely reads as
+  // a highlight, so hovering one goes white, same as the schema diagram. A value
+  // or conditional edge already has a color worth keeping, so hovering keeps it.
+  var hoverColor = (isValueEdge || edge.conditional) ? baseColor : "#ffffff";
+  var edgeColor = isHovered ? hoverColor : baseColor;
   var edgeLineW = (isHovered ? 2.5 : (isValueEdge ? 1 : 1.5)) / epZoom;
 
   if (isHovered) {
     epCtx.save();
-    epCtx.shadowColor = "#ffffff";
+    epCtx.shadowColor = hoverColor;
     epCtx.shadowBlur = 8;
   } else if (isValueEdge) {
     epCtx.setLineDash([2 / epZoom, 3 / epZoom]);
@@ -4665,14 +4680,13 @@ function epDrawOneEdge(edge, fromN, toN, isHovered) {
 
   if (isHovered) epCtx.restore();
 
-  // Label the value edge with the producer's assigned variable, at the midpoint of
-  // its (usually horizontal, same-rank) middle segment.
+  // Value-edge label: the producer's assigned variable, centred over the horizontal
+  // run, just above the first leg (pts[0]..pts[1] is horizontal on every path shape).
   if (isValueEdge && fromN.assignedTo) {
-    var segStart = pts.length === 4 ? 1 : 0;
-    var labelX = (pts[segStart].x + pts[segStart + 1].x) / 2;
-    var labelY = (pts[segStart].y + pts[segStart + 1].y) / 2;
+    var labelX = (pts[0].x + pts[pts.length - 1].x) / 2;
+    var labelY = Math.min(pts[0].y, pts[1].y);
     epCtx.font = "9px monospace";
-    epCtx.fillStyle = isHovered ? "#ffffff" : EP_VALUE_EDGE_COLOR;
+    epCtx.fillStyle = EP_VALUE_EDGE_COLOR;
     epCtx.textAlign = "center";
     epCtx.textBaseline = "bottom";
     epCtx.fillText(fromN.assignedTo, labelX, labelY - 2 / epZoom);

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1138,6 +1138,11 @@ canvas:active { cursor: grabbing; }
   transition: background 0.15s;
 }
 #endpoints-diag-header:hover { background: var(--surface-hover); }
+.ep-diag-scope {
+  font-size: 11px; color: var(--text-dim); font-family: monospace;
+  text-transform: none; margin-left: -4px; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; min-width: 0;
+}
 .ep-diag-caveat {
   padding: 0 12px 6px; font-size: 10px; color: var(--text-dim);
 }

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1068,9 +1068,66 @@ canvas:active { cursor: grabbing; }
 }
 #endpoints-canvas:active { cursor: grabbing; }
 #endpoints-toolbar {
-  position: absolute; top: 12px; right: 12px; z-index: 10;
-  display: flex; gap: 4px;
+  position: absolute; top: 12px; right: 12px; z-index: 11;
+  display: flex; align-items: center; gap: 4px;
 }
+#endpoints-zoombar {
+  display: flex; align-items: center; gap: 6px;
+  height: 28px; padding: 0 8px; border-radius: 6px;
+  background: rgba(50,50,50,0.9);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255,255,255,0.22);
+}
+#endpoints-zoom-range {
+  -webkit-appearance: none; appearance: none;
+  width: 110px; height: 3px; border-radius: 2px;
+  background: rgba(255,255,255,0.25); outline: none; cursor: pointer;
+}
+#endpoints-zoom-range::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 11px; height: 11px; border-radius: 50%;
+  background: var(--nest-red); cursor: pointer;
+}
+#endpoints-zoom-range::-moz-range-thumb {
+  width: 11px; height: 11px; border: none; border-radius: 50%;
+  background: var(--nest-red); cursor: pointer;
+}
+/* Endpoint tooltip sits below the code panel so an open panel isn't hidden by it. */
+#endpoints-tooltip { z-index: 9; }
+#endpoints-truncated-banner {
+  position: absolute; top: 12px; left: 12px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 8px 6px 12px; border-radius: 6px; max-width: 420px;
+  background: rgba(120,53,15,0.92); border: 1px solid rgba(245,158,11,0.5);
+  color: #fde68a; font-size: 12px;
+  backdrop-filter: blur(4px);
+}
+#endpoints-truncated-dismiss {
+  background: none; border: none; color: #fde68a; opacity: 0.8;
+  cursor: pointer; font-size: 16px; line-height: 1; padding: 0 2px; flex-shrink: 0;
+}
+#endpoints-truncated-dismiss:hover { opacity: 1; }
+#endpoints-legend {
+  position: absolute; top: 48px; right: 12px; z-index: 11;
+  width: 220px; max-height: calc(100% - 60px); overflow-y: auto;
+  padding: 10px 12px; border-radius: 6px;
+  background: rgba(26,26,26,0.95); border: 1px solid rgba(255,255,255,0.15);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+  font-size: 11px; color: var(--text);
+}
+.ep-legend-title { font-weight: 600; color: var(--white); margin-bottom: 6px; }
+.ep-legend-row { display: flex; align-items: center; gap: 8px; padding: 3px 0; }
+.ep-legend-swatch {
+  width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0; display: inline-block;
+}
+.ep-legend-dashed {
+  background: none; border: 1px dashed #f59e0b; height: 8px;
+}
+.ep-legend-glyph { width: 14px; text-align: center; flex-shrink: 0; font-size: 11px; }
+.ep-legend-order {
+  width: 14px; text-align: center; flex-shrink: 0; font-size: 9px; color: #999;
+}
+.ep-legend-divider { border-top: 1px solid var(--border); margin: 6px 0; }
 #endpoints-diag-panel {
   flex: none; border-top: 1px solid var(--border); background: var(--surface);
 }
@@ -1125,10 +1182,10 @@ canvas:active { cursor: grabbing; }
 
 /* ── Endpoint code panel ── */
 .ep-code-panel {
-  position: absolute; left: 0; top: 0; bottom: 0; width: 500px; z-index: 10;
-  background: var(--surface); border-right: 1px solid var(--border);
+  position: absolute; right: 0; top: 0; bottom: 0; width: 500px; z-index: 10;
+  background: var(--surface); border-left: 1px solid var(--border);
   display: flex; flex-direction: column;
-  transform: translateX(-100%); transition: transform 0.25s ease;
+  transform: translateX(100%); transition: transform 0.25s ease;
 }
 .ep-code-panel.open { transform: translateX(0); }
 .ep-code-panel-header {
@@ -1162,7 +1219,7 @@ canvas:active { cursor: grabbing; }
   padding: 24px;
 }
 .ep-code-panel-resize {
-  position: absolute; right: -2px; top: 0; bottom: 0; width: 5px;
+  position: absolute; left: -2px; top: 0; bottom: 0; width: 5px;
   cursor: col-resize; z-index: 11;
   background: transparent;
   transition: background 0.15s;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -875,7 +875,8 @@ canvas:active { cursor: grabbing; }
   font-size: 11px; font-family: var(--font); color: var(--text);
   box-shadow: 0 4px 12px rgba(0,0,0,0.5);
 }
-#schema-sidebar .has-tip:is(:hover, :focus-visible)::after {
+#schema-sidebar .has-tip:is(:hover, :focus-visible)::after,
+#endpoints-sidebar .has-tip:is(:hover, :focus-visible)::after {
   white-space: normal; width: max-content; max-width: 240px;
 }
 /* An icon sits near the left edge, so its tip has to open rightwards. */

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1138,6 +1138,9 @@ canvas:active { cursor: grabbing; }
 .ep-legend-dashed {
   background: none; border: 1px dashed #f59e0b; height: 8px;
 }
+.ep-legend-break {
+  background: #1a1408; border: 1px solid #f59e0b; border-left: 3px solid #ea2845;
+}
 .ep-legend-glyph { width: 14px; text-align: center; flex-shrink: 0; font-size: 11px; }
 .ep-legend-order {
   width: 14px; text-align: center; flex-shrink: 0; font-size: 9px; color: #999;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1069,7 +1069,7 @@ canvas:active { cursor: grabbing; }
 }
 #endpoints-canvas:active { cursor: grabbing; }
 #endpoints-toolbar {
-  position: absolute; top: 12px; right: 12px; z-index: 11;
+  position: absolute; top: 12px; right: 12px; z-index: 12;
   display: flex; align-items: center; gap: 4px;
 }
 #endpoints-zoombar {
@@ -1109,7 +1109,7 @@ canvas:active { cursor: grabbing; }
 }
 #endpoints-truncated-dismiss:hover { opacity: 1; }
 #endpoints-legend {
-  position: absolute; top: 48px; right: 12px; z-index: 11;
+  position: absolute; top: 48px; right: 12px; z-index: 12;
   width: 220px; max-height: calc(100% - 60px); overflow-y: auto;
   padding: 10px 12px; border-radius: 6px;
   background: rgba(26,26,26,0.95); border: 1px solid rgba(255,255,255,0.15);
@@ -1183,7 +1183,7 @@ canvas:active { cursor: grabbing; }
 
 /* ── Endpoint code panel ── */
 .ep-code-panel {
-  position: absolute; left: 0; top: 0; bottom: 0; width: 500px; z-index: 10;
+  position: absolute; left: 0; top: 0; bottom: 0; width: 500px; z-index: 11;
   background: var(--surface); border-right: 1px solid var(--border);
   display: flex; flex-direction: column;
   transform: translateX(-100%); opacity: 0;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1044,7 +1044,17 @@ canvas:active { cursor: grabbing; }
   padding: 16px 16px 12px; display: flex; align-items: center; gap: 8px;
   border-bottom: 1px solid var(--border);
 }
+.endpoints-sidebar-search {
+  padding: 10px 16px; border-bottom: 1px solid var(--border);
+}
+.endpoints-sidebar-search input {
+  width: 100%; font-size: 12px; padding: 6px 10px; border-radius: 6px;
+  background: rgba(255,255,255,0.06); border: 1px solid var(--border);
+  color: var(--text); font-family: var(--font); outline: none;
+}
+.endpoints-sidebar-search input:focus { border-color: var(--border-hover); }
 #endpoints-list { padding: 4px 0; }
+.ep-module-row { margin-top: 4px; }
 #endpoints-main {
   flex: 1; overflow: hidden; background: var(--bg);
   display: flex; flex-direction: column; min-width: 0;
@@ -1078,9 +1088,30 @@ canvas:active { cursor: grabbing; }
 .ep-method-put { background: rgba(245,158,11,0.15); color: #f59e0b; }
 .ep-method-patch { background: rgba(245,158,11,0.15); color: #f59e0b; }
 .ep-method-delete { background: rgba(239,68,68,0.15); color: #ef4444; }
+.ep-method-all { background: rgba(6,182,212,0.15); color: #06b6d4; }
+.ep-method-head { background: rgba(100,116,139,0.15); color: #64748b; }
+.ep-method-options { background: rgba(148,163,184,0.15); color: #94a3b8; }
+.ep-method-query { background: rgba(139,92,246,0.15); color: #8b5cf6; }
+.ep-method-mutation { background: rgba(168,85,247,0.15); color: #a855f7; }
+.ep-method-subscription { background: rgba(192,38,211,0.15); color: #c026d3; }
+.ep-method-unknown { background: rgba(136,136,136,0.15); color: #888; }
 .ep-endpoint-row { padding-left: 4px; }
 .ep-endpoint-row:hover { background: rgba(255,255,255,0.04); }
 .ep-endpoint-row.st-selected { background: rgba(59,130,246,0.18); }
+.ep-auth-shield {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 14px; height: 14px; margin-left: 6px; font-size: 10px;
+  font-weight: 700; flex-shrink: 0; cursor: default;
+}
+.ep-auth-guarded { color: var(--score-green); }
+.ep-auth-public { color: var(--sev-info); }
+.ep-auth-unguarded { color: var(--sev-warning); }
+.ep-auth-unknown { color: var(--text-dim); }
+.ep-diag-badge {
+  display: inline-flex; align-items: center; gap: 3px;
+  font-size: 10px; color: var(--text-dim); margin-left: 6px; flex-shrink: 0;
+}
+.ep-diag-dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
 
 /* ── Endpoint code panel ── */
 .ep-code-panel {

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1141,6 +1141,9 @@ canvas:active { cursor: grabbing; }
 .ep-legend-break {
   background: #1a1408; border: 1px solid #f59e0b; border-left: 3px solid #ea2845;
 }
+.ep-legend-value-edge {
+  background: none; border: 1px dotted #5b9bd5; height: 8px;
+}
 .ep-legend-glyph { width: 14px; text-align: center; flex-shrink: 0; font-size: 11px; }
 .ep-legend-order {
   width: 14px; text-align: center; flex-shrink: 0; font-size: 9px; color: #999;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1071,12 +1071,22 @@ canvas:active { cursor: grabbing; }
   position: absolute; top: 12px; right: 12px; z-index: 10;
   display: flex; gap: 4px;
 }
-#endpoints-empty-state {
-  display: none; position: absolute; top: 0; left: 0; right: 0; bottom: 0;
-  flex-direction: column; align-items: center; justify-content: center;
-  color: var(--text-muted); gap: 12px; text-align: center; z-index: 5;
+#endpoints-diag-panel {
+  flex: none; border-top: 1px solid var(--border); background: var(--surface);
 }
-#endpoints-empty-state p { font-size: 14px; color: var(--text-dim); margin: 0; }
+#endpoints-diag-header {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 12px; cursor: pointer; user-select: none;
+  transition: background 0.15s;
+}
+#endpoints-diag-header:hover { background: var(--surface-hover); }
+.ep-diag-caveat {
+  padding: 0 12px 6px; font-size: 10px; color: var(--text-dim);
+}
+#endpoints-diag-body {
+  max-height: 220px; overflow-y: auto;
+  border-top: 1px solid var(--border);
+}
 .ep-method-badge {
   display: inline-block; font-size: 9px; font-weight: 700;
   padding: 1px 6px; border-radius: 3px; margin-right: 6px;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1068,6 +1068,20 @@ canvas:active { cursor: grabbing; }
   cursor: grab; display: block;
 }
 #endpoints-canvas:active { cursor: grabbing; }
+#tab-endpoints.sidebar-collapsed #endpoints-sidebar { display: none; }
+#endpoints-sidebar-show { display: none; }
+#tab-endpoints.sidebar-collapsed #endpoints-sidebar-show {
+  display: flex; position: absolute; top: 12px; left: 12px; z-index: 10;
+  width: 28px; height: 28px; justify-content: center;
+  background: rgba(50,50,50,0.9);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255,255,255,0.22);
+  color: rgba(255,255,255,0.7);
+}
+#tab-endpoints.sidebar-collapsed #endpoints-sidebar-show:hover {
+  background: rgba(70,70,70,0.95); color: #fff;
+}
+#endpoints-sidebar-show:is(:hover, :focus-visible)::after { left: 0; right: auto; }
 #endpoints-toolbar {
   position: absolute; top: 12px; right: 12px; z-index: 12;
   display: flex; align-items: center; gap: 4px;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1183,12 +1183,13 @@ canvas:active { cursor: grabbing; }
 
 /* ── Endpoint code panel ── */
 .ep-code-panel {
-  position: absolute; right: 0; top: 0; bottom: 0; width: 500px; z-index: 10;
-  background: var(--surface); border-left: 1px solid var(--border);
+  position: absolute; left: 0; top: 0; bottom: 0; width: 500px; z-index: 10;
+  background: var(--surface); border-right: 1px solid var(--border);
   display: flex; flex-direction: column;
-  transform: translateX(100%); transition: transform 0.25s ease;
+  transform: translateX(-100%); opacity: 0;
+  transition: transform 0.16s ease-out, opacity 0.16s ease-out;
 }
-.ep-code-panel.open { transform: translateX(0); }
+.ep-code-panel.open { transform: translateX(0); opacity: 1; }
 .ep-code-panel-header {
   padding: 14px 16px 10px; border-bottom: 1px solid var(--border);
   position: relative; flex-shrink: 0;
@@ -1220,7 +1221,7 @@ canvas:active { cursor: grabbing; }
   padding: 24px;
 }
 .ep-code-panel-resize {
-  position: absolute; left: -2px; top: 0; bottom: 0; width: 5px;
+  position: absolute; right: -2px; top: 0; bottom: 0; width: 5px;
   cursor: col-resize; z-index: 11;
   background: transparent;
   transition: background 0.15s;

--- a/packages/nestjs-doctor/tests/unit/endpoint-diagnostics.test.ts
+++ b/packages/nestjs-doctor/tests/unit/endpoint-diagnostics.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import type { Diagnostic } from "../../src/common/diagnostic.js";
+import type { EndpointNode } from "../../src/common/endpoint.js";
+import {
+	computeEndpointDiagnostics,
+	type EndpointDiagnosticCounts,
+} from "../../src/report/formatters/endpoint-diagnostics.js";
+
+function emptyCounts(): EndpointDiagnosticCounts {
+	return { perEndpoint: {}, perFile: {} };
+}
+
+function fakeEndpoint(overrides: Partial<EndpointNode>): EndpointNode {
+	return {
+		controllerClass: "CatsController",
+		dependencies: [],
+		endLine: 10,
+		filePath: "cats.controller.ts",
+		handlerMethod: "list",
+		httpMethod: "GET",
+		line: 5,
+		returnType: null,
+		routePath: "cats",
+		swagger: null,
+		...overrides,
+	};
+}
+
+function fakeCodeDiagnostic(overrides: Partial<Diagnostic> = {}): Diagnostic {
+	return {
+		category: "correctness",
+		column: 1,
+		filePath: "cats.controller.ts",
+		help: "help text",
+		line: 7,
+		message: "message text",
+		rule: "correctness/fake-rule",
+		severity: "warning",
+		...overrides,
+	};
+}
+
+function fakeSchemaDiagnostic(overrides: Partial<Diagnostic> = {}): Diagnostic {
+	return {
+		category: "schema",
+		entity: "Cat",
+		filePath: "cats.controller.ts",
+		help: "help text",
+		message: "message text",
+		rule: "schema/fake-rule",
+		severity: "warning",
+		...overrides,
+	};
+}
+
+describe("computeEndpointDiagnostics", () => {
+	it("counts a diagnostic on the handler line for the matching endpoint", () => {
+		const endpoints = [fakeEndpoint({ line: 5, endLine: 10 })];
+		const diagnostics = [fakeCodeDiagnostic({ line: 7 })];
+
+		const result = computeEndpointDiagnostics(endpoints, diagnostics);
+
+		expect(result.perEndpoint["0"]).toEqual({
+			error: 0,
+			warning: 1,
+			info: 0,
+		});
+		expect(result.perFile).toEqual({});
+	});
+
+	it("counts a diagnostic on both endpoints when one handler emits GET+POST", () => {
+		const endpoints = [
+			fakeEndpoint({ line: 5, endLine: 10, httpMethod: "GET" }),
+			fakeEndpoint({ line: 5, endLine: 10, httpMethod: "POST" }),
+		];
+		const diagnostics = [fakeCodeDiagnostic({ line: 8 })];
+
+		const result = computeEndpointDiagnostics(endpoints, diagnostics);
+
+		expect(result.perEndpoint["0"]).toEqual({
+			error: 0,
+			warning: 1,
+			info: 0,
+		});
+		expect(result.perEndpoint["1"]).toEqual({
+			error: 0,
+			warning: 1,
+			info: 0,
+		});
+	});
+
+	it("puts a diagnostic outside every handler range into perFile", () => {
+		const endpoints = [fakeEndpoint({ line: 5, endLine: 10 })];
+		const diagnostics = [fakeCodeDiagnostic({ line: 2 })];
+
+		const result = computeEndpointDiagnostics(endpoints, diagnostics);
+
+		expect(result.perEndpoint).toEqual({});
+		expect(result.perFile["cats.controller.ts"]).toEqual({
+			error: 0,
+			warning: 1,
+			info: 0,
+		});
+	});
+
+	it("ignores schema diagnostics without crashing", () => {
+		const endpoints = [fakeEndpoint({ line: 5, endLine: 10 })];
+		const diagnostics = [fakeSchemaDiagnostic()];
+
+		const result = computeEndpointDiagnostics(endpoints, diagnostics);
+
+		expect(result).toEqual(emptyCounts());
+	});
+
+	it("ignores diagnostics in files with no endpoints", () => {
+		const endpoints = [fakeEndpoint({ filePath: "cats.controller.ts" })];
+		const diagnostics = [
+			fakeCodeDiagnostic({ filePath: "dogs.controller.ts", line: 3 }),
+		];
+
+		const result = computeEndpointDiagnostics(endpoints, diagnostics);
+
+		expect(result).toEqual(emptyCounts());
+	});
+
+	it("buckets severities correctly", () => {
+		const endpoints = [fakeEndpoint({ line: 5, endLine: 10 })];
+		const diagnostics = [
+			fakeCodeDiagnostic({ line: 6, severity: "error" }),
+			fakeCodeDiagnostic({ line: 7, severity: "warning" }),
+			fakeCodeDiagnostic({ line: 8, severity: "info" }),
+			fakeCodeDiagnostic({ line: 9, severity: "error" }),
+		];
+
+		const result = computeEndpointDiagnostics(endpoints, diagnostics);
+
+		expect(result.perEndpoint["0"]).toEqual({
+			error: 2,
+			warning: 1,
+			info: 1,
+		});
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import {
+	getReportScripts,
+	type ReportScriptData,
+} from "../../src/report/ui/scripts.js";
+
+const EMPTY: ReportScriptData = {
+	diagnosticsJson: "[]",
+	elapsedMsJson: "0",
+	endpointDiagnosticsJson: '{"perEndpoint":{},"perFile":{}}',
+	endpointsJson: '{"endpoints":[]}',
+	examplesJson: "[]",
+	fileSourcesJson: "{}",
+	graphJson: '{"modules":[],"edges":[]}',
+	projectJson: "{}",
+	providersJson: "[]",
+	schemaJson: "null",
+	sourceLinesJson: "{}",
+	summaryJson: "{}",
+};
+
+const EP_BOX_W = 320;
+
+interface Box {
+	controllerClass: string;
+	endpointIndices: number[];
+	h: number;
+	w: number;
+	x: number;
+	y: number;
+}
+
+interface Group {
+	boxes: Box[];
+	h: number;
+	headerY: number;
+	label: string;
+	w: number;
+}
+
+/**
+ * Pulls the pure box-sizing helpers out of the emitted script by name, the same
+ * way report-schema-layout.test.ts extracts sNodeHeight/sVisibleColCount.
+ */
+function getSizingHelpers(): {
+	epBoxHeight: (count: number) => number;
+	epRowCount: (count: number) => number;
+	EP_BOX_HEADER_H: number;
+	EP_BOX_PAD_BOTTOM: number;
+	EP_MAX_VISIBLE_ROWS: number;
+	EP_ROW_H: number;
+} {
+	const scripts = getReportScripts(EMPTY);
+	const start = scripts.indexOf("var EP_BOX_W");
+	const end = scripts.indexOf("function epCacheOverviewLabels");
+	if (start < 0 || end <= start) {
+		throw new Error(
+			"box sizing helpers not found in the emitted report script"
+		);
+	}
+	const factory = new Function(
+		`${scripts.slice(start, end)}\nreturn { epRowCount: epRowCount, epBoxHeight: epBoxHeight, EP_BOX_HEADER_H: EP_BOX_HEADER_H, EP_ROW_H: EP_ROW_H, EP_BOX_PAD_BOTTOM: EP_BOX_PAD_BOTTOM, EP_MAX_VISIBLE_ROWS: EP_MAX_VISIBLE_ROWS };`
+	);
+	return factory();
+}
+
+/**
+ * Pulls the pure layout function out of the emitted script and runs it against
+ * synthetic module/controller groups, the same extraction technique
+ * report-schema-layout.test.ts uses for sComputeOverviewLayout.
+ */
+function runOverviewLayout(groups: Group[], boxWidth: number): void {
+	const scripts = getReportScripts(EMPTY);
+	const start = scripts.indexOf("// ep-overview-layout-start");
+	const end = scripts.indexOf("// ep-overview-layout-end");
+	if (start < 0 || end <= start) {
+		throw new Error("layout functions not found in the emitted report script");
+	}
+
+	const factory = new Function(
+		"groups",
+		"boxWidth",
+		`${scripts.slice(start, end)}\nepComputeOverviewLayout(groups, boxWidth);`
+	);
+	factory(groups, boxWidth);
+}
+
+function overlaps(a: Box, b: Box): boolean {
+	return (
+		Math.abs(a.x - b.x) < (a.w + b.w) / 2 &&
+		Math.abs(a.y - b.y) < (a.h + b.h) / 2
+	);
+}
+
+function findOverlap(boxes: Box[]): string | null {
+	for (let i = 0; i < boxes.length; i++) {
+		for (let j = i + 1; j < boxes.length; j++) {
+			if (overlaps(boxes[i], boxes[j])) {
+				return `${boxes[i].controllerClass} overlaps ${boxes[j].controllerClass}`;
+			}
+		}
+	}
+	return null;
+}
+
+/** 30 endpoints across 8 controllers in 3 modules; one controller exceeds the 12-row cap. */
+function buildFixture(epBoxHeight: (count: number) => number): {
+	groups: Group[];
+	totalEndpoints: number;
+} {
+	const controllerCounts: Array<{
+		controller: string;
+		count: number;
+		module: string;
+	}> = [
+		{ controller: "UsersController", count: 15, module: "UsersModule" },
+		{ controller: "ProfilesController", count: 3, module: "UsersModule" },
+		{ controller: "SessionsController", count: 2, module: "UsersModule" },
+		{ controller: "OrdersController", count: 4, module: "OrdersModule" },
+		{ controller: "InvoicesController", count: 2, module: "OrdersModule" },
+		{ controller: "HealthController", count: 1, module: "AdminModule" },
+		{ controller: "MetricsController", count: 2, module: "AdminModule" },
+		{ controller: "AuditController", count: 1, module: "AdminModule" },
+	];
+
+	let index = 0;
+	const byModule = new Map<string, Box[]>();
+	const moduleOrder: string[] = [];
+	let totalEndpoints = 0;
+
+	for (const entry of controllerCounts) {
+		const endpointIndices: number[] = [];
+		for (let i = 0; i < entry.count; i++) {
+			endpointIndices.push(index++);
+		}
+		totalEndpoints += entry.count;
+
+		if (!byModule.has(entry.module)) {
+			byModule.set(entry.module, []);
+			moduleOrder.push(entry.module);
+		}
+		byModule.get(entry.module)?.push({
+			controllerClass: entry.controller,
+			endpointIndices,
+			h: epBoxHeight(entry.count),
+			w: EP_BOX_W,
+			x: 0,
+			y: 0,
+		});
+	}
+
+	const groups: Group[] = moduleOrder.map((label) => ({
+		boxes: byModule.get(label) ?? [],
+		h: 0,
+		headerY: 0,
+		label,
+		w: 0,
+	}));
+
+	return { groups, totalEndpoints };
+}
+
+describe("endpoints overview box sizing", () => {
+	it("caps visible rows at 12 and adds one +N more row only once past the cap", () => {
+		const {
+			epRowCount,
+			epBoxHeight,
+			EP_BOX_HEADER_H,
+			EP_ROW_H,
+			EP_BOX_PAD_BOTTOM,
+			EP_MAX_VISIBLE_ROWS,
+		} = getSizingHelpers();
+
+		expect(EP_MAX_VISIBLE_ROWS).toBe(12);
+		expect(epRowCount(30)).toBe(12);
+		expect(epRowCount(5)).toBe(5);
+
+		// Exactly at the cap: no hidden endpoints, no "+N more" row.
+		const atCap = epBoxHeight(12);
+		expect(atCap).toBe(EP_BOX_HEADER_H + 12 * EP_ROW_H + EP_BOX_PAD_BOTTOM);
+
+		// One past the cap: a single extra row for "+1 more".
+		const onePast = epBoxHeight(13);
+		expect(onePast).toBe(atCap + EP_ROW_H);
+
+		// Any further growth adds no more height — still just one "+N more" row.
+		const wayPast = epBoxHeight(30);
+		expect(wayPast).toBe(onePast);
+	});
+});
+
+describe("endpoints overview layout", () => {
+	it("packs boxes without overlap within or across module clusters", () => {
+		const { epBoxHeight } = getSizingHelpers();
+		const { groups } = buildFixture(epBoxHeight);
+		runOverviewLayout(groups, EP_BOX_W);
+
+		const allBoxes = groups.flatMap((g) => g.boxes);
+		expect(allBoxes).toHaveLength(8);
+		expect(findOverlap(allBoxes)).toBeNull();
+	});
+
+	it("keeps every module's boxes in a Y-band that does not overlap another module's", () => {
+		const { epBoxHeight } = getSizingHelpers();
+		const { groups } = buildFixture(epBoxHeight);
+		runOverviewLayout(groups, EP_BOX_W);
+
+		const bands = groups.map((g) => {
+			const tops = g.boxes.map((b) => b.y - b.h / 2);
+			const bottoms = g.boxes.map((b) => b.y + b.h / 2);
+			return { min: Math.min(...tops), max: Math.max(...bottoms) };
+		});
+
+		for (let i = 0; i < bands.length; i++) {
+			for (let j = i + 1; j < bands.length; j++) {
+				const disjoint =
+					bands[i].max <= bands[j].min || bands[j].max <= bands[i].min;
+				expect(disjoint).toBe(true);
+			}
+		}
+	});
+
+	it("preserves which module each controller box belongs to", () => {
+		const { epBoxHeight } = getSizingHelpers();
+		const { groups } = buildFixture(epBoxHeight);
+		const before = groups.map((g) => ({
+			label: g.label,
+			controllers: g.boxes.map((b) => b.controllerClass),
+		}));
+
+		runOverviewLayout(groups, EP_BOX_W);
+
+		const after = groups.map((g) => ({
+			label: g.label,
+			controllers: g.boxes.map((b) => b.controllerClass),
+		}));
+		expect(after).toEqual(before);
+	});
+
+	it("produces an identical layout across repeated runs", () => {
+		const { epBoxHeight } = getSizingHelpers();
+		const first = buildFixture(epBoxHeight).groups;
+		const second = buildFixture(epBoxHeight).groups;
+
+		runOverviewLayout(first, EP_BOX_W);
+		runOverviewLayout(second, EP_BOX_W);
+
+		const strip = (groups: Group[]) =>
+			groups.map((g) => ({
+				headerY: g.headerY,
+				w: g.w,
+				h: g.h,
+				boxes: g.boxes.map((b) => ({ x: b.x, y: b.y, w: b.w, h: b.h })),
+			}));
+
+		expect(strip(first)).toEqual(strip(second));
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
@@ -120,6 +120,177 @@ function runTreeVisibility(nodes: TreeNode[], edges: TreeEdge[]): void {
 	factory(nodes, edges);
 }
 
+interface DepParam {
+	name: string;
+	type: string | null;
+}
+
+interface DepGuardThrow {
+	branchKind: string | null;
+	callSiteLine: number;
+	className: string;
+	conditionText: string | null;
+	message: string | null;
+}
+
+interface DepFixture {
+	assignedTo: string | null;
+	branchKind: string | null;
+	className: string;
+	conditional: boolean;
+	conditionText: string | null;
+	dependencies: DepFixture[];
+	endLine: number;
+	filePath: string;
+	guardThrow: DepGuardThrow | null;
+	iterationKind: string | null;
+	iterationLabel: string | null;
+	line: number;
+	methodName: string;
+	parameters: DepParam[];
+	throwMessage: string | null;
+	totalMethods: number;
+	type: string;
+}
+
+interface EndpointFixture {
+	controllerClass: string;
+	dependencies: DepFixture[];
+	endLine: number;
+	filePath: string;
+	handlerMethod: string;
+	line: number;
+}
+
+interface BuildGraphNode {
+	assignedTo?: string | null;
+	className: string;
+	displayOrder?: number;
+	expanded: boolean;
+	id: number;
+	kind?: string;
+	methodName: string | null;
+}
+
+interface BuildGraphEdge {
+	conditional: boolean;
+	from: number;
+	to: number;
+}
+
+/**
+ * Pulls epBuildGraph (and everything it calls — epClipText, epBuildNodeExtras,
+ * epBuildBreakNodeExtras, epComputeTreeVisibility) out of the emitted script and
+ * runs it against a synthetic endpoint. epNodes/epEdges are declared locally in the
+ * wrapper so epBuildGraph's plain assignments land there instead of leaking globals;
+ * epCtx is stubbed with a measureText so label truncation runs for real.
+ */
+function runBuildGraph(ep: EndpointFixture): {
+	edges: BuildGraphEdge[];
+	nodes: BuildGraphNode[];
+} {
+	const scripts = getReportScripts(EMPTY);
+	const start = scripts.indexOf("// ep-build-graph-start");
+	const end = scripts.indexOf("// ep-build-graph-end");
+	if (start < 0 || end <= start) {
+		throw new Error(
+			"graph-build functions not found in the emitted report script"
+		);
+	}
+
+	const factory = new Function(
+		"ep",
+		"epCtx",
+		`var epNodes, epEdges;\n${scripts.slice(start, end)}\nepBuildGraph(ep);\nreturn { nodes: epNodes, edges: epEdges };`
+	);
+	const stubCtx = {
+		font: "",
+		measureText: (text: string) => ({ width: text.length }),
+	};
+	return factory(ep, stubCtx);
+}
+
+/**
+ * AccessController.deleteAccess() shape: access() (guarded, assigns originalAccess,
+ * itself calling a repository), then deleteAccess(). Mirrors the real Ghostfolio
+ * DELETE /access/:id handler this feature was built against.
+ */
+function buildGuardThrowFixture(): EndpointFixture {
+	return {
+		controllerClass: "AccessController",
+		dependencies: [
+			{
+				assignedTo: "originalAccess",
+				branchKind: null,
+				className: "AccessService",
+				conditional: false,
+				conditionText: null,
+				dependencies: [
+					{
+						assignedTo: null,
+						branchKind: null,
+						className: "PrismaService",
+						conditional: false,
+						conditionText: null,
+						dependencies: [],
+						endLine: 3,
+						filePath: "prisma.service.ts",
+						guardThrow: null,
+						iterationKind: null,
+						iterationLabel: null,
+						line: 3,
+						methodName: "findUnique",
+						parameters: [],
+						throwMessage: null,
+						totalMethods: 1,
+						type: "repository",
+					},
+				],
+				endLine: 5,
+				filePath: "access.service.ts",
+				guardThrow: {
+					branchKind: "if",
+					callSiteLine: 12,
+					className: "HttpException",
+					conditionText: "!originalAccess",
+					message: "Forbidden",
+				},
+				iterationKind: null,
+				iterationLabel: null,
+				line: 5,
+				methodName: "access",
+				parameters: [{ name: "where", type: "AccessWhereInput" }],
+				throwMessage: null,
+				totalMethods: 1,
+				type: "service",
+			},
+			{
+				assignedTo: null,
+				branchKind: null,
+				className: "AccessService",
+				conditional: false,
+				conditionText: null,
+				dependencies: [],
+				endLine: 8,
+				filePath: "access.service.ts",
+				guardThrow: null,
+				iterationKind: null,
+				iterationLabel: null,
+				line: 8,
+				methodName: "deleteAccess",
+				parameters: [{ name: "id", type: "string" }],
+				throwMessage: null,
+				totalMethods: 1,
+				type: "service",
+			},
+		],
+		endLine: 20,
+		filePath: "access.controller.ts",
+		handlerMethod: "deleteAccess",
+		line: 10,
+	};
+}
+
 /**
  * root(0) -> A(1), B(2); A(1) -> A1(3), A2(4); B(2) -> B1(5); A1(3) -> A1a(6).
  * Root starts expanded (depth-1 default-visible), everything else collapsed.
@@ -471,5 +642,73 @@ describe("endpoints focused-tree visibility", () => {
 			}));
 
 		expect(strip(first.nodes)).toEqual(strip(second.nodes));
+	});
+});
+
+describe("endpoints focused-tree display numbering", () => {
+	it("numbers the Ghostfolio flagship case #1 access / #2 break / #3 deleteAccess", () => {
+		const { nodes, edges } = runBuildGraph(buildGuardThrowFixture());
+
+		// Root is always id 0 — the first node epBuildGraph creates.
+		const rootLevelIds = edges.filter((e) => e.from === 0).map((e) => e.to);
+		const rootLevel = rootLevelIds.map(
+			(id) => nodes.find((n) => n.id === id) as BuildGraphNode
+		);
+
+		expect(rootLevel.map((n) => n.methodName ?? n.kind)).toEqual([
+			"access",
+			"break",
+			"deleteAccess",
+		]);
+		expect(rootLevel.map((n) => n.displayOrder)).toEqual([0, 1, 2]);
+	});
+
+	it("inserts the break node under the guarded call's own parent, not its subtree", () => {
+		const { nodes, edges } = runBuildGraph(buildGuardThrowFixture());
+
+		const accessNode = nodes.find((n) => n.methodName === "access");
+		const breakNode = nodes.find((n) => n.kind === "break");
+		const accessEdge = edges.find((e) => e.to === accessNode?.id);
+		const breakEdge = edges.find((e) => e.to === breakNode?.id);
+
+		// Same parent as the guarded call (the root/caller), not the call itself.
+		expect(breakEdge?.from).toBe(accessEdge?.from);
+
+		// access()'s own child (findUnique) hangs off access(), not off the break node.
+		const childEdge = edges.find((e) => e.from === accessNode?.id);
+		expect(childEdge).toBeDefined();
+		expect(childEdge?.from).not.toBe(breakNode?.id);
+	});
+
+	it("restarts numbering per sibling level instead of sorting the whole tree", () => {
+		const { nodes, edges } = runBuildGraph(buildGuardThrowFixture());
+
+		const accessNode = nodes.find((n) => n.methodName === "access");
+		const findUniqueEdge = edges.find((e) => e.from === accessNode?.id);
+		const findUniqueNode = nodes.find((n) => n.id === findUniqueEdge?.to);
+
+		// access()'s only child is the first (and only) call at its own level, #1
+		// again — same number as access() itself at the root level, by design.
+		expect(findUniqueNode?.displayOrder).toBe(0);
+	});
+
+	it("keeps display numbers stable across a simulated collapse/expand", () => {
+		const { nodes, edges } = runBuildGraph(buildGuardThrowFixture());
+		const before = nodes.map((n) => ({
+			id: n.id,
+			displayOrder: n.displayOrder,
+		}));
+
+		const root = nodes.find((n) => n.id === 0) as unknown as TreeNode;
+		root.expanded = false;
+		runTreeVisibility(nodes as unknown as TreeNode[], edges);
+		root.expanded = true;
+		runTreeVisibility(nodes as unknown as TreeNode[], edges);
+
+		const after = nodes.map((n) => ({
+			id: n.id,
+			displayOrder: n.displayOrder,
+		}));
+		expect(after).toEqual(before);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
@@ -175,6 +175,7 @@ interface BuildGraphNode {
 interface BuildGraphEdge {
 	conditional: boolean;
 	from: number;
+	kind?: string;
 	to: number;
 }
 
@@ -675,16 +676,22 @@ describe("endpoints focused-tree display numbering", () => {
 		expect(breakEdge?.from).toBe(accessEdge?.from);
 
 		// access()'s own child (findUnique) hangs off access(), not off the break node.
-		const childEdge = edges.find((e) => e.from === accessNode?.id);
+		// Excludes the value edge (access() also has one of those to the break node).
+		const childEdge = edges.find(
+			(e) => e.from === accessNode?.id && e.kind !== "value"
+		);
 		expect(childEdge).toBeDefined();
-		expect(childEdge?.from).not.toBe(breakNode?.id);
+		expect(childEdge?.to).not.toBe(breakNode?.id);
 	});
 
 	it("restarts numbering per sibling level instead of sorting the whole tree", () => {
 		const { nodes, edges } = runBuildGraph(buildGuardThrowFixture());
 
 		const accessNode = nodes.find((n) => n.methodName === "access");
-		const findUniqueEdge = edges.find((e) => e.from === accessNode?.id);
+		// Excludes the value edge (access() also has one of those to the break node).
+		const findUniqueEdge = edges.find(
+			(e) => e.from === accessNode?.id && e.kind !== "value"
+		);
 		const findUniqueNode = nodes.find((n) => n.id === findUniqueEdge?.to);
 
 		// access()'s only child is the first (and only) call at its own level, #1
@@ -710,5 +717,36 @@ describe("endpoints focused-tree display numbering", () => {
 			displayOrder: n.displayOrder,
 		}));
 		expect(after).toEqual(before);
+	});
+});
+
+describe("endpoints focused-tree value edges", () => {
+	it("adds a value edge from the guarded call to its break step, alongside the structural edge", () => {
+		const { nodes, edges } = runBuildGraph(buildGuardThrowFixture());
+
+		const accessNode = nodes.find((n) => n.methodName === "access");
+		const breakNode = nodes.find((n) => n.kind === "break");
+
+		const valueEdge = edges.find(
+			(e) => e.kind === "value" && e.to === breakNode?.id
+		);
+		expect(valueEdge?.from).toBe(accessNode?.id);
+
+		// Additional to, not instead of, the structural caller-to-break-step edge.
+		const structuralEdgesToBreak = edges.filter(
+			(e) => e.to === breakNode?.id && e.kind !== "value"
+		);
+		expect(structuralEdgesToBreak).toHaveLength(1);
+		expect(structuralEdgesToBreak[0].from).not.toBe(accessNode?.id);
+	});
+
+	it("leaves non-guard edges without a kind", () => {
+		const { edges } = runBuildGraph(buildGuardThrowFixture());
+
+		const nonValueEdges = edges.filter((e) => e.kind !== "value");
+		expect(nonValueEdges.length).toBeGreaterThan(0);
+		for (const e of nonValueEdges) {
+			expect(e.kind).toBeUndefined();
+		}
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
@@ -85,6 +85,81 @@ function runOverviewLayout(groups: Group[], boxWidth: number): void {
 	factory(groups, boxWidth);
 }
 
+interface TreeNode {
+	childCount?: number;
+	expanded: boolean;
+	id: number;
+	visible?: boolean;
+}
+
+interface TreeEdge {
+	from: number;
+	to: number;
+}
+
+/**
+ * Pulls the pure visibility function out of the emitted script and runs it
+ * against synthetic nodes/edges, the same extraction technique
+ * runOverviewLayout uses for epComputeOverviewLayout.
+ */
+function runTreeVisibility(nodes: TreeNode[], edges: TreeEdge[]): void {
+	const scripts = getReportScripts(EMPTY);
+	const start = scripts.indexOf("// ep-tree-visibility-start");
+	const end = scripts.indexOf("// ep-tree-visibility-end");
+	if (start < 0 || end <= start) {
+		throw new Error(
+			"tree visibility function not found in the emitted report script"
+		);
+	}
+
+	const factory = new Function(
+		"nodes",
+		"edges",
+		`${scripts.slice(start, end)}\nepComputeTreeVisibility(nodes, edges);`
+	);
+	factory(nodes, edges);
+}
+
+/**
+ * root(0) -> A(1), B(2); A(1) -> A1(3), A2(4); B(2) -> B1(5); A1(3) -> A1a(6).
+ * Root starts expanded (depth-1 default-visible), everything else collapsed.
+ */
+function buildTreeFixture(): { edges: TreeEdge[]; nodes: TreeNode[] } {
+	const nodes: TreeNode[] = [
+		{ id: 0, expanded: true },
+		{ id: 1, expanded: false },
+		{ id: 2, expanded: false },
+		{ id: 3, expanded: false },
+		{ id: 4, expanded: false },
+		{ id: 5, expanded: false },
+		{ id: 6, expanded: false },
+	];
+	const edges: TreeEdge[] = [
+		{ from: 0, to: 1 },
+		{ from: 0, to: 2 },
+		{ from: 1, to: 3 },
+		{ from: 1, to: 4 },
+		{ from: 2, to: 5 },
+		{ from: 3, to: 6 },
+	];
+	return { nodes, edges };
+}
+
+function visibleIds(nodes: TreeNode[]): number[] {
+	return nodes
+		.filter((n) => n.visible)
+		.map((n) => n.id)
+		.sort((a, b) => a - b);
+}
+
+function findNode(nodes: TreeNode[], id: number): TreeNode {
+	const found = nodes.find((n) => n.id === id);
+	if (!found) {
+		throw new Error(`fixture missing node ${id}`);
+	}
+	return found;
+}
+
 function overlaps(a: Box, b: Box): boolean {
 	return (
 		Math.abs(a.x - b.x) < (a.w + b.w) / 2 &&
@@ -335,5 +410,66 @@ describe("endpoints overview layout — many small modules (real-project shape)"
 			}));
 
 		expect(strip(first)).toEqual(strip(second));
+	});
+});
+
+describe("endpoints focused-tree visibility", () => {
+	it("defaults to the root plus its direct children", () => {
+		const { nodes, edges } = buildTreeFixture();
+		runTreeVisibility(nodes, edges);
+
+		expect(visibleIds(nodes)).toEqual([0, 1, 2]);
+		expect(findNode(nodes, 0).childCount).toBe(2);
+		expect(findNode(nodes, 1).childCount).toBe(2);
+		expect(findNode(nodes, 2).childCount).toBe(1);
+		expect(findNode(nodes, 6).childCount).toBe(0);
+	});
+
+	it("expanding a node reveals exactly its own children, not grandchildren", () => {
+		const { nodes, edges } = buildTreeFixture();
+		runTreeVisibility(nodes, edges);
+
+		findNode(nodes, 1).expanded = true; // expand A
+		runTreeVisibility(nodes, edges);
+
+		expect(visibleIds(nodes)).toEqual([0, 1, 2, 3, 4]);
+	});
+
+	it("collapsing an ancestor hides descendants while their own expanded flags persist", () => {
+		const { nodes, edges } = buildTreeFixture();
+
+		findNode(nodes, 1).expanded = true; // A
+		findNode(nodes, 3).expanded = true; // A1
+		runTreeVisibility(nodes, edges);
+		expect(visibleIds(nodes)).toEqual([0, 1, 2, 3, 4, 6]);
+
+		findNode(nodes, 1).expanded = false; // collapse A
+		runTreeVisibility(nodes, edges);
+		expect(visibleIds(nodes)).toEqual([0, 1, 2]);
+		expect(findNode(nodes, 3).expanded).toBe(true); // A1's own flag untouched
+
+		findNode(nodes, 1).expanded = true; // re-expand A
+		runTreeVisibility(nodes, edges);
+		// A1a (6) reappears without re-toggling A1 (3) — its flag never changed.
+		expect(visibleIds(nodes)).toEqual([0, 1, 2, 3, 4, 6]);
+	});
+
+	it("is deterministic across repeated runs", () => {
+		const first = buildTreeFixture();
+		const second = buildTreeFixture();
+		first.nodes[1].expanded = true;
+		second.nodes[1].expanded = true;
+
+		runTreeVisibility(first.nodes, first.edges);
+		runTreeVisibility(second.nodes, second.edges);
+
+		const strip = (nodes: TreeNode[]) =>
+			nodes.map((n) => ({
+				id: n.id,
+				visible: n.visible,
+				childCount: n.childCount,
+			}));
+
+		expect(strip(first.nodes)).toEqual(strip(second.nodes));
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
@@ -160,6 +160,33 @@ function buildFixture(epBoxHeight: (count: number) => number): {
 	return { groups, totalEndpoints };
 }
 
+/** 40 modules, each with one controller and 1-2 endpoints — Twenty-shaped: lots of tiny modules. */
+function buildManySmallModulesFixture(
+	epBoxHeight: (count: number) => number
+): Group[] {
+	const groups: Group[] = [];
+	for (let m = 0; m < 40; m++) {
+		const count = m % 2 === 0 ? 1 : 2;
+		groups.push({
+			boxes: [
+				{
+					controllerClass: `Controller${m}`,
+					endpointIndices: Array.from({ length: count }, (_, i) => i),
+					h: epBoxHeight(count),
+					w: EP_BOX_W,
+					x: 0,
+					y: 0,
+				},
+			],
+			h: 0,
+			headerY: 0,
+			label: `Module${m}`,
+			w: 0,
+		});
+	}
+	return groups;
+}
+
 describe("endpoints overview box sizing", () => {
 	it("caps visible rows at 12 and adds one +N more row only once past the cap", () => {
 		const {
@@ -241,6 +268,60 @@ describe("endpoints overview layout", () => {
 		const { epBoxHeight } = getSizingHelpers();
 		const first = buildFixture(epBoxHeight).groups;
 		const second = buildFixture(epBoxHeight).groups;
+
+		runOverviewLayout(first, EP_BOX_W);
+		runOverviewLayout(second, EP_BOX_W);
+
+		const strip = (groups: Group[]) =>
+			groups.map((g) => ({
+				headerY: g.headerY,
+				w: g.w,
+				h: g.h,
+				boxes: g.boxes.map((b) => ({ x: b.x, y: b.y, w: b.w, h: b.h })),
+			}));
+
+		expect(strip(first)).toEqual(strip(second));
+	});
+});
+
+describe("endpoints overview layout — many small modules (real-project shape)", () => {
+	it("packs one-controller modules onto shared rows instead of one per row", () => {
+		const { epBoxHeight } = getSizingHelpers();
+		const groups = buildManySmallModulesFixture(epBoxHeight);
+		runOverviewLayout(groups, EP_BOX_W);
+
+		const allBoxes = groups.flatMap((g) => g.boxes);
+		expect(findOverlap(allBoxes)).toBeNull();
+
+		// (b) more than one group per row: some pair of groups' headerY..headerY+h
+		// ranges overlap, instead of every group getting its own vertical band.
+		const bands = groups.map((g) => ({ min: g.headerY, max: g.headerY + g.h }));
+		let sharedRow = false;
+		for (let i = 0; i < bands.length && !sharedRow; i++) {
+			for (let j = i + 1; j < bands.length; j++) {
+				if (bands[i].max > bands[j].min && bands[j].max > bands[i].min) {
+					sharedRow = true;
+					break;
+				}
+			}
+		}
+		expect(sharedRow).toBe(true);
+
+		// (c) bounded aspect ratio: a skyscraper of 40 one-per-row modules would be
+		// far taller than wide; packed onto rows it stays close to square-ish.
+		const minX = Math.min(...allBoxes.map((b) => b.x - b.w / 2));
+		const maxX = Math.max(...allBoxes.map((b) => b.x + b.w / 2));
+		const minY = Math.min(...groups.map((g) => g.headerY));
+		const maxY = Math.max(...allBoxes.map((b) => b.y + b.h / 2));
+		const width = maxX - minX;
+		const height = maxY - minY;
+		expect(height).toBeLessThanOrEqual(width * 3);
+	});
+
+	it("produces an identical layout across repeated runs", () => {
+		const { epBoxHeight } = getSizingHelpers();
+		const first = buildManySmallModulesFixture(epBoxHeight);
+		const second = buildManySmallModulesFixture(epBoxHeight);
 
 		runOverviewLayout(first, EP_BOX_W);
 		runOverviewLayout(second, EP_BOX_W);

--- a/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-endpoints-layout.test.ts
@@ -164,12 +164,18 @@ interface EndpointFixture {
 
 interface BuildGraphNode {
 	assignedTo?: string | null;
+	childCount?: number;
 	className: string;
 	displayOrder?: number;
 	expanded: boolean;
+	h?: number;
 	id: number;
 	kind?: string;
 	methodName: string | null;
+	visible?: boolean;
+	w?: number;
+	x?: number;
+	y?: number;
 }
 
 interface BuildGraphEdge {
@@ -209,6 +215,89 @@ function runBuildGraph(ep: EndpointFixture): {
 		measureText: (text: string) => ({ width: text.length }),
 	};
 	return factory(ep, stubCtx);
+}
+
+interface FakeDagreEdge {
+	from: number;
+	to: number;
+}
+
+/**
+ * Minimal stand-in for dagre's graphlib.Graph, just enough of the API epLayout
+ * calls (setGraph/setDefaultEdgeLabel/setNode/setEdge/node, dagre.layout). Ranks
+ * nodes by longest path over the edges actually passed to setEdge — the same
+ * rule real dagre uses — so a value edge that leaks through still visibly pushes
+ * its target a rank deeper, the way it did against real dagre 0.8.5.
+ */
+function makeFakeDagre(): { dagre: unknown; recordedEdges: FakeDagreEdge[] } {
+	const recordedEdges: FakeDagreEdge[] = [];
+	const sizes = new Map<number, unknown>();
+	let positions = new Map<number, { x: number; y: number }>();
+
+	function FakeGraph(this: Record<string, unknown>) {
+		this.setGraph = () => undefined;
+		this.setDefaultEdgeLabel = () => undefined;
+		this.setNode = (id: number, opts: unknown) => sizes.set(id, opts);
+		this.setEdge = (from: number, to: number) =>
+			recordedEdges.push({ from, to });
+		this.node = (id: number) => positions.get(id);
+	}
+
+	const dagre = {
+		graphlib: { Graph: FakeGraph },
+		layout: () => {
+			const rank = new Map<number, number>();
+			const rankOf = (id: number): number => {
+				const cached = rank.get(id);
+				if (cached !== undefined) {
+					return cached;
+				}
+				const parents = recordedEdges
+					.filter((e) => e.to === id)
+					.map((e) => e.from);
+				const r =
+					parents.length === 0 ? 0 : Math.max(...parents.map(rankOf)) + 1;
+				rank.set(id, r);
+				return r;
+			};
+			for (const id of sizes.keys()) {
+				rankOf(id);
+			}
+			positions = new Map();
+			for (const id of sizes.keys()) {
+				positions.set(id, { x: 0, y: (rank.get(id) ?? 0) * 100 });
+			}
+		},
+	};
+
+	return { dagre, recordedEdges };
+}
+
+/**
+ * Pulls epLayout out of the emitted script and runs it against nodes/edges
+ * already produced by runBuildGraph, with the fake dagre standing in for the
+ * real CDN-loaded one (this repo has no dagre npm dependency to import).
+ */
+function runLayout(
+	nodes: BuildGraphNode[],
+	edges: BuildGraphEdge[]
+): { recordedEdges: FakeDagreEdge[] } {
+	const scripts = getReportScripts(EMPTY);
+	const start = scripts.indexOf("// ep-layout-start");
+	const end = scripts.indexOf("// ep-layout-end");
+	if (start < 0 || end <= start) {
+		throw new Error("epLayout not found in the emitted report script");
+	}
+
+	const { dagre, recordedEdges } = makeFakeDagre();
+	const factory = new Function(
+		"epNodes",
+		"epEdges",
+		"dagre",
+		`${scripts.slice(start, end)}\nepLayout();`
+	);
+	factory(nodes, edges, dagre);
+	return { recordedEdges };
 }
 
 /**
@@ -748,5 +837,30 @@ describe("endpoints focused-tree value edges", () => {
 		for (const e of nonValueEdges) {
 			expect(e.kind).toBeUndefined();
 		}
+	});
+
+	it("does not count the value edge toward the guarded call's childCount", () => {
+		const { nodes } = runBuildGraph(buildGuardThrowFixture());
+
+		const accessNode = nodes.find((n) => n.methodName === "access");
+		// access() has exactly one real child (findUnique) — the value edge to the
+		// break step must not inflate this to 2.
+		expect(accessNode?.childCount).toBe(1);
+	});
+
+	it("does not feed the value edge to dagre, so the break step lands on the same rank as its guarded call", () => {
+		const { nodes, edges } = runBuildGraph(buildGuardThrowFixture());
+		const { recordedEdges } = runLayout(nodes, edges);
+
+		const accessNode = nodes.find((n) => n.methodName === "access");
+		const breakNode = nodes.find((n) => n.kind === "break");
+
+		expect(
+			recordedEdges.some(
+				(e) => e.from === accessNode?.id && e.to === breakNode?.id
+			)
+		).toBe(false);
+
+		expect(breakNode?.y).toBe(accessNode?.y);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -7,6 +7,7 @@ import {
 const EMPTY: ReportScriptData = {
 	diagnosticsJson: "[]",
 	elapsedMsJson: "0",
+	endpointDiagnosticsJson: '{"perEndpoint":{},"perFile":{}}',
 	endpointsJson: '{"endpoints":[]}',
 	examplesJson: "[]",
 	fileSourcesJson: "{}",

--- a/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
@@ -7,6 +7,7 @@ import {
 const EMPTY: ReportScriptData = {
 	diagnosticsJson: "[]",
 	elapsedMsJson: "0",
+	endpointDiagnosticsJson: '{"perEndpoint":{},"perFile":{}}',
 	endpointsJson: '{"endpoints":[]}',
 	examplesJson: "[]",
 	fileSourcesJson: "{}",


### PR DESCRIPTION
## Context

Stacked on #223 (`feat/endpoint-auth-metadata`), which gave every `EndpointNode` decorator-derived `auth` state, `module` ownership, and monorepo `project` attribution. This PR renders that data: the endpoints tab becomes an API-surface overview instead of a one-endpoint-at-a-time viewer. Merge #223 first; this PR's base is that branch.

## Problem

The endpoints tab answers "what does this handler call", never "what is this API and where is it risky". You land on an empty canvas; a fixture with 8 security warnings shows none of them anywhere in the tab. The primary drill-down interaction is broken: any 1px mouse movement between mousedown and mouseup cancels the click and teleports the dragged node's centre to the cursor, so the code panel is effectively unreachable with a real pointer (visual QA could only open it with synthetic events). There is no search, no legend, no zoom UI, and two mismatched zoom clamps.

## Possible flows

| Path into the changed code | Affected |
|---|---|
| `--report` HTML generation | Yes — new default overview, sidebar, drawer; per-endpoint diagnostic counts computed in `prepareReportData` (unit-tested in Node) |
| Focused per-endpoint tree | Kept as drill-down; click threshold, grab offset, zoom toolbar, camera preservation, truncation banner, legend, right-anchored code panel |
| Schema / modules / other tabs | Untouched (verified: schema zoombar and drawer code not in the diff) |
| Offline report (no CDN) | Overview layout is pure arithmetic — works without dagre; focused tree keeps its existing CDN dependency and fallback |
| Scoped scans | Dots follow the report's diagnostics; the drawer header states: "Counts reflect this report's diagnostics; a narrowed scan scope reports fewer, not cleaner." |

## Solution

- Overview (default, auto-fit): module clusters → controller boxes → endpoint rows — method chip, route path, auth shield (`guarded` ✓ / `declared-public` ○ / `unguarded` ⚠ / `unknown` ?), severity-coloured diagnostic dot. No edges by design; deliberately a grouped inventory, not a graph.
- GraphQL rows never claim coverage from a global `APP_GUARD` (`auth.globalGuard` suppressed for `QUERY`/`MUTATION`/`SUBSCRIPTION`).
- Problems drawer (schema parity) joins diagnostics to endpoints by exact index/range — no message-text scraping — with per-file rollups so out-of-handler diagnostics don't disappear; click navigates to the focused tree + code panel at the diagnostic line.
- Sidebar regrouped module → controller → endpoint with a filtering search box; selection is by endpoint index (identity: `filePath`+`line`+`httpMethod`+`routePath`), fixing the first-match-wins bug for same-named controllers.
- Not done here: overview edges, git-churn overlays, base-revision diffing (next phase), the 641–839px viewport band where the code panel can still overlap the sidebar.

## Before vs after

| Case | Before | After |
|---|---|---|
| Tab entry | Empty canvas, "select an endpoint" | Auto-fitted overview of every route with auth + diagnostics |
| Security warnings in the tab | Invisible | Dots per row + drawer with rule ids, click-to-navigate |
| Click a tree node | Cancelled by 1px movement; node teleports | 4px threshold, grab offset preserved, panel opens |
| Truncated trace (5000-node cap) | Rendered identical to complete | Dismissible banner |
| Zoom | ctrl+wheel only, clamps `[0.3,1.5]` vs `[0.2,3]` | Toolbar −/+/% with one `epZoomFloor()` |
| Schema tab, modules tab, CLI output, scoring | unchanged | unchanged |

## Example

```
node packages/nestjs-doctor/dist/cli/index.mjs packages/nestjs-doctor/tests/fixtures/endpoint-graph-patterns --report report.html
```

Old: endpoints tab opens on an empty canvas; the fixture's 8 `security/require-guards-on-endpoints` warnings appear only in the diagnosis tab.

New: the tab opens on an auto-fitted overview — `AppModule` cluster with `LeadsController` / `OrdersController` / `RecipesResolver` boxes; every REST row shows ⚠ Unguarded, the GraphQL `recipes` row shows ⚠ Unguarded without a global-guard qualifier, and warning dots match the drawer's 8 entries. Verified live in Chrome against both fixtures plus a synthetic app exercising all four shield states (✓ with `guards: JwtGuard` tooltip, ○ `@Public()`, ⚠ bare, and `APP_GUARD` shown on REST rows only).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8wonsBbJmC3dC5k8yuup9
