### PR TITLE
feat(cli): add `ci install` to scaffold the pull request workflow

### DIFF
--- a/.changeset/ci-install-command.md
+++ b/.changeset/ci-install-command.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": minor
+---
+
+Add `nestjs-doctor ci install`, which scaffolds `.github/workflows/nestjs-doctor.yml` so the pull request review is one command away instead of a copy from the docs. The workflow runs on `pull_request` and on pushes to the branch `origin/HEAD` points at, checks out with `fetch-depth: 0` so the scan can reach the merge base, and carries every action input commented out — the check comments and sets a status but never fails until you set `blocking` or `min-score`.
+
+An existing workflow is left untouched unless `--force` is passed, and the file lands at the git repository root, so running it from a package directory in a monorepo still writes to the right place. Verbs are read from the positional argument rather than a citty subcommand, so `nestjs-doctor <path>` keeps working exactly as before; only `ci install` and an unknown `ci <verb>` are intercepted.

--- a/.changeset/ci-install-command.md
+++ b/.changeset/ci-install-command.md
@@ -2,6 +2,8 @@
 "nestjs-doctor": minor
 ---
 
-Add `nestjs-doctor ci install`, which scaffolds `.github/workflows/nestjs-doctor.yml` so the pull request review is one command away instead of a copy from the docs. The workflow runs on `pull_request` and on pushes to the branch `origin/HEAD` points at, checks out with `fetch-depth: 0` so the scan can reach the merge base, and carries every action input commented out — the check comments and sets a status but never fails until you set `blocking` or `min-score`.
+Add `nestjs-doctor ci install`, which scaffolds `.github/workflows/nestjs-doctor.yml` so the pull request review is one command away instead of a copy from the docs. The workflow runs on `pull_request` and on pushes to the default branch, checks out with `fetch-depth: 0` so the scan can reach the merge base, and carries the common action inputs commented out — the check comments and sets a status but never fails until you set `blocking` or `min-score`.
 
-An existing workflow is left untouched unless `--force` is passed, and the file lands at the git repository root, so running it from a package directory in a monorepo still writes to the right place. Verbs are read from the positional argument rather than a citty subcommand, so `nestjs-doctor <path>` keeps working exactly as before; only `ci install` and an unknown `ci <verb>` are intercepted.
+The file lands at the git repository root, so running it from a package directory in a monorepo still writes to the right place, and the command refuses to run outside a repository rather than dropping a `.github/` tree into the current directory. An existing workflow is left untouched unless `--force` is passed, and a symlink anywhere on the path is refused, so the write cannot escape the repository through one. The push trigger is keyed to the branch `origin/HEAD` points at, verified to still exist, falling back to `origin/main`, `origin/master`, then the checked out branch, and the chosen branch is printed.
+
+Verbs are read from the positional argument rather than a citty subcommand, so `nestjs-doctor <path>` keeps working exactly as before; only `ci install` and an unrecognised `ci <verb>` are intercepted.

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -123,17 +123,23 @@ Reviews every pull request and reports **only what the change introduced**, not
 your existing backlog. Posts a sticky summary comment, inline review comments on
 the changed lines, and a commit status with the score.
 
-Scaffold the workflow from the repository root:
+Scaffold the workflow:
 
 ```bash
 npx nestjs-doctor@latest ci install
 ```
 
-It writes `.github/workflows/nestjs-doctor.yml`, keyed to the branch
-`origin/HEAD` points at, and leaves an existing file alone unless you pass
-`--force`. What it writes is the workflow below plus a concurrency guard and
-every input from the table further down as a comment, so the check stays
-advisory until you choose a gate.
+The file always lands at the git repository root, so running it from a package
+directory in a monorepo still writes to the right place. It refuses to run
+outside a repository rather than guessing, and leaves an existing file alone
+unless you pass `--force`.
+
+What it writes is a fuller version of the workflow below: same triggers and
+permissions, plus `ready_for_review` in the pull request types, a concurrency
+guard, and the common inputs commented out, so the check stays advisory until
+you choose a gate. The push trigger is keyed to the branch `origin/HEAD` points
+at, falling back to `origin/main`, `origin/master`, then the checked out branch
+— it prints which one it chose.
 
 ```yaml
 # .github/workflows/nestjs-doctor.yml
@@ -265,6 +271,10 @@ Exit codes: `1` if a gate fails, `2` for bad input.
 ```
 Usage: nestjs-doctor [directory] [options]
 
+Commands:
+  ci install            Scaffold .github/workflows/nestjs-doctor.yml
+
+Options:
   --verbose             Show file paths and line numbers per diagnostic
   --score               Output only the numeric score (for CI)
   --json                JSON output (for tooling)

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -123,6 +123,18 @@ Reviews every pull request and reports **only what the change introduced**, not
 your existing backlog. Posts a sticky summary comment, inline review comments on
 the changed lines, and a commit status with the score.
 
+Scaffold the workflow from the repository root:
+
+```bash
+npx nestjs-doctor@latest ci install
+```
+
+It writes `.github/workflows/nestjs-doctor.yml`, keyed to the branch
+`origin/HEAD` points at, and leaves an existing file alone unless you pass
+`--force`. What it writes is the workflow below plus a concurrency guard and
+every input from the table further down as a comment, so the check stays
+advisory until you choose a gate.
+
 ```yaml
 # .github/workflows/nestjs-doctor.yml
 name: NestJS Doctor
@@ -270,6 +282,7 @@ Usage: nestjs-doctor [directory] [options]
   --config <p>          Path to config file
   --list-rules          List every built-in rule and exit
   --init                Set up the /nestjs-doctor skill for AI coding agents
+  --force               Overwrite an existing file (with `ci install`)
   -h, --help            Show help
 ```
 

--- a/packages/nestjs-doctor/src/cli/ci-install.ts
+++ b/packages/nestjs-doctor/src/cli/ci-install.ts
@@ -1,0 +1,149 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { findGitRepo, runGit } from "../engine/git.js";
+import { logger } from "./ui/logger.js";
+
+const ORIGIN_HEAD_RE = /^origin\/(.+)$/;
+const WORKFLOW_FILE = join(".github", "workflows", "nestjs-doctor.yml");
+
+interface CiInstallResult {
+	status: "created" | "exists" | "failed";
+	workflowPath: string;
+}
+
+/** Branch the repository's `origin` points at, or `main` when git can't say. */
+export const resolveDefaultBranch = (root: string): string => {
+	const head = runGit(root, [
+		"symbolic-ref",
+		"--short",
+		"refs/remotes/origin/HEAD",
+	]);
+	const match = head?.trim().match(ORIGIN_HEAD_RE);
+	if (match) {
+		return match[1];
+	}
+	for (const branch of ["main", "master"]) {
+		if (
+			runGit(root, ["rev-parse", "--verify", "--quiet", `origin/${branch}`])
+		) {
+			return branch;
+		}
+	}
+	return "main";
+};
+
+export const buildWorkflow = (
+	defaultBranch: string
+): string => `# nestjs-doctor — health score, diagnostics, and pull request review for NestJS.
+#
+# Docs:   https://nestjs.doctor/docs/ci
+# Source: https://github.com/RoloBits/nestjs-doctor
+
+name: nestjs-doctor
+
+on:
+  # Reviews the pull request and reports only what the change introduced.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  # Scans ${defaultBranch} on every push, so the score keeps a trend line.
+  push:
+    branches: ["${defaultBranch}"]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+# A new commit cancels the run still in flight, so the comment matches the head.
+concurrency:
+  group: nestjs-doctor-\${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 gives the scan the history it needs to find the merge base.
+      # A shallow checkout has none, so a pull request falls back to reporting every
+      # finding in the changed files instead of only the ones it introduced.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: RoloBits/nestjs-doctor@v1
+        # Advisory by default: the action comments and publishes a commit status,
+        # and never fails the check. Uncomment a key below to change that.
+        # with:
+        #   blocking: error           # Fail on: none (default), warning, error
+        #   min-score: "80"           # Fail when the whole-project score drops below this
+        #   scope: files              # Pull request scope: changed (default), files, lines, full
+        #   directory: apps/api       # Scan a sub-directory (default: ".")
+        #   comment: "false"          # Turn off the sticky summary comment
+        #   review-comments: "false"  # Turn off inline comments on the changed lines
+        #   commit-status: "false"    # Turn off the commit status
+        #   sarif: "true"             # Also write SARIF for GitHub code scanning
+        #   version: "1.2.3"          # Pin the nestjs-doctor version (default: latest)
+`;
+
+const writeWorkflow = async (
+	workflowPath: string,
+	content: string
+): Promise<boolean> => {
+	try {
+		await mkdir(dirname(workflowPath), { recursive: true });
+		await writeFile(workflowPath, content, "utf-8");
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/** Writes the pull request workflow into the repository that contains `targetPath`. */
+export const installCiWorkflow = async (
+	targetPath: string,
+	force: boolean
+): Promise<CiInstallResult> => {
+	const repo = findGitRepo(targetPath);
+	const root = repo?.root ?? targetPath;
+	const workflowPath = join(root, WORKFLOW_FILE);
+
+	if (existsSync(workflowPath) && !force) {
+		return { status: "exists", workflowPath };
+	}
+
+	const content = buildWorkflow(resolveDefaultBranch(root));
+	const written = await writeWorkflow(workflowPath, content);
+	return { status: written ? "created" : "failed", workflowPath };
+};
+
+export const runCiInstall = async (
+	targetPath: string,
+	force: boolean
+): Promise<number> => {
+	const { status, workflowPath } = await installCiWorkflow(targetPath, force);
+	const fromCwd = relative(process.cwd(), workflowPath);
+	// An empty or upward path means the file sits outside cwd; show it in full.
+	const shown = fromCwd && !fromCwd.startsWith("..") ? fromCwd : workflowPath;
+
+	if (status === "failed") {
+		logger.error(`Could not write ${shown}`);
+		return 1;
+	}
+
+	if (status === "exists") {
+		logger.warn(`${shown} already exists — left untouched.`);
+		logger.dim("Run with --force to replace it.");
+		return 0;
+	}
+
+	logger.success(`Created ${shown}`);
+	logger.break();
+	logger.dim(
+		"Commit it and open a pull request. nestjs-doctor comments on what the change introduced,"
+	);
+	logger.dim(
+		"and never fails the check until you set blocking or min-score in the workflow."
+	);
+	return 0;
+};

--- a/packages/nestjs-doctor/src/cli/ci-install.ts
+++ b/packages/nestjs-doctor/src/cli/ci-install.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { lstatSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { findGitRepo, runGit } from "../engine/git.js";
@@ -7,30 +7,53 @@ import { logger } from "./ui/logger.js";
 const ORIGIN_HEAD_RE = /^origin\/(.+)$/;
 const WORKFLOW_FILE = join(".github", "workflows", "nestjs-doctor.yml");
 
+type InstallStatus = "created" | "exists" | "failed" | "no-repo" | "symlink";
+
 interface CiInstallResult {
-	status: "created" | "exists" | "failed";
+	branch?: string;
+	reason?: string;
+	status: InstallStatus;
 	workflowPath: string;
 }
 
-/** Branch the repository's `origin` points at, or `main` when git can't say. */
+const refExists = (root: string, ref: string): boolean =>
+	runGit(root, ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]) !==
+	null;
+
+const shortRef = (root: string, ref: string): string | undefined =>
+	runGit(root, ["symbolic-ref", "--quiet", "--short", ref])?.trim() ||
+	undefined;
+
+/** Branch the workflow's push trigger is keyed to. Every candidate is verified. */
 export const resolveDefaultBranch = (root: string): string => {
-	const head = runGit(root, [
-		"symbolic-ref",
-		"--short",
-		"refs/remotes/origin/HEAD",
-	]);
-	const match = head?.trim().match(ORIGIN_HEAD_RE);
-	if (match) {
-		return match[1];
+	const named = shortRef(root, "refs/remotes/origin/HEAD")?.match(
+		ORIGIN_HEAD_RE
+	)?.[1];
+	if (named && refExists(root, `origin/${named}`)) {
+		return named;
 	}
 	for (const branch of ["main", "master"]) {
-		if (
-			runGit(root, ["rev-parse", "--verify", "--quiet", `origin/${branch}`])
-		) {
+		if (refExists(root, `origin/${branch}`)) {
 			return branch;
 		}
 	}
-	return "main";
+	return shortRef(root, "HEAD") ?? "main";
+};
+
+/** Path of the first symlink on the way to the workflow, or null when there is none. */
+const findSymlink = (root: string): string | null => {
+	const segments = [".github", join(".github", "workflows"), WORKFLOW_FILE];
+	for (const segment of segments) {
+		const candidate = join(root, segment);
+		try {
+			if (lstatSync(candidate).isSymbolicLink()) {
+				return candidate;
+			}
+		} catch {
+			// Missing segments are created below.
+		}
+	}
+	return null;
 };
 
 export const buildWorkflow = (
@@ -46,9 +69,9 @@ on:
   # Reviews the pull request and reports only what the change introduced.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  # Scans ${defaultBranch} on every push, so the score keeps a trend line.
+  # Scans the default branch on every push, so the score keeps a trend line.
   push:
-    branches: ["${defaultBranch}"]
+    branches: [${JSON.stringify(defaultBranch)}]
 
 permissions:
   contents: read
@@ -74,6 +97,7 @@ jobs:
       - uses: RoloBits/nestjs-doctor@v1
         # Advisory by default: the action comments and publishes a commit status,
         # and never fails the check. Uncomment a key below to change that.
+        # Every input: https://nestjs.doctor/docs/ci
         # with:
         #   blocking: error           # Fail on: none (default), warning, error
         #   min-score: "80"           # Fail when the whole-project score drops below this
@@ -86,58 +110,81 @@ jobs:
         #   version: "1.2.3"          # Pin the nestjs-doctor version (default: latest)
 `;
 
-const writeWorkflow = async (
-	workflowPath: string,
-	content: string
-): Promise<boolean> => {
-	try {
-		await mkdir(dirname(workflowPath), { recursive: true });
-		await writeFile(workflowPath, content, "utf-8");
-		return true;
-	} catch {
-		return false;
-	}
-};
-
 /** Writes the pull request workflow into the repository that contains `targetPath`. */
 export const installCiWorkflow = async (
 	targetPath: string,
 	force: boolean
 ): Promise<CiInstallResult> => {
 	const repo = findGitRepo(targetPath);
-	const root = repo?.root ?? targetPath;
-	const workflowPath = join(root, WORKFLOW_FILE);
-
-	if (existsSync(workflowPath) && !force) {
-		return { status: "exists", workflowPath };
+	if (!repo) {
+		return { status: "no-repo", workflowPath: join(targetPath, WORKFLOW_FILE) };
 	}
 
-	const content = buildWorkflow(resolveDefaultBranch(root));
-	const written = await writeWorkflow(workflowPath, content);
-	return { status: written ? "created" : "failed", workflowPath };
+	const symlink = findSymlink(repo.root);
+	if (symlink) {
+		return { status: "symlink", workflowPath: symlink };
+	}
+
+	const workflowPath = join(repo.root, WORKFLOW_FILE);
+	const branch = resolveDefaultBranch(repo.root);
+	try {
+		await mkdir(dirname(workflowPath), { recursive: true });
+		await writeFile(workflowPath, buildWorkflow(branch), {
+			encoding: "utf-8",
+			flag: force ? "w" : "wx",
+		});
+		return { branch, status: "created", workflowPath };
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "EEXIST") {
+			return { status: "exists", workflowPath };
+		}
+		return { reason: code ?? "unknown", status: "failed", workflowPath };
+	}
+};
+
+const display = (workflowPath: string): string => {
+	const fromCwd = relative(process.cwd(), workflowPath);
+	// An empty or upward path means the file sits outside cwd; show it in full.
+	return fromCwd && !fromCwd.startsWith("..") ? fromCwd : workflowPath;
 };
 
 export const runCiInstall = async (
 	targetPath: string,
 	force: boolean
 ): Promise<number> => {
-	const { status, workflowPath } = await installCiWorkflow(targetPath, force);
-	const fromCwd = relative(process.cwd(), workflowPath);
-	// An empty or upward path means the file sits outside cwd; show it in full.
-	const shown = fromCwd && !fromCwd.startsWith("..") ? fromCwd : workflowPath;
+	const result = await installCiWorkflow(targetPath, force);
+	const shown = display(result.workflowPath);
 
-	if (status === "failed") {
-		logger.error(`Could not write ${shown}`);
+	if (result.status === "no-repo") {
+		logger.error(
+			"Not a git repository, so there is no repository root to write to."
+		);
+		logger.dim("Run this from your project, or `git init` first.");
+		return 2;
+	}
+
+	if (result.status === "symlink") {
+		logger.error(`Refusing to write through a symlink: ${shown}`);
+		logger.dim(
+			"Replace it with a real directory or file, then run this again."
+		);
+		return 2;
+	}
+
+	if (result.status === "failed") {
+		logger.error(`Could not write ${shown} (${result.reason})`);
 		return 1;
 	}
 
-	if (status === "exists") {
+	if (result.status === "exists") {
 		logger.warn(`${shown} already exists — left untouched.`);
 		logger.dim("Run with --force to replace it.");
 		return 0;
 	}
 
 	logger.success(`Created ${shown}`);
+	logger.dim(`Push trigger keyed to the ${result.branch} branch.`);
 	logger.break();
 	logger.dim(
 		"Commit it and open a pull request. nestjs-doctor comments on what the change introduced,"

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -81,6 +81,11 @@ export const flags = {
 			"Set up the nestjs-doctor skill for AI coding agents (Claude Code, Cursor, Codex, etc.)",
 		default: false,
 	},
+	force: {
+		type: "boolean",
+		description: "Overwrite an existing file (with `ci install`)",
+		default: false,
+	},
 	"list-rules": {
 		type: "boolean",
 		description: "List every built-in rule and exit",

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -34,6 +34,7 @@ const main = defineCommand({
 		const ctx = await new CliSetup(args as CliArgs, version)
 			.resolveTargetPath()
 			.handleListRules()
+			.handleCiInstall()
 			.validateTargetPath()
 			.handleInit()
 			.handleReport()

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -17,7 +17,7 @@ const main = defineCommand({
 		name: "nestjs-doctor",
 		version,
 		description:
-			"Static analysis tool for NestJS — health score, diagnostics, and interactive HTML report",
+			"Static analysis tool for NestJS — health score, diagnostics, and interactive HTML report.\nCommands: ci install (scaffold .github/workflows/nestjs-doctor.yml)",
 	},
 	args: {
 		path: {

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -139,13 +139,14 @@ export class CliSetup {
 	/** `nestjs-doctor ci install` scaffolds the workflow and exits. */
 	handleCiInstall(): this {
 		this.steps.push(async () => {
-			const [group, verb] = this.args._ ?? [];
-			if (group !== "ci" || verb === undefined) {
+			const [group, verb, ...rest] = this.args._ ?? [];
+			if (group !== "ci" || !verb) {
 				return true;
 			}
-			if (verb !== "install") {
+			if (verb !== "install" || rest.length > 0) {
+				const given = [verb, ...rest].join(" ");
 				failWith(
-					`Unknown command: "ci ${verb}". Try: nestjs-doctor ci install`
+					`Unknown command: "ci ${given}". Try: nestjs-doctor ci install`
 				);
 			}
 			const { runCiInstall } = await import("./ci-install.js");

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -37,10 +37,12 @@ interface SetupContext {
 }
 
 export interface CliArgs {
+	_: string[];
 	base: string | undefined;
 	blocking: string | undefined;
 	"changed-files-from": string | undefined;
 	config: string | undefined;
+	force: boolean;
 	format: string | undefined;
 	init: boolean;
 	json: boolean;
@@ -130,6 +132,28 @@ export class CliSetup {
 				return false;
 			}
 			return true;
+		});
+		return this;
+	}
+
+	/** `nestjs-doctor ci install` scaffolds the workflow and exits. */
+	handleCiInstall(): this {
+		this.steps.push(async () => {
+			const [group, verb] = this.args._ ?? [];
+			if (group !== "ci" || verb === undefined) {
+				return true;
+			}
+			if (verb !== "install") {
+				failWith(
+					`Unknown command: "ci ${verb}". Try: nestjs-doctor ci install`
+				);
+			}
+			const { runCiInstall } = await import("./ci-install.js");
+			const code = await runCiInstall(process.cwd(), this.args.force ?? false);
+			if (code !== 0) {
+				process.exit(code);
+			}
+			return false;
 		});
 		return this;
 	}

--- a/packages/nestjs-doctor/tests/unit/ci-install.test.ts
+++ b/packages/nestjs-doctor/tests/unit/ci-install.test.ts
@@ -2,18 +2,38 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
 	buildWorkflow,
 	installCiWorkflow,
 	resolveDefaultBranch,
 } from "../../src/cli/ci-install.js";
 
-const tempRootDirectory = fs.mkdtempSync(
-	path.join(os.tmpdir(), "nestjs-doctor-ci-install-test-")
-);
+// The suite runs from a husky pre-commit hook, and git exports GIT_DIR and
+// friends to every hook. Inherited, they point these fixture repos at the
+// outer repository, so `commit` lands in the wrong index.
+const CLEAN_GIT_ENV = { ...process.env };
+for (const name of [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_NAMESPACE",
+	"GIT_PREFIX",
+	"GIT_CEILING_DIRECTORIES",
+]) {
+	delete CLEAN_GIT_ENV[name];
+}
 
 const WORKFLOW_PATH = path.join(".github", "workflows", "nestjs-doctor.yml");
+
+let tempRootDirectory: string;
+
+const git = (cwd: string, ...args: string[]): void => {
+	execFileSync("git", args, { cwd, env: CLEAN_GIT_ENV, stdio: "ignore" });
+};
 
 const makeDirectory = (name: string): string => {
 	const directory = path.join(tempRootDirectory, name);
@@ -21,23 +41,33 @@ const makeDirectory = (name: string): string => {
 	return directory;
 };
 
-const git = (cwd: string, ...args: string[]): void => {
-	execFileSync("git", args, { cwd, stdio: "ignore" });
+/** A repository with one commit, no remote refs unless the test adds them. */
+const makeRepo = (name: string, branch: string): string => {
+	const directory = makeDirectory(name);
+	git(directory, "init", "-q", "-b", branch);
+	git(directory, "config", "user.email", "test@example.com");
+	git(directory, "config", "user.name", "Test");
+	git(directory, "config", "commit.gpgsign", "false");
+	git(directory, "commit", "-q", "--allow-empty", "-m", "init");
+	return directory;
 };
 
-const makeRepo = (name: string, defaultBranch: string): string => {
-	const directory = makeDirectory(name);
-	git(directory, "init", "-q", "-b", defaultBranch);
-	git(directory, "commit", "-q", "--allow-empty", "-m", "init");
-	git(directory, "update-ref", `refs/remotes/origin/${defaultBranch}`, "HEAD");
+const withOriginHead = (directory: string, branch: string): string => {
+	git(directory, "update-ref", `refs/remotes/origin/${branch}`, "HEAD");
 	git(
 		directory,
 		"symbolic-ref",
 		"refs/remotes/origin/HEAD",
-		`refs/remotes/origin/${defaultBranch}`
+		`refs/remotes/origin/${branch}`
 	);
 	return directory;
 };
+
+beforeAll(() => {
+	tempRootDirectory = fs.mkdtempSync(
+		path.join(os.tmpdir(), "nestjs-doctor-ci-install-test-")
+	);
+});
 
 afterAll(() => {
 	fs.rmSync(tempRootDirectory, { recursive: true, force: true });
@@ -67,27 +97,58 @@ describe("buildWorkflow", () => {
 		expect(workflow).toContain('branches: ["trunk"]');
 	});
 
-	it("leaves every input commented out, so the check stays advisory", () => {
+	it("writes the input reference, every key commented out", () => {
 		const workflow = buildWorkflow("main");
-		const uncommented = workflow
+		const active = workflow
 			.split("\n")
 			.filter(
 				(line) => line.includes("blocking:") && !line.trim().startsWith("#")
 			);
 
-		expect(uncommented).toEqual([]);
+		expect(workflow).toContain("#   blocking: error");
+		expect(workflow).toContain("#   min-score:");
+		expect(active).toEqual([]);
+	});
+
+	it("escapes a branch name that would otherwise break out of the YAML string", () => {
+		const workflow = buildWorkflow('main","evil');
+
+		expect(workflow).toContain('branches: ["main\\",\\"evil"]');
+		expect(workflow).not.toContain('branches: ["main","evil"]');
 	});
 });
 
 describe("resolveDefaultBranch", () => {
 	it("reads the branch origin/HEAD points at", () => {
-		const repo = makeRepo("origin-head", "develop");
+		const repo = withOriginHead(makeRepo("origin-head", "develop"), "develop");
 
 		expect(resolveDefaultBranch(repo)).toBe("develop");
 	});
 
+	it("ignores an origin/HEAD pointing at a branch that no longer exists", () => {
+		const repo = withOriginHead(makeRepo("stale-head", "gone"), "gone");
+		git(repo, "update-ref", "-d", "refs/remotes/origin/gone");
+		git(repo, "update-ref", "refs/remotes/origin/main", "HEAD");
+
+		expect(resolveDefaultBranch(repo)).toBe("main");
+	});
+
+	it("falls back to origin/master when there is no origin/main", () => {
+		const repo = makeRepo("master-remote", "master");
+		git(repo, "update-ref", "refs/remotes/origin/master", "HEAD");
+
+		expect(resolveDefaultBranch(repo)).toBe("master");
+	});
+
+	it("uses the checked out branch when the remote has no main or master", () => {
+		const repo = makeRepo("trunk-only", "trunk");
+		git(repo, "update-ref", "refs/remotes/origin/trunk", "HEAD");
+
+		expect(resolveDefaultBranch(repo)).toBe("trunk");
+	});
+
 	it("falls back to main outside a repository", () => {
-		const directory = makeDirectory("no-repo");
+		const directory = makeDirectory("no-repo-branch");
 
 		expect(resolveDefaultBranch(directory)).toBe("main");
 	});
@@ -95,7 +156,7 @@ describe("resolveDefaultBranch", () => {
 
 describe("installCiWorkflow", () => {
 	it("writes the workflow at the repository root, not the working directory", async () => {
-		const repo = makeRepo("nested", "main");
+		const repo = withOriginHead(makeRepo("nested", "main"), "main");
 		const nested = path.join(repo, "apps", "api");
 		fs.mkdirSync(nested, { recursive: true });
 
@@ -106,7 +167,16 @@ describe("installCiWorkflow", () => {
 		expect(result.workflowPath).toBe(
 			path.join(fs.realpathSync(repo), WORKFLOW_PATH)
 		);
-		expect(fs.existsSync(result.workflowPath)).toBe(true);
+		expect(result.branch).toBe("main");
+	});
+
+	it("refuses to write when there is no repository to write into", async () => {
+		const directory = makeDirectory("no-repo");
+
+		const result = await installCiWorkflow(directory, false);
+
+		expect(result.status).toBe("no-repo");
+		expect(fs.existsSync(path.join(directory, ".github"))).toBe(false);
 	});
 
 	it("leaves an existing workflow untouched", async () => {
@@ -135,16 +205,51 @@ describe("installCiWorkflow", () => {
 		);
 	});
 
-	it("reports failure instead of throwing when the path is not writable", async () => {
-		const directory = makeDirectory("unwritable");
-		fs.writeFileSync(
-			path.join(directory, ".github"),
-			"not a directory",
-			"utf-8"
-		);
+	it("refuses to follow a symlink standing in for the workflow", async () => {
+		const repo = makeRepo("symlink-file", "main");
+		const outside = path.join(tempRootDirectory, "outside-target.txt");
+		fs.writeFileSync(outside, "keep me\n", "utf-8");
+		const workflowPath = path.join(repo, WORKFLOW_PATH);
+		fs.mkdirSync(path.dirname(workflowPath), { recursive: true });
+		fs.symlinkSync(outside, workflowPath);
 
-		const result = await installCiWorkflow(directory, false);
+		const result = await installCiWorkflow(repo, true);
+
+		expect(result.status).toBe("symlink");
+		expect(fs.readFileSync(outside, "utf-8")).toBe("keep me\n");
+	});
+
+	it("refuses a dangling symlink, which no exists check would catch", async () => {
+		const repo = makeRepo("symlink-dangling", "main");
+		const missing = path.join(tempRootDirectory, "not-created-yet.txt");
+		const workflowPath = path.join(repo, WORKFLOW_PATH);
+		fs.mkdirSync(path.dirname(workflowPath), { recursive: true });
+		fs.symlinkSync(missing, workflowPath);
+
+		const result = await installCiWorkflow(repo, false);
+
+		expect(result.status).toBe("symlink");
+		expect(fs.existsSync(missing)).toBe(false);
+	});
+
+	it("refuses when .github itself is a symlink out of the repository", async () => {
+		const repo = makeRepo("symlink-dir", "main");
+		const outside = makeDirectory("outside-github");
+		fs.symlinkSync(outside, path.join(repo, ".github"));
+
+		const result = await installCiWorkflow(repo, false);
+
+		expect(result.status).toBe("symlink");
+		expect(fs.existsSync(path.join(outside, "workflows"))).toBe(false);
+	});
+
+	it("reports the errno instead of throwing when the path is not writable", async () => {
+		const repo = makeRepo("unwritable", "main");
+		fs.writeFileSync(path.join(repo, ".github"), "not a directory", "utf-8");
+
+		const result = await installCiWorkflow(repo, false);
 
 		expect(result.status).toBe("failed");
+		expect(result.reason).toBe("ENOTDIR");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/ci-install.test.ts
+++ b/packages/nestjs-doctor/tests/unit/ci-install.test.ts
@@ -1,0 +1,150 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+	buildWorkflow,
+	installCiWorkflow,
+	resolveDefaultBranch,
+} from "../../src/cli/ci-install.js";
+
+const tempRootDirectory = fs.mkdtempSync(
+	path.join(os.tmpdir(), "nestjs-doctor-ci-install-test-")
+);
+
+const WORKFLOW_PATH = path.join(".github", "workflows", "nestjs-doctor.yml");
+
+const makeDirectory = (name: string): string => {
+	const directory = path.join(tempRootDirectory, name);
+	fs.mkdirSync(directory, { recursive: true });
+	return directory;
+};
+
+const git = (cwd: string, ...args: string[]): void => {
+	execFileSync("git", args, { cwd, stdio: "ignore" });
+};
+
+const makeRepo = (name: string, defaultBranch: string): string => {
+	const directory = makeDirectory(name);
+	git(directory, "init", "-q", "-b", defaultBranch);
+	git(directory, "commit", "-q", "--allow-empty", "-m", "init");
+	git(directory, "update-ref", `refs/remotes/origin/${defaultBranch}`, "HEAD");
+	git(
+		directory,
+		"symbolic-ref",
+		"refs/remotes/origin/HEAD",
+		`refs/remotes/origin/${defaultBranch}`
+	);
+	return directory;
+};
+
+afterAll(() => {
+	fs.rmSync(tempRootDirectory, { recursive: true, force: true });
+});
+
+describe("buildWorkflow", () => {
+	it("pins the action and keeps the full history the merge base needs", () => {
+		const workflow = buildWorkflow("main");
+
+		expect(workflow).toContain("uses: RoloBits/nestjs-doctor@v1");
+		expect(workflow).toContain("uses: actions/checkout@v4");
+		expect(workflow).toContain("fetch-depth: 0");
+	});
+
+	it("requests only the permissions the action documents", () => {
+		const workflow = buildWorkflow("main");
+
+		expect(workflow).toContain("contents: read");
+		expect(workflow).toContain("pull-requests: write");
+		expect(workflow).toContain("statuses: write");
+	});
+
+	it("runs on pull requests and on pushes to the default branch", () => {
+		const workflow = buildWorkflow("trunk");
+
+		expect(workflow).toContain("pull_request:");
+		expect(workflow).toContain('branches: ["trunk"]');
+	});
+
+	it("leaves every input commented out, so the check stays advisory", () => {
+		const workflow = buildWorkflow("main");
+		const uncommented = workflow
+			.split("\n")
+			.filter(
+				(line) => line.includes("blocking:") && !line.trim().startsWith("#")
+			);
+
+		expect(uncommented).toEqual([]);
+	});
+});
+
+describe("resolveDefaultBranch", () => {
+	it("reads the branch origin/HEAD points at", () => {
+		const repo = makeRepo("origin-head", "develop");
+
+		expect(resolveDefaultBranch(repo)).toBe("develop");
+	});
+
+	it("falls back to main outside a repository", () => {
+		const directory = makeDirectory("no-repo");
+
+		expect(resolveDefaultBranch(directory)).toBe("main");
+	});
+});
+
+describe("installCiWorkflow", () => {
+	it("writes the workflow at the repository root, not the working directory", async () => {
+		const repo = makeRepo("nested", "main");
+		const nested = path.join(repo, "apps", "api");
+		fs.mkdirSync(nested, { recursive: true });
+
+		const result = await installCiWorkflow(nested, false);
+
+		expect(result.status).toBe("created");
+		// git reports the canonical root; on macOS /var resolves to /private/var.
+		expect(result.workflowPath).toBe(
+			path.join(fs.realpathSync(repo), WORKFLOW_PATH)
+		);
+		expect(fs.existsSync(result.workflowPath)).toBe(true);
+	});
+
+	it("leaves an existing workflow untouched", async () => {
+		const repo = makeRepo("existing", "main");
+		const workflowPath = path.join(repo, WORKFLOW_PATH);
+		fs.mkdirSync(path.dirname(workflowPath), { recursive: true });
+		fs.writeFileSync(workflowPath, "name: mine\n", "utf-8");
+
+		const result = await installCiWorkflow(repo, false);
+
+		expect(result.status).toBe("exists");
+		expect(fs.readFileSync(workflowPath, "utf-8")).toBe("name: mine\n");
+	});
+
+	it("replaces an existing workflow when forced", async () => {
+		const repo = makeRepo("forced", "main");
+		const workflowPath = path.join(repo, WORKFLOW_PATH);
+		fs.mkdirSync(path.dirname(workflowPath), { recursive: true });
+		fs.writeFileSync(workflowPath, "name: mine\n", "utf-8");
+
+		const result = await installCiWorkflow(repo, true);
+
+		expect(result.status).toBe("created");
+		expect(fs.readFileSync(workflowPath, "utf-8")).toContain(
+			"uses: RoloBits/nestjs-doctor@v1"
+		);
+	});
+
+	it("reports failure instead of throwing when the path is not writable", async () => {
+		const directory = makeDirectory("unwritable");
+		fs.writeFileSync(
+			path.join(directory, ".github"),
+			"not a directory",
+			"utf-8"
+		);
+
+		const result = await installCiWorkflow(directory, false);
+
+		expect(result.status).toBe("failed");
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/ci-install.test.ts
+++ b/packages/nestjs-doctor/tests/unit/ci-install.test.ts
@@ -163,10 +163,11 @@ describe("installCiWorkflow", () => {
 		const result = await installCiWorkflow(nested, false);
 
 		expect(result.status).toBe("created");
-		// git reports the canonical root; on macOS /var resolves to /private/var.
-		expect(result.workflowPath).toBe(
-			path.join(fs.realpathSync(repo), WORKFLOW_PATH)
-		);
+		// git canonicalises the root: /var becomes /private/var on macOS, and a
+		// Windows 8.3 short path becomes its long form. Compare structure, not text.
+		expect(result.workflowPath.endsWith(WORKFLOW_PATH)).toBe(true);
+		expect(result.workflowPath).not.toContain(path.join("apps", "api"));
+		expect(fs.existsSync(path.join(repo, WORKFLOW_PATH))).toBe(true);
 		expect(result.branch).toBe("main");
 	});
 

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -21,6 +21,10 @@ npm install -D nestjs-doctor
 ```
 Usage: nestjs-doctor [directory] [options]
 
+Commands:
+  ci install            Scaffold .github/workflows/nestjs-doctor.yml
+
+Options:
   --verbose             Show file paths, line numbers, and source context per diagnostic
   --score               Output only the numeric score (for CI)
   --json                JSON output (for tooling)
@@ -36,6 +40,7 @@ Usage: nestjs-doctor [directory] [options]
   --report              Generate an interactive HTML report (--graph also works)
   --timings <path>      SerializedGraph dump to overlay bootstrap init times on the report
   --config <p>          Path to config file
+  --force               Overwrite an existing file (with ci install)
   --list-rules          List every built-in rule and exit
   --init                Set up the /nestjs-doctor skill for AI coding agents
   -h, --help            Show help
@@ -62,6 +67,9 @@ The score always reflects the whole project, whatever the scope. `--min-score`
 gates on that score; `--blocking` gates on the reported findings.
 
 ## GitHub Action
+
+Scaffold the workflow with `npx nestjs-doctor@latest ci install`, which writes
+.github/workflows/nestjs-doctor.yml at the git repository root. Or add it by hand:
 
 ```yaml
 - uses: actions/checkout@v4

--- a/packages/website/src/app/docs/ci/page.mdx
+++ b/packages/website/src/app/docs/ci/page.mdx
@@ -12,13 +12,21 @@ introduced, and leaving the existing backlog to the score.
 
 ## GitHub Action
 
-Scaffold the workflow from the repository root:
+### Scaffolding the workflow
 
 ```bash
 npx nestjs-doctor@latest ci install
 ```
 
-It writes `.github/workflows/nestjs-doctor.yml`, keyed to the branch `origin/HEAD` points at, and leaves an existing file alone unless you pass `--force`. What it writes is the workflow below plus a concurrency guard and every action input as a comment, so the check stays advisory until you pick a gate.
+Writes `.github/workflows/nestjs-doctor.yml` and prints which branch it keyed the push trigger to.
+
+**Where it writes.** Always at the git repository root, so running it from `apps/api` in a monorepo still lands the file in the right place. Outside a git repository it refuses rather than dropping a `.github/` tree into whatever directory you happen to be in.
+
+**What it will not touch.** An existing workflow is left alone unless you pass `--force`, and a symlink anywhere on the path (`.github`, `.github/workflows`, or the file itself) is refused outright, so the write can never escape the repository through one.
+
+**Which branch the push trigger uses.** The branch `origin/HEAD` points at, verified to still exist; then `origin/main`, then `origin/master`, then the branch you have checked out. A clone made with `--single-branch`, or a remote added by hand, has no `origin/HEAD` at all — that is why the fallback chain exists, and why the command tells you what it picked.
+
+**What it writes** is a fuller version of the workflow below: the same triggers and permissions, plus `ready_for_review` in the pull request types, a concurrency guard that cancels superseded runs, and the common inputs commented out. The check comments and sets a status but never fails until you uncomment `blocking` or `min-score`.
 
 ```yaml
 # .github/workflows/nestjs-doctor.yml

--- a/packages/website/src/app/docs/ci/page.mdx
+++ b/packages/website/src/app/docs/ci/page.mdx
@@ -12,6 +12,14 @@ introduced, and leaving the existing backlog to the score.
 
 ## GitHub Action
 
+Scaffold the workflow from the repository root:
+
+```bash
+npx nestjs-doctor@latest ci install
+```
+
+It writes `.github/workflows/nestjs-doctor.yml`, keyed to the branch `origin/HEAD` points at, and leaves an existing file alone unless you pass `--force`. What it writes is the workflow below plus a concurrency guard and every action input as a comment, so the check stays advisory until you pick a gate.
+
 ```yaml
 # .github/workflows/nestjs-doctor.yml
 name: NestJS Doctor

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -35,6 +35,10 @@ npm install -D nestjs-doctor
 ```
 Usage: nestjs-doctor [directory] [options]
 
+Commands:
+  ci install            Scaffold .github/workflows/nestjs-doctor.yml
+
+Options:
   --verbose             Show file paths and line numbers per diagnostic
   --score               Output only the numeric score (for CI)
   --json                JSON output (for tooling)

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -52,6 +52,7 @@ Usage: nestjs-doctor [directory] [options]
   --config <p>          Path to config file
   --list-rules          List every built-in rule and exit
   --init                Set up the /nestjs-doctor skill for AI coding agents
+  --force               Overwrite an existing file (with `ci install`)
   -h, --help            Show help
 ```
 


### PR DESCRIPTION
## Context

Setting up the GitHub Action means copying a YAML block out of the README into `.github/workflows/nestjs-doctor.yml`. The action itself has shipped for a while; the friction is entirely in getting the file into the repository. react-doctor solves the same problem with `npx react-doctor@latest ci install`, and the landing page copy we are writing points at the same shape of command.

## Problem

The workflow has three details that are easy to get wrong by hand, and each one fails quietly:

- **`fetch-depth: 0` is required.** Without it there is no merge base, so a pull request run silently reports every finding in the changed files instead of only the ones the change introduced. The scan still passes, it just reviews the wrong thing.
- **The `push:` trigger has to name the real default branch.** A copied snippet says `main`. On a repository whose default is `develop` or `master`, the trend-line scan never runs, and nothing says so.
- **The permissions block is not obvious.** Miss `statuses: write` and the commit status is skipped with a warning most people never read.

## Possible flows

Every way the CLI is invoked, and whether this change touches it:

| Invocation | Before | After |
|---|---|---|
| `nestjs-doctor` | scans `.` | unchanged |
| `nestjs-doctor <path>` | scans the path | unchanged |
| `nestjs-doctor --format json .` | JSON on stdout | unchanged |
| `nestjs-doctor ci` (a directory named `ci`) | scans `./ci` | unchanged, still scans it |
| `nestjs-doctor ci install` | scanned `./ci` | writes the workflow |
| `nestjs-doctor ci <other>` | scanned `./ci`, extra arg ignored | exits 2, names the valid verb |
| GitHub Action (`action.yml`) | one positional, always | unchanged, cannot reach the new path |

Verbs are read from the positional argument, not a citty subcommand. citty 0.2.2 throws `E_UNKNOWN_COMMAND` for any first token that is not a registered subcommand, which would break every `nestjs-doctor <path>` invocation, and it runs the parent command *after* the subcommand rather than instead of it.

## Solution

`nestjs-doctor ci install` writes `.github/workflows/nestjs-doctor.yml` at the git repository root, with `fetch-depth: 0`, the right permissions, a concurrency guard, and the common action inputs commented out so the check stays advisory until a gate is chosen.

The push trigger is keyed to the branch `origin/HEAD` points at, **verified to still exist**, falling back to `origin/main`, `origin/master`, then the checked out branch. The chosen branch is printed. This mirrors what `resolveBaseRef` in `engine/git.ts` already does.

What it deliberately does **not** do:

- **No interactive prompts.** react-doctor asks four questions and bundles a YAML parser to rewrite answers later. The inputs are commented into the file instead, which is editable with no second command and no new dependency.
- **No `ci config` or `ci upgrade`.** Nothing to upgrade from yet.
- **No writing outside a git repository.** It refuses rather than guessing a root.
- **No following symlinks.** A symlink at `.github`, `.github/workflows`, or the workflow itself is refused outright rather than resolved, so the write cannot escape the repository through one. This includes dangling symlinks, which an `existsSync` guard does not catch.

## Before vs after

| Case | Before | After |
|---|---|---|
| Fresh repository | copy YAML from the README | one command |
| Repository whose default is `develop` | snippet says `main`, push scans never run | `branches: ["develop"]`, and it says so |
| No `origin/HEAD` (`--single-branch` clone) | n/a | falls back through `origin/main`, `origin/master`, checked out branch |
| Workflow already present | n/a | left untouched, exits 0, points at `--force` |
| Not a git repository | n/a | refuses, exits 2 |
| `.github` is a symlink | n/a | refuses, exits 2 |
| Branch named `main","evil` | n/a | escaped, cannot add a trigger |
| `nestjs-doctor <path>` | scans | **unchanged** |

## Example

```
$ cd ~/projects/acme-api && npx nestjs-doctor@latest ci install
Created .github/workflows/nestjs-doctor.yml
Push trigger keyed to the trunk branch.

Commit it and open a pull request. nestjs-doctor comments on what the change introduced,
and never fails the check until you set blocking or min-score in the workflow.

$ npx nestjs-doctor@latest ci install
.github/workflows/nestjs-doctor.yml already exists — left untouched.
Run with --force to replace it.

$ cd /tmp && npx nestjs-doctor@latest ci install
Not a git repository, so there is no repository root to write to.
Run this from your project, or `git init` first.
$ echo $?
2
```

## Review notes

The second commit is the result of a multi-agent review of the first. It fixes five defects found there: the silent write into a non-repository directory, three symlink escapes (one of which needed no `--force`), the unverified default branch, and YAML injection through the branch name. The test file also gained the repo-scoping git env scrub that `git.test.ts` and `scope.test.ts` already use — without it, `GIT_DIR` in the environment sends fixture commits into the outer repository, which is exactly what happened during the review.

Docs corrected in the same pass: the generated file was described as carrying every action input when it carries nine of fourteen, and as matching the README snippet, which omits the concurrency guard and `ready_for_review`.
