### PR TITLE
fix(website): number the landing figures consecutively

### DIFF
--- a/packages/website/src/components/landing/graph-and-schema.tsx
+++ b/packages/website/src/components/landing/graph-and-schema.tsx
@@ -54,7 +54,7 @@ const BOOT = [
 ];
 
 const ModuleGraph = () => (
-	<Figure caption="Fig. 04 — Module graph" meta="6 modules · 1 cycle">
+	<Figure caption="Fig. 03 — Module graph" meta="6 modules · 1 cycle">
 		<div className={BODY}>
 			<svg
 				aria-hidden="true"
@@ -177,7 +177,7 @@ const LEVEL = {
 
 const SchemaDiagram = () => (
 	<Figure
-		caption="Fig. 05 — Entity relation sketch"
+		caption="Fig. 04 — Entity relation sketch"
 		meta="prisma · 12 entities"
 	>
 		<div className={BODY}>

--- a/packages/website/src/components/landing/pr-review.tsx
+++ b/packages/website/src/components/landing/pr-review.tsx
@@ -70,7 +70,7 @@ const FINDINGS = [
 ];
 
 const PullRequestMock = () => (
-	<Figure caption="Fig. 03 — Pull request review" meta="delta vs base branch">
+	<Figure caption="Fig. 02 — Pull request review" meta="delta vs base branch">
 		<div
 			className="font-sans text-[12px] leading-normal tracking-normal"
 			style={{ background: G.bg, color: "#e6edf3" }}


### PR DESCRIPTION
## Problem

The landing page's figure captions read 01, 03, 04, 05. Fig. 02 was the examination report poster, cut while trimming the page down, and the remaining captions were never renumbered.

## Solution

Shift the three captions after the gap down by one.

| Figure | Before | After |
|---|---|---|
| Terminal recording | Fig. 01 | Fig. 01 |
| Pull request review | Fig. 03 | **Fig. 02** |
| Module graph | Fig. 04 | **Fig. 03** |
| Entity relation sketch | Fig. 05 | **Fig. 04** |

Nothing outside the landing components refers to these numbers, so there is nothing else to update.