### PR TITLE
feat(website): open external landing links in a new tab, trim the footer

### DIFF
--- a/packages/website/src/app/page.tsx
+++ b/packages/website/src/app/page.tsx
@@ -46,6 +46,8 @@ const Home = () => (
 							}`}
 							href={link.href}
 							key={link.href}
+							rel={link.href.startsWith("http") ? "noreferrer" : undefined}
+							target={link.href.startsWith("http") ? "_blank" : undefined}
 						>
 							{link.label}
 						</a>
@@ -55,11 +57,17 @@ const Home = () => (
 
 			<footer className="border-white/30 border-t py-5 pb-10">
 				<div className="flex flex-wrap justify-between gap-3 font-bold text-[11px] text-white/75 uppercase tracking-[0.1em]">
-					<span>
-						NDX-001 · nestjs-doctor · MIT · will look the same next year
-					</span>
+					<span>nestjs-doctor · MIT</span>
 					<span className="normal-case tracking-[0.06em]">
-						no telemetry · no network calls at scan time · RoloBits
+						no telemetry · no network calls at scan time ·{" "}
+						<a
+							className="text-white/75 underline decoration-white/30 underline-offset-2 transition-colors hover:text-white hover:decoration-white"
+							href="https://x.com/FranLoPy"
+							rel="noreferrer"
+							target="_blank"
+						>
+							RoloBits
+						</a>
 					</span>
 				</div>
 			</footer>

--- a/packages/website/src/components/landing/hero.tsx
+++ b/packages/website/src/components/landing/hero.tsx
@@ -100,6 +100,8 @@ export const Nav = () => (
 					className="inline-flex items-center border border-white/30 px-4 py-1.5 font-bold text-[11px] text-white/75 uppercase tracking-[0.08em] no-underline transition-colors hover:border-white hover:bg-white hover:text-black"
 					href={link.href}
 					key={link.href}
+					rel={link.href.startsWith("http") ? "noreferrer" : undefined}
+					target={link.href.startsWith("http") ? "_blank" : undefined}
 				>
 					{link.label}
 				</a>


### PR DESCRIPTION
## Context

The landing page ends in a row of link buttons and a two-line footer. Four of those links leave the site.

## Problem

Every off-site link replaced the current tab, so a reader who clicked GitHub, the VS Code marketplace, or the GitHub Action listing lost the page they were reading.

The footer carried two strings that say nothing. `NDX-001` refers to no real identifier anywhere in the project. "will look the same next year" is a claim the page has no way to keep.

`RoloBits` was plain text.

## Possible flows

| Link | Before | After |
|---|---|---|
| GitHub button | same tab | new tab |
| VS Code extension | same tab | new tab |
| GitHub Action | same tab | new tab |
| Nav GitHub | same tab | new tab |
| Docs button and nav Docs | same tab | unchanged, same site |

## Solution

`target` and `rel` are derived from whether the href starts with `http`, rather than set per link, so a link added later gets the same treatment without anyone remembering to.

The nav's GitHub link was not in the request but had the same defect, and leaving one of two GitHub buttons behaving differently would read as a bug.

`RoloBits` links to https://x.com/FranLoPy in a new tab. It carries a faint underline instead of matching the plain text beside it: a link that looks exactly like its neighbours is clickable but undiscoverable.

## Before vs after

| | Before | After |
|---|---|---|
| External links opening in a new tab | 0 of 5 | 5 of 5 |
| Internal links opening in a new tab | 0 | 0 |
| Footer left | `NDX-001 · nestjs-doctor · MIT · will look the same next year` | `nestjs-doctor · MIT` |
| `RoloBits` | plain text | link to x.com/FranLoPy |

## Example

```tsx
rel={link.href.startsWith("http") ? "noreferrer" : undefined}
target={link.href.startsWith("http") ? "_blank" : undefined}
```

Verified against the built HTML: 5 external anchors carry `target="_blank"`, none lack it, and both `/docs` anchors stay in the same tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGVR6E5GSeEBp6fVGAc9CS