### PR TITLE
feat: let a rule report without moving the score

### DIFF
--- a/.changeset/diagnostic-surfaces.md
+++ b/.changeset/diagnostic-surfaces.md
@@ -1,37 +1,47 @@
 ---
 "nestjs-doctor": minor
+"nestjs-doctor-lsp": minor
 ---
 
 Add diagnostic surfaces, so a rule can be reported without moving the score.
 
-`meta.surfaces` names where a rule's diagnostics may appear: `cli` for the
-report, `score` for the 0-100 number, and `ciFailure` for `--blocking`.
-Omitting it means all three, so every existing rule and every custom rule
-behaves exactly as before.
+`meta.surfaces` names where a rule's diagnostics may appear:
+
+| Surface | Where |
+| --- | --- |
+| `cli` | The console report and the HTML report |
+| `prComment` | The pull request summary, its inline review comments, the GitHub annotations, `--format sarif` and `--format gitlab` |
+| `score` | The 0-100 number |
+| `ciFailure` | `--blocking` |
+
+Omitting it means all four, so every existing rule and every custom rule
+behaves exactly as before. `--format json` still carries every finding, with
+`surfaces` on each one, so a consumer filters however it wants.
 
 `correctness/no-async-without-await` and `correctness/prefer-readonly-injection`
 are now `["cli"]`. Measured across ten real NestJS repositories, those two were
 52% of all output, and on one of them 148 of 251 findings. Both encode a
 preference rather than a defect, and both were dragging every score that met
-them. They still report in full, and they no longer fail a build.
+them. They still report every finding in the console and the HTML report, and
+they no longer comment on a pull request or fail a build.
 
 Scores rise as a result. On the same ten repositories the change is between
 0 and +12 points.
 
-Every surface says which findings are report-only: the console appends
-`· not scored`, the pull request comment marks the severity cell, and the HTML
-report carries a badge beside the rule id plus an "N of M not scored" line
-under the score, so the number and the issue count reconcile.
+The console appends `· not scored` to a finding that does not reach the score.
+The HTML report carries a badge beside the rule id, an `N of M not scored` line
+under the score so the two numbers reconcile, and a **Show not scored**
+checkbox that starts off.
 
-A pull request comment is its own surface. `prComment` keeps a report-only rule
-out of the summary table and out of the inline review comments, so a house
-style never lands as a review note on someone's branch.
-
-Surfaces are also configurable. `"rules": { "<id>": { "surfaces": [...] } }`
+Surfaces are configurable. `"rules": { "<id>": { "surfaces": [...] } }`
 replaces what a rule declares, so a team that does want a style enforced can
-put it back on the score and the build.
+put it back on the score and the build. A value that is not a list of known
+surface names is ignored rather than applied, so a typo cannot quietly narrow
+what gets reported.
 
-In the editor, a report-only finding is reported as a hint rather than a
-warning, so it stays visible while you write without sitting in the Problems
-panel beside real defects. `DiagnosticSurface` and `onSurface` are exported, so
-a custom rule can declare surfaces and a consumer can read them.
+In the editor, a finding that can neither score nor fail a build is reported as
+a hint rather than a warning, so it stays visible while you write without
+sitting in the Problems panel beside real defects.
+
+`DiagnosticSurface`, `BaseDiagnostic`, `onSurface` and `forSurface` are
+exported, so a custom rule can declare surfaces and a consumer can read them.

--- a/.changeset/diagnostic-surfaces.md
+++ b/.changeset/diagnostic-surfaces.md
@@ -30,3 +30,8 @@ style never lands as a review note on someone's branch.
 Surfaces are also configurable. `"rules": { "<id>": { "surfaces": [...] } }`
 replaces what a rule declares, so a team that does want a style enforced can
 put it back on the score and the build.
+
+In the editor, a report-only finding is reported as a hint rather than a
+warning, so it stays visible while you write without sitting in the Problems
+panel beside real defects. `DiagnosticSurface` and `onSurface` are exported, so
+a custom rule can declare surfaces and a consumer can read them.

--- a/.changeset/diagnostic-surfaces.md
+++ b/.changeset/diagnostic-surfaces.md
@@ -22,3 +22,11 @@ Every surface says which findings are report-only: the console appends
 `· not scored`, the pull request comment marks the severity cell, and the HTML
 report carries a badge beside the rule id plus an "N of M not scored" line
 under the score, so the number and the issue count reconcile.
+
+A pull request comment is its own surface. `prComment` keeps a report-only rule
+out of the summary table and out of the inline review comments, so a house
+style never lands as a review note on someone's branch.
+
+Surfaces are also configurable. `"rules": { "<id>": { "surfaces": [...] } }`
+replaces what a rule declares, so a team that does want a style enforced can
+put it back on the score and the build.

--- a/.changeset/diagnostic-surfaces.md
+++ b/.changeset/diagnostic-surfaces.md
@@ -1,0 +1,19 @@
+---
+"nestjs-doctor": minor
+---
+
+Add diagnostic surfaces, so a rule can be reported without moving the score.
+
+`meta.surfaces` names where a rule's diagnostics may appear: `cli` for the
+report, `score` for the 0-100 number, and `ciFailure` for `--blocking`.
+Omitting it means all three, so every existing rule and every custom rule
+behaves exactly as before.
+
+`correctness/no-async-without-await` and `correctness/prefer-readonly-injection`
+are now `["cli"]`. Measured across ten real NestJS repositories, those two were
+52% of all output, and on one of them 148 of 251 findings. Both encode a
+preference rather than a defect, and both were dragging every score that met
+them. They still report in full, and they no longer fail a build.
+
+Scores rise as a result. On the same ten repositories the change is between
+0 and +12 points.

--- a/.changeset/diagnostic-surfaces.md
+++ b/.changeset/diagnostic-surfaces.md
@@ -17,3 +17,8 @@ them. They still report in full, and they no longer fail a build.
 
 Scores rise as a result. On the same ten repositories the change is between
 0 and +12 points.
+
+Every surface says which findings are report-only: the console appends
+`· not scored`, the pull request comment marks the severity cell, and the HTML
+report carries a badge beside the rule id plus an "N of M not scored" line
+under the score, so the number and the issue count reconcile.

--- a/.claude/skills/nestjs-doctor/SKILL.md
+++ b/.claude/skills/nestjs-doctor/SKILL.md
@@ -39,9 +39,10 @@ npx nestjs-doctor@latest . --verbose
 Work down by severity: errors, then warnings, then info. Security and
 correctness weigh most in the score, performance least.
 
-Some rules are report-only. They are listed with everything else but count
-toward neither the score nor `--blocking`, so fixing one moves no number. Fix
-it because the code reads better, not to raise the score.
+Some rules are report-only. They are listed with everything else but never
+comment on a pull request, move the score, or fail a build, so fixing one moves
+no number. Fix it because the code reads better, not to raise the score. A
+project can put one back with `"rules": { "<id>": { "surfaces": [...] } }`.
 
 ## Fixing a finding
 

--- a/.claude/skills/nestjs-doctor/SKILL.md
+++ b/.claude/skills/nestjs-doctor/SKILL.md
@@ -39,6 +39,10 @@ npx nestjs-doctor@latest . --verbose
 Work down by severity: errors, then warnings, then info. Security and
 correctness weigh most in the score, performance least.
 
+Some rules are report-only. They are listed with everything else but count
+toward neither the score nor `--blocking`, so fixing one moves no number. Fix
+it because the code reads better, not to raise the score.
+
 ## Fixing a finding
 
 Every diagnostic carries a rule id and a `help` line naming the fix. Apply it in

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 ## Checklist
 
-- [ ] `pnpm check && pnpm typecheck && pnpm test && pnpm build` all pass
+- [ ] `pnpm check && pnpm test && pnpm build && pnpm typecheck` all pass (`typecheck` after `build`, it reads the built types)
 - [ ] Tests cover both directions — code that should be flagged and similar code that must not be
 - [ ] A changeset is included (`pnpm changeset add`) if this affects a published package
 - [ ] Docs updated (`README.md`, `packages/website/`) if behaviour or flags changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - run: pnpm build
       - run: pnpm typecheck
       - run: pnpm --filter nestjs-doctor smoke:packed
+      # Only the built bundle shows whether the server still pulls the
+      # analyzer in, which no unit test importing src can see.
+      - run: pnpm --filter nestjs-doctor-lsp smoke:bundle
 
   test:
     # The scanner normalises paths, shells out to git, and resolves tsconfig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       # Only the built bundle shows whether the server still pulls the
       # analyzer in, which no unit test importing src can see.
       - run: pnpm --filter nestjs-doctor-lsp smoke:bundle
+      # The extension hand-copies the two LSP bundles and wires itself to
+      # its manifest by string, both of which fail silently.
+      - run: pnpm --filter nestjs-doctor-vscode verify:package
 
   test:
     # The scanner normalises paths, shells out to git, and resolves tsconfig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
       - run: pnpm knip
-      - run: pnpm typecheck
+      # The LSP typechecks against nestjs-doctor's built .d.mts, so build first.
       - run: pnpm build
+      - run: pnpm typecheck
       - run: pnpm --filter nestjs-doctor smoke:packed
 
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ pnpm dev          # Watch mode
 pnpm test         # Run tests (Vitest)
 pnpm check        # Lint with Biome (via Ultracite)
 pnpm fix          # Auto-fix lint + formatting
-pnpm typecheck    # TypeScript type checking
+pnpm typecheck    # TypeScript type checking (run it after pnpm build)
 pnpm knip         # Find unused files, exports, and dependencies
 ```
 
@@ -195,11 +195,14 @@ Always test both directions: code that should trigger the rule and code that sho
 ### 5. Verify
 
 ```bash
-pnpm test         # All tests pass
 pnpm check        # Linting passes
-pnpm typecheck    # No type errors
+pnpm test         # All tests pass
 pnpm build        # Build succeeds
+pnpm typecheck    # No type errors
 ```
+
+`typecheck` runs last because the LSP package resolves `nestjs-doctor` to its
+built `dist` types. On a clean checkout it fails until `build` has run.
 
 If all of those pass, the pre-commit hook will too.
 

--- a/action.yml
+++ b/action.yml
@@ -363,7 +363,10 @@ runs:
             // alone rather than acting on nothing.
             return;
           }
-          const diagnostics = Array.isArray(report.diagnostics) ? report.diagnostics : [];
+          const all = Array.isArray(report.diagnostics) ? report.diagnostics : [];
+          // A rule kept off the prComment surface never comments on a pull
+          // request, and never counts as a reason to keep an old thread open.
+          const diagnostics = all.filter((d) => !d || !Array.isArray(d.surfaces) || d.surfaces.includes("prComment"));
 
           const MARKER = "<!-- nestjs-doctor:review -->";
           const KEY_RE = /<!-- nestjs-doctor:key ([A-Za-z0-9+/=]+) -->/;
@@ -437,8 +440,6 @@ runs:
           const wanted = new Map();
           for (const diagnostic of diagnostics) {
             if (!diagnostic || typeof diagnostic.line !== "number" || diagnostic.line <= 0) continue;
-            // A rule kept off the prComment surface never comments on a pull request.
-            if (Array.isArray(diagnostic.surfaces) && !diagnostic.surfaces.includes("prComment")) continue;
             const repoPath = toRepoPath(diagnostic.filePath);
             if (!repoPath) continue;
             const commentable = commentableByFile.get(repoPath);

--- a/action.yml
+++ b/action.yml
@@ -437,6 +437,8 @@ runs:
           const wanted = new Map();
           for (const diagnostic of diagnostics) {
             if (!diagnostic || typeof diagnostic.line !== "number" || diagnostic.line <= 0) continue;
+            // A rule kept off the prComment surface never comments on a pull request.
+            if (Array.isArray(diagnostic.surfaces) && !diagnostic.surfaces.includes("prComment")) continue;
             const repoPath = toRepoPath(diagnostic.filePath);
             if (!repoPath) continue;
             const commentable = commentableByFile.get(repoPath);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "pnpm --filter nestjs-doctor run test",
     "check": "ultracite check",
     "fix": "ultracite fix",
-    "typecheck": "pnpm --filter nestjs-doctor run typecheck",
+    "typecheck": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run typecheck",
     "build:website": "pnpm --filter website run build",
     "changeset": "changeset",
     "version": "changeset version && pnpm install --no-frozen-lockfile && node scripts/sync-skill-version.mjs",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@10.2.0",
   "scripts": {
     "dev": "pnpm --filter nestjs-doctor run dev",
-    "build": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run build",
+    "build": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp --filter nestjs-doctor-vscode run build",
     "test": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run test",
     "check": "ultracite check",
     "fix": "ultracite fix",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "pnpm --filter nestjs-doctor run dev",
     "build": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run build",
-    "test": "pnpm --filter nestjs-doctor run test",
+    "test": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run test",
     "check": "ultracite check",
     "fix": "ultracite fix",
     "typecheck": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp --filter nestjs-doctor-vscode run typecheck",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "pnpm --filter nestjs-doctor run test",
     "check": "ultracite check",
     "fix": "ultracite fix",
-    "typecheck": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run typecheck",
+    "typecheck": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp --filter nestjs-doctor-vscode run typecheck",
     "build:website": "pnpm --filter website run build",
     "changeset": "changeset",
     "version": "changeset version && pnpm install --no-frozen-lockfile && node scripts/sync-skill-version.mjs",

--- a/packages/nestjs-doctor-lsp/package.json
+++ b/packages/nestjs-doctor-lsp/package.json
@@ -16,6 +16,8 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "smoke:bundle": "node scripts/smoke-bundle.mjs",
+    "test": "vitest run",
     "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit"
   },
@@ -40,6 +42,7 @@
     "nestjs-doctor": "workspace:>=0.8.0"
   },
   "devDependencies": {
-    "tsdown": "^0.20.3"
+    "tsdown": "^0.20.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/nestjs-doctor-lsp/scripts/smoke-bundle.mjs
+++ b/packages/nestjs-doctor-lsp/scripts/smoke-bundle.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// The server resolves nestjs-doctor from the user's workspace, so the bundle
+// must not require it. Unit tests import the source and never see the bundle,
+// which is where that regression lived: a value-import put
+// require("nestjs-doctor") at the top of dist/server.cjs and every install
+// outside this monorepo died with MODULE_NOT_FOUND before reading a request.
+import { spawn } from "node:child_process";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
+import { isBuiltin } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const bundle = join(pkgRoot, "dist", "server.cjs");
+const REQUIRE_RE = /require\("([^"]+)"\)/g;
+
+if (!existsSync(bundle)) {
+	console.error(`Missing ${bundle}. Run \`pnpm build\` first.`);
+	process.exit(1);
+}
+
+const fail = (message) => {
+	console.error(`LSP bundle smoke failed: ${message}`);
+	process.exit(1);
+};
+
+// 1. Nothing outside Node's builtins may be required.
+const source = readFileSync(bundle, "utf-8");
+const required = [...source.matchAll(REQUIRE_RE)].map((m) => m[1]);
+const bare = [...new Set(required.filter((id) => !isBuiltin(id)))];
+if (bare.length > 0) {
+	fail(`bundle requires ${bare.join(", ")}, which is not installed beside it`);
+}
+
+// 2. It has to actually start with no nestjs-doctor anywhere above it.
+const work = mkdtempSync(join(tmpdir(), "nd-lsp-smoke-"));
+mkdirSync(join(work, "dist"));
+copyFileSync(bundle, join(work, "dist", "server.cjs"));
+
+const child = spawn(process.execPath, ["dist/server.cjs", "--stdio"], {
+	cwd: work,
+	stdio: ["pipe", "pipe", "pipe"],
+});
+
+let stderr = "";
+let stdout = "";
+child.stderr.on("data", (chunk) => {
+	stderr += chunk;
+});
+child.stdout.on("data", (chunk) => {
+	stdout += chunk;
+});
+
+// A well-formed initialize request; a live server answers, a dead one does not.
+const body = JSON.stringify({
+	jsonrpc: "2.0",
+	id: 1,
+	method: "initialize",
+	params: { processId: null, rootUri: null, capabilities: {} },
+});
+child.stdin.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+
+setTimeout(() => {
+	child.kill();
+	rmSync(work, { recursive: true, force: true });
+
+	if (
+		stderr.includes("MODULE_NOT_FOUND") ||
+		stderr.includes("Cannot find module")
+	) {
+		fail(
+			`server could not load outside a workspace:\n${stderr.split("\n").slice(0, 6).join("\n")}`
+		);
+	}
+	if (!stdout.includes("capabilities")) {
+		fail(
+			`server did not answer initialize. stdout: ${stdout.slice(0, 200) || "(empty)"}\nstderr: ${stderr.slice(0, 400) || "(empty)"}`
+		);
+	}
+
+	console.log(
+		"LSP bundle ok: builtins only, answers initialize outside a workspace"
+	);
+}, 3000);

--- a/packages/nestjs-doctor-lsp/src/convert.ts
+++ b/packages/nestjs-doctor-lsp/src/convert.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "node:url";
-import { type Diagnostic, onSurface, type Severity } from "nestjs-doctor";
+import type { Diagnostic, DiagnosticSurface, Severity } from "nestjs-doctor";
 import {
 	DiagnosticSeverity,
 	type Diagnostic as LspDiagnostic,
@@ -11,6 +11,11 @@ const severityMap: Record<Severity, DiagnosticSeverity> = {
 	info: DiagnosticSeverity.Information,
 };
 
+/** Inlined rather than imported: nestjs-doctor is resolved from the user's
+ *  workspace, so the server bundle must not require it. */
+const on = (d: Diagnostic, surface: DiagnosticSurface): boolean =>
+	d.surfaces?.includes(surface) ?? true;
+
 function toRange(line: number, column: number) {
 	const l = Math.max(line - 1, 0);
 	const c = Math.max(column - 1, 0);
@@ -19,16 +24,14 @@ function toRange(line: number, column: number) {
 
 function toLspDiagnostic(d: Diagnostic): LspDiagnostic {
 	const range = "line" in d ? toRange(d.line, d.column) : toRange(1, 1);
-	// A report-only rule shows as a hint, so it stays visible while you edit
-	// without adding to the warning count beside real defects.
-	const notScored = !onSurface(d, "score");
+	const advisory = !(on(d, "score") || on(d, "ciFailure"));
 	return {
 		range,
-		severity: notScored ? DiagnosticSeverity.Hint : severityMap[d.severity],
+		severity: advisory ? DiagnosticSeverity.Hint : severityMap[d.severity],
 		code: d.rule,
 		source: "nestjs-doctor",
 		message: d.message,
-		data: { category: d.category, help: d.help, notScored },
+		data: { advisory, category: d.category, help: d.help },
 	};
 }
 

--- a/packages/nestjs-doctor-lsp/src/convert.ts
+++ b/packages/nestjs-doctor-lsp/src/convert.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Diagnostic, DiagnosticSurface, Severity } from "nestjs-doctor";
 import {
@@ -42,9 +43,11 @@ export function groupByFile(
 	const grouped = new Map<string, LspDiagnostic[]>();
 
 	for (const d of diagnostics) {
-		const absolutePath = d.filePath.startsWith("/")
+		// A leading slash is not what absolute looks like on Windows, where a
+		// scanned path arrives drive-prefixed as D:/proj/src/a.ts.
+		const absolutePath = isAbsolute(d.filePath)
 			? d.filePath
-			: `${workspaceRoot}/${d.filePath}`;
+			: resolve(workspaceRoot, d.filePath);
 		const uri = pathToFileURL(absolutePath).toString();
 
 		let list = grouped.get(uri);

--- a/packages/nestjs-doctor-lsp/src/convert.ts
+++ b/packages/nestjs-doctor-lsp/src/convert.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "node:url";
-import type { Diagnostic, Severity } from "nestjs-doctor";
+import { type Diagnostic, onSurface, type Severity } from "nestjs-doctor";
 import {
 	DiagnosticSeverity,
 	type Diagnostic as LspDiagnostic,
@@ -19,13 +19,16 @@ function toRange(line: number, column: number) {
 
 function toLspDiagnostic(d: Diagnostic): LspDiagnostic {
 	const range = "line" in d ? toRange(d.line, d.column) : toRange(1, 1);
+	// A report-only rule shows as a hint, so it stays visible while you edit
+	// without adding to the warning count beside real defects.
+	const notScored = !onSurface(d, "score");
 	return {
 		range,
-		severity: severityMap[d.severity],
+		severity: notScored ? DiagnosticSeverity.Hint : severityMap[d.severity],
 		code: d.rule,
 		source: "nestjs-doctor",
 		message: d.message,
-		data: { help: d.help, category: d.category },
+		data: { category: d.category, help: d.help, notScored },
 	};
 }
 

--- a/packages/nestjs-doctor-lsp/src/diagnostic-cache.ts
+++ b/packages/nestjs-doctor-lsp/src/diagnostic-cache.ts
@@ -1,0 +1,67 @@
+const BACKSLASH_RE = /\\/g;
+const DRIVE_RE = /^([a-zA-Z]):/;
+
+/**
+ * One spelling of a path for the cache. The scanner reports forward slashes
+ * while the editor sends native ones, so on Windows the same file arrives as
+ * both D:/proj/a.ts and D:\proj\a.ts.
+ */
+export function toCacheKey(filePath: string): string {
+	const posix = filePath.replace(BACKSLASH_RE, "/");
+	return posix.replace(
+		DRIVE_RE,
+		(_match, letter: string) => `${letter.toLowerCase()}:`
+	);
+}
+
+/** Per-file findings from the last scan that touched each file. */
+export class DiagnosticCache {
+	private readonly byFile = new Map<string, unknown[]>();
+
+	set(filePath: string, diagnostics: unknown[]): void {
+		this.byFile.set(toCacheKey(filePath), diagnostics);
+	}
+
+	clear(): void {
+		this.byFile.clear();
+	}
+
+	/** Replaces everything, grouping a full scan's findings by their file. */
+	replaceAll(diagnostics: Array<{ filePath?: string }>): void {
+		this.byFile.clear();
+		for (const diagnostic of diagnostics) {
+			const key = toCacheKey(diagnostic.filePath ?? "");
+			let list = this.byFile.get(key);
+			if (!list) {
+				list = [];
+				this.byFile.set(key, list);
+			}
+			list.push(diagnostic);
+		}
+	}
+
+	/** Every cached file finding, followed by the project-wide ones. */
+	withProject(projectDiagnostics: unknown[]): unknown[] {
+		const all: unknown[] = [];
+		for (const diagnostics of this.byFile.values()) {
+			all.push(...diagnostics);
+		}
+		all.push(...projectDiagnostics);
+		return all;
+	}
+
+	get size(): number {
+		return this.byFile.size;
+	}
+}
+
+/**
+ * Whether a startup failure is the analyzer being absent from the workspace,
+ * which the user fixes by installing it, rather than a fault to report.
+ */
+export function isMissingAnalyzer(message: string): boolean {
+	return (
+		message.includes("Cannot find module 'nestjs-doctor'") ||
+		message.includes('Cannot find module "nestjs-doctor"')
+	);
+}

--- a/packages/nestjs-doctor-lsp/src/publish.ts
+++ b/packages/nestjs-doctor-lsp/src/publish.ts
@@ -1,0 +1,56 @@
+import type { Diagnostic as LspDiagnostic } from "vscode-languageserver/node";
+
+export type SendDiagnostics = (
+	uri: string,
+	diagnostics: LspDiagnostic[]
+) => void;
+
+/** Compares what the editor renders, so an unchanged file is not republished. */
+export function diagnosticsEqual(
+	a: LspDiagnostic[],
+	b: LspDiagnostic[]
+): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	for (let i = 0; i < a.length; i++) {
+		const da = a[i];
+		const db = b[i];
+		if (
+			da.code !== db.code ||
+			da.message !== db.message ||
+			da.severity !== db.severity ||
+			da.range.start.line !== db.range.start.line ||
+			da.range.start.character !== db.range.start.character
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Sends what changed and an empty list for every file that dropped out, which
+ * is what clears a finding the user has just fixed. Returns the new cache.
+ */
+export function publishDiagnostics(
+	previous: Map<string, LspDiagnostic[]>,
+	next: Map<string, LspDiagnostic[]>,
+	send: SendDiagnostics
+): Map<string, LspDiagnostic[]> {
+	for (const uri of previous.keys()) {
+		if (!next.has(uri)) {
+			send(uri, []);
+		}
+	}
+
+	for (const [uri, diagnostics] of next) {
+		const cached = previous.get(uri);
+		if (cached && diagnosticsEqual(cached, diagnostics)) {
+			continue;
+		}
+		send(uri, diagnostics);
+	}
+
+	return next;
+}

--- a/packages/nestjs-doctor-lsp/src/scan-worker.ts
+++ b/packages/nestjs-doctor-lsp/src/scan-worker.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
 import { parentPort, workerData } from "node:worker_threads";
+import { DiagnosticCache, isMissingAnalyzer } from "./diagnostic-cache.js";
 import type {
 	ServerMessage,
 	WorkerData,
@@ -34,16 +35,7 @@ interface NestjsDoctorApi {
 }
 
 let ctx: ScanContext | null = null;
-const fileDiagCache = new Map<string, unknown[]>();
-
-function collectAllDiagnostics(projectDiagnostics: unknown[]): unknown[] {
-	const all: unknown[] = [];
-	for (const diags of fileDiagCache.values()) {
-		all.push(...diags);
-	}
-	all.push(...projectDiagnostics);
-	return all;
-}
+const fileDiagCache = new DiagnosticCache();
 
 function handleFileChanged(api: NestjsDoctorApi, filePath: string) {
 	if (!ctx) {
@@ -57,7 +49,7 @@ function handleFileChanged(api: NestjsDoctorApi, filePath: string) {
 	const elapsedMs = performance.now() - start;
 	post({
 		kind: "result",
-		diagnostics: collectAllDiagnostics(projectResult.diagnostics),
+		diagnostics: fileDiagCache.withProject(projectResult.diagnostics),
 		elapsedMs,
 		scanType: "incremental",
 	});
@@ -69,21 +61,14 @@ function handleFullScan(api: NestjsDoctorApi) {
 	}
 	const start = performance.now();
 	const fileResult = api.checkAllFiles(ctx);
-	fileDiagCache.clear();
-	for (const d of fileResult.diagnostics as Array<{ filePath?: string }>) {
-		const key = d.filePath ?? "";
-		let list = fileDiagCache.get(key);
-		if (!list) {
-			list = [];
-			fileDiagCache.set(key, list);
-		}
-		list.push(d);
-	}
+	fileDiagCache.replaceAll(
+		fileResult.diagnostics as Array<{ filePath?: string }>
+	);
 	const projectResult = api.checkProject(ctx);
 	const elapsedMs = performance.now() - start;
 	post({
 		kind: "result",
-		diagnostics: collectAllDiagnostics(projectResult.diagnostics),
+		diagnostics: fileDiagCache.withProject(projectResult.diagnostics),
 		elapsedMs,
 		scanType: "full",
 	});
@@ -118,7 +103,7 @@ async function initialize() {
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 
-		if (message.includes("Cannot find module 'nestjs-doctor'")) {
+		if (isMissingAnalyzer(message)) {
 			post({ kind: "missing" });
 		} else {
 			post({ kind: "error", message });

--- a/packages/nestjs-doctor-lsp/src/server.ts
+++ b/packages/nestjs-doctor-lsp/src/server.ts
@@ -147,7 +147,7 @@ function spawnWorker() {
 		}
 	});
 
-	worker.on("error", (err) => {
+	worker.on("error", (err: Error) => {
 		connection.window.showErrorMessage(
 			`NestJS Doctor worker error: ${err.message}`
 		);

--- a/packages/nestjs-doctor-lsp/src/server.ts
+++ b/packages/nestjs-doctor-lsp/src/server.ts
@@ -12,6 +12,7 @@ import {
 	TextDocumentSyncKind,
 } from "vscode-languageserver/node";
 import { groupByFile } from "./convert.js";
+import { publishDiagnostics } from "./publish.js";
 import type {
 	ServerMessage,
 	WorkerData,
@@ -42,44 +43,6 @@ let workerReady = false;
 let pendingMessages: ServerMessage[] = [];
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 let saveReceivedAt = 0;
-
-function diagnosticsEqual(a: LspDiagnostic[], b: LspDiagnostic[]): boolean {
-	if (a.length !== b.length) {
-		return false;
-	}
-	for (let i = 0; i < a.length; i++) {
-		const da = a[i];
-		const db = b[i];
-		if (
-			da.code !== db.code ||
-			da.message !== db.message ||
-			da.severity !== db.severity ||
-			da.range.start.line !== db.range.start.line ||
-			da.range.start.character !== db.range.start.character
-		) {
-			return false;
-		}
-	}
-	return true;
-}
-
-function publishDiagnostics(grouped: Map<string, LspDiagnostic[]>) {
-	for (const uri of cache.keys()) {
-		if (!grouped.has(uri)) {
-			connection.sendDiagnostics({ uri, diagnostics: [] });
-		}
-	}
-
-	for (const [uri, diagnostics] of grouped) {
-		const cached = cache.get(uri);
-		if (cached && diagnosticsEqual(cached, diagnostics)) {
-			continue;
-		}
-		connection.sendDiagnostics({ uri, diagnostics });
-	}
-
-	cache = grouped;
-}
 
 function sendToWorker(msg: ServerMessage) {
 	if (!activeWorker) {
@@ -122,7 +85,9 @@ function spawnWorker() {
 				msg.diagnostics as Parameters<typeof groupByFile>[0],
 				workspaceRoot
 			);
-			publishDiagnostics(grouped);
+			cache = publishDiagnostics(cache, grouped, (uri, diagnostics) =>
+				connection.sendDiagnostics({ uri, diagnostics })
+			);
 
 			if (saveReceivedAt > 0) {
 				const e2eMs = performance.now() - saveReceivedAt;

--- a/packages/nestjs-doctor-lsp/src/server.ts
+++ b/packages/nestjs-doctor-lsp/src/server.ts
@@ -147,10 +147,9 @@ function spawnWorker() {
 		}
 	});
 
-	worker.on("error", (err: Error) => {
-		connection.window.showErrorMessage(
-			`NestJS Doctor worker error: ${err.message}`
-		);
+	worker.on("error", (err: unknown) => {
+		const detail = err instanceof Error ? err.message : String(err);
+		connection.window.showErrorMessage(`NestJS Doctor worker error: ${detail}`);
 		terminateWorker();
 		setTimeout(() => spawnWorker(), 3000);
 	});

--- a/packages/nestjs-doctor-lsp/tests/convert.test.ts
+++ b/packages/nestjs-doctor-lsp/tests/convert.test.ts
@@ -1,0 +1,126 @@
+import type { Diagnostic } from "nestjs-doctor";
+import { describe, expect, it } from "vitest";
+import { DiagnosticSeverity } from "vscode-languageserver";
+import { groupByFile } from "../src/convert.js";
+
+const ROOT = "/repo";
+
+const code = (overrides: Partial<Diagnostic> = {}): Diagnostic =>
+	({
+		rule: "performance/no-sync-io",
+		category: "performance",
+		severity: "warning",
+		filePath: "/repo/src/a.service.ts",
+		message: "Synchronous I/O blocks the event loop.",
+		help: "Use the async variant.",
+		line: 4,
+		column: 3,
+		...overrides,
+	}) as Diagnostic;
+
+const only = (diagnostics: Diagnostic[]) => {
+	const grouped = groupByFile(diagnostics, ROOT);
+	const [first] = [...grouped.values()];
+	return first;
+};
+
+describe("editor severity by surface", () => {
+	it("keeps the rule's own severity when it declares no surfaces", () => {
+		const [lsp] = only([code()]);
+
+		expect(lsp.severity).toBe(DiagnosticSeverity.Warning);
+		expect(lsp.data).toMatchObject({ advisory: false });
+	});
+
+	it("keeps it for a rule that still scores", () => {
+		const [lsp] = only([code({ surfaces: ["cli", "score"] })]);
+
+		expect(lsp.severity).toBe(DiagnosticSeverity.Warning);
+	});
+
+	it("keeps it for a rule that fails a build without scoring", () => {
+		const [lsp] = only([code({ surfaces: ["cli", "ciFailure"] })]);
+
+		expect(lsp.severity).toBe(DiagnosticSeverity.Warning);
+		expect(lsp.data).toMatchObject({ advisory: false });
+	});
+
+	it("demotes to a hint only when it can neither score nor gate", () => {
+		const [lsp] = only([
+			code({
+				rule: "correctness/prefer-readonly-injection",
+				surfaces: ["cli"],
+			}),
+		]);
+
+		expect(lsp.severity).toBe(DiagnosticSeverity.Hint);
+		expect(lsp.data).toMatchObject({ advisory: true });
+	});
+
+	it("demotes an error the same way, since severity is not the question", () => {
+		const [lsp] = only([code({ severity: "error", surfaces: ["cli"] })]);
+
+		expect(lsp.severity).toBe(DiagnosticSeverity.Hint);
+	});
+
+	it("maps each severity when the finding is not advisory", () => {
+		const severities = only([
+			code({ severity: "error", line: 1 }),
+			code({ severity: "warning", line: 2 }),
+			code({ severity: "info", line: 3 }),
+		]).map((d) => d.severity);
+
+		expect(severities).toEqual([
+			DiagnosticSeverity.Error,
+			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Information,
+		]);
+	});
+});
+
+describe("groupByFile", () => {
+	it("converts to a file URI and groups every finding under it", () => {
+		const grouped = groupByFile([code({ line: 1 }), code({ line: 2 })], ROOT);
+
+		expect([...grouped.keys()]).toEqual(["file:///repo/src/a.service.ts"]);
+		expect(grouped.get("file:///repo/src/a.service.ts")).toHaveLength(2);
+	});
+
+	it("resolves a relative path against the workspace root", () => {
+		const grouped = groupByFile([code({ filePath: "src/b.ts" })], ROOT);
+
+		expect([...grouped.keys()]).toEqual(["file:///repo/src/b.ts"]);
+	});
+
+	it("converts one-based positions to the editor's zero-based range", () => {
+		const [lsp] = only([code({ line: 4, column: 3 })]);
+
+		expect(lsp.range).toEqual({
+			start: { line: 3, character: 2 },
+			end: { line: 3, character: 2 },
+		});
+	});
+
+	it("clamps a zero line to the top of the file rather than going negative", () => {
+		const [lsp] = only([code({ line: 0, column: 0 })]);
+
+		expect(lsp.range.start).toEqual({ line: 0, character: 0 });
+	});
+
+	it("puts a schema finding, which carries no line, on line one", () => {
+		const [lsp] = only([
+			{
+				rule: "schema/require-primary-key",
+				category: "schema",
+				severity: "error",
+				filePath: "/repo/prisma/schema.prisma",
+				message: "Entity 'User' has no primary key.",
+				help: "Add one.",
+				entity: "User",
+			} as Diagnostic,
+		]);
+
+		expect(lsp.range.start).toEqual({ line: 0, character: 0 });
+		expect(lsp.severity).toBe(DiagnosticSeverity.Error);
+	});
+});

--- a/packages/nestjs-doctor-lsp/tests/convert.test.ts
+++ b/packages/nestjs-doctor-lsp/tests/convert.test.ts
@@ -1,16 +1,20 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import type { Diagnostic } from "nestjs-doctor";
 import { describe, expect, it } from "vitest";
 import { DiagnosticSeverity } from "vscode-languageserver";
 import { groupByFile } from "../src/convert.js";
 
-const ROOT = "/repo";
+const ROOT = resolve("/repo");
+const SERVICE = resolve("/repo/src/a.service.ts");
+const uriOf = (path: string) => pathToFileURL(path).toString();
 
 const code = (overrides: Partial<Diagnostic> = {}): Diagnostic =>
 	({
 		rule: "performance/no-sync-io",
 		category: "performance",
 		severity: "warning",
-		filePath: "/repo/src/a.service.ts",
+		filePath: SERVICE,
 		message: "Synchronous I/O blocks the event loop.",
 		help: "Use the async variant.",
 		line: 4,
@@ -82,14 +86,25 @@ describe("groupByFile", () => {
 	it("converts to a file URI and groups every finding under it", () => {
 		const grouped = groupByFile([code({ line: 1 }), code({ line: 2 })], ROOT);
 
-		expect([...grouped.keys()]).toEqual(["file:///repo/src/a.service.ts"]);
-		expect(grouped.get("file:///repo/src/a.service.ts")).toHaveLength(2);
+		expect([...grouped.keys()]).toEqual([uriOf(SERVICE)]);
+		expect(grouped.get(uriOf(SERVICE))).toHaveLength(2);
 	});
 
 	it("resolves a relative path against the workspace root", () => {
 		const grouped = groupByFile([code({ filePath: "src/b.ts" })], ROOT);
 
-		expect([...grouped.keys()]).toEqual(["file:///repo/src/b.ts"]);
+		expect([...grouped.keys()]).toEqual([uriOf(resolve(ROOT, "src/b.ts"))]);
+	});
+
+	it("leaves an already absolute path alone instead of joining it again", () => {
+		// The scanner reports forward slashes on every platform, so on Windows a
+		// path arrives as D:/proj/src/a.ts and never starts with a slash.
+		const scanned = resolve("/repo/src/a.service.ts").replace(/\\/g, "/");
+		const grouped = groupByFile([code({ filePath: scanned })], ROOT);
+
+		const [uri] = [...grouped.keys()];
+		expect(uri).toBe(uriOf(SERVICE));
+		expect(uri).not.toContain("repo/src/a.service.ts/");
 	});
 
 	it("converts one-based positions to the editor's zero-based range", () => {

--- a/packages/nestjs-doctor-lsp/tests/diagnostic-cache.test.ts
+++ b/packages/nestjs-doctor-lsp/tests/diagnostic-cache.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+	DiagnosticCache,
+	isMissingAnalyzer,
+	toCacheKey,
+} from "../src/diagnostic-cache.js";
+
+const at = (filePath: string, message = "finding") => ({ filePath, message });
+
+describe("toCacheKey", () => {
+	it("leaves a posix path alone", () => {
+		expect(toCacheKey("/proj/src/a.ts")).toBe("/proj/src/a.ts");
+	});
+
+	it("spells a native Windows path the way the scanner does", () => {
+		expect(toCacheKey("D:\\proj\\src\\a.ts")).toBe("d:/proj/src/a.ts");
+	});
+
+	it("agrees with itself across both spellings of the same file", () => {
+		expect(toCacheKey("D:\\proj\\src\\a.ts")).toBe(
+			toCacheKey("D:/proj/src/a.ts")
+		);
+	});
+
+	it("folds the drive letter, which the editor and the scanner disagree on", () => {
+		expect(toCacheKey("c:/proj/a.ts")).toBe(toCacheKey("C:/proj/a.ts"));
+	});
+
+	it("does not fold anything else, since posix paths are case sensitive", () => {
+		expect(toCacheKey("/proj/A.ts")).not.toBe(toCacheKey("/proj/a.ts"));
+	});
+});
+
+describe("DiagnosticCache", () => {
+	it("returns file findings followed by the project-wide ones", () => {
+		const cache = new DiagnosticCache();
+		cache.set("/proj/a.ts", [at("/proj/a.ts", "one")]);
+		cache.set("/proj/b.ts", [at("/proj/b.ts", "two")]);
+
+		expect(cache.withProject([at("", "cycle")])).toEqual([
+			at("/proj/a.ts", "one"),
+			at("/proj/b.ts", "two"),
+			at("", "cycle"),
+		]);
+	});
+
+	it("groups a full scan by file", () => {
+		const cache = new DiagnosticCache();
+		cache.replaceAll([
+			at("/proj/a.ts", "one"),
+			at("/proj/a.ts", "two"),
+			at("/proj/b.ts", "three"),
+		]);
+
+		expect(cache.size).toBe(2);
+		expect(cache.withProject([])).toHaveLength(3);
+	});
+
+	it("drops the previous scan rather than adding to it", () => {
+		const cache = new DiagnosticCache();
+		cache.replaceAll([at("/proj/a.ts", "stale")]);
+		cache.replaceAll([at("/proj/b.ts", "fresh")]);
+
+		expect(cache.withProject([])).toEqual([at("/proj/b.ts", "fresh")]);
+	});
+
+	it("replaces a file's findings on edit instead of appending", () => {
+		const cache = new DiagnosticCache();
+		cache.replaceAll([at("/proj/a.ts", "before")]);
+		cache.set("/proj/a.ts", [at("/proj/a.ts", "after")]);
+
+		expect(cache.withProject([])).toEqual([at("/proj/a.ts", "after")]);
+	});
+
+	it("treats a native edit path as the file the scan already stored", () => {
+		// The full scan keys by the scanner's forward-slash path, the edit by the
+		// editor's native one. Two entries here means every finding in the file
+		// shows twice on Windows, with the pre-edit set never clearing.
+		const cache = new DiagnosticCache();
+		cache.replaceAll([at("D:/proj/src/a.ts", "before")]);
+		cache.set("D:\\proj\\src\\a.ts", [at("D:/proj/src/a.ts", "after")]);
+
+		expect(cache.size).toBe(1);
+		expect(cache.withProject([])).toEqual([at("D:/proj/src/a.ts", "after")]);
+	});
+
+	it("empties on clear", () => {
+		const cache = new DiagnosticCache();
+		cache.replaceAll([at("/proj/a.ts")]);
+		cache.clear();
+
+		expect(cache.size).toBe(0);
+		expect(cache.withProject([at("", "cycle")])).toEqual([at("", "cycle")]);
+	});
+});
+
+describe("isMissingAnalyzer", () => {
+	it("recognises the workspace not having nestjs-doctor installed", () => {
+		expect(isMissingAnalyzer("Cannot find module 'nestjs-doctor'")).toBe(true);
+	});
+
+	it("recognises the double-quoted spelling some Node versions emit", () => {
+		expect(isMissingAnalyzer('Cannot find module "nestjs-doctor"')).toBe(true);
+	});
+
+	it("does not swallow a different module going missing", () => {
+		expect(isMissingAnalyzer("Cannot find module 'ts-morph'")).toBe(false);
+	});
+
+	it("does not swallow a real fault, which the user needs to see", () => {
+		expect(isMissingAnalyzer("Unexpected token in tsconfig.json")).toBe(false);
+	});
+});

--- a/packages/nestjs-doctor-lsp/tests/publish.test.ts
+++ b/packages/nestjs-doctor-lsp/tests/publish.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import type { Diagnostic as LspDiagnostic } from "vscode-languageserver/node";
+import { diagnosticsEqual, publishDiagnostics } from "../src/publish.js";
+
+const diag = (overrides: Partial<LspDiagnostic> = {}): LspDiagnostic =>
+	({
+		range: {
+			start: { line: 3, character: 2 },
+			end: { line: 3, character: 2 },
+		},
+		severity: 2,
+		code: "performance/no-sync-io",
+		source: "nestjs-doctor",
+		message: "Synchronous I/O blocks the event loop.",
+		...overrides,
+	}) as LspDiagnostic;
+
+const recorder = () => {
+	const sent: Array<{ uri: string; diagnostics: LspDiagnostic[] }> = [];
+	return {
+		sent,
+		send: (uri: string, diagnostics: LspDiagnostic[]) => {
+			sent.push({ uri, diagnostics });
+		},
+	};
+};
+
+const A = "file:///proj/a.ts";
+const B = "file:///proj/b.ts";
+
+describe("publishDiagnostics", () => {
+	it("sends every file on the first scan", () => {
+		const { sent, send } = recorder();
+
+		publishDiagnostics(new Map(), new Map([[A, [diag()]]]), send);
+
+		expect(sent).toEqual([{ uri: A, diagnostics: [diag()] }]);
+	});
+
+	it("clears a file whose findings are all gone", () => {
+		const { sent, send } = recorder();
+		const previous = new Map([[A, [diag()]]]);
+
+		publishDiagnostics(previous, new Map(), send);
+
+		expect(sent).toEqual([{ uri: A, diagnostics: [] }]);
+	});
+
+	it("says nothing about a file that did not change", () => {
+		const { sent, send } = recorder();
+		const previous = new Map([[A, [diag()]]]);
+
+		publishDiagnostics(previous, new Map([[A, [diag()]]]), send);
+
+		expect(sent).toEqual([]);
+	});
+
+	it("sends the file that changed and leaves the other alone", () => {
+		const { sent, send } = recorder();
+		const previous = new Map([
+			[A, [diag()]],
+			[B, [diag()]],
+		]);
+		const next = new Map([
+			[A, [diag()]],
+			[B, [diag({ message: "something else" })]],
+		]);
+
+		publishDiagnostics(previous, next, send);
+
+		expect(sent.map((s) => s.uri)).toEqual([B]);
+	});
+
+	it("returns the new map so the next call compares against it", () => {
+		const { send } = recorder();
+		const next = new Map([[A, [diag()]]]);
+
+		expect(publishDiagnostics(new Map(), next, send)).toBe(next);
+	});
+
+	it("clears one file while publishing another in the same pass", () => {
+		const { sent, send } = recorder();
+		const previous = new Map([[A, [diag()]]]);
+
+		publishDiagnostics(previous, new Map([[B, [diag()]]]), send);
+
+		expect(sent).toEqual([
+			{ uri: A, diagnostics: [] },
+			{ uri: B, diagnostics: [diag()] },
+		]);
+	});
+});
+
+describe("diagnosticsEqual", () => {
+	it("is true for the same findings", () => {
+		expect(diagnosticsEqual([diag()], [diag()])).toBe(true);
+	});
+
+	it.each([
+		["a different count", [diag(), diag()]],
+		["a different message", [diag({ message: "other" })]],
+		["a different rule", [diag({ code: "correctness/other" })]],
+		["a different severity", [diag({ severity: 1 })]],
+		[
+			"a moved line",
+			[
+				diag({
+					range: {
+						start: { line: 9, character: 2 },
+						end: { line: 9, character: 2 },
+					},
+				}),
+			],
+		],
+	])("is false for %s", (_label, other) => {
+		expect(diagnosticsEqual([diag()], other as LspDiagnostic[])).toBe(false);
+	});
+
+	it("is true for two empty lists, so a clean file is not republished", () => {
+		expect(diagnosticsEqual([], [])).toBe(true);
+	});
+});

--- a/packages/nestjs-doctor-lsp/tsconfig.json
+++ b/packages/nestjs-doctor-lsp/tsconfig.json
@@ -2,11 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
     "noEmit": true,
     "declarationMap": true,
     "strictNullChecks": true
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/nestjs-doctor-lsp/vitest.config.ts
+++ b/packages/nestjs-doctor-lsp/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -76,6 +76,7 @@
   "scripts": {
     "build": "tsdown && cp ../nestjs-doctor-lsp/dist/server.cjs dist/server.cjs && cp ../nestjs-doctor-lsp/dist/scan-worker.cjs dist/scan-worker.cjs",
     "dev": "pnpm --filter nestjs-doctor-lsp build && tsdown --watch",
+    "verify:package": "node scripts/verify-package.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -89,6 +90,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/vscode": "^1.85.0",
+    "nestjs-doctor-lsp": "workspace:*",
     "tsdown": "^0.20.3"
   }
 }

--- a/packages/nestjs-doctor-vscode/scripts/verify-package.mjs
+++ b/packages/nestjs-doctor-vscode/scripts/verify-package.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// The extension ships three bundles, two of them hand-copied out of the LSP
+// package by the build script, and it wires itself to the manifest by string.
+// Nothing else checks either, and both fail silently: a missing server.cjs
+// means the client never starts, a renamed command means the status bar does
+// nothing when clicked.
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(
+	readFileSync(join(pkgRoot, "package.json"), "utf-8")
+);
+const source = readFileSync(join(pkgRoot, "src", "extension.ts"), "utf-8");
+const problems = [];
+
+// The entry the manifest names, plus the two the extension spawns.
+const entry = manifest.main.replace(/^\.\//, "");
+for (const file of [entry, "dist/server.cjs", "dist/scan-worker.cjs"]) {
+	if (!existsSync(join(pkgRoot, file))) {
+		problems.push(`${file} is missing. Run \`pnpm build\` first.`);
+	}
+}
+
+// Every command the extension registers has to be contributed, or it cannot
+// be invoked from the palette.
+const contributed = new Set(
+	(manifest.contributes?.commands ?? []).map((c) => c.command)
+);
+const registered = [...source.matchAll(/registerCommand\(\s*"([^"]+)"/g)].map(
+	(m) => m[1]
+);
+const wired = [...source.matchAll(/\.command\s*=\s*"([^"]+)"/g)].map(
+	(m) => m[1]
+);
+for (const command of [...registered, ...wired]) {
+	if (!contributed.has(command)) {
+		problems.push(`command "${command}" is used in source but not contributed`);
+	}
+}
+for (const command of contributed) {
+	if (!(registered.includes(command) || wired.includes(command))) {
+		problems.push(`command "${command}" is contributed but never registered`);
+	}
+}
+
+// Settings the server and the extension read, which the manifest has to
+// declare or the user gets no default and no editor completion.
+const declared = new Set(
+	Object.keys(manifest.contributes?.configuration?.properties ?? {})
+);
+const serverSource = readFileSync(
+	join(pkgRoot, "..", "nestjs-doctor-lsp", "src", "server.ts"),
+	"utf-8"
+);
+const section = "nestjsDoctor";
+const read = new Set([
+	...[...source.matchAll(/config\.get<[^>]*>\(\s*"([^"]+)"/g)].map((m) => m[1]),
+	...[...serverSource.matchAll(/settings\.([a-zA-Z]+)/g)].map((m) => m[1]),
+]);
+for (const key of read) {
+	if (!declared.has(`${section}.${key}`)) {
+		problems.push(`setting "${section}.${key}" is read but not contributed`);
+	}
+}
+
+if (problems.length > 0) {
+	console.error("VS Code package verification failed:");
+	for (const problem of problems) {
+		console.error(`  - ${problem}`);
+	}
+	process.exit(1);
+}
+
+console.log(
+	`VS Code package ok: 3 bundles, ${contributed.size} command(s), ${read.size} setting(s) all wired`
+);

--- a/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
@@ -39,9 +39,10 @@ npx nestjs-doctor@latest . --verbose
 Work down by severity: errors, then warnings, then info. Security and
 correctness weigh most in the score, performance least.
 
-Some rules are report-only. They are listed with everything else but count
-toward neither the score nor `--blocking`, so fixing one moves no number. Fix
-it because the code reads better, not to raise the score.
+Some rules are report-only. They are listed with everything else but never
+comment on a pull request, move the score, or fail a build, so fixing one moves
+no number. Fix it because the code reads better, not to raise the score. A
+project can put one back with `"rules": { "<id>": { "surfaces": [...] } }`.
 
 ## Fixing a finding
 

--- a/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
@@ -39,6 +39,10 @@ npx nestjs-doctor@latest . --verbose
 Work down by severity: errors, then warnings, then info. Security and
 correctness weigh most in the score, performance least.
 
+Some rules are report-only. They are listed with everything else but count
+toward neither the score nor `--blocking`, so fixing one moves no number. Fix
+it because the code reads better, not to raise the score.
+
 ## Fixing a finding
 
 Every diagnostic carries a rule id and a `help` line naming the fix. Apply it in

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -23,6 +23,7 @@ export type {
 } from "../common/diagnostic.js";
 // biome-ignore lint/performance/noBarrelFile: this is the public API surface
 export {
+	forSurface,
 	isCodeDiagnostic,
 	isSchemaDiagnostic,
 	onSurface,

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -17,6 +17,7 @@ export type {
 	Category,
 	CodeDiagnostic,
 	Diagnostic,
+	DiagnosticSurface,
 	SchemaDiagnostic,
 	Severity,
 } from "../common/diagnostic.js";
@@ -24,6 +25,7 @@ export type {
 export {
 	isCodeDiagnostic,
 	isSchemaDiagnostic,
+	onSurface,
 } from "../common/diagnostic.js";
 export type {
 	DependencyType,

--- a/packages/nestjs-doctor/src/cli/blocking.ts
+++ b/packages/nestjs-doctor/src/cli/blocking.ts
@@ -1,4 +1,4 @@
-import type { DiagnoseSummary } from "../common/result.js";
+import { type Diagnostic, onSurface } from "../common/diagnostic.js";
 
 /** Severity at or above which findings fail the run. */
 export type BlockingLevel = "none" | "warning" | "error";
@@ -28,16 +28,19 @@ export function resolveBlocking(
 	return isMachineReadable ? "none" : "error";
 }
 
-/** True when the findings in `summary` should fail the run at `level`. */
+/** True when the findings in `diagnostics` should fail the run at `level`. */
 export function shouldBlock(
-	summary: DiagnoseSummary,
+	diagnostics: Diagnostic[],
 	level: BlockingLevel
 ): boolean {
 	if (level === "none") {
 		return false;
 	}
+	const gating = diagnostics.filter((d) => onSurface(d, "ciFailure"));
 	if (level === "warning") {
-		return summary.errors + summary.warnings > 0;
+		return gating.some(
+			(d) => d.severity === "error" || d.severity === "warning"
+		);
 	}
-	return summary.errors > 0;
+	return gating.some((d) => d.severity === "error");
 }

--- a/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from "../../common/diagnostic.js";
+import { type Diagnostic, onSurface } from "../../common/diagnostic.js";
 import type { DiagnoseResult, MonorepoResult } from "../../common/result.js";
 import { highlighter } from "../ui/highlighter.js";
 import { logger } from "../ui/logger.js";
@@ -205,7 +205,11 @@ const printDiagnostics = (
 		const countLabel =
 			count > 1 ? colorizeBySeverity(` (${count})`, first.severity) : "";
 
-		logger.log(`  ${icon} ${first.message}${countLabel}`);
+		const notScored = onSurface(first, "score")
+			? ""
+			: highlighter.dim(" · not scored");
+
+		logger.log(`  ${icon} ${first.message}${countLabel}${notScored}`);
 
 		if (first.help) {
 			logger.dim(`    ${first.help}`);

--- a/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
@@ -369,7 +369,10 @@ export function printMonorepoReport(
 	logger.break();
 
 	for (const subProject of monorepoResult.subProjects) {
-		const { name, result } = subProject;
+		const { name } = subProject;
+		// Same narrowing the combined report above uses, so a line here cannot
+		// count findings the tree never shows.
+		const result = withSurface(subProject.result, "cli");
 		const scoreText = colorizeByScore(
 			String(result.score.value),
 			result.score.value

--- a/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
@@ -1,5 +1,6 @@
 import { type Diagnostic, onSurface } from "../../common/diagnostic.js";
 import type { DiagnoseResult, MonorepoResult } from "../../common/result.js";
+import { withSurface } from "../../engine/result-builder.js";
 import { highlighter } from "../ui/highlighter.js";
 import { logger } from "../ui/logger.js";
 
@@ -230,9 +231,10 @@ const printDiagnostics = (
 // --- Main reporter ---
 
 export function printConsoleReport(
-	result: DiagnoseResult,
+	fullResult: DiagnoseResult,
 	verbose: boolean
 ): void {
+	const result = withSurface(fullResult, "cli");
 	const { score, diagnostics, project, summary, elapsedMs } = result;
 
 	logger.break();

--- a/packages/nestjs-doctor/src/cli/formatters/github-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/github-reporter.ts
@@ -1,6 +1,6 @@
 import { appendFileSync } from "node:fs";
 import type { Diagnostic, Severity } from "../../common/diagnostic.js";
-import { isCodeDiagnostic } from "../../common/diagnostic.js";
+import { forSurface, isCodeDiagnostic } from "../../common/diagnostic.js";
 import type { DiagnoseResult } from "../../common/result.js";
 import { toRelativePath } from "../../engine/fingerprint.js";
 import {
@@ -74,7 +74,7 @@ export function buildAnnotations(
 	};
 	const lines: string[] = [];
 
-	for (const diagnostic of result.diagnostics) {
+	for (const diagnostic of forSurface(result.diagnostics, "prComment")) {
 		const level = LEVEL_BY_SEVERITY[diagnostic.severity];
 		if (emitted[level] >= MAX_ANNOTATIONS_PER_LEVEL) {
 			continue;

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -60,7 +60,7 @@ function enforceGates(
 		process.exit(FAILURE_EXIT_CODE);
 	}
 
-	if (shouldBlock(result.summary, options.blocking)) {
+	if (shouldBlock(result.diagnostics, options.blocking)) {
 		process.exit(FAILURE_EXIT_CODE);
 	}
 }

--- a/packages/nestjs-doctor/src/common/config.ts
+++ b/packages/nestjs-doctor/src/common/config.ts
@@ -1,10 +1,12 @@
-import type { Category, Severity } from "./diagnostic.js";
+import type { Category, DiagnosticSurface, Severity } from "./diagnostic.js";
 
 export interface RuleOverride {
 	enabled?: boolean;
 	excludeClasses?: string[];
 	options?: Record<string, unknown>;
 	severity?: Severity;
+	/** Replaces the rule's own `meta.surfaces`. */
+	surfaces?: DiagnosticSurface[];
 }
 
 export interface NestjsDoctorIgnoreConfig {

--- a/packages/nestjs-doctor/src/common/diagnostic.ts
+++ b/packages/nestjs-doctor/src/common/diagnostic.ts
@@ -60,3 +60,9 @@ export const onSurface = (
 	diagnostic: BaseDiagnostic,
 	surface: DiagnosticSurface
 ): boolean => diagnostic.surfaces?.includes(surface) ?? true;
+
+/** The diagnostics a surface is allowed to show. */
+export const forSurface = <T extends BaseDiagnostic>(
+	diagnostics: T[],
+	surface: DiagnosticSurface
+): T[] => diagnostics.filter((diagnostic) => onSurface(diagnostic, surface));

--- a/packages/nestjs-doctor/src/common/diagnostic.ts
+++ b/packages/nestjs-doctor/src/common/diagnostic.ts
@@ -6,7 +6,7 @@ export type Severity = "error" | "warning" | "info";
  * Where a diagnostic is allowed to appear. A rule can be reported without
  * moving the score or failing a build.
  */
-export type DiagnosticSurface = "cli" | "score" | "ciFailure";
+export type DiagnosticSurface = "cli" | "prComment" | "score" | "ciFailure";
 
 export type Category =
 	| "security"

--- a/packages/nestjs-doctor/src/common/diagnostic.ts
+++ b/packages/nestjs-doctor/src/common/diagnostic.ts
@@ -1,6 +1,13 @@
 import type { RuleScope } from "../engine/rules/types.js";
 
 export type Severity = "error" | "warning" | "info";
+
+/**
+ * Where a diagnostic is allowed to appear. A rule can be reported without
+ * moving the score or failing a build.
+ */
+export type DiagnosticSurface = "cli" | "score" | "ciFailure";
+
 export type Category =
 	| "security"
 	| "performance"
@@ -21,6 +28,8 @@ export interface BaseDiagnostic {
 	rule: string;
 	scope?: RuleScope;
 	severity: Severity;
+	/** Absent means every surface. */
+	surfaces?: DiagnosticSurface[];
 	/** The emitting rule's `meta.tags`, when it declares any. */
 	tags?: string[];
 }
@@ -45,3 +54,9 @@ export function isCodeDiagnostic(d: Diagnostic): d is CodeDiagnostic {
 export function isSchemaDiagnostic(d: Diagnostic): d is SchemaDiagnostic {
 	return "entity" in d;
 }
+
+/** Absent surfaces mean the diagnostic appears everywhere. */
+export const onSurface = (
+	diagnostic: BaseDiagnostic,
+	surface: DiagnosticSurface
+): boolean => diagnostic.surfaces?.includes(surface) ?? true;

--- a/packages/nestjs-doctor/src/engine/result-builder.ts
+++ b/packages/nestjs-doctor/src/engine/result-builder.ts
@@ -1,4 +1,9 @@
-import { type Diagnostic, isSchemaDiagnostic } from "../common/diagnostic.js";
+import {
+	type Diagnostic,
+	type DiagnosticSurface,
+	forSurface,
+	isSchemaDiagnostic,
+} from "../common/diagnostic.js";
 import type { EndpointNode } from "../common/endpoint.js";
 import type {
 	DiagnoseResult,
@@ -50,6 +55,21 @@ export function withScopedDiagnostics(
 		summary: buildSummary(diagnostics),
 		...(scope ? { scope } : {}),
 	};
+}
+
+/**
+ * The result as one surface sees it: diagnostics and counts narrowed, score
+ * left alone because it always reflects the whole project.
+ */
+export function withSurface(
+	result: DiagnoseResult,
+	surface: DiagnosticSurface
+): DiagnoseResult {
+	const diagnostics = forSurface(result.diagnostics, surface);
+	if (diagnostics.length === result.diagnostics.length) {
+		return result;
+	}
+	return { ...result, diagnostics, summary: buildSummary(diagnostics) };
 }
 
 function buildSummary(diagnostics: Diagnostic[]): DiagnoseSummary {

--- a/packages/nestjs-doctor/src/engine/rule-runner.ts
+++ b/packages/nestjs-doctor/src/engine/rule-runner.ts
@@ -84,6 +84,9 @@ function runFileRulesOnFile(
 					...(Array.isArray(rule.meta.tags)
 						? { tags: [...rule.meta.tags] }
 						: {}),
+					...(Array.isArray(rule.meta.surfaces)
+						? { surfaces: [...rule.meta.surfaces] }
+						: {}),
 					sourceLines,
 				});
 			},
@@ -144,6 +147,9 @@ export function runProjectRules(
 					...(Array.isArray(rule.meta.tags)
 						? { tags: [...rule.meta.tags] }
 						: {}),
+					...(Array.isArray(rule.meta.surfaces)
+						? { surfaces: [...rule.meta.surfaces] }
+						: {}),
 				});
 			},
 		};
@@ -178,6 +184,9 @@ export function runSchemaRules(
 					severity: rule.meta.severity,
 					...(Array.isArray(rule.meta.tags)
 						? { tags: [...rule.meta.tags] }
+						: {}),
+					...(Array.isArray(rule.meta.surfaces)
+						? { surfaces: [...rule.meta.surfaces] }
 						: {}),
 				});
 			},

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-async-without-await.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-async-without-await.ts
@@ -26,6 +26,7 @@ export const noAsyncWithoutAwait: Rule = {
 		id: "correctness/no-async-without-await",
 		category: "correctness",
 		severity: "warning",
+		surfaces: ["cli"],
 		description:
 			"Async functions/methods should contain at least one await expression",
 		help: "Either add an await expression or remove the async keyword. Framework entry points are exempted, since Nest awaits what they return: route handlers, GraphQL resolvers, WebSocket, microservice, ts-rest and gRPC handlers.",

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/prefer-readonly-injection.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/prefer-readonly-injection.ts
@@ -7,6 +7,7 @@ export const preferReadonlyInjection: Rule = {
 		id: "correctness/prefer-readonly-injection",
 		category: "correctness",
 		severity: "warning",
+		surfaces: ["cli"],
 		description:
 			"Constructor DI parameters should be readonly to prevent accidental reassignment",
 		help: "Add the 'readonly' modifier to the constructor parameter.",

--- a/packages/nestjs-doctor/src/engine/rules/rule-pipeline.ts
+++ b/packages/nestjs-doctor/src/engine/rules/rule-pipeline.ts
@@ -1,4 +1,5 @@
 import type { NestjsDoctorConfig } from "../../common/config.js";
+import type { DiagnosticSurface } from "../../common/diagnostic.js";
 import type { AnyRule, ProjectRule, Rule, SchemaRule } from "./types.js";
 import { isProjectRule, isSchemaRule } from "./types.js";
 
@@ -27,7 +28,23 @@ export function mergeRules(
 	return merged;
 }
 
-/** A rule with `config.rules[id].surfaces` applied over its own declaration. */
+const KNOWN_SURFACES: readonly DiagnosticSurface[] = [
+	"cli",
+	"prComment",
+	"score",
+	"ciFailure",
+];
+
+/** True for a non-empty array naming only known surfaces. */
+const isSurfaceList = (value: unknown): value is DiagnosticSurface[] =>
+	Array.isArray(value) &&
+	value.length > 0 &&
+	value.every((entry) => KNOWN_SURFACES.includes(entry as DiagnosticSurface));
+
+/**
+ * A rule with `config.rules[id].surfaces` applied over its own declaration.
+ * An unusable override is ignored, so a typo widens rather than narrows.
+ */
 const withConfiguredSurfaces = (
 	config: NestjsDoctorConfig,
 	rule: AnyRule
@@ -35,10 +52,15 @@ const withConfiguredSurfaces = (
 	const ruleConfig = config.rules?.[rule.meta.id];
 	const surfaces =
 		typeof ruleConfig === "object" ? ruleConfig.surfaces : undefined;
-	if (!surfaces) {
+	if (surfaces === undefined || !isSurfaceList(surfaces)) {
 		return rule;
 	}
-	return { ...rule, meta: { ...rule.meta, surfaces } } as AnyRule;
+	// check is bound so a class-instance rule keeps its prototype methods.
+	return {
+		...rule,
+		check: rule.check.bind(rule),
+		meta: { ...rule.meta, surfaces },
+	} as AnyRule;
 };
 
 export function filterRules(

--- a/packages/nestjs-doctor/src/engine/rules/rule-pipeline.ts
+++ b/packages/nestjs-doctor/src/engine/rules/rule-pipeline.ts
@@ -27,26 +27,42 @@ export function mergeRules(
 	return merged;
 }
 
+/** A rule with `config.rules[id].surfaces` applied over its own declaration. */
+const withConfiguredSurfaces = (
+	config: NestjsDoctorConfig,
+	rule: AnyRule
+): AnyRule => {
+	const ruleConfig = config.rules?.[rule.meta.id];
+	const surfaces =
+		typeof ruleConfig === "object" ? ruleConfig.surfaces : undefined;
+	if (!surfaces) {
+		return rule;
+	}
+	return { ...rule, meta: { ...rule.meta, surfaces } } as AnyRule;
+};
+
 export function filterRules(
 	config: NestjsDoctorConfig,
 	rules: AnyRule[]
 ): AnyRule[] {
-	return rules.filter((rule) => {
-		const ruleConfig = config.rules?.[rule.meta.id];
-		if (ruleConfig === false) {
-			return false;
-		}
-		if (typeof ruleConfig === "object" && ruleConfig.enabled === false) {
-			return false;
-		}
+	return rules
+		.filter((rule) => {
+			const ruleConfig = config.rules?.[rule.meta.id];
+			if (ruleConfig === false) {
+				return false;
+			}
+			if (typeof ruleConfig === "object" && ruleConfig.enabled === false) {
+				return false;
+			}
 
-		const categoryEnabled = config.categories?.[rule.meta.category];
-		if (categoryEnabled === false) {
-			return false;
-		}
+			const categoryEnabled = config.categories?.[rule.meta.category];
+			if (categoryEnabled === false) {
+				return false;
+			}
 
-		return true;
-	});
+			return true;
+		})
+		.map((rule) => withConfiguredSurfaces(config, rule));
 }
 
 export function separateRules(rules: AnyRule[]): {

--- a/packages/nestjs-doctor/src/engine/rules/types.ts
+++ b/packages/nestjs-doctor/src/engine/rules/types.ts
@@ -3,6 +3,7 @@ import type { NestjsDoctorConfig } from "../../common/config.js";
 import type {
 	Category,
 	CodeDiagnostic,
+	DiagnosticSurface,
 	SchemaDiagnostic,
 	Severity,
 } from "../../common/diagnostic.js";
@@ -21,6 +22,11 @@ export interface RuleMeta {
 	id: string;
 	scope?: RuleScope;
 	severity: Severity;
+	/**
+	 * Where the rule's diagnostics may appear. Omitted means every surface.
+	 * `["cli"]` reports without touching the score or failing a build.
+	 */
+	surfaces?: readonly DiagnosticSurface[];
 	/**
 	 * Labels stamped onto every diagnostic the rule emits. `module-graph`
 	 * marks module wiring rules for the report's problems drawer.

--- a/packages/nestjs-doctor/src/engine/scorer/index.ts
+++ b/packages/nestjs-doctor/src/engine/scorer/index.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from "../../common/diagnostic.js";
+import { type Diagnostic, onSurface } from "../../common/diagnostic.js";
 import type { Score } from "../../common/result.js";
 import { getScoreLabel } from "./labels.js";
 import { CATEGORY_MULTIPLIERS, SEVERITY_WEIGHTS } from "./weights.js";
@@ -35,6 +35,9 @@ export function calculateScore(
 	let totalPenalty = 0;
 
 	for (const d of diagnostics) {
+		if (!onSurface(d, "score")) {
+			continue;
+		}
 		const severityWeight = SEVERITY_WEIGHTS[d.severity];
 		const categoryMultiplier = CATEGORY_MULTIPLIERS[d.category];
 		totalPenalty += severityWeight * categoryMultiplier;

--- a/packages/nestjs-doctor/src/formatters/gitlab-report.ts
+++ b/packages/nestjs-doctor/src/formatters/gitlab-report.ts
@@ -1,5 +1,5 @@
 import type { Diagnostic, Severity } from "../common/diagnostic.js";
-import { isCodeDiagnostic } from "../common/diagnostic.js";
+import { forSurface, isCodeDiagnostic } from "../common/diagnostic.js";
 import type { DiagnoseResult } from "../common/result.js";
 import { fingerprint, toRelativePath } from "../engine/fingerprint.js";
 
@@ -26,16 +26,20 @@ export function buildCodeQualityReport(
 	result: DiagnoseResult,
 	targetPath: string
 ): CodeQualityIssue[] {
-	return result.diagnostics.map((diagnostic: Diagnostic) => ({
-		description: `${diagnostic.message} ${diagnostic.help}`.trim(),
-		check_name: diagnostic.rule,
-		fingerprint: fingerprint(diagnostic, targetPath),
-		severity: SEVERITY_MAP[diagnostic.severity],
-		location: {
-			path: toRelativePath(targetPath, diagnostic.filePath),
-			lines: {
-				begin: isCodeDiagnostic(diagnostic) ? Math.max(1, diagnostic.line) : 1,
+	return forSurface(result.diagnostics, "prComment").map(
+		(diagnostic: Diagnostic) => ({
+			description: `${diagnostic.message} ${diagnostic.help}`.trim(),
+			check_name: diagnostic.rule,
+			fingerprint: fingerprint(diagnostic, targetPath),
+			severity: SEVERITY_MAP[diagnostic.severity],
+			location: {
+				path: toRelativePath(targetPath, diagnostic.filePath),
+				lines: {
+					begin: isCodeDiagnostic(diagnostic)
+						? Math.max(1, diagnostic.line)
+						: 1,
+				},
 			},
-		},
-	}));
+		})
+	);
 }

--- a/packages/nestjs-doctor/src/formatters/markdown-report.ts
+++ b/packages/nestjs-doctor/src/formatters/markdown-report.ts
@@ -1,5 +1,5 @@
 import type { Category, Diagnostic } from "../common/diagnostic.js";
-import { isCodeDiagnostic } from "../common/diagnostic.js";
+import { isCodeDiagnostic, onSurface } from "../common/diagnostic.js";
 import type { DiagnoseResult, MonorepoResult } from "../common/result.js";
 import type { ScopeInfo } from "../common/scope.js";
 import { toRelativePath } from "../engine/fingerprint.js";
@@ -139,7 +139,7 @@ function renderFindingsTable(
 	const shown = sorted.slice(0, MAX_TABLE_ROWS);
 	const rows = shown.map(
 		(diagnostic) =>
-			`| ${diagnostic.severity} | \`${diagnostic.rule}\` | ${locationOf(diagnostic, targetPath)} | ${escapeCell(diagnostic.message)} |`
+			`| ${diagnostic.severity}${onSurface(diagnostic, "score") ? "" : " (not scored)"} | \`${diagnostic.rule}\` | ${locationOf(diagnostic, targetPath)} | ${escapeCell(diagnostic.message)} |`
 	);
 
 	const overflow =

--- a/packages/nestjs-doctor/src/formatters/markdown-report.ts
+++ b/packages/nestjs-doctor/src/formatters/markdown-report.ts
@@ -1,8 +1,9 @@
 import type { Category, Diagnostic } from "../common/diagnostic.js";
-import { isCodeDiagnostic, onSurface } from "../common/diagnostic.js";
+import { isCodeDiagnostic } from "../common/diagnostic.js";
 import type { DiagnoseResult, MonorepoResult } from "../common/result.js";
 import type { ScopeInfo } from "../common/scope.js";
 import { toRelativePath } from "../engine/fingerprint.js";
+import { withSurface } from "../engine/result-builder.js";
 
 /** Square logo, sized to sit on the heading's baseline. */
 const LOGO =
@@ -135,9 +136,7 @@ function renderFindingsTable(
 		return [];
 	}
 
-	const sorted = sortDiagnostics(
-		result.diagnostics.filter((d) => onSurface(d, "prComment"))
-	);
+	const sorted = sortDiagnostics(result.diagnostics);
 	const shown = sorted.slice(0, MAX_TABLE_ROWS);
 	const rows = shown.map(
 		(diagnostic) =>
@@ -176,10 +175,10 @@ function renderMonorepoTable(monorepo: MonorepoResult | undefined): string[] {
 		"",
 		"| Project | Score | Findings |",
 		"| --- | ---: | ---: |",
-		...monorepo.subProjects.map(
-			({ name, result }) =>
-				`| \`${name}\` | ${result.score.value}/100 | ${result.summary.total} |`
-		),
+		...monorepo.subProjects.map(({ name, result }) => {
+			const shown = withSurface(result, "prComment");
+			return `| \`${name}\` | ${result.score.value}/100 | ${shown.summary.total} |`;
+		}),
 		"",
 		"</details>",
 	];
@@ -205,18 +204,21 @@ export function buildMarkdownReport(
 	options: MarkdownReportOptions
 ): string {
 	const warnings = (options.warnings ?? []).filter(Boolean);
+	// Every renderer below reads the same narrowed result, so the headline, the
+	// category table and the rows cannot disagree about how many findings exist.
+	const shown = withSurface(result, "prComment");
 
 	return [
 		MARKDOWN_COMMENT_MARKER,
 		`## ${LOGO} nestjs-doctor`,
 		"",
-		renderHeadline(result, options.scope),
+		renderHeadline(shown, options.scope),
 		...renderScopeNote(options.scope),
 		...(warnings.length
 			? ["", "> [!NOTE]", ...warnings.map((warning) => `> ${warning}`)]
 			: []),
-		...renderCategoryTable(result),
-		...renderFindingsTable(result, options.targetPath),
+		...renderCategoryTable(shown),
+		...renderFindingsTable(shown, options.targetPath),
 		...renderMonorepoTable(options.monorepo),
 		...renderFooter(options),
 		"",

--- a/packages/nestjs-doctor/src/formatters/markdown-report.ts
+++ b/packages/nestjs-doctor/src/formatters/markdown-report.ts
@@ -135,11 +135,13 @@ function renderFindingsTable(
 		return [];
 	}
 
-	const sorted = sortDiagnostics(result.diagnostics);
+	const sorted = sortDiagnostics(
+		result.diagnostics.filter((d) => onSurface(d, "prComment"))
+	);
 	const shown = sorted.slice(0, MAX_TABLE_ROWS);
 	const rows = shown.map(
 		(diagnostic) =>
-			`| ${diagnostic.severity}${onSurface(diagnostic, "score") ? "" : " (not scored)"} | \`${diagnostic.rule}\` | ${locationOf(diagnostic, targetPath)} | ${escapeCell(diagnostic.message)} |`
+			`| ${diagnostic.severity} | \`${diagnostic.rule}\` | ${locationOf(diagnostic, targetPath)} | ${escapeCell(diagnostic.message)} |`
 	);
 
 	const overflow =

--- a/packages/nestjs-doctor/src/formatters/sarif-report.ts
+++ b/packages/nestjs-doctor/src/formatters/sarif-report.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from "node:url";
 import type { Diagnostic, Severity } from "../common/diagnostic.js";
-import { isCodeDiagnostic } from "../common/diagnostic.js";
+import { forSurface, isCodeDiagnostic } from "../common/diagnostic.js";
 import type { DiagnoseResult } from "../common/result.js";
 import { fingerprint, toRelativePath } from "../engine/fingerprint.js";
 import { getRules } from "../engine/rules/index.js";
@@ -143,9 +143,10 @@ export function buildSarifLog(
 	targetPath: string,
 	version: string
 ): SarifLog {
-	const { rules, indexById } = buildRuleCatalogue(result.diagnostics);
+	const diagnostics = forSurface(result.diagnostics, "prComment");
+	const { rules, indexById } = buildRuleCatalogue(diagnostics);
 
-	const results: SarifResult[] = result.diagnostics.map((diagnostic) => {
+	const results: SarifResult[] = diagnostics.map((diagnostic) => {
 		const isCode = isCodeDiagnostic(diagnostic);
 		return {
 			ruleId: diagnostic.rule,

--- a/packages/nestjs-doctor/src/report/formatters/report-data.ts
+++ b/packages/nestjs-doctor/src/report/formatters/report-data.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { forSurface } from "../../common/diagnostic.js";
 import type { DiagnoseResult } from "../../common/result.js";
 import type { ModuleGraph } from "../../engine/graph/module-graph.js";
 import type { ProviderInfo } from "../../engine/graph/type-resolver.js";
@@ -69,14 +70,15 @@ export function prepareReportData(
 		options?.timings
 	);
 
-	const diagnosticsWithoutSource = result.diagnostics.map((d) => {
+	const shown = forSurface(result.diagnostics, "cli");
+	const diagnosticsWithoutSource = shown.map((d) => {
 		if ("sourceLines" in d) {
 			const { sourceLines: _sl, ...rest } = d;
 			return rest;
 		}
 		return d;
 	});
-	const sourceLinesArray = result.diagnostics.map((d) =>
+	const sourceLinesArray = shown.map((d) =>
 		"sourceLines" in d ? (d.sourceLines ?? null) : null
 	);
 

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -31,7 +31,29 @@ export function getReportHtml(): string {
 <div class="tab-content" id="tab-diagnosis">
   <div id="diagnosis-sidebar">
     <div class="diagnosis-toolbar">
+      <div class="schema-sidebar-header">
+        <span class="schema-sidebar-title">Files</span>
+        <span class="schema-entity-count" id="diag-file-count"></span>
+        <span style="flex:1"></span>
+        <button class="st-btn has-tip" id="diag-expand-all" aria-label="Expand all" data-tip="Expand all \u00b7 open every folder in the list">
+          <svg viewBox="0 0 17 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="1" y1="3" x2="8" y2="3"/><line x1="1" y1="7" x2="8" y2="7"/><line x1="1" y1="11" x2="8" y2="11"/>
+            <path d="M11 5l2.5 3L16 5"/>
+          </svg>
+        </button>
+        <button class="st-btn has-tip" id="diag-collapse-all" aria-label="Collapse all" data-tip="Collapse all \u00b7 close every folder in the list">
+          <svg viewBox="0 0 17 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="1" y1="3" x2="8" y2="3"/><line x1="1" y1="7" x2="8" y2="7"/><line x1="1" y1="11" x2="8" y2="11"/>
+            <path d="M11 11l2.5-3L16 11"/>
+          </svg>
+        </button>
+      </div>
       <div class="filter-rows">
+        <label class="schema-sync" id="diag-notscored-row">
+          <input type="checkbox" id="diag-show-notscored">
+          <span>Show not scored</span>
+        </label>
+        <hr class="diag-divider" id="diag-notscored-divider">
         <div class="sev-filters">
           <span class="filter-label">Severity</span>
           <button class="sev-pill active" data-sev="all">All</button>
@@ -46,14 +68,6 @@ export function getReportHtml(): string {
           <button class="scope-pill" data-scope="project">Project</button>
         </div>
       </div>
-      <button class="collapse-all-btn" title="Collapse all folders">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="4 14 10 14 10 20"/>
-          <polyline points="20 10 14 10 14 4"/>
-          <line x1="14" y1="10" x2="21" y2="3"/>
-          <line x1="3" y1="21" x2="10" y2="14"/>
-        </svg>
-      </button>
     </div>
     <div id="diagnosis-rule-list"></div>
   </div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -48,12 +48,12 @@ export function getReportHtml(): string {
           </svg>
         </button>
       </div>
+      <label class="schema-sync" id="diag-notscored-row">
+        <input type="checkbox" id="diag-show-notscored">
+        <span>Show not scored</span>
+      </label>
+      <hr class="diag-divider" id="diag-notscored-divider">
       <div class="filter-rows">
-        <label class="schema-sync" id="diag-notscored-row">
-          <input type="checkbox" id="diag-show-notscored">
-          <span>Show not scored</span>
-        </label>
-        <hr class="diag-divider" id="diag-notscored-divider">
         <div class="sev-filters">
           <span class="filter-label">Severity</span>
           <button class="sev-pill active" data-sev="all">All</button>

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2591,19 +2591,16 @@ function renderDiagnosis() {
   });
 
   // Collapse-all toggle
-  const collapseAllBtn = sidebarEl.querySelector(".collapse-all-btn");
-  collapseAllBtn.addEventListener("click", function() {
+  function diagSetAllFolders(collapsed) {
     const folders = ruleListEl.querySelectorAll(".tree-folder");
-    let someExpanded = false;
     for (let i = 0; i < folders.length; i++) {
-      if (!folders[i].classList.contains("collapsed")) { someExpanded = true; break; }
+      folders[i].classList.toggle("collapsed", collapsed);
     }
-    for (let i = 0; i < folders.length; i++) {
-      if (someExpanded) folders[i].classList.add("collapsed");
-      else folders[i].classList.remove("collapsed");
-    }
-    collapseAllBtn.classList.toggle("all-collapsed", someExpanded);
-  });
+  }
+  const expandAllBtn = document.getElementById("diag-expand-all");
+  const collapseAllBtn = document.getElementById("diag-collapse-all");
+  if (expandAllBtn) expandAllBtn.addEventListener("click", function() { diagSetAllFolders(false); });
+  if (collapseAllBtn) collapseAllBtn.addEventListener("click", function() { diagSetAllFolders(true); });
 
   // Severity filter
   let activeSev = "all";
@@ -2613,7 +2610,15 @@ function renderDiagnosis() {
   let activeScope = "all";
   const scopePills = sidebarEl.querySelectorAll(".scope-pill");
 
+  let showNotScored = false;
+  const notScoredToggle = document.getElementById("diag-show-notscored");
+
+  function isNotScored(d) {
+    return !!(d.surfaces && d.surfaces.indexOf("score") === -1);
+  }
+
   function isDiagVisible(entry) {
+    if (!showNotScored && isNotScored(entry.d)) return false;
     if (activeSev !== "all" && entry.d.severity !== activeSev) return false;
     if (activeScope !== "all" && entry.d.scope !== activeScope) return false;
     return true;
@@ -2630,6 +2635,14 @@ function renderDiagnosis() {
   }
 
   function updateTreeVisibility() {
+    const countEl = document.getElementById("diag-file-count");
+    if (countEl) {
+      let shownFiles = 0;
+      for (const fp in fileMap) {
+        if (countFileVisibleDiags(fp) > 0) shownFiles++;
+      }
+      countEl.textContent = shownFiles;
+    }
     // 1. File nodes — hide if 0 matching diags, update count + severity icon
     const fileNodes = ruleListEl.querySelectorAll(".tree-file");
     for (let f = 0; f < fileNodes.length; f++) {
@@ -2717,6 +2730,20 @@ function renderDiagnosis() {
       updateTreeVisibility();
     });
   }
+  if (notScoredToggle) {
+    // The row is pointless when nothing is filtered by it.
+    const anyNotScored = diagnostics.some(isNotScored);
+    const hideable = ["diag-notscored-row", "diag-notscored-divider"];
+    for (let hi = 0; hi < hideable.length; hi++) {
+      const el = document.getElementById(hideable[hi]);
+      if (el) el.style.display = anyNotScored ? "" : "none";
+    }
+    notScoredToggle.addEventListener("change", function() {
+      showNotScored = this.checked;
+      updateTreeVisibility();
+    });
+  }
+  updateTreeVisibility();
 }
 
 function escHtml(s) {
@@ -2859,6 +2886,7 @@ function renderSummary() {
   let html = '<div class="summary-grid">';
 
   // Score card (full width)
+  var NOT_SCORED_HELP = 'Reported only \u00b7 never counts toward the score or a build failure';
   var notScoredCount = (diagnostics || []).filter(function (d) {
     return d.surfaces && d.surfaces.indexOf('score') === -1;
   }).length;
@@ -2875,8 +2903,13 @@ function renderSummary() {
     '<div class="ov-breakdown-item"><div class="ov-breakdown-dot" style="background:var(--sev-info)"></div> ' + summary.info + ' info</div>' +
     '</div>' +
     (notScoredCount > 0
-      ? '<div class="ov-notscored" title="Reported only. These count toward neither the score nor --blocking.">' +
-        notScoredCount + ' of ' + (summary.total || 0) + ' not scored</div>'
+      ? '<div class="ov-notscored">' + notScoredCount + ' of ' + (summary.total || 0) +
+        ' not scored' +
+        '<span class="ov-info has-tip" tabindex="0" role="img" aria-label="' + NOT_SCORED_HELP + '" data-tip="' + NOT_SCORED_HELP + '">' +
+        '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+        '<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>' +
+        '</span>' +
+        '</div>'
       : '') +
     '</div></div></div>';
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2738,6 +2738,7 @@ function renderDiagnosis() {
       const el = document.getElementById(hideable[hi]);
       if (el) el.style.display = anyNotScored ? "" : "none";
     }
+    showNotScored = notScoredToggle.checked;
     notScoredToggle.addEventListener("change", function() {
       showNotScored = this.checked;
       updateTreeVisibility();

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -142,15 +142,21 @@ function makeScoreRingSvg(size, strokeW, value) {
 })();
 
 // ── Diagnosis count badge ──
-(function() {
+function diagIsNotScored(d) {
+  return !!(d.surfaces && d.surfaces.indexOf("score") === -1);
+}
+/** Matches what the tab lists: the not-scored ones only once they are shown. */
+function setDiagnosisBadge(withNotScored) {
   const badge = document.getElementById("diagnosis-count-badge");
-  if (diagnostics.length > 0) {
-    badge.textContent = diagnostics.length;
-  } else {
-    badge.textContent = "0";
-    badge.classList.add("clean");
+  if (!badge) return;
+  let shown = 0;
+  for (let i = 0; i < diagnostics.length; i++) {
+    if (withNotScored || !diagIsNotScored(diagnostics[i])) shown++;
   }
-})();
+  badge.textContent = shown;
+  badge.classList.toggle("clean", diagnostics.length === 0);
+}
+setDiagnosisBadge(false);
 
 // ── Tab switching ──
 let activeTab = "summary";
@@ -2613,9 +2619,7 @@ function renderDiagnosis() {
   let showNotScored = false;
   const notScoredToggle = document.getElementById("diag-show-notscored");
 
-  function isNotScored(d) {
-    return !!(d.surfaces && d.surfaces.indexOf("score") === -1);
-  }
+  const isNotScored = diagIsNotScored;
 
   function isDiagVisible(entry) {
     if (!showNotScored && isNotScored(entry.d)) return false;
@@ -2739,8 +2743,10 @@ function renderDiagnosis() {
       if (el) el.style.display = anyNotScored ? "" : "none";
     }
     showNotScored = notScoredToggle.checked;
+    setDiagnosisBadge(showNotScored);
     notScoredToggle.addEventListener("change", function() {
       showNotScored = this.checked;
+      setDiagnosisBadge(showNotScored);
       updateTreeVisibility();
     });
   }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2535,6 +2535,9 @@ function renderDiagnosis() {
             '<div class="sev-dot" style="background:' + sevColor + '"></div>' +
             '<span class="code-sev-badge ' + d.severity + '">' + d.severity + '</span>' +
             '<span class="code-rule-badge">' + escHtml(d.rule) + '</span>' +
+            (d.surfaces && d.surfaces.indexOf('score') === -1
+              ? '<span class="code-notscored-badge" title="Reported only. Counts toward neither the score nor --blocking.">not scored</span>'
+              : '') +
             locationLabel +
           '</div>' +
           '<div class="diag-info-msg">' + escHtml(d.message) + '</div>';
@@ -2856,6 +2859,9 @@ function renderSummary() {
   let html = '<div class="summary-grid">';
 
   // Score card (full width)
+  var notScoredCount = (diagnostics || []).filter(function (d) {
+    return d.surfaces && d.surfaces.indexOf('score') === -1;
+  }).length;
   html += '<div class="ov-card full-width"><h3>Health Score</h3>' +
     '<div class="ov-score-row">' +
     '<div class="ov-score-ring">' + makeScoreRingSvg(120, 8, sv) + '</div>' +
@@ -2867,7 +2873,12 @@ function renderSummary() {
     '<div class="ov-breakdown-item"><div class="ov-breakdown-dot" style="background:var(--sev-error)"></div> ' + summary.errors + ' errors</div>' +
     '<div class="ov-breakdown-item"><div class="ov-breakdown-dot" style="background:var(--sev-warning)"></div> ' + summary.warnings + ' warnings</div>' +
     '<div class="ov-breakdown-item"><div class="ov-breakdown-dot" style="background:var(--sev-info)"></div> ' + summary.info + ' info</div>' +
-    '</div></div></div></div>';
+    '</div>' +
+    (notScoredCount > 0
+      ? '<div class="ov-notscored" title="Reported only. These count toward neither the score nor --blocking.">' +
+        notScoredCount + ' of ' + (summary.total || 0) + ' not scored</div>'
+      : '') +
+    '</div></div></div>';
 
   // Project info card
   html += '<div class="ov-card"><h3>Project Info</h3><div class="ov-info-grid">' +

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -471,15 +471,6 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   letter-spacing: 0.5px;
   width: 100%;
 }
-.collapse-all-btn {
-  display: flex; align-items: center; justify-content: center;
-  width: 28px; height: 28px; border-radius: 8px;
-  border: 1px solid var(--border); background: transparent;
-  color: var(--text-muted); cursor: pointer;
-  transition: all 0.15s; flex-shrink: 0; align-self: flex-start;
-}
-.collapse-all-btn:hover { border-color: var(--border-hover); color: var(--text); }
-.collapse-all-btn.all-collapsed { background: rgba(255,255,255,0.08); color: var(--white); border-color: var(--border-hover); }
 .sev-pill, .scope-pill {
   font-size: 11px; padding: 4px 12px; border-radius: 12px;
   border: 1px solid var(--border); background: transparent;
@@ -1175,6 +1166,12 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 /* An icon sits near the left edge, so its tip has to open rightwards. */
 .st-icon.has-tip:is(:hover, :focus-visible)::after { left: 0; right: auto; top: calc(100% + 2px); }
+/* This one sits mid-card, so its tip opens rightwards and wraps. Sizing it
+   against the 13px icon would leave one word per line. */
+.ov-info.has-tip:is(:hover, :focus-visible)::after {
+  white-space: normal; width: max-content; max-width: 220px;
+  left: 0; right: auto; line-height: 1.4;
+}
 .schema-diagram-btn {
   width: 28px; height: 28px; justify-content: center;
   background: rgba(50,50,50,0.9);

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -459,11 +459,10 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   position: sticky; top: 0; z-index: 5;
   background: rgba(17,17,17,0.95);
   backdrop-filter: blur(8px);
-  padding: 12px 14px;
   border-bottom: 1px solid var(--border);
-  display: flex; flex-direction: column; align-items: stretch; gap: 8px;
+  display: flex; flex-direction: column; align-items: stretch;
 }
-.filter-rows { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; }
+.filter-rows { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; padding: 0 16px 12px; }
 .sev-filters, .scope-filters { display: flex; flex-wrap: wrap; gap: 6px; }
 .filter-label {
   font-size: 10px;
@@ -649,11 +648,11 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .ov-info:hover,
 .ov-info:focus-visible { color: rgba(255,255,255,0.7); outline: none; }
-#diag-notscored-row { padding: 0; }
+#diag-notscored-row { margin: 0 -16px; }
 .diag-divider {
   border: none;
   border-top: 1px solid var(--border);
-  margin: 2px 0 4px;
+  margin: 0 -16px 10px;
 }
 .ov-notscored {
   margin-top: 10px;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -462,7 +462,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   border-bottom: 1px solid var(--border);
   display: flex; flex-direction: column; align-items: stretch;
 }
-.filter-rows { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; padding: 0 16px 12px; }
+.filter-rows { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; padding: 10px 16px 12px; }
 .sev-filters, .scope-filters { display: flex; flex-wrap: wrap; gap: 6px; }
 .filter-label {
   font-size: 10px;
@@ -648,11 +648,11 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .ov-info:hover,
 .ov-info:focus-visible { color: rgba(255,255,255,0.7); outline: none; }
-#diag-notscored-row { margin: 0 -16px; }
+
 .diag-divider {
   border: none;
   border-top: 1px solid var(--border);
-  margin: 0 -16px 10px;
+  margin: 0;
 }
 .ov-notscored {
   margin-top: 10px;

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -639,6 +639,19 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   background: rgba(255,255,255,0.06); color: var(--text-muted);
   border: 1px solid var(--border);
 }
+.ov-notscored {
+  margin-top: 10px;
+  font-size: 12px;
+  color: rgba(255,255,255,0.4);
+}
+.code-notscored-badge {
+  padding: 2px 6px;
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 4px;
+  font-size: 11px;
+  color: rgba(255,255,255,0.45);
+  white-space: nowrap;
+}
 .diag-info-item .diag-info-header .diag-linecol {
   font-size: 11px; font-family: monospace; color: var(--text-dim);
 }

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -461,7 +461,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   backdrop-filter: blur(8px);
   padding: 12px 14px;
   border-bottom: 1px solid var(--border);
-  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  display: flex; flex-direction: column; align-items: stretch; gap: 8px;
 }
 .filter-rows { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; }
 .sev-filters, .scope-filters { display: flex; flex-wrap: wrap; gap: 6px; }
@@ -638,6 +638,22 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   padding: 2px 8px; border-radius: 4px;
   background: rgba(255,255,255,0.06); color: var(--text-muted);
   border: 1px solid var(--border);
+}
+.ov-info {
+  position: relative;
+  display: inline-flex;
+  margin-left: 6px;
+  vertical-align: -2px;
+  color: rgba(255,255,255,0.35);
+  cursor: help;
+}
+.ov-info:hover,
+.ov-info:focus-visible { color: rgba(255,255,255,0.7); outline: none; }
+#diag-notscored-row { padding: 0; }
+.diag-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2px 0 4px;
 }
 .ov-notscored {
   margin-top: 10px;

--- a/packages/nestjs-doctor/tests/unit/blocking.test.ts
+++ b/packages/nestjs-doctor/tests/unit/blocking.test.ts
@@ -6,25 +6,31 @@ import {
 	shouldBlock,
 	validateBlockingArg,
 } from "../../src/cli/blocking.js";
-import type { DiagnoseSummary } from "../../src/common/result.js";
+import type {
+	Diagnostic,
+	DiagnosticSurface,
+	Severity,
+} from "../../src/common/diagnostic.js";
 
-const summary = (
-	errors: number,
-	warnings: number,
-	info = 0
-): DiagnoseSummary => ({
-	total: errors + warnings + info,
-	errors,
-	warnings,
-	info,
-	byCategory: {
-		security: 0,
-		performance: 0,
-		correctness: 0,
-		architecture: 0,
-		schema: 0,
-	},
-});
+const at = (severity: Severity, surfaces?: DiagnosticSurface[]): Diagnostic =>
+	({
+		category: "correctness",
+		column: 1,
+		filePath: "a.ts",
+		help: "",
+		line: 1,
+		message: "",
+		rule: "correctness/example",
+		severity,
+		...(surfaces ? { surfaces } : {}),
+	}) as Diagnostic;
+
+/** Diagnostics with no surfaces declared, which is every rule by default. */
+const found = (errors: number, warnings: number, info = 0): Diagnostic[] => [
+	...Array.from({ length: errors }, () => at("error")),
+	...Array.from({ length: warnings }, () => at("warning")),
+	...Array.from({ length: info }, () => at("info")),
+];
 
 describe("blocking levels", () => {
 	it("exposes exactly the three documented levels", () => {
@@ -67,24 +73,40 @@ describe("resolveBlocking", () => {
 
 describe("shouldBlock", () => {
 	it("never blocks at level none", () => {
-		expect(shouldBlock(summary(9, 9, 9), "none")).toBe(false);
+		expect(shouldBlock(found(9, 9, 9), "none")).toBe(false);
 	});
 
 	it("blocks at level error only when errors are present", () => {
-		expect(shouldBlock(summary(1, 0), "error")).toBe(true);
-		expect(shouldBlock(summary(0, 5), "error")).toBe(false);
-		expect(shouldBlock(summary(0, 0, 5), "error")).toBe(false);
+		expect(shouldBlock(found(1, 0), "error")).toBe(true);
+		expect(shouldBlock(found(0, 5), "error")).toBe(false);
+		expect(shouldBlock(found(0, 0, 5), "error")).toBe(false);
 	});
 
 	it("blocks at level warning on errors or warnings, but not on info", () => {
-		expect(shouldBlock(summary(0, 1), "warning")).toBe(true);
-		expect(shouldBlock(summary(2, 0), "warning")).toBe(true);
-		expect(shouldBlock(summary(0, 0, 3), "warning")).toBe(false);
+		expect(shouldBlock(found(0, 1), "warning")).toBe(true);
+		expect(shouldBlock(found(2, 0), "warning")).toBe(true);
+		expect(shouldBlock(found(0, 0, 3), "warning")).toBe(false);
 	});
 
-	it("passes a clean summary at every level", () => {
+	it("passes a clean run at every level", () => {
 		for (const level of BLOCKING_LEVELS) {
-			expect(shouldBlock(summary(0, 0), level)).toBe(false);
+			expect(shouldBlock(found(0, 0), level)).toBe(false);
 		}
+	});
+
+	it("ignores diagnostics that are not on the ciFailure surface", () => {
+		const reportOnly = [at("error", ["cli"]), at("warning", ["cli"])];
+		expect(shouldBlock(reportOnly, "error")).toBe(false);
+		expect(shouldBlock(reportOnly, "warning")).toBe(false);
+	});
+
+	it("still blocks when a gating diagnostic sits beside report-only ones", () => {
+		const mixed = [at("error", ["cli"]), at("error")];
+		expect(shouldBlock(mixed, "error")).toBe(true);
+	});
+
+	it("blocks on a rule that opted into ciFailure explicitly", () => {
+		const explicit = [at("error", ["cli", "ciFailure"])];
+		expect(shouldBlock(explicit, "error")).toBe(true);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/console-reporter.test.ts
+++ b/packages/nestjs-doctor/tests/unit/console-reporter.test.ts
@@ -5,7 +5,9 @@ import {
 	getNestBirds,
 	getSeverityIcon,
 	getStarRating,
+	printConsoleReport,
 	printFramedBox,
+	printMonorepoReport,
 } from "../../src/cli/formatters/console-reporter.js";
 import type { Diagnostic } from "../../src/common/diagnostic.js";
 
@@ -400,5 +402,112 @@ describe("console-reporter", () => {
 			// Should NOT show --verbose hint in verbose mode
 			expect(fullOutput).not.toContain("Run with --verbose");
 		});
+	});
+});
+
+describe("printConsoleReport surfaces", () => {
+	const capture = (): { lines: string[]; restore: () => void } => {
+		const lines: string[] = [];
+		const spy = vi
+			.spyOn(console, "log")
+			.mockImplementation((...args: unknown[]) => {
+				lines.push(args.join(" "));
+			});
+		return { lines, restore: () => spy.mockRestore() };
+	};
+
+	const reportOnly = makeDiagnostic({
+		rule: "correctness/prefer-readonly-injection",
+		message: "Constructor parameter 'repo' should be readonly.",
+		surfaces: ["cli"],
+	});
+	const scored = makeDiagnostic({
+		rule: "performance/no-unused-providers",
+		message: "Provider is never injected.",
+	});
+
+	it("prints a report-only finding and marks it not scored", () => {
+		const { lines, restore } = capture();
+		printConsoleReport(makeResult({ diagnostics: [reportOnly, scored] }), true);
+		restore();
+		const output = lines.join("\n");
+
+		expect(output).toContain("should be readonly");
+		expect(output).toContain("not scored");
+		expect(output).toContain("Provider is never injected");
+	});
+
+	it("leaves out a finding that never reaches the cli surface", () => {
+		const hidden = makeDiagnostic({
+			rule: "correctness/hidden",
+			message: "Never shown in the console.",
+			surfaces: ["score"],
+		});
+		const { lines, restore } = capture();
+		printConsoleReport(makeResult({ diagnostics: [hidden, scored] }), true);
+		restore();
+		const output = lines.join("\n");
+
+		expect(output).not.toContain("Never shown in the console");
+		expect(output).toContain("Provider is never injected");
+	});
+});
+
+describe("printMonorepoReport surfaces", () => {
+	it("counts each sub-project on the same surface as the combined report", () => {
+		const reportOnly = makeDiagnostic({
+			rule: "correctness/prefer-readonly-injection",
+			severity: "warning",
+			surfaces: ["cli"],
+		});
+		const offCli = makeDiagnostic({
+			rule: "correctness/hidden",
+			severity: "error",
+			surfaces: ["score"],
+		});
+		const api = makeResult({
+			diagnostics: [reportOnly, offCli],
+			project: {
+				name: "api",
+				nestVersion: "11.0.0",
+				orm: "prisma",
+				framework: "express",
+				moduleCount: 2,
+				fileCount: 8,
+			},
+			summary: {
+				total: 2,
+				errors: 1,
+				warnings: 1,
+				info: 0,
+				byCategory: {
+					security: 0,
+					architecture: 0,
+					correctness: 2,
+					performance: 0,
+				},
+			},
+		});
+
+		const lines: string[] = [];
+		const spy = vi
+			.spyOn(console, "log")
+			.mockImplementation((...args: unknown[]) => {
+				lines.push(args.join(" "));
+			});
+		printMonorepoReport(
+			{
+				combined: makeResult({ diagnostics: [reportOnly, offCli] }),
+				elapsedMs: 10,
+				isMonorepo: true,
+				subProjects: [{ name: "api", result: api }],
+			} as never,
+			false
+		);
+		spy.mockRestore();
+
+		const line = lines.find((l) => l.includes("api:")) ?? "";
+		expect(line).toContain("1 warnings");
+		expect(line).not.toContain("1 errors");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/console-reporter.test.ts
+++ b/packages/nestjs-doctor/tests/unit/console-reporter.test.ts
@@ -405,17 +405,18 @@ describe("console-reporter", () => {
 	});
 });
 
-describe("printConsoleReport surfaces", () => {
-	const capture = (): { lines: string[]; restore: () => void } => {
-		const lines: string[] = [];
-		const spy = vi
-			.spyOn(console, "log")
-			.mockImplementation((...args: unknown[]) => {
-				lines.push(args.join(" "));
-			});
-		return { lines, restore: () => spy.mockRestore() };
-	};
+const ANSI_RE = /\u001B\[[0-9;]*m/g;
 
+/** Colour is on whenever CI is set, so strip it before matching on text. */
+const capture = (): { lines: string[]; restore: () => void } => {
+	const lines: string[] = [];
+	const spy = vi.spyOn(console, "log").mockImplementation((...args) => {
+		lines.push(args.join(" ").replace(ANSI_RE, ""));
+	});
+	return { lines, restore: () => spy.mockRestore() };
+};
+
+describe("printConsoleReport surfaces", () => {
 	const reportOnly = makeDiagnostic({
 		rule: "correctness/prefer-readonly-injection",
 		message: "Constructor parameter 'repo' should be readonly.",
@@ -489,12 +490,7 @@ describe("printMonorepoReport surfaces", () => {
 			},
 		});
 
-		const lines: string[] = [];
-		const spy = vi
-			.spyOn(console, "log")
-			.mockImplementation((...args: unknown[]) => {
-				lines.push(args.join(" "));
-			});
+		const { lines, restore } = capture();
 		printMonorepoReport(
 			{
 				combined: makeResult({ diagnostics: [reportOnly, offCli] }),
@@ -504,7 +500,7 @@ describe("printMonorepoReport surfaces", () => {
 			} as never,
 			false
 		);
-		spy.mockRestore();
+		restore();
 
 		const line = lines.find((l) => l.includes("api:")) ?? "";
 		expect(line).toContain("1 warnings");

--- a/packages/nestjs-doctor/tests/unit/formatters.test.ts
+++ b/packages/nestjs-doctor/tests/unit/formatters.test.ts
@@ -367,3 +367,62 @@ describe("GitHub Actions annotations", () => {
 		expect(buildAnnotations(resultWith(many), ROOT)).toHaveLength(10);
 	});
 });
+
+describe("surface filtering across formatters", () => {
+	const reportOnly = code({
+		line: 4,
+		rule: "correctness/prefer-readonly-injection",
+		category: "correctness",
+		surfaces: ["cli"],
+	});
+	const everywhere = code({ line: 9 });
+	const result = resultWith([reportOnly, everywhere]);
+
+	it("counts only prComment findings in the markdown headline", () => {
+		const markdown = buildMarkdownReport(result, {
+			targetPath: ROOT,
+			version: "1.0.0",
+		});
+
+		expect(markdown).toContain("**1 finding** reported");
+		expect(markdown).toContain("<b>Findings (1)</b>");
+		expect(markdown).toContain("| performance | 1 |");
+		expect(markdown).not.toContain("prefer-readonly-injection");
+	});
+
+	it("keeps the score whole-project even when the counts narrow", () => {
+		const markdown = buildMarkdownReport(result, {
+			targetPath: ROOT,
+			version: "1.0.0",
+		});
+
+		expect(markdown).toContain("**Score 72/100");
+	});
+
+	it("drops the whole findings block when nothing reaches the comment", () => {
+		const markdown = buildMarkdownReport(resultWith([reportOnly]), {
+			targetPath: ROOT,
+			version: "1.0.0",
+		});
+
+		expect(markdown).toContain("No findings reported.");
+		expect(markdown).not.toContain("<summary><b>Findings");
+		expect(markdown).not.toContain("| Category | Findings |");
+	});
+
+	it("spends no annotation on a finding kept off the comment", () => {
+		const lines = buildAnnotations(result, ROOT);
+
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toContain("performance/no-sync-io");
+	});
+
+	it("leaves it out of sarif and gitlab too", () => {
+		const sarif = buildSarifLog(result, ROOT, "1.0.0");
+		const gitlab = buildCodeQualityReport(result, ROOT);
+
+		expect(sarif.runs[0].results).toHaveLength(1);
+		expect(gitlab).toHaveLength(1);
+		expect(gitlab[0].check_name).toBe("performance/no-sync-io");
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/report-surfaces.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-surfaces.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type {
+	CodeDiagnostic,
+	Diagnostic,
+} from "../../src/common/diagnostic.js";
+import type { DiagnoseResult } from "../../src/common/result.js";
+import type { ModuleGraph } from "../../src/engine/graph/module-graph.js";
+import { prepareReportData } from "../../src/report/formatters/report-data.js";
+
+const emptyGraph = (): ModuleGraph => ({
+	edges: new Map(),
+	modules: new Map(),
+	providerToModule: new Map(),
+});
+
+const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
+	rule: "performance/no-unused-providers",
+	category: "performance",
+	severity: "warning",
+	filePath: "/repo/src/a.service.ts",
+	message: "Provider is never injected.",
+	help: "Remove it.",
+	line: 3,
+	column: 1,
+	...overrides,
+});
+
+const resultWith = (diagnostics: Diagnostic[]): DiagnoseResult =>
+	({
+		score: { value: 90, label: "Excellent" },
+		diagnostics,
+		project: {
+			name: "app",
+			nestVersion: "11.0.0",
+			orm: "prisma",
+			framework: "express",
+			fileCount: 4,
+			moduleCount: 1,
+		},
+		summary: {
+			total: diagnostics.length,
+			errors: 0,
+			warnings: diagnostics.length,
+			info: 0,
+			byCategory: {
+				security: 0,
+				performance: diagnostics.length,
+				correctness: 0,
+				architecture: 0,
+				schema: 0,
+			},
+		},
+		ruleErrors: [],
+		elapsedMs: 10,
+	}) as DiagnoseResult;
+
+describe("html report surfaces", () => {
+	it("keeps a report-only finding, which the not-scored toggle reveals", () => {
+		const data = prepareReportData(
+			emptyGraph(),
+			resultWith([
+				code({
+					rule: "correctness/no-async-without-await",
+					category: "correctness",
+					message: "Async method has no await expression.",
+					surfaces: ["cli"],
+				}),
+			])
+		);
+
+		const shown = JSON.parse(data.diagnosticsJson) as Diagnostic[];
+		expect(shown).toHaveLength(1);
+		expect(shown[0].surfaces).toEqual(["cli"]);
+	});
+
+	it("drops a finding the cli surface never shows", () => {
+		const data = prepareReportData(
+			emptyGraph(),
+			resultWith([
+				code({ rule: "correctness/hidden", surfaces: ["score"] }),
+				code({}),
+			])
+		);
+
+		const shown = JSON.parse(data.diagnosticsJson) as Diagnostic[];
+		expect(shown.map((d) => d.rule)).toEqual([
+			"performance/no-unused-providers",
+		]);
+	});
+
+	it("keeps sourceLines aligned with the findings it kept", () => {
+		const data = prepareReportData(
+			emptyGraph(),
+			resultWith([
+				code({ rule: "correctness/hidden", surfaces: ["score"] }),
+				code({}),
+			])
+		);
+
+		const shown = JSON.parse(data.diagnosticsJson) as Diagnostic[];
+		const sourceLines = JSON.parse(data.sourceLinesJson) as unknown[];
+		expect(sourceLines).toHaveLength(shown.length);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/rule-pipeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rule-pipeline.test.ts
@@ -25,6 +25,50 @@ function stubRule(
 	} as AnyRule;
 }
 
+describe("filterRules surfaces", () => {
+	it("leaves a rule's own surfaces alone when config says nothing", () => {
+		const rule = stubRule("correctness/example");
+		rule.meta.surfaces = ["cli"];
+
+		const [only] = filterRules({} as NestjsDoctorConfig, [rule]);
+
+		expect(only.meta.surfaces).toEqual(["cli"]);
+	});
+
+	it("replaces them when the rule override names surfaces", () => {
+		const rule = stubRule("correctness/example");
+		rule.meta.surfaces = ["cli"];
+		const config = {
+			rules: {
+				"correctness/example": {
+					surfaces: ["cli", "prComment", "score", "ciFailure"],
+				},
+			},
+		} as unknown as NestjsDoctorConfig;
+
+		const [only] = filterRules(config, [rule]);
+
+		expect(only.meta.surfaces).toEqual([
+			"cli",
+			"prComment",
+			"score",
+			"ciFailure",
+		]);
+	});
+
+	it("does not mutate the registered rule", () => {
+		const rule = stubRule("correctness/example");
+		rule.meta.surfaces = ["cli"];
+		const config = {
+			rules: { "correctness/example": { surfaces: ["score"] } },
+		} as unknown as NestjsDoctorConfig;
+
+		filterRules(config, [rule]);
+
+		expect(rule.meta.surfaces).toEqual(["cli"]);
+	});
+});
+
 describe("filterRules", () => {
 	it("excludes a rule disabled with `false`", () => {
 		const rules = [

--- a/packages/nestjs-doctor/tests/unit/rule-pipeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rule-pipeline.test.ts
@@ -35,6 +35,49 @@ describe("filterRules surfaces", () => {
 		expect(only.meta.surfaces).toEqual(["cli"]);
 	});
 
+	it("keeps a class-instance rule callable through the override", () => {
+		class CountingRule {
+			meta = {
+				id: "custom/counting",
+				category: "correctness",
+				severity: "warning",
+				description: "counts",
+				help: "help",
+			};
+			seen = 0;
+			check() {
+				this.seen += 1;
+			}
+		}
+		const rule = new CountingRule() as unknown as AnyRule;
+		const config: NestjsDoctorConfig = {
+			rules: { "custom/counting": { surfaces: ["score"] } },
+		};
+
+		const [only] = filterRules(config, [rule]);
+		(only.check as () => void)();
+
+		expect(only.meta.surfaces).toEqual(["score"]);
+		expect((rule as unknown as CountingRule).seen).toBe(1);
+	});
+
+	it.each([
+		["a bare string", "cli"],
+		["an empty array", []],
+		["an unknown name", ["Score"]],
+		["a non-string entry", [1]],
+	])("ignores %s so the override cannot narrow", (_label, surfaces) => {
+		const rule = stubRule("correctness/example");
+		rule.meta.surfaces = ["cli", "score"];
+		const config = {
+			rules: { "correctness/example": { surfaces } },
+		} as unknown as NestjsDoctorConfig;
+
+		const [only] = filterRules(config, [rule]);
+
+		expect(only.meta.surfaces).toEqual(["cli", "score"]);
+	});
+
 	it("replaces them when the rule override names surfaces", () => {
 		const rule = stubRule("correctness/example");
 		rule.meta.surfaces = ["cli"];

--- a/packages/nestjs-doctor/tests/unit/rule-runner.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rule-runner.test.ts
@@ -1,6 +1,8 @@
 import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
 import type { NestjsDoctorConfig } from "../../src/common/config.js";
+import type { DiagnosticSurface } from "../../src/common/diagnostic.js";
+import { onSurface } from "../../src/common/diagnostic.js";
 import type { SchemaEntity, SchemaGraph } from "../../src/common/schema.js";
 import { runFileRules, runSchemaRules } from "../../src/engine/rule-runner.js";
 import { separateRules } from "../../src/engine/rules/rule-pipeline.js";
@@ -252,5 +254,66 @@ describe("runFileRules", () => {
 		expect(errors).toHaveLength(0);
 		expect(diagnostics).toHaveLength(1);
 		expect(diagnostics[0].message).toBe("config received");
+	});
+});
+
+describe("surfaces on reported diagnostics", () => {
+	const reporting = (id: string, surfaces?: DiagnosticSurface[]): Rule => ({
+		meta: {
+			id,
+			category: "correctness",
+			severity: "warning",
+			description: "",
+			help: "",
+			...(surfaces ? { surfaces } : {}),
+		},
+		check(context) {
+			context.report({
+				filePath: context.filePath,
+				message: "reported",
+				help: "",
+				line: 1,
+				column: 1,
+			});
+		},
+	});
+
+	it("stamps a file rule's surfaces onto every diagnostic it reports", () => {
+		const project = new Project({ useInMemoryFileSystem: true });
+		project.createSourceFile("test.ts", "const value = 1;");
+
+		const { diagnostics } = runFileRules(
+			project,
+			["test.ts"],
+			[reporting("correctness/stamped", ["cli"])]
+		);
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].surfaces).toEqual(["cli"]);
+	});
+
+	it("leaves surfaces off when the rule declares none", () => {
+		const project = new Project({ useInMemoryFileSystem: true });
+		project.createSourceFile("test.ts", "const value = 1;");
+
+		const { diagnostics } = runFileRules(
+			project,
+			["test.ts"],
+			[reporting("correctness/unstamped")]
+		);
+
+		expect(diagnostics[0]).not.toHaveProperty("surfaces");
+		expect(onSurface(diagnostics[0], "score")).toBe(true);
+	});
+
+	it("copies the array so a rule cannot mutate its own declaration", () => {
+		const project = new Project({ useInMemoryFileSystem: true });
+		project.createSourceFile("test.ts", "const value = 1;");
+		const rule = reporting("correctness/copied", ["cli", "score"]);
+
+		const { diagnostics } = runFileRules(project, ["test.ts"], [rule]);
+		diagnostics[0].surfaces?.push("ciFailure");
+
+		expect(rule.meta.surfaces).toEqual(["cli", "score"]);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/scorer.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scorer.test.ts
@@ -17,6 +17,30 @@ function makeDiagnostic(overrides: Partial<Diagnostic> = {}): Diagnostic {
 }
 
 describe("scorer", () => {
+	it("leaves the score untouched by report-only diagnostics", () => {
+		const gating = makeDiagnostic({ severity: "error" });
+		const reportOnly = makeDiagnostic({
+			severity: "error",
+			surfaces: ["cli"],
+		});
+
+		const alone = calculateScore([gating], 10);
+		const withNoise = calculateScore(
+			[gating, ...Array.from({ length: 50 }, () => reportOnly)],
+			10
+		);
+
+		expect(withNoise.value).toBe(alone.value);
+	});
+
+	it("counts a diagnostic that lists the score surface", () => {
+		const scored = makeDiagnostic({
+			severity: "error",
+			surfaces: ["cli", "score"],
+		});
+		expect(calculateScore([scored], 10).value).toBeLessThan(100);
+	});
+
 	it("returns 100 for no diagnostics", () => {
 		const score = calculateScore([], 10);
 		expect(score.value).toBe(100);

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -156,10 +156,11 @@ Auto-detected using five strategies (first match wins): `nest-cli.json` monorepo
 
 ## Scoring
 
-Weighted by severity and category, normalized by file count. Only rules whose
-`meta.surfaces` includes `score` are counted; a rule set to `["cli"]` is
+Weighted by severity and category, normalized by file count. A rule declares
+surfaces: `cli`, `prComment`, `score`, `ciFailure`, all four by default. Only
+rules whose surfaces include `score` are counted; a rule set to `["cli"]` is
 reported in full and weighs nothing. `correctness/no-async-without-await` and
-`correctness/prefer-readonly-injection` are report-only.
+`correctness/prefer-readonly-injection` are report-only, so they also never comment on a pull request. Override per rule with `"rules": { "<id>": { "surfaces": [...] } }`.
 
 Severity weights: error = 3.0, warning = 1.5, info = 0.5
 Category multipliers: security = 1.5x, correctness = 1.3x, schema = 1.1x, architecture = 1.0x, performance = 0.8x

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -158,9 +158,10 @@ Auto-detected using five strategies (first match wins): `nest-cli.json` monorepo
 
 Weighted by severity and category, normalized by file count. A rule declares
 surfaces: `cli`, `prComment`, `score`, `ciFailure`, all four by default. Only
-rules whose surfaces include `score` are counted; a rule set to `["cli"]` is
-reported in full and weighs nothing. `correctness/no-async-without-await` and
-`correctness/prefer-readonly-injection` are report-only, so they also never comment on a pull request. Override per rule with `"rules": { "<id>": { "surfaces": [...] } }`.
+rules whose surfaces include `score` are counted; a rule set to `["cli"]` still
+reports every finding in the console and the HTML report, and weighs nothing.
+`correctness/no-async-without-await` and `correctness/prefer-readonly-injection`
+are `["cli"]`, so they never comment on a pull request and never fail a build. Override per rule with `"rules": { "<id>": { "surfaces": [...] } }`.
 
 Severity weights: error = 3.0, warning = 1.5, info = 0.5
 Category multipliers: security = 1.5x, correctness = 1.3x, schema = 1.1x, architecture = 1.0x, performance = 0.8x

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -156,7 +156,10 @@ Auto-detected using five strategies (first match wins): `nest-cli.json` monorepo
 
 ## Scoring
 
-Weighted by severity and category, normalized by file count.
+Weighted by severity and category, normalized by file count. Only rules whose
+`meta.surfaces` includes `score` are counted; a rule set to `["cli"]` is
+reported in full and weighs nothing. `correctness/no-async-without-await` and
+`correctness/prefer-readonly-injection` are report-only.
 
 Severity weights: error = 3.0, warning = 1.5, info = 0.5
 Category multipliers: security = 1.5x, correctness = 1.3x, schema = 1.1x, architecture = 1.0x, performance = 0.8x

--- a/packages/website/src/app/docs/ci/gates/page.mdx
+++ b/packages/website/src/app/docs/ci/gates/page.mdx
@@ -74,9 +74,10 @@ applies.
 ## Which findings count
 
 Both gates count what the run reports, with one exception: a rule can be
-report-only. Those appear in the report and count toward neither gate, because
-they encode a preference rather than a defect. See
-[Surfaces](/docs/custom-rules#surfaces).
+report-only. Those appear in the report and count toward neither gate, and they
+do not comment on the pull request either, because they encode a preference
+rather than a defect. A project that wants one enforced can say so per rule.
+See [Surfaces](/docs/custom-rules#surfaces).
 
 The config file is the third lever. Disable a rule or a whole category and it
 stops counting toward either gate. See [Configuration](/docs/configuration).

--- a/packages/website/src/app/docs/ci/gates/page.mdx
+++ b/packages/website/src/app/docs/ci/gates/page.mdx
@@ -73,9 +73,13 @@ applies.
 
 ## Which findings count
 
-Both gates count whatever the run reports, so the config file is the third
-lever. Disable a rule or a whole category and it stops counting toward either
-gate. See [Configuration](/docs/configuration).
+Both gates count what the run reports, with one exception: a rule can be
+report-only. Those appear in the report and count toward neither gate, because
+they encode a preference rather than a defect. See
+[Surfaces](/docs/custom-rules#surfaces).
+
+The config file is the third lever. Disable a rule or a whole category and it
+stops counting toward either gate. See [Configuration](/docs/configuration).
 
 Inline `nestjs-doctor-ignore` comments work the same way. A suppressed finding
 is not reported, so it cannot fail a gate.

--- a/packages/website/src/app/docs/configuration/page.mdx
+++ b/packages/website/src/app/docs/configuration/page.mdx
@@ -68,7 +68,7 @@ See [Config loading](/docs/pipeline/config-loading) for implementation details.
 | `categories` | `Record<string, boolean>` | Enable/disable entire categories |
 | `customRulesDir` | `string` | Path to a directory of custom `.ts` rule files |
 
-Set a rule to `false` to disable it. The object form does the same through `enabled`:
+Set a rule to `false` to disable it. The object form does the same through `enabled`, and `surfaces` decides where the rule may appear (see [Surfaces](/docs/custom-rules#surfaces)):
 
 ```json
 {

--- a/packages/website/src/app/docs/custom-rules/page.mdx
+++ b/packages/website/src/app/docs/custom-rules/page.mdx
@@ -59,17 +59,41 @@ export const myRule = {
 
 ### Surfaces
 
-A rule appears on three surfaces by default: `cli` for the report, `score` for
-the 0-100 number, and `ciFailure` for `--blocking`. Naming a subset narrows it:
+A rule appears on four surfaces by default:
+
+| Surface | Where |
+| ------- | ----- |
+| `cli` | The console report and the HTML report |
+| `prComment` | The pull request summary and its inline review comments |
+| `score` | The 0-100 number |
+| `ciFailure` | `--blocking` |
+
+Naming a subset narrows it:
 
 ```ts
 surfaces: ["cli"],
 ```
 
-That rule still shows every finding and still says how to fix it. It cannot
-move the score and cannot fail a build. Use it for a rule that encodes a
-preference rather than a defect, so a project that disagrees is not punished
-for it.
+That rule still shows every finding and still says how to fix it. It never
+comments on a pull request, never moves the score, and never fails a build.
+Use it for a rule that encodes a preference rather than a defect, so a project
+that disagrees is not punished for it.
+
+A project can decide otherwise. `surfaces` on a rule override replaces what the
+rule declares:
+
+```json
+{
+  "rules": {
+    "correctness/prefer-readonly-injection": {
+      "surfaces": ["cli", "prComment", "score", "ciFailure"]
+    }
+  }
+}
+```
+
+That is how a team that does want a house style enforced puts it back on the
+score and the build.
 
 ### Tags
 

--- a/packages/website/src/app/docs/custom-rules/page.mdx
+++ b/packages/website/src/app/docs/custom-rules/page.mdx
@@ -64,9 +64,12 @@ A rule appears on four surfaces by default:
 | Surface | Where |
 | ------- | ----- |
 | `cli` | The console report and the HTML report |
-| `prComment` | The pull request summary and its inline review comments |
+| `prComment` | The pull request summary, its inline review comments, the GitHub annotations, `--format sarif` and `--format gitlab` |
 | `score` | The 0-100 number |
 | `ciFailure` | `--blocking` |
+
+`--format json` is the exception: it carries every finding, with `surfaces` on
+each one, so a consumer filters however it wants.
 
 Naming a subset narrows it:
 

--- a/packages/website/src/app/docs/custom-rules/page.mdx
+++ b/packages/website/src/app/docs/custom-rules/page.mdx
@@ -55,6 +55,21 @@ export const myRule = {
 | `help`        | `string`   | Yes      | Fix guidance shown alongside diagnostics                                |
 | `scope`       | `string`   | No       | `"file"` (default) or `"project"`                                       |
 | `tags`        | `string[]` | No       | Labels stamped onto every diagnostic the rule emits                     |
+| `surfaces`    | `string[]` | No       | Where the rule may appear. Omitted means everywhere                     |
+
+### Surfaces
+
+A rule appears on three surfaces by default: `cli` for the report, `score` for
+the 0-100 number, and `ciFailure` for `--blocking`. Naming a subset narrows it:
+
+```ts
+surfaces: ["cli"],
+```
+
+That rule still shows every finding and still says how to fix it. It cannot
+move the score and cannot fail a build. Use it for a rule that encodes a
+preference rather than a defect, so a project that disagrees is not punished
+for it.
 
 ### Tags
 

--- a/packages/website/src/app/docs/pipeline/scoring/page.mdx
+++ b/packages/website/src/app/docs/pipeline/scoring/page.mdx
@@ -33,9 +33,9 @@ interface Score {
 
 A rule declares which surfaces it appears on. Only diagnostics carrying the
 `score` surface reach the formula below. A rule marked `surfaces: ["cli"]`
-is reported in full and weighs nothing, which keeps a matter of taste from
-moving a number meant to track defects. See
-[Custom rules](/docs/custom-rules#surfaces).
+still reports every finding in the console and the HTML report, and weighs
+nothing, which keeps a matter of taste from moving a number meant to track
+defects. See [Custom rules](/docs/custom-rules#surfaces).
 
 ## Formula
 

--- a/packages/website/src/app/docs/pipeline/scoring/page.mdx
+++ b/packages/website/src/app/docs/pipeline/scoring/page.mdx
@@ -29,6 +29,14 @@ interface Score {
 }
 ```
 
+## What counts
+
+A rule declares which surfaces it appears on. Only diagnostics carrying the
+`score` surface reach the formula below. A rule marked `surfaces: ["cli"]`
+is reported in full and weighs nothing, which keeps a matter of taste from
+moving a number meant to track defects. See
+[Custom rules](/docs/custom-rules#surfaces).
+
 ## Formula
 
 The score starts at 100 and loses points for every diagnostic:

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -72,7 +72,7 @@ either stream.
 
 | Flag | Does |
 |---|---|
-| `--blocking <level>` | Severity that fails the run: `none`, `warning`, `error` |
+| `--blocking <level>` | Severity that fails the run: `none`, `warning`, `error`. Skips report-only rules |
 | `--min-score <n>` | Fail when the project's score is below this |
 
 `--min-score` overrides the config file's `minScore`, which applies on its own

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -72,7 +72,7 @@ either stream.
 
 | Flag | Does |
 |---|---|
-| `--blocking <level>` | Severity that fails the run: `none`, `warning`, `error`. Skips report-only rules |
+| `--blocking <level>` | Severity that fails the run: `none`, `warning`, `error`. Only findings on the `ciFailure` surface can trip it |
 | `--min-score <n>` | Fail when the project's score is below this |
 
 `--min-score` overrides the config file's `minScore`, which applies on its own

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -42,6 +42,16 @@ no controllers and no ORM entities sees four tabs. The Endpoints tab is badged
 Pick a module in the graph. The detail panel lists what it imports, exports,
 provides, and what breaks if you change it.
 
+## Findings that do not score
+
+A rule can report without moving the score. Summary shows how many under the
+number, as `70 of 407 not scored`, so the two reconcile. Diagnosis hides those
+findings behind a **Show not scored** checkbox above the severity filters, and
+badges each one `not scored` beside its rule id when you turn it on.
+
+Which rules those are is up to the rule and your config. See
+[Custom rules](/docs/custom-rules#surfaces).
+
 ## Boot trace
 
 The graph can overlay how long every provider and controller took to construct

--- a/packages/website/src/app/docs/rules/correctness/page.mdx
+++ b/packages/website/src/app/docs/rules/correctness/page.mdx
@@ -303,6 +303,8 @@ Detects constructor DI parameters missing the `readonly` modifier.
 
 **Why:** Injected dependencies should not be reassigned. The `readonly` modifier prevents accidental mutation and communicates intent.
 
+**Note:** Report-only. It is listed in full and counts toward neither the score nor `--blocking`, because it is a house style rather than a defect. See [Surfaces](/docs/custom-rules#surfaces).
+
 <CodeGroup labels={["Bad", "Good"]}>
 ```typescript
 @Injectable()
@@ -362,6 +364,8 @@ Framework entry points are exempt, because Nest awaits what they return. A metho
 | Microservices | `@MessagePattern`, `@EventPattern`, `@GrpcMethod`, `@GrpcStreamMethod` |
 | WebSockets | `@SubscribeMessage` |
 | ts-rest | `@TsRestHandler` |
+
+**Note:** Report-only. It is listed in full and counts toward neither the score nor `--blocking`, because it is a house style rather than a defect. See [Surfaces](/docs/custom-rules#surfaces).
 
 <CodeGroup labels={["Bad", "Good"]}>
 ```typescript

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(oxc-resolver@11.19.1)(typescript@5.9.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.31.1)(yaml@2.8.2)
 
   packages/nestjs-doctor-vscode:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@types/vscode':
         specifier: ^1.85.0
         version: 1.109.0
+      nestjs-doctor-lsp:
+        specifier: workspace:*
+        version: link:../nestjs-doctor-lsp
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(oxc-resolver@11.19.1)(typescript@5.9.3)


### PR DESCRIPTION
## Context

Reporting a finding, scoring it, commenting on a pull request about it, and failing a build on it were the same decision. react-doctor separates them with a surface per rule; measuring our own output against ten real NestJS repositories showed why that matters here.

## Problem

Two rules are 52% of everything we emit: `no-async-without-await` at 305 findings and `prefer-readonly-injection` at 146, out of 871 across ten repositories. Security is 8%.

On `buqiyuan/nest-admin` we report 97 readonly-injection findings and score it **82**, while that same repository carries an auth bypass (`ignoreExpiration: isDev`) and a CORS wildcard sent with credentials. The number was being set by matters of taste.

Neither rule is wrong. Deleting them loses real signal for projects that want them.

## Possible flows

| Rule declares | Console + report | PR comment | Score | `--blocking` | Editor |
|---|---|---|---|---|---|
| nothing (every existing rule) | yes | yes | yes | yes | warning |
| `["cli"]` | yes, marked | no | no | no | hint |
| `["cli", "ciFailure"]` | yes, marked | no | no | yes | hint |

## Solution

`meta.surfaces` names where a rule's diagnostics may appear: `cli`, `prComment`, `score`, `ciFailure`. Omitting it means all four, so every built-in rule and every custom rule anyone has already written behaves exactly as before.

The two rules above become `["cli"]`. They report in full, with the same help text, and weigh nothing.

**It is not our call alone.** `"rules": { "<id>": { "surfaces": [...] } }` replaces what a rule declares, so a team that does want a house style enforced puts it back. It sits beside `severity` in `RuleOverride`, the key that is declared and read by nothing; this one is read. Applied in `filterRules`, copying the rule rather than mutating the registered one, so a monorepo scanning 45 projects cannot leak one project's config into the next.

**Every surface says which findings the score never saw**, because the docs explaining report-only rules while the product stayed silent is just a warning you fix and a number that does not move:

- Console appends a dim `· not scored`.
- The HTML report badges each one beside the rule id, and the score card reads `70 of 407 not scored` with an info icon, which is what makes the number and the issue count reconcile.
- Diagnosis hides them behind `Show not scored`, off by default. Every count follows, because `isDiagVisible` is the single gate the tree, folder counts and detail pane already route through.
- The editor reports them as hints, so they stay inline while you write without joining the warning count.
- Pull requests do not mention them at all.

`shouldBlock` now takes diagnostics rather than the summary, because a count cannot say which findings are allowed to fail a build.

## Before vs after

Scored with the built CLI against ten repositories, toggling only the two rule declarations:

| Repository | Before | After |
|---|---|---|
| buqiyuan/nest-admin | 82 | 94 |
| AdrianLopezGue/daruma-backend | 93 | 98 |
| andrechristikan/ack-nestjs-boilerplate | 93 | 98 |
| CatsMiaow/nestjs-project-structure | 92 | 97 |
| brocoders/nestjs-boilerplate | 95 | 95 |
| Papooch/nestjs-cls | 98 | 98 |

On `nest-admin`, 148 of 251 findings become report-only, taking security from 8% of output to **20% of what is scored**. With the override naming all four surfaces, the 39 pull request rows come back and the score returns to 86.

## Compatibility

Nothing breaks, and every change loosens rather than tightens.

- `shouldBlock` is internal to `cli/`, so its new signature reaches nobody.
- SARIF and GitLab build their own objects; `surfaces` does not leak into them.
- `--json` is additive: the key appears only on report-only diagnostics.
- `meta.surfaces` is optional, so every existing custom rule is unchanged.
- Existing inline review threads are resolved with a reply by the action's own reconciliation rather than left dangling.

**The one real regression:** a team relying on either rule to fail their build silently stops being protected. Nothing errors, the gate goes quiet. That belongs in the release notes above the fold, with the override snippet.

Shipping needs both halves. The action's `version` input defaults to `latest`, so the CLI side arrives on publish, but the inline-comment filter lives in `action.yml` and needs the `v1` tag moved. Publish without retagging and the summary table filters while inline comments keep appearing.

## Example

```json
{
  "rules": {
    "correctness/prefer-readonly-injection": {
      "surfaces": ["cli", "prComment", "score", "ciFailure"]
    }
  }
}
```

Two pre-existing problems surfaced on the way and are fixed here. The root `typecheck` only ever covered the `nestjs-doctor` package, so `nestjs-doctor-lsp` had never been typechecked in CI and the bundler does not typecheck either; under that gap sat `worker.on("error", (err) => …)` with `err` implicitly `unknown`. It matters more now that the LSP consumes an API this branch extends.

Worth stating plainly rather than burying: the scored range across those ten repositories narrowed from 82-98 to 94-99. Removing the noise did not make the score discriminate better, it exposed that there are not yet enough high-signal rules for it to discriminate with. On compass, a 1444-file monorepo, per-project scores still range 27 to 99, so the compression is a property of small repositories rather than of the change. That is the argument for the security rules next, not against this.
