### PR TITLE
chore(release): let changesets version the extension, and say what shipped

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,11 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["website", "nestjs-doctor-vscode"]
+  "ignore": [
+    "website"
+  ],
+  "privatePackages": {
+    "version": true,
+    "publish": false
+  }
 }

--- a/.changeset/diagnostic-surfaces.md
+++ b/.changeset/diagnostic-surfaces.md
@@ -45,3 +45,18 @@ sitting in the Problems panel beside real defects.
 
 `DiagnosticSurface`, `BaseDiagnostic`, `onSurface` and `forSurface` are
 exported, so a custom rule can declare surfaces and a consumer can read them.
+
+Two Windows fixes for the editor ride along, both older than this change.
+
+The language server decided a path was absolute by testing for a leading
+slash. Nothing the scanner reports on Windows has one, because ts-morph uses
+forward slashes with a drive, so `D:/proj/src/a.ts` was appended to the
+workspace root anyway and became `D:\proj/D:/proj/src/a.ts`. That points at no
+file, so every finding attached to nothing.
+
+The worker also kept one diagnostic cache written from two sources that spell
+a path differently: a full scan keys by the scanner's path, an edit keys by the
+document URI converted to a native one. They agree everywhere except Windows,
+where the first edit added a second entry for the same file, so each finding
+appeared twice and the set from before the edit never cleared.
+

--- a/.changeset/release-hygiene.md
+++ b/.changeset/release-hygiene.md
@@ -1,0 +1,11 @@
+---
+"nestjs-doctor-vscode": patch
+---
+
+Fix the packaged extension being able to ship a stale language server. The
+build copies `server.cjs` and `scan-worker.cjs` out of the LSP package but
+never declared it as a dependency, so pnpm ran the two builds in parallel. A
+clean checkout failed outright and a warm one copied whatever the previous
+build left behind. It is a workspace dependency now, so the order is fixed.
+
+The extension also no longer ships its own packaging check inside the vsix.

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,11 +1,11 @@
 name: Publish VS Code Extension
 
-# Manual only. A changesets release already publishes the extension through the
-# `publish-vscode` job in release.yml, which knows whether anything was actually
-# released. This ran on every published release, including ones that have
-# nothing to do with the extension — and since it is in changesets' `ignore`
-# list its version is bumped by hand, so an unrelated release would push
-# whatever `packages/nestjs-doctor-vscode/package.json` happened to carry.
+# Manual only, for republishing the current version by hand. A changesets
+# release publishes the extension through the `publish-vscode` job in
+# release.yml, which knows whether anything was actually released. Changesets
+# versions the extension now that it is out of the `ignore` list, so a release
+# that does not touch it leaves its version alone and the publish is a
+# no-op through `skipDuplicate`.
 on:
   workflow_dispatch:
 

--- a/packages/nestjs-doctor-vscode/.vscodeignore
+++ b/packages/nestjs-doctor-vscode/.vscodeignore
@@ -1,4 +1,5 @@
 src/**
+scripts/**
 node_modules/**
 tsconfig.json
 tsdown.config.ts

--- a/packages/nestjs-doctor-vscode/CHANGELOG.md
+++ b/packages/nestjs-doctor-vscode/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+Entries from 0.1.4 on are written by changesets. The three below it were
+reconstructed from commit history, from when the version was bumped by hand.
+
+## 0.1.3
+
+- Republished against the current engine.
+
+## 0.1.2
+
+- Fix an LSP crash, a status bar spinner that hung, and worker recovery.
+- Align the debounce default to 200ms across the extension and the server.
+
+## 0.1.1
+
+- Packaging and marketplace metadata.
+
 ## 0.1.0
 
 - Initial release

--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -3,6 +3,7 @@
   "displayName": "NestJS Doctor",
   "description": "Static analysis for NestJS \u2014 inline diagnostics and health score",
   "version": "0.1.3",
+  "private": true,
   "publisher": "rolobits",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Context

#250 merged with a changeset and two fixes that its changeset does not mention, and the VS Code extension sits outside changesets, so its version and changelog are maintained by hand. Release PR #238 is open and has not merged, so both are still fixable before anything ships.

## Problem

The changeset for #250 describes diagnostic surfaces and neither Windows fix that rode along with it. A Windows user reading `nestjs-doctor-lsp`'s changelog would find nothing about why their findings stopped attaching to no file, or why each one stopped appearing twice after the first edit.

The extension is worse, because it fails quietly. The Marketplace is already serving `0.1.3` and `package.json` still says `0.1.3`. `release.yml`'s `publish-vscode` job runs whenever a release publishes anything, with `skipDuplicate: true`. So the next release would have run the job, seen the version already published, skipped, and reported success. The stale-server fix from #250 would have reached nobody, with nothing red to notice.

Its changelog also stops at `0.1.0` while shipping `0.1.3`.

## Possible flows

| Path | Before | Affected |
|---|---|---|
| `changeset publish` → npm | `nestjs-doctor`, `nestjs-doctor-lsp` | no, unchanged |
| `changeset version` → extension | ignored, version untouched | **yes**, now bumps and writes its changelog |
| `publish-vscode` job on release | skips, version already published | **yes**, version now moves so the publish lands |
| `publish-vscode.yml` manual dispatch | republish current version | no, still what it does |
| vsix contents | carried `scripts/verify-package.mjs` | **yes**, excluded |

## Solution

Amend `.changeset/diagnostic-surfaces.md` to describe both Windows fixes. It is unreleased, so this is still the changelog users will read.

Take `nestjs-doctor-vscode` out of changesets' `ignore` and mark it `private: true`. Changesets then versions it and writes its changelog like every other package, while `privatePackages.publish: false` keeps it off npm. `vsce package` does not object to a private manifest — checked against the real thing rather than assumed.

What I did not do: hand-bump it to `0.1.4` again. That is what left it three versions behind, and doing it once more would have fixed this release and not the next one.

The three missing changelog entries are reconstructed from commit subjects and labelled as such, since there is no record of what actually went out in them.

## Before vs after

| | Before | After |
|---|---|---|
| LSP changelog mentions the Windows fixes | no | yes |
| Extension version on next release | `0.1.3`, publish skipped | `0.1.4`, publish lands |
| Who bumps the extension | a person, last done at `0.1.3` | changesets |
| Extension published to npm | no | no |
| `nestjs-doctor` / `nestjs-doctor-lsp` versions | `0.9.0` / `5.0.0` | unchanged |
| `scripts/` inside the vsix | shipped | excluded |

## Example

A trial `changeset version`, reverted afterwards:

```
nestjs-doctor        0.9.0
nestjs-doctor-lsp    5.0.0
nestjs-doctor-vscode 0.1.4     ← was not bumped at all before
```

and the entry changesets wrote by itself:

```markdown
## 0.1.4

### Patch Changes

- Fix the packaged extension being able to ship a stale language server.
```

Merge this before #238.
