### PR TITLE
feat(report): name the tabs for what they hold, and give each one an icon

### DIFF
--- a/.changeset/report-tab-names.md
+++ b/.changeset/report-tab-names.md
@@ -9,3 +9,7 @@ the word the pull request comment already uses, so a reader arriving from
 
 The `data-tab` values and element ids are unchanged, so a saved report and any
 tooling reading the markup keep working.
+
+Each tab also carries an outline icon, in the same stroked style as the icons
+already in the report, so it inherits the tab's own colour and dims with it.
+

--- a/.changeset/report-tab-names.md
+++ b/.changeset/report-tab-names.md
@@ -1,0 +1,11 @@
+---
+"nestjs-doctor": patch
+---
+
+Rename two tabs in the HTML report. **Diagnosis** is now **Findings**, matching
+the word the pull request comment already uses, so a reader arriving from
+"**3 findings**" lands on a tab spelling it the same way. **Lab** is now
+**Rule Lab**, which says what it is without needing the tab open.
+
+The `data-tab` values and element ids are unchanged, so a saved report and any
+tooling reading the markup keep working.

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -16,11 +16,11 @@ export function getReportHtml(): string {
 <!-- ── Header Row 2 (Tab bar) ── -->
 <div id="header-row2">
   <button class="tab-btn active" data-tab="summary">Summary</button>
-  <button class="tab-btn" data-tab="diagnosis">Diagnosis <span class="count-badge" id="diagnosis-count-badge"></span></button>
+  <button class="tab-btn" data-tab="diagnosis">Findings <span class="count-badge" id="diagnosis-count-badge"></span></button>
   <button class="tab-btn" data-tab="modules">Modules Graph</button>
   <button class="tab-btn" data-tab="endpoints" id="tab-btn-endpoints" style="display:none">Endpoints <span class="beta-badge">Beta</span></button>
   <button class="tab-btn" data-tab="schema" id="tab-btn-schema" style="display:none">Relational Schema</button>
-  <button class="tab-btn" data-tab="lab">Lab</button>
+  <button class="tab-btn" data-tab="lab">Rule Lab</button>
   <div class="tab-spacer"></div>
 </div>
 

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -15,12 +15,12 @@ export function getReportHtml(): string {
 
 <!-- ── Header Row 2 (Tab bar) ── -->
 <div id="header-row2">
-  <button class="tab-btn active" data-tab="summary">Summary</button>
-  <button class="tab-btn" data-tab="diagnosis">Findings <span class="count-badge" id="diagnosis-count-badge"></span></button>
-  <button class="tab-btn" data-tab="modules">Modules Graph</button>
-  <button class="tab-btn" data-tab="endpoints" id="tab-btn-endpoints" style="display:none">Endpoints <span class="beta-badge">Beta</span></button>
-  <button class="tab-btn" data-tab="schema" id="tab-btn-schema" style="display:none">Relational Schema</button>
-  <button class="tab-btn" data-tab="lab">Rule Lab</button>
+  <button class="tab-btn active" data-tab="summary"><svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></svg>Summary</button>
+  <button class="tab-btn" data-tab="diagnosis"><svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>Findings <span class="count-badge" id="diagnosis-count-badge"></span></button>
+  <button class="tab-btn" data-tab="modules"><svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="16" y="16" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="9" y="2" width="6" height="6" rx="1"/><path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3"/><path d="M12 12V8"/></svg>Modules Graph</button>
+  <button class="tab-btn" data-tab="endpoints" id="tab-btn-endpoints" style="display:none"><svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/></svg>Endpoints <span class="beta-badge">Beta</span></button>
+  <button class="tab-btn" data-tab="schema" id="tab-btn-schema" style="display:none"><svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/></svg>Relational Schema</button>
+  <button class="tab-btn" data-tab="lab"><svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 2v7.527a2 2 0 0 1-.211.896L4.72 20.55a1 1 0 0 0 .9 1.45h12.76a1 1 0 0 0 .9-1.45l-5.069-10.127A2 2 0 0 1 14 9.527V2"/><path d="M8.5 2h7"/><path d="M7 16h10"/></svg>Rule Lab</button>
   <div class="tab-spacer"></div>
 </div>
 

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -85,6 +85,8 @@ canvas:active { cursor: grabbing; }
   transition: color 0.15s, border-color 0.15s;
   display: flex; align-items: center; gap: 6px;
 }
+.tab-icon { width: 15px; height: 15px; flex-shrink: 0; opacity: 0.75; }
+.tab-btn:hover .tab-icon, .tab-btn.active .tab-icon { opacity: 1; }
 .tab-btn:hover { color: var(--text); }
 .tab-btn.active { color: var(--white); border-bottom-color: var(--nest-red); }
 .tab-btn .count-badge {

--- a/packages/website/src/app/docs/custom-rules/page.mdx
+++ b/packages/website/src/app/docs/custom-rules/page.mdx
@@ -198,9 +198,9 @@ Install it with `npx nestjs-doctor --init`, then call
 4. Sets `customRulesDir` in your config.
 5. Runs nestjs-doctor to confirm the rule loads.
 
-## The Lab tab
+## The Rule Lab tab
 
-The HTML report has a Lab tab for writing and testing custom rules in the browser:
+The HTML report has a Rule Lab tab for writing and testing custom rules in the browser:
 
 ```bash
 npx nestjs-doctor . --report

--- a/packages/website/src/app/docs/pipeline/output/page.mdx
+++ b/packages/website/src/app/docs/pipeline/output/page.mdx
@@ -105,7 +105,7 @@ npx nestjs-doctor . --report
 The report has up to six tabs:
 
 - **Summary:** health score overview with a category breakdown.
-- **Diagnosis:** source-level diagnostics with a code viewer and fix examples.
+- **Findings:** source-level diagnostics with a code viewer and fix examples.
 - **Modules Graph:** clustered module diagram with a searchable project sidebar and a per-module detail panel (used by, blast radius, providers, imports, exports, wiring). Selecting a module animates its edges, colored by direction, and the view offers cycle focus plus toggles for `@Global()` reach and external modules. A Module problems drawer lists module-wiring diagnostics from rules tagged `module-graph`, custom rules included.
 - **Endpoints:** badged `Beta`, traced HTTP routes per controller with their dependency chains. Controllers and handlers behind a project wrapper decorator, meaning a custom decorator composing `@Controller()` or `@Get()`, are resolved and traced too.
 - **Relational Schema:** entity-relationship diagram of the database models.

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -29,11 +29,11 @@ not load. Everything else works.
 | Tab | Shows |
 |---|---|
 | Summary | The score, the category breakdown, and the counts behind them |
-| Diagnosis | Every finding with a code viewer and a fix example |
+| Findings | Every finding with a code viewer and a fix example |
 | Modules Graph | Your real module graph, clustered, with cycles in red |
 | Endpoints | Traced HTTP routes per controller and the dependencies each one pulls |
 | Relational Schema | The ER diagram extracted from your ORM |
-| Lab | A playground for writing a custom rule against your own code |
+| Rule Lab | A playground for writing a custom rule against your own code |
 
 Endpoints and Relational Schema stay hidden until there is data. A project with
 no controllers and no ORM entities sees four tabs. The Endpoints tab is badged
@@ -45,7 +45,7 @@ provides, and what breaks if you change it.
 ## Findings that do not score
 
 A rule can report without moving the score. Summary shows how many under the
-number, as `70 of 407 not scored`, so the two reconcile. Diagnosis hides those
+number, as `70 of 407 not scored`, so the two reconcile. Findings hides those
 findings behind a **Show not scored** checkbox above the severity filters, and
 badges each one `not scored` beside its rule id when you turn it on.
 


### PR DESCRIPTION
## Context

The HTML report has six tabs. Four name what they hold (Summary, Modules Graph, Endpoints, Relational Schema) and two named themselves instead: **Diagnosis** and **Lab**. Every tab is also the same weight of plain text, so the bar is six words with nothing to aim at.

## Problem

`Diagnosis` disagreed with every other place the same list is shown. The repo splits its vocabulary on purpose: user-facing surfaces say **finding**, reference and internals say **diagnostic**. The pull request comment writes `**3 findings**`, and the tab badge counts exactly that set, so a reader following the comment into the report met a third word for the thing they were already looking at.

`Lab` says nothing until you open it. It is the only tab whose name does not survive being read out of context.

Neither is a bug. Both cost a reader a beat every time, which is the whole job of a tab bar.

## Possible flows

Every place the two names appear:

| Where | Affected |
|---|---|
| Report tab bar | yes, both renamed |
| `docs/report` tab table and the not-scored prose | yes |
| `docs/pipeline/output` tab list | yes |
| `docs/custom-rules` heading `## The Lab tab` | yes, and nothing linked its anchor |
| `data-tab` values, element ids, `diag-*` CSS | no, deliberately unchanged |
| README, `llms.txt` | no, neither names a tab |

## Solution

**Diagnosis becomes Findings.** It is the house word for this half of the vocabulary, it matches the pull request comment a reader may have arrived from, and it is one word, so it sits beside Summary and Endpoints rather than stretching the bar.

**Lab becomes Rule Lab.** Two words rather than three: `Custom Rules Lab` is more precise on its own and worse in a six-tab bar, and a lab for writing rules is custom by definition.

**Every tab gets an outline icon**, in the stroked 24-viewBox style the report already uses for its folder and file glyphs, so they read as one family rather than an import. They take `currentColor`, which means they follow the tab through muted, hover and active with no extra rule, and they sit at `0.75` opacity until hovered so an icon never reads brighter than its own label. Marked `aria-hidden`, since the label already names the tab.

What I deliberately did not do: rename `data-tab`, the element ids, or the `diag-*` CSS. Those are internal identifiers, the CSS section comments name them, and churning them buys nothing. A report saved before this change keeps working.

## Before vs after

| | Before | After |
|---|---|---|
| Second tab | `Diagnosis` | `Findings` |
| Last tab | `Lab` | `Rule Lab` |
| Word used for a finding, comment vs report | `findings` vs `Diagnosis` | `findings` both |
| Icons | none | six, outline, `currentColor` |
| `data-tab` / element ids | `diagnosis`, `lab` | unchanged |
| Docs pages naming a tab | 3 pages stale | updated |

## Example

The bar, before:

```
Summary   Diagnosis 160   Modules Graph   Endpoints BETA   Relational Schema   Lab
```

and after, each label now led by its icon:

```
◔ Summary   ⚠ Findings 160   ⛬ Modules Graph   ⤳ Endpoints BETA   ⛁ Relational Schema   ⌬ Rule Lab
```

Rendered from a real scan of a 362-file monorepo, the icons are gauge, warning triangle, network, route, database and flask.
