### PR TITLE
docs: lead the custom rules page with the agent route

### DIFF
--- a/.changeset/custom-rules-agent-first.md
+++ b/.changeset/custom-rules-agent-first.md
@@ -1,0 +1,5 @@
+---
+---
+
+Website only. The custom rules page leads with the agent route before the
+manual steps. No published package changes.

--- a/packages/website/src/app/docs/custom-rules/page.mdx
+++ b/packages/website/src/app/docs/custom-rules/page.mdx
@@ -8,6 +8,25 @@ export const metadata = docsMetadata["/docs/custom-rules"];
 
 Extend the built-in rule set with project-specific checks. Custom rules encode domain conventions, team standards, or patterns the built-in rules don't cover.
 
+## Let an agent do it
+
+Writing a rule is mostly matching an AST, and an agent can do it:
+
+```bash
+npx nestjs-doctor@latest --init
+```
+
+That installs a `nestjs-doctor-create-rule` skill. Describe the convention you
+want enforced and the agent checks static analysis can see it, picks file or
+project scope, writes the `.ts` file, points `customRulesDir` at it, and runs a
+scan to confirm the rule loads. It works in Claude Code, Cursor, Codex, and the
+other agents on [Coding agents](/docs/coding-agents).
+
+A rule it cannot detect statically is worth knowing about early. The skill says
+so instead of writing something that never fires.
+
+The rest of this page is the same work by hand.
+
 ## Setup
 
 1. Create a directory for your rules (e.g. `rules/` at your project root).
@@ -187,17 +206,6 @@ Fix the warning and re-run. The rest of the scan continues unaffected.
 
 Toggle a custom rule by its prefixed id, through the same `rules` and `ignore.rules` keys built-in rules use. See [Configuration](/docs/configuration).
 
-## Using AI to create rules
-
-Install it with `npx nestjs-doctor --init`, then call
-`/nestjs-doctor-create-rule` in your agent's chat. It:
-
-1. Checks the detection is possible with static analysis.
-2. Picks file or project scope.
-3. Writes the `.ts` file.
-4. Sets `customRulesDir` in your config.
-5. Runs nestjs-doctor to confirm the rule loads.
-
 ## The Rule Lab tab
 
 The HTML report has a Rule Lab tab for writing and testing custom rules in the browser:
@@ -206,4 +214,4 @@ The HTML report has a Rule Lab tab for writing and testing custom rules in the b
 npx nestjs-doctor . --report
 ```
 
-Scaffold a rule with `/nestjs-doctor-create-rule`, test it in the Lab, then save the `.ts` file to your `customRulesDir`.
+Scaffold a rule with `/nestjs-doctor-create-rule`, test it in the Rule Lab, then save the `.ts` file to your `customRulesDir`.


### PR DESCRIPTION
> Stacked on #252, which renames a heading in this same file. **Merge #252 first.**

## Context

Two pages describe work an agent can do for you. [Boot trace](/docs/report/boot-trace) puts that first, under **Let an agent do it**, then says "the rest of this page is the same work by hand". Custom rules did the opposite.

## Problem

Custom rules opened with `## Setup` and mentioned the skill 190 lines later, under `## Using AI to create rules`. A reader who would rather not hand-write an AST matcher had to read most of the page to learn they did not have to.

The heading was also named after the technology rather than the outcome. `Using AI to create rules` answers "what is this", where `Let an agent do it` answers "can I skip this".

## Possible flows

| Reader | Before | After |
|---|---|---|
| Wants the agent to do it | reads the page, finds it at the bottom | first thing under the intro |
| Wants to write it by hand | starts at Setup | starts at Setup, one section lower |
| Arrives from Coding agents | two descriptions of one skill | one, on the page about the thing |
| Followed a link to `#using-ai-to-create-rules` | nothing linked it | unaffected |

## Solution

`Let an agent do it` goes above `Setup`, matching the boot trace page.

It says what the skill does rather than listing its five steps. One of those steps is worth pulling out and the rest are not: the skill checks static analysis can see the pattern at all, and says so when it cannot, rather than writing a rule that never fires. That is the answer worth having before any code exists.

`Using AI to create rules` is deleted. It said the same thing twice, and nothing linked its anchor, so no redirect is needed.

## Before vs after

| | Before | After |
|---|---|---|
| First section after the intro | `Setup` | `Let an agent do it` |
| Where the skill is described | line 190 of 218 | line 11 |
| Heading names | the technology | the outcome |
| Sections describing the skill | 2 | 1 |
| Manual instructions | unchanged | unchanged |

## Example

The heading order, before:

```
Setup · Rule shape · Example · ID prefixing · When a rule fails to load
· Disabling custom rules · Using AI to create rules · The Lab tab
```

and after:

```
Let an agent do it · Setup · Rule shape · Example · ID prefixing
· When a rule fails to load · Disabling custom rules · The Rule Lab tab
```

Also catches one sentence in the same file that still said "test it in the Lab" after #252 renamed the tab.
