### PR TITLE
feat(report): site design language, layered schema diagram, orthogonal routing

### DIFF
--- a/.changeset/olive-pots-shake.md
+++ b/.changeset/olive-pots-shake.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Restyle the HTML report to match the docs site and landing page: IBM Plex Mono throughout (UI, code editors, and the graph canvases), a black full-width nav with an uppercase wordmark and a bordered GitHub button, uppercase tab labels, and square-cornered summary cards with a bordered caption strip.

--- a/.changeset/schema-layered-layout.md
+++ b/.changeset/schema-layered-layout.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Lay out the schema diagram in layered columns (referenced hubs left, referencing tables right, barycenter-ordered rows) and route every relation orthogonally through the gutters between columns, with per-gutter lane spreading, port fan-out on hub tables, and box-avoiding crossings. Replaces the dagre-based placement and the diagonal fallback routes that made large schemas unreadable.

--- a/packages/nestjs-doctor/src/report/html-report.ts
+++ b/packages/nestjs-doctor/src/report/html-report.ts
@@ -38,6 +38,9 @@ export function buildHtmlReport(
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>nestjs-doctor — Health Report</title>
 <link rel="icon" type="image/png" href="${FAVICON_DATA_URI}">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@200;400;500;600;700&display=swap">
 <style>${getReportStyles()}</style>
 ${getCodeMirrorImportMap()}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dagre/0.8.5/dagre.min.js" integrity="sha512-psLUZfcgPmi012lcpVHkWoOqyztollwCGu4w/mXijFMK/YcdUdP06voJNVOJ7f/dUIlO2tGlDLuypRyXX2lcvQ==" crossorigin="anonymous"></script>

--- a/packages/nestjs-doctor/src/report/ui/codemirror.ts
+++ b/packages/nestjs-doctor/src/report/ui/codemirror.ts
@@ -117,7 +117,7 @@ window.createCodeViewer = function(container, code, options) {
     EditorView.theme({
       "&": { fontSize: "12px" },
       ".cm-scroller": {
-        fontFamily: '"SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace',
+        fontFamily: '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
         fontSize: "12px",
         lineHeight: "1.6",
         overflow: "auto",

--- a/packages/nestjs-doctor/src/report/ui/codemirror.ts
+++ b/packages/nestjs-doctor/src/report/ui/codemirror.ts
@@ -1,3 +1,5 @@
+import { REPORT_FONT_STACK } from "./styles.js";
+
 export function getCodeMirrorImportMap(): string {
 	return `<script type="importmap">
 {
@@ -117,7 +119,7 @@ window.createCodeViewer = function(container, code, options) {
     EditorView.theme({
       "&": { fontSize: "12px" },
       ".cm-scroller": {
-        fontFamily: '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+        fontFamily: '${REPORT_FONT_STACK}',
         fontSize: "12px",
         lineHeight: "1.6",
         overflow: "auto",

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -452,11 +452,9 @@ for (let i = 0; i < lines.length; i++) {
     <div id="mg-dock-header">
       <span class="mg-dock-tab" id="mg-dock-tab-problems" data-dock-tab="problems">Module problems <span class="schema-entity-count" id="mg-problems-count"></span></span>
       <span class="mg-dock-tab" id="mg-dock-tab-trace" data-dock-tab="trace" style="display:none">Boot trace <span class="schema-entity-count" id="mg-trace-ms"></span></span>
-      <span class="mg-trace-legend" id="mg-trace-legend">
-        <span class="mg-trace-info" tabindex="0" role="img" aria-label="How to read the trace" data-tip="How to read the trace&#10;\u2022 bars scale to the slowest row&#10;\u2022 yellow segment \u2248 the class's own work&#10;\u2022 dimmed hollow bar = reused, built earlier&#10;\u2022 rows are the create phase&#10;\u2022 +ms chips = lifecycle hooks">
+      <span class="mg-trace-info" tabindex="0" role="img" aria-label="How to read the trace" data-tip="How to read the trace&#10;\u2022 bars scale to the slowest row&#10;\u2022 yellow segment \u2248 the class's own work&#10;\u2022 dimmed hollow bar = reused, built earlier&#10;\u2022 rows are the create phase&#10;\u2022 +ms chips = lifecycle hooks">
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
         </span>
-      </span>
       <span style="flex:1"></span>
       <span class="mg-problems-chevron" id="mg-dock-chevron">▴</span>
     </div>

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -8,9 +8,10 @@ export function getReportHtml(): string {
   </div>
   <div class="meta" id="header-meta"></div>
   <div class="spacer"></div>
-  <a class="github-link" href="https://github.com/RoloBits/nestjs-doctor" target="_blank" rel="noopener">
-    <svg width="18" height="18" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-  </a>
+  <div class="nav-actions">
+    <a class="nav-btn" href="https://nestjs.doctor/docs" target="_blank" rel="noopener">docs</a>
+    <a class="nav-btn" href="https://github.com/RoloBits/nestjs-doctor" target="_blank" rel="noopener">github</a>
+  </div>
 </div>
 
 <!-- ── Header Row 2 (Tab bar) ── -->
@@ -48,12 +49,21 @@ export function getReportHtml(): string {
           </svg>
         </button>
       </div>
+      <div class="mg-side-search">
+        <input type="search" id="diag-search" placeholder="Search files" spellcheck="false" autocomplete="off">
+      </div>
       <label class="schema-sync" id="diag-notscored-row">
         <input type="checkbox" id="diag-show-notscored">
         <span>Show not scored</span>
       </label>
       <hr class="diag-divider" id="diag-notscored-divider">
-      <div class="filter-rows">
+      <button class="diag-filters-toggle" id="diag-filters-toggle" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+        Filters
+        <span class="diag-filters-count" id="diag-filters-count" style="display:none"></span>
+        <span class="diag-filters-caret">\u25B8</span>
+      </button>
+      <div class="filter-rows" id="diag-filters-body">
         <div class="sev-filters">
           <span class="filter-label">Severity</span>
           <button class="sev-pill active" data-sev="all">All</button>
@@ -66,6 +76,15 @@ export function getReportHtml(): string {
           <button class="scope-pill active" data-scope="all">All</button>
           <button class="scope-pill" data-scope="file">File</button>
           <button class="scope-pill" data-scope="project">Project</button>
+        </div>
+        <div class="cat-filters">
+          <span class="filter-label">Category</span>
+          <button class="cat-pill active" data-cat="all">All</button>
+          <button class="cat-pill" data-cat="security">Security</button>
+          <button class="cat-pill" data-cat="correctness">Correctness</button>
+          <button class="cat-pill" data-cat="schema">Schema</button>
+          <button class="cat-pill" data-cat="architecture">Architecture</button>
+          <button class="cat-pill" data-cat="performance">Performance</button>
         </div>
       </div>
     </div>
@@ -212,6 +231,9 @@ for (let i = 0; i < lines.length; i++) {
             <polyline points="9 3 4 8 9 13"/><line x1="13" y1="3" x2="13" y2="13"/>
           </svg>
         </button>
+      </div>
+      <div class="mg-side-search">
+        <input type="search" id="schema-search" placeholder="Search tables" spellcheck="false" autocomplete="off">
       </div>
       <label class="schema-sync has-tip" data-tip="Sync \u00b7 the list follows the table you pick in the diagram">
         <input type="checkbox" id="schema-sync-sidebar" checked>
@@ -430,7 +452,11 @@ for (let i = 0; i < lines.length; i++) {
     <div id="mg-dock-header">
       <span class="mg-dock-tab" id="mg-dock-tab-problems" data-dock-tab="problems">Module problems <span class="schema-entity-count" id="mg-problems-count"></span></span>
       <span class="mg-dock-tab" id="mg-dock-tab-trace" data-dock-tab="trace" style="display:none">Boot trace <span class="schema-entity-count" id="mg-trace-ms"></span></span>
-      <span class="mg-trace-legend" id="mg-trace-legend">bars scale to the slowest row · <span class="mg-trace-legend-self"></span> ≈ own work · dimmed hollow = reused, built earlier · rows = create phase, +ms chips = lifecycle hooks</span>
+      <span class="mg-trace-legend" id="mg-trace-legend">
+        <span class="mg-trace-info" tabindex="0" role="img" aria-label="How to read the trace" data-tip="How to read the trace&#10;\u2022 bars scale to the slowest row&#10;\u2022 yellow segment \u2248 the class's own work&#10;\u2022 dimmed hollow bar = reused, built earlier&#10;\u2022 rows are the create phase&#10;\u2022 +ms chips = lifecycle hooks">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+        </span>
+      </span>
       <span style="flex:1"></span>
       <span class="mg-problems-chevron" id="mg-dock-chevron">▴</span>
     </div>

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -51,8 +51,8 @@ function makeScoreRingSvg(size, strokeW, value) {
   const offset = c - (value / 100) * c;
   const color = getScoreColor(value);
   return '<svg width="' + size + '" height="' + size + '" viewBox="0 0 ' + size + ' ' + size + '">' +
-    '<circle cx="' + size/2 + '" cy="' + size/2 + '" r="' + r + '" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="' + strokeW + '"/>' +
-    '<circle cx="' + size/2 + '" cy="' + size/2 + '" r="' + r + '" fill="none" stroke="' + color + '" stroke-width="' + strokeW + '" stroke-linecap="round" stroke-dasharray="' + c + '" stroke-dashoffset="' + offset + '" transform="rotate(-90 ' + size/2 + ' ' + size/2 + ')"/>' +
+    '<circle cx="' + size/2 + '" cy="' + size/2 + '" r="' + r + '" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="1"/>' +
+    '<circle cx="' + size/2 + '" cy="' + size/2 + '" r="' + r + '" fill="none" stroke="' + color + '" stroke-width="' + strokeW + '" stroke-linecap="butt" stroke-dasharray="' + c + '" stroke-dashoffset="' + offset + '" transform="rotate(-90 ' + size/2 + ' ' + size/2 + ')"/>' +
     '<text x="' + size/2 + '" y="' + size/2 + '" text-anchor="middle" dominant-baseline="central" fill="' + color + '" font-size="' + Math.round(size * 0.32) + '" font-weight="700" font-family="var(--font)">' + value + '</text>' +
     '</svg>';
 }
@@ -2943,7 +2943,7 @@ function renderSummary() {
   }).length;
   html += '<div class="ov-card full-width"><h3>Health Score</h3><div class="ov-card-body">' +
     '<div class="ov-score-row">' +
-    '<div class="ov-score-ring">' + makeScoreRingSvg(120, 8, sv) + '</div>' +
+    '<div class="ov-score-ring">' + makeScoreRingSvg(120, 6, sv) + '</div>' +
     '<div class="ov-score-details">' +
     '<div class="ov-score-label">' + sv + ' / 100</div>' +
     '<div class="ov-score-sublabel">' + escHtml(project.score.label) + '</div>' +

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -2458,7 +2458,7 @@ function renderDiagnosis() {
       if (segments.length > 0 && segments[segments.length - 1].end < totalLines) {
         const belowCount = totalLines - segments[segments.length - 1].end;
         const belowRow = document.createElement("div");
-        belowRow.className = "code-expand-row";
+        belowRow.className = "code-expand-row code-expand-below";
         belowRow.innerHTML = SVG_DOWN + " Expand " + Math.min(EXPAND_STEP, belowCount) + " lines";
         (function(fp) {
           belowRow.addEventListener("click", function() {
@@ -2466,8 +2466,7 @@ function renderDiagnosis() {
             expandState["__file_" + fp].below += EXPAND_STEP;
             showFile(fp, true);
             const newCodeEl = document.getElementById("diagnosis-file-code");
-            const rows = newCodeEl.querySelectorAll(".code-expand-row");
-            const anchor = rows.length > 0 ? rows[rows.length - 1] : newCodeEl;
+            const anchor = newCodeEl.querySelector(".code-expand-below") || newCodeEl;
             anchor.scrollIntoView({ block: "end" });
             // The editors grow as CodeMirror measures; keep the anchor pinned until they settle.
             const ro = new ResizeObserver(function() {
@@ -3293,14 +3292,13 @@ function renderLab() {
       if (segments.length > 0 && segments[segments.length - 1].end < totalLines) {
         const belowCount = totalLines - segments[segments.length - 1].end;
         const belowRow = document.createElement("div");
-        belowRow.className = "code-expand-row";
+        belowRow.className = "code-expand-row code-expand-below";
         belowRow.innerHTML = SVG_DOWN + " Expand " + Math.min(PG_EXPAND_STEP, belowCount) + " lines";
         (function(fp) {
           belowRow.addEventListener("click", function() {
             pgExpandState[fp].below += PG_EXPAND_STEP;
             showPgFile(fp, true);
-            const rows = pgFileCode.querySelectorAll(".code-expand-row");
-            const anchor = rows.length > 0 ? rows[rows.length - 1] : pgFileCode;
+            const anchor = pgFileCode.querySelector(".code-expand-below") || pgFileCode;
             anchor.scrollIntoView({ block: "end" });
             // The editors grow as CodeMirror measures; keep the anchor pinned until they settle.
             const ro = new ResizeObserver(function() {
@@ -3875,26 +3873,6 @@ function sCorridorY(colList, target) {
   var best = cands[0];
   for (i = 1; i < cands.length; i++) {
     if (Math.abs(cands[i] - target) < Math.abs(best - target)) best = cands[i];
-  }
-  return best;
-}
-
-/** A horizontal crossing of a column band picks the nearest box-free y. */
-function sClearY(col, y) {
-  var boxes = col.boxes;
-  var blocked = false;
-  for (var i = 0; i < boxes.length; i++) {
-    if (y > boxes[i].top && y < boxes[i].bot) { blocked = true; break; }
-  }
-  if (!blocked) return y;
-  var cands = [boxes[0].top - 10];
-  for (i = 0; i + 1 < boxes.length; i++) {
-    if (boxes[i + 1].top - boxes[i].bot > 12) cands.push((boxes[i].bot + boxes[i + 1].top) / 2);
-  }
-  cands.push(boxes[boxes.length - 1].bot + 10);
-  var best = cands[0];
-  for (i = 1; i < cands.length; i++) {
-    if (Math.abs(cands[i] - y) < Math.abs(best - y)) best = cands[i];
   }
   return best;
 }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -1,3 +1,5 @@
+import { REPORT_FONT_STACK } from "./styles.js";
+
 export interface ReportScriptData {
 	diagnosticsJson: string;
 	elapsedMsJson: string;
@@ -256,7 +258,7 @@ var MG_CROSS_EDGE = "#22d3ee";
 var MG_CYCLE = "#ea2845";
 var MG_GLOBAL = "#fbbf24";
 var MG_NODE_H = 40;
-var RPT_FONT = '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+var RPT_FONT = '${REPORT_FONT_STACK}';
 
 var mgCanvas = null, mgCtx = null, mgDpr = window.devicePixelRatio || 1;
 var mgW = 0, mgH = 0;
@@ -759,19 +761,9 @@ function mgClusterAlpha(c) {
 }
 
 // ── Modules graph: drawing ──
-function mgRoundRect(x, y, w, h, r) {
-  r = 0;
+function mgRect(x, y, w, h) {
   mgCtx.beginPath();
-  mgCtx.moveTo(x + r, y);
-  mgCtx.lineTo(x + w - r, y);
-  mgCtx.quadraticCurveTo(x + w, y, x + w, y + r);
-  mgCtx.lineTo(x + w, y + h - r);
-  mgCtx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-  mgCtx.lineTo(x + r, y + h);
-  mgCtx.quadraticCurveTo(x, y + h, x, y + h - r);
-  mgCtx.lineTo(x, y + r);
-  mgCtx.quadraticCurveTo(x, y, x + r, y);
-  mgCtx.closePath();
+  mgCtx.rect(x, y, w, h);
 }
 
 /** Where the line from a node's centre towards a point leaves its box. */
@@ -810,7 +802,7 @@ function mgDrawClusters() {
     if (mgHideExternal && c.key === MG_EXTERNAL_PROJECT) continue;
     var color = c.key ? (projectColorMap[c.key] || "#555") : "#555";
     mgCtx.globalAlpha = mgClusterAlpha(c) * 0.5;
-    mgRoundRect(c.x, c.y, c.w, c.h, 10);
+    mgRect(c.x, c.y, c.w, c.h);
     mgCtx.fillStyle = "rgba(255,255,255,0.022)";
     mgCtx.fill();
     mgCtx.strokeStyle = color;
@@ -925,7 +917,7 @@ function mgDrawEdges() {
     var l = labels[j];
     var w = mgCtx.measureText(l.text).width + 8;
     mgCtx.globalAlpha = l.alpha;
-    mgRoundRect(l.x - w / 2, l.y - 7, w, 14, 3);
+    mgRect(l.x - w / 2, l.y - 7, w, 14);
     mgCtx.fillStyle = "#0f0f0f";
     mgCtx.fill();
     mgCtx.strokeStyle = "rgba(255,255,255,0.14)";
@@ -991,7 +983,7 @@ function mgDrawNodes() {
     mgCtx.globalAlpha = alpha;
 
     if (n.isGlobal) {
-      mgRoundRect(x - 4, y - 4, n.w + 8, n.h + 8, 10);
+      mgRect(x - 4, y - 4, n.w + 8, n.h + 8);
       mgCtx.strokeStyle = "rgba(251,191,36,0.35)";
       mgCtx.lineWidth = 2;
       mgCtx.setLineDash([]);
@@ -1005,7 +997,7 @@ function mgDrawNodes() {
     if (isCirc) { fill = "#2e1a1a"; stroke = MG_CYCLE; }
     if (isSel) { stroke = "#fff"; }
 
-    mgRoundRect(x, y, n.w, n.h, 6);
+    mgRect(x, y, n.w, n.h);
     mgCtx.fillStyle = fill;
     mgCtx.fill();
     mgCtx.strokeStyle = stroke;
@@ -2462,18 +2454,9 @@ function renderDiagnosis() {
         belowRow.innerHTML = SVG_DOWN + " Expand " + Math.min(EXPAND_STEP, belowCount) + " lines";
         (function(fp) {
           belowRow.addEventListener("click", function() {
-            const mEl = document.getElementById("diagnosis-main");
             expandState["__file_" + fp].below += EXPAND_STEP;
             showFile(fp, true);
-            const newCodeEl = document.getElementById("diagnosis-file-code");
-            const anchor = newCodeEl.querySelector(".code-expand-below") || newCodeEl;
-            anchor.scrollIntoView({ block: "end" });
-            // The editors grow as CodeMirror measures; keep the anchor pinned until they settle.
-            const ro = new ResizeObserver(function() {
-              anchor.scrollIntoView({ block: "end" });
-            });
-            ro.observe(anchor.parentElement);
-            setTimeout(function() { ro.disconnect(); }, 1000);
+            pinExpandBelow(document.getElementById("diagnosis-file-code"));
           });
         })(filePath);
         codeEl.appendChild(belowRow);
@@ -2752,29 +2735,22 @@ function renderDiagnosis() {
       showFile(activeFilePath);
     }
   }
-  for (let pi = 0; pi < pills.length; pi++) {
-    pills[pi].addEventListener("click", function() {
-      activeSev = this.dataset.sev;
-      for (let pp = 0; pp < pills.length; pp++) pills[pp].classList.toggle("active", pills[pp] === this);
-      updateFiltersBadge();
-      updateTreeVisibility();
-    });
-  }
-  for (let si = 0; si < scopePills.length; si++) {
-    scopePills[si].addEventListener("click", function() {
-      activeScope = this.dataset.scope;
-      for (let sp = 0; sp < scopePills.length; sp++) scopePills[sp].classList.toggle("active", scopePills[sp] === this);
-      updateFiltersBadge();
-      updateTreeVisibility();
-    });
-  }
-  for (let ci = 0; ci < catPills.length; ci++) {
-    catPills[ci].addEventListener("click", function() {
-      activeCat = this.dataset.cat;
-      for (let cp = 0; cp < catPills.length; cp++) catPills[cp].classList.toggle("active", catPills[cp] === this);
-      updateFiltersBadge();
-      updateTreeVisibility();
-    });
+  const pillGroups = [
+    { pills: pills, key: "sev", set: function(v) { activeSev = v; } },
+    { pills: scopePills, key: "scope", set: function(v) { activeScope = v; } },
+    { pills: catPills, key: "cat", set: function(v) { activeCat = v; } },
+  ];
+  for (const group of pillGroups) {
+    for (let pi = 0; pi < group.pills.length; pi++) {
+      group.pills[pi].addEventListener("click", function() {
+        group.set(this.dataset[group.key]);
+        for (let pp = 0; pp < group.pills.length; pp++) {
+          group.pills[pp].classList.toggle("active", group.pills[pp] === this);
+        }
+        updateFiltersBadge();
+        updateTreeVisibility();
+      });
+    }
   }
   const filtersToggle = document.getElementById("diag-filters-toggle");
   if (filtersToggle) {
@@ -2939,6 +2915,17 @@ function renderFileHeader(filePath, items, getSeverity) {
   return '<div class="file-view-title">' + escHtml(fileName) + '</div>' +
     (parentDir ? '<div class="file-view-dir">' + escHtml(parentDir) + '/</div>' : '') +
     '<div class="file-view-counts">' + countsHtml + '</div>';
+}
+
+/** Keeps the below expander at the viewport bottom while the editors grow. */
+function pinExpandBelow(containerEl) {
+  const anchor = containerEl.querySelector(".code-expand-below") || containerEl;
+  anchor.scrollIntoView({ block: "end" });
+  const ro = new ResizeObserver(function() {
+    anchor.scrollIntoView({ block: "end" });
+  });
+  ro.observe(anchor.parentElement);
+  setTimeout(function() { ro.disconnect(); }, 1000);
 }
 
 // ── Summary Tab rendering ──
@@ -3298,14 +3285,7 @@ function renderLab() {
           belowRow.addEventListener("click", function() {
             pgExpandState[fp].below += PG_EXPAND_STEP;
             showPgFile(fp, true);
-            const anchor = pgFileCode.querySelector(".code-expand-below") || pgFileCode;
-            anchor.scrollIntoView({ block: "end" });
-            // The editors grow as CodeMirror measures; keep the anchor pinned until they settle.
-            const ro = new ResizeObserver(function() {
-              anchor.scrollIntoView({ block: "end" });
-            });
-            ro.observe(anchor.parentElement);
-            setTimeout(function() { ro.disconnect(); }, 1000);
+            pinExpandBelow(pgFileCode);
           });
         })(filePath);
         pgFileCode.appendChild(belowRow);
@@ -3542,7 +3522,6 @@ var sCanvas, sCtx, sDpr, sW, sH;
 var sCamX = 0, sCamY = 0, sZoom = 1;
 var sDragging = null, sPanning = false, sPanStart = {x: 0, y: 0};
 var sDragMoved = false;
-var sPressStart = {x: 0, y: 0};
 var sDragOffset = {x: 0, y: 0};
 var sHoveredEntity = null, sHoveredRelation = null;
 var sSelectedEntity = null;
@@ -3836,7 +3815,7 @@ function sBuildGrids() {
         colOf[members[m].name] = i;
       }
       boxes.sort(function(a, b) { return a.top - b.top; });
-      cols.push({ x: xs[i], left: xs[i] - 90, right: xs[i] + 90, boxes: boxes });
+      cols.push({ left: xs[i] - S_BOX_W / 2, right: xs[i] + S_BOX_W / 2, boxes: boxes });
     }
     var gutters = [];
     for (i = 0; i <= cols.length; i++) {
@@ -3896,10 +3875,10 @@ function sRelPortNames(rel) {
   var child = sNodeMap[rel.fromEntity];
   var fkName = null;
   if (child && rel.propertyName) {
-    var base = sKeyName(rel.propertyName);
+    var keys = sFkKeys(rel.propertyName);
     for (var i = 0; i < child.entity.columns.length; i++) {
       var kn = sKeyName(child.entity.columns[i].name);
-      if (kn === base || kn === base + "id") { fkName = child.entity.columns[i].name; break; }
+      if (kn === keys[0] || kn === keys[1]) { fkName = child.entity.columns[i].name; break; }
     }
   }
   var parent = sNodeMap[rel.toEntity];
@@ -3992,8 +3971,7 @@ function sChannelRouteAll() {
       runs.push({ g: jb.grid.gutters[jb.ca + 1], fromY: jb.ya, toY: jb.yb });
     } else {
       var step = jb.ca < jb.cb ? 1 : -1;
-      var between = [];
-      for (var c = jb.ca + step; c !== jb.cb; c += step) between.push(jb.grid.cols[c]);
+      var between = jb.grid.cols.slice(Math.min(jb.ca, jb.cb) + 1, Math.max(jb.ca, jb.cb));
       var gFirst = jb.grid.gutters[step === 1 ? jb.ca + 1 : jb.ca];
       var gLast = jb.grid.gutters[step === 1 ? jb.cb : jb.cb + 1];
       if (between.length === 0) {
@@ -4013,18 +3991,16 @@ function sChannelRouteAll() {
   }
 
   // Lane assignment: spread the vertical runs sharing a gutter
-  for (i = 0; i < jobs.length; i++) {
-    for (r = 0; r < jobs[i].runs.length; r++) jobs[i].runs[r].g._done = false;
-  }
-  for (i = 0; i < jobs.length; i++) {
-    for (r = 0; r < jobs[i].runs.length; r++) {
-      var gut = jobs[i].runs[r].g;
-      if (gut._done) continue;
-      gut._done = true;
+  for (var gk in sCompGrids) {
+    if (!Object.prototype.hasOwnProperty.call(sCompGrids, gk)) continue;
+    var gutters = sCompGrids[gk].gutters;
+    for (i = 0; i < gutters.length; i++) {
+      var gut = gutters[i];
       var live = [];
       for (j = 0; j < gut.runs.length; j++) {
         if (Math.abs(gut.runs[j].fromY - gut.runs[j].toY) >= 0.5) live.push(gut.runs[j]);
       }
+      gut.runs = [];
       live.sort(function(u, v) {
         return (u.fromY + u.toY) / 2 - (v.fromY + v.toY) / 2;
       });
@@ -4059,17 +4035,12 @@ function sChannelRouteAll() {
     sEdgeRoutes[jb.key] = sSimplifyPath(pts);
     sEdgeKeys.push(jb.key);
   }
-  // Runs accumulate per routing pass; reset for the next relayout
-  for (var gk in sCompGrids) {
-    if (!Object.prototype.hasOwnProperty.call(sCompGrids, gk)) continue;
-    for (i = 0; i < sCompGrids[gk].gutters.length; i++) sCompGrids[gk].gutters[i].runs = [];
-  }
 }
 
 function sRouteAllEdges() {
   sEdgeRoutes = {};
   sEdgeKeys = [];
-  if (!sFocusedMode && sCompGrids) {
+  if (sCompGrids) {
     sChannelRouteAll();
     return;
   }
@@ -4170,6 +4141,7 @@ function sComputeComponents(nodes) {
 }
 
 /** Positions one component from its own origin: layered left-to-right. */
+var S_BOX_W = 180;
 var S_COL_GAP = 110;
 var S_ROW_GAP = 44;
 var S_COL_CAP = 2400;
@@ -4279,7 +4251,7 @@ function sLayoutComponent(nodes) {
       nd.y = yCur + nd.h / 2;
       yCur += nd.h + S_ROW_GAP;
     }
-    xCur += 180 + S_COL_GAP;
+    xCur += S_BOX_W + S_COL_GAP;
   }
   for (t = 0; t < 3; t++) {
     for (i = 0; i < phys.length; i++) {
@@ -4470,13 +4442,19 @@ function sKeyName(text) {
   return String(text).toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
+function sFkKeys(propertyName) {
+  var base = sKeyName(propertyName);
+  return [base, base + "id"];
+}
+
 function sForeignKeyColumns(entity) {
   var names = Object.create(null);
   for (var i = 0; i < entity.relations.length; i++) {
     var prop = entity.relations[i].propertyName;
     if (!prop) continue;
-    names[sKeyName(prop)] = true;
-    names[sKeyName(prop) + "id"] = true;
+    var keys = sFkKeys(prop);
+    names[keys[0]] = true;
+    names[keys[1]] = true;
   }
   return names;
 }
@@ -4599,6 +4577,7 @@ function sCacheNodeLabels(nodes) {
 
 function sSetVisibleSubset(entityName) {
   if (!sFocusedMode) return;
+  sCompGrids = null;
 
   var emptyState = document.getElementById("schema-empty-state");
 
@@ -4666,21 +4645,6 @@ function sCenterCamera() {
   }
   sCamX = sW / 2 - cx;
   sCamY = sH / 2 - cy;
-}
-
-// Round rect helper
-function sRoundRect(ctx, x, y, w, h, r) {
-  ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + w - r, y);
-  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
-  ctx.lineTo(x + w, y + h - r);
-  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-  ctx.lineTo(x + r, y + h);
-  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
-  ctx.lineTo(x, y + r);
-  ctx.quadraticCurveTo(x, y, x + r, y);
-  ctx.closePath();
 }
 
 // Drawing
@@ -4758,7 +4722,6 @@ function schemaDraw() {
 
   // Draw entity boxes
   var BOX_W = 180;
-  var R = 0;
   var HDR_H = 24;
   var COL_ROW_H = 16;
   var showCols = sApplyNodeSizes(sNodes);
@@ -4787,7 +4750,8 @@ function schemaDraw() {
     }
 
     // Body background (full box)
-    sRoundRect(sCtx, x, y, BOX_W, BOX_H, R);
+    sCtx.beginPath();
+    sCtx.rect(x, y, BOX_W, BOX_H);
     sCtx.fillStyle = "#151515";
     sCtx.fill();
 
@@ -4798,21 +4762,9 @@ function schemaDraw() {
 
     if (isSelected) sCtx.restore();
 
-    // Header background (top portion, clipped to rounded top)
-    sCtx.save();
-    sCtx.beginPath();
-    sCtx.moveTo(x + R, y);
-    sCtx.lineTo(x + BOX_W - R, y);
-    sCtx.quadraticCurveTo(x + BOX_W, y, x + BOX_W, y + R);
-    sCtx.lineTo(x + BOX_W, y + HDR_H);
-    sCtx.lineTo(x, y + HDR_H);
-    sCtx.lineTo(x, y + R);
-    sCtx.quadraticCurveTo(x, y, x + R, y);
-    sCtx.closePath();
-    sCtx.clip();
+    // Header background (top portion)
     sCtx.fillStyle = "#0d0d0d";
     sCtx.fillRect(x, y, BOX_W, HDR_H);
-    sCtx.restore();
 
     // Separator line between header and body
     sCtx.beginPath();
@@ -5571,7 +5523,7 @@ function renderSchema() {
     var pos = sScreenToWorld(sx, sy);
     var hit = sHitTestEntity(pos.x, pos.y);
     sDragMoved = false;
-    sPressStart = { x: e.clientX, y: e.clientY };
+    sPanStart = { x: e.clientX, y: e.clientY };
     if (hit) {
       sDragging = hit;
       sDragOffset = { x: hit.x - pos.x, y: hit.y - pos.y };
@@ -5579,7 +5531,6 @@ function renderSchema() {
       sHideRelBadge();
     } else {
       sPanning = true;
-      sPanStart = { x: e.clientX, y: e.clientY };
     }
   });
 
@@ -5589,10 +5540,11 @@ function renderSchema() {
     var sy = e.clientY - rect.top;
     var pos = sScreenToWorld(sx, sy);
 
+    if ((sDragging || sPanning) && !sDragMoved &&
+        Math.abs(e.clientX - sPanStart.x) < 4 &&
+        Math.abs(e.clientY - sPanStart.y) < 4) return;
+
     if (sDragging) {
-      if (!sDragMoved &&
-          Math.abs(e.clientX - sPressStart.x) < 4 &&
-          Math.abs(e.clientY - sPressStart.y) < 4) return;
       sDragMoved = true;
       sDragging.x = pos.x + sDragOffset.x;
       sDragging.y = pos.y + sDragOffset.y;
@@ -5601,9 +5553,6 @@ function renderSchema() {
       sHideTooltip();
       sHideRelBadge();
     } else if (sPanning) {
-      if (!sDragMoved &&
-          Math.abs(e.clientX - sPressStart.x) < 4 &&
-          Math.abs(e.clientY - sPressStart.y) < 4) return;
       sDragMoved = true;
       sCamX += (e.clientX - sPanStart.x) / sZoom;
       sCamY += (e.clientY - sPanStart.y) / sZoom;

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -256,7 +256,7 @@ var MG_CROSS_EDGE = "#22d3ee";
 var MG_CYCLE = "#ea2845";
 var MG_GLOBAL = "#fbbf24";
 var MG_NODE_H = 40;
-var MG_FONT = '-apple-system, BlinkMacSystemFont, sans-serif';
+var RPT_FONT = '"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
 
 var mgCanvas = null, mgCtx = null, mgDpr = window.devicePixelRatio || 1;
 var mgW = 0, mgH = 0;
@@ -515,9 +515,9 @@ function mgMeasureNode(n) {
   if (n.initTimings && n.initTimings.length > 0) {
     sub += " \\u00b7 " + mgFormatMs(n.initTimings[0].initTime);
   }
-  mgCtx.font = "bold 12px " + MG_FONT;
+  mgCtx.font = "bold 12px " + RPT_FONT;
   var lw = mgCtx.measureText(label).width;
-  mgCtx.font = "10px " + MG_FONT;
+  mgCtx.font = "10px " + RPT_FONT;
   var sw = mgCtx.measureText(sub).width;
   n.label = label;
   n.sub = sub;
@@ -760,6 +760,7 @@ function mgClusterAlpha(c) {
 
 // ── Modules graph: drawing ──
 function mgRoundRect(x, y, w, h, r) {
+  r = 0;
   mgCtx.beginPath();
   mgCtx.moveTo(x + r, y);
   mgCtx.lineTo(x + w - r, y);
@@ -819,12 +820,12 @@ function mgDrawClusters() {
     if (c.key) {
       mgCtx.globalAlpha = mgClusterAlpha(c);
       mgCtx.fillStyle = color;
-      mgCtx.font = "bold 12px " + MG_FONT;
+      mgCtx.font = "bold 12px " + RPT_FONT;
       mgCtx.textAlign = "left";
       mgCtx.textBaseline = "middle";
       mgCtx.fillText(c.key, c.x + 12, c.y + 15);
       mgCtx.fillStyle = "#666";
-      mgCtx.font = "10px " + MG_FONT;
+      mgCtx.font = "10px " + RPT_FONT;
       mgCtx.fillText(c.nodes.length + (c.nodes.length === 1 ? " module" : " modules"),
         c.x + 16 + mgCtx.measureText(c.key).width * 1.15, c.y + 15);
     }
@@ -917,7 +918,7 @@ function mgDrawEdges() {
   }
   mgCtx.globalAlpha = 1;
 
-  mgCtx.font = "9px " + MG_FONT;
+  mgCtx.font = "9px " + RPT_FONT;
   mgCtx.textAlign = "center";
   mgCtx.textBaseline = "middle";
   for (var j = 0; j < labels.length; j++) {
@@ -1016,10 +1017,10 @@ function mgDrawNodes() {
     mgCtx.textAlign = "center";
     mgCtx.textBaseline = "middle";
     mgCtx.fillStyle = n.external ? "#9ca3af" : "#fff";
-    mgCtx.font = "bold 12px " + MG_FONT;
+    mgCtx.font = "bold 12px " + RPT_FONT;
     mgCtx.fillText(n.label, n.x, n.y - 6);
     mgCtx.fillStyle = "#888";
-    mgCtx.font = "10px " + MG_FONT;
+    mgCtx.font = "10px " + RPT_FONT;
     mgCtx.fillText(n.sub, n.x, n.y + 9);
   }
   mgCtx.globalAlpha = 1;
@@ -2300,7 +2301,7 @@ function renderDiagnosis() {
   let activeFileEl = null;
 
   // Show all diagnostics for a file in the main panel
-  function showFile(filePath) {
+  function showFile(filePath, skipHighlightScroll) {
     const diags = fileMap[filePath];
     if (!diags) return;
 
@@ -2402,7 +2403,7 @@ function renderDiagnosis() {
             const mEl = document.getElementById("diagnosis-main");
             const scrollBefore = mEl.scrollTop;
             expandState["__file_" + fp].above += EXPAND_STEP;
-            showFile(fp);
+            showFile(fp, true);
             mEl.scrollTop = scrollBefore;
           });
         })(filePath);
@@ -2448,7 +2449,7 @@ function renderDiagnosis() {
             highlightLines: hlLines,
             lineMetadata: lineMetadata,
             firstLineNumber: firstLineNum,
-            skipScrollIntoView: sg > 0,
+            skipScrollIntoView: sg > 0 || !!skipHighlightScroll,
           });
         }
       }
@@ -2462,10 +2463,18 @@ function renderDiagnosis() {
         (function(fp) {
           belowRow.addEventListener("click", function() {
             const mEl = document.getElementById("diagnosis-main");
-            const scrollBefore = mEl.scrollTop;
             expandState["__file_" + fp].below += EXPAND_STEP;
-            showFile(fp);
-            mEl.scrollTop = scrollBefore;
+            showFile(fp, true);
+            const newCodeEl = document.getElementById("diagnosis-file-code");
+            const rows = newCodeEl.querySelectorAll(".code-expand-row");
+            const anchor = rows.length > 0 ? rows[rows.length - 1] : newCodeEl;
+            anchor.scrollIntoView({ block: "end" });
+            // The editors grow as CodeMirror measures; keep the anchor pinned until they settle.
+            const ro = new ResizeObserver(function() {
+              anchor.scrollIntoView({ block: "end" });
+            });
+            ro.observe(anchor.parentElement);
+            setTimeout(function() { ro.disconnect(); }, 1000);
           });
         })(filePath);
         codeEl.appendChild(belowRow);
@@ -2608,6 +2617,9 @@ function renderDiagnosis() {
   if (expandAllBtn) expandAllBtn.addEventListener("click", function() { diagSetAllFolders(false); });
   if (collapseAllBtn) collapseAllBtn.addEventListener("click", function() { diagSetAllFolders(true); });
 
+  // Search filter
+  let diagSearchQuery = "";
+
   // Severity filter
   let activeSev = "all";
   const pills = sidebarEl.querySelectorAll(".sev-pill");
@@ -2615,6 +2627,10 @@ function renderDiagnosis() {
   // Scope filter
   let activeScope = "all";
   const scopePills = sidebarEl.querySelectorAll(".scope-pill");
+
+  // Category filter
+  let activeCat = "all";
+  const catPills = sidebarEl.querySelectorAll(".cat-pill");
 
   let showNotScored = false;
   const notScoredToggle = document.getElementById("diag-show-notscored");
@@ -2625,7 +2641,19 @@ function renderDiagnosis() {
     if (!showNotScored && isNotScored(entry.d)) return false;
     if (activeSev !== "all" && entry.d.severity !== activeSev) return false;
     if (activeScope !== "all" && entry.d.scope !== activeScope) return false;
+    if (activeCat !== "all" && entry.d.category !== activeCat) return false;
     return true;
+  }
+
+  function updateFiltersBadge() {
+    const badge = document.getElementById("diag-filters-count");
+    if (!badge) return;
+    let n = 0;
+    if (activeSev !== "all") n++;
+    if (activeScope !== "all") n++;
+    if (activeCat !== "all") n++;
+    badge.textContent = n;
+    badge.style.display = n > 0 ? "" : "none";
   }
 
   function countFileVisibleDiags(filePath) {
@@ -2638,12 +2666,16 @@ function renderDiagnosis() {
     return count;
   }
 
+  function diagMatchesSearch(filePath) {
+    return diagSearchQuery === "" || filePath.toLowerCase().indexOf(diagSearchQuery) >= 0;
+  }
+
   function updateTreeVisibility() {
     const countEl = document.getElementById("diag-file-count");
     if (countEl) {
       let shownFiles = 0;
       for (const fp in fileMap) {
-        if (countFileVisibleDiags(fp) > 0) shownFiles++;
+        if (countFileVisibleDiags(fp) > 0 && diagMatchesSearch(fp)) shownFiles++;
       }
       countEl.textContent = shownFiles;
     }
@@ -2652,7 +2684,7 @@ function renderDiagnosis() {
     for (let f = 0; f < fileNodes.length; f++) {
       const fPath = fileNodes[f].dataset.path;
       const visCount = countFileVisibleDiags(fPath);
-      fileNodes[f].classList.toggle("hidden", visCount === 0);
+      fileNodes[f].classList.toggle("hidden", visCount === 0 || !diagMatchesSearch(fPath));
       const fc = fileNodes[f].querySelector(".tree-count");
       if (fc) fc.textContent = visCount;
       // Update severity indicator
@@ -2679,6 +2711,7 @@ function renderDiagnosis() {
       const body = folder.querySelector(".tree-folder-body");
       const visChildren = body.querySelectorAll(":scope > .tree-file:not(.hidden), :scope > .tree-folder:not(.hidden)");
       folder.classList.toggle("hidden", visChildren.length === 0);
+      if (diagSearchQuery !== "" && visChildren.length > 0) folder.classList.remove("collapsed");
       // Count visible diags in all descendant files
       const descendantFiles = folder.querySelectorAll(".tree-file:not(.hidden)");
       let totalCount = 0;
@@ -2724,6 +2757,7 @@ function renderDiagnosis() {
     pills[pi].addEventListener("click", function() {
       activeSev = this.dataset.sev;
       for (let pp = 0; pp < pills.length; pp++) pills[pp].classList.toggle("active", pills[pp] === this);
+      updateFiltersBadge();
       updateTreeVisibility();
     });
   }
@@ -2731,9 +2765,33 @@ function renderDiagnosis() {
     scopePills[si].addEventListener("click", function() {
       activeScope = this.dataset.scope;
       for (let sp = 0; sp < scopePills.length; sp++) scopePills[sp].classList.toggle("active", scopePills[sp] === this);
+      updateFiltersBadge();
       updateTreeVisibility();
     });
   }
+  for (let ci = 0; ci < catPills.length; ci++) {
+    catPills[ci].addEventListener("click", function() {
+      activeCat = this.dataset.cat;
+      for (let cp = 0; cp < catPills.length; cp++) catPills[cp].classList.toggle("active", catPills[cp] === this);
+      updateFiltersBadge();
+      updateTreeVisibility();
+    });
+  }
+  const filtersToggle = document.getElementById("diag-filters-toggle");
+  if (filtersToggle) {
+    filtersToggle.addEventListener("click", function() {
+      const open = sidebarEl.querySelector(".diagnosis-toolbar").classList.toggle("filters-open");
+      this.setAttribute("aria-expanded", open ? "true" : "false");
+    });
+  }
+  const diagSearchEl = document.getElementById("diag-search");
+  if (diagSearchEl) {
+    diagSearchEl.addEventListener("input", function() {
+      diagSearchQuery = this.value.trim().toLowerCase();
+      updateTreeVisibility();
+    });
+  }
+
   if (notScoredToggle) {
     // The row is pointless when nothing is filtered by it.
     const anyNotScored = diagnostics.some(isNotScored);
@@ -2841,7 +2899,7 @@ function renderTreeHtml(root, config) {
       const folderSev = worstSevNode(child, config.itemsKey, config.getSeverity);
       const folderCount = countItems(child, config.itemsKey);
       html += '<div class="tree-folder">' +
-        '<div class="tree-folder-header" style="padding-left:calc(14px + ' + pad + ')">' +
+        '<div class="tree-folder-header" style="padding-left:calc(14px + ' + pad + ');--guides:' + (depth * 12) + 'px">' +
         '<span class="tree-chevron">&#9660;</span>' +
         '<span class="tree-folder-icon sev-indicator-' + folderSev + '">' + SVG_FOLDER + '</span>' +
         '<span class="tree-folder-name">' + escHtml(child.name) + '</span>' +
@@ -2858,7 +2916,7 @@ function renderTreeHtml(root, config) {
       let extraAttrs = "";
       if (config.collectSevs) extraAttrs = ' data-sevs="' + config.collectSevs(fileNode[config.itemsKey]) + '"';
       html += '<div class="tree-file" data-path="' + escHtml(fileNode.fullPath) + '"' + extraAttrs + '>' +
-        '<div class="tree-file-header" style="padding-left:calc(14px + ' + pad + ')">' +
+        '<div class="tree-file-header" style="padding-left:calc(14px + ' + pad + ');--guides:' + (depth * 12) + 'px">' +
         '<span class="tree-file-icon sev-indicator-' + fileSev + '">' + SVG_FILE + '</span>' +
         '<span class="tree-file-name">' + escHtml(fileNode.name) + '</span>' +
         '<span class="tree-count">' + fileCount + '</span>' +
@@ -2897,7 +2955,7 @@ function renderSummary() {
   var notScoredCount = (diagnostics || []).filter(function (d) {
     return d.surfaces && d.surfaces.indexOf('score') === -1;
   }).length;
-  html += '<div class="ov-card full-width"><h3>Health Score</h3>' +
+  html += '<div class="ov-card full-width"><h3>Health Score</h3><div class="ov-card-body">' +
     '<div class="ov-score-row">' +
     '<div class="ov-score-ring">' + makeScoreRingSvg(120, 8, sv) + '</div>' +
     '<div class="ov-score-details">' +
@@ -2918,20 +2976,20 @@ function renderSummary() {
         '</span>' +
         '</div>'
       : '') +
-    '</div></div></div>';
+    '</div></div></div></div>';
 
   // Project info card
-  html += '<div class="ov-card"><h3>Project Info</h3><div class="ov-info-grid">' +
+  html += '<div class="ov-card"><h3>Project Info</h3><div class="ov-card-body"><div class="ov-info-grid">' +
     '<div class="ov-info-item"><label>Name</label><span>' + escHtml(project.name) + '</span></div>' +
     '<div class="ov-info-item"><label>NestJS</label><span>' + (project.nestVersion || "—") + '</span></div>' +
     '<div class="ov-info-item"><label>Framework</label><span>' + (project.framework || "—") + '</span></div>' +
     '<div class="ov-info-item"><label>ORM</label><span>' + (project.orm || "—") + '</span></div>' +
     '<div class="ov-info-item"><label>Files</label><span>' + project.fileCount + '</span></div>' +
     '<div class="ov-info-item"><label>Modules</label><span>' + project.moduleCount + '</span></div>' +
-    '</div></div>';
+    '</div></div></div>';
 
   // Category breakdown card
-  html += '<div class="ov-card"><h3>Issues by Category</h3>';
+  html += '<div class="ov-card"><h3>Issues by Category</h3><div class="ov-card-body">';
   for (const cat of CAT_ORDER) {
     const m = CAT_META[cat];
     const count = (summary.byCategory && summary.byCategory[cat]) || 0;
@@ -2940,22 +2998,22 @@ function renderSummary() {
       '<span class="ov-cat-name">' + m.label + '</span>' +
       '<span class="ov-cat-count">' + count + '</span></div>';
   }
-  html += '</div>';
+  html += '</div></div>';
 
   // Module graph stats card
-  html += '<div class="ov-card"><h3>Module Graph</h3>' +
+  html += '<div class="ov-card"><h3>Module Graph</h3><div class="ov-card-body">' +
     '<div class="ov-stat-row"><span class="ov-stat-label">Total modules</span><span class="ov-stat-value">' + graph.modules.length + '</span></div>' +
     '<div class="ov-stat-row"><span class="ov-stat-label">Root modules</span><span class="ov-stat-value">' + rootModules.size + '</span></div>' +
     '<div class="ov-stat-row"><span class="ov-stat-label">Edges</span><span class="ov-stat-value">' + graph.edges.length + '</span></div>' +
     '<div class="ov-stat-row"><span class="ov-stat-label">Circular deps</span><span class="ov-stat-value">' + graph.circularDeps.length + '</span></div>' +
-    '</div>';
+    '</div></div>';
 
   // Analysis card
-  html += '<div class="ov-card"><h3>Analysis</h3>' +
+  html += '<div class="ov-card"><h3>Analysis</h3><div class="ov-card-body">' +
     '<div class="ov-stat-row"><span class="ov-stat-label">Duration</span><span class="ov-stat-value">' + (elapsedMs / 1000).toFixed(2) + 's</span></div>' +
     '<div class="ov-stat-row"><span class="ov-stat-label">Files scanned</span><span class="ov-stat-value">' + project.fileCount + '</span></div>' +
     '<div class="ov-stat-row"><span class="ov-stat-label">Total issues</span><span class="ov-stat-value">' + summary.total + '</span></div>' +
-    '</div>';
+    '</div></div>';
 
   html += '</div>';
   container.innerHTML = html;
@@ -3115,7 +3173,7 @@ function renderLab() {
   });
 
 
-  function showPgFile(filePath) {
+  function showPgFile(filePath, skipHighlightScroll) {
     const findings = currentPgFileMap[filePath];
     if (!findings) return;
 
@@ -3181,8 +3239,11 @@ function renderLab() {
         aboveRow.innerHTML = SVG_UP + " Expand " + Math.min(PG_EXPAND_STEP, aboveCount) + " lines";
         (function(fp) {
           aboveRow.addEventListener("click", function() {
+            const paneEl = document.querySelector(".playground-results");
+            const scrollBefore = paneEl.scrollTop;
             pgExpandState[fp].above += PG_EXPAND_STEP;
-            showPgFile(fp);
+            showPgFile(fp, true);
+            paneEl.scrollTop = scrollBefore;
           });
         })(filePath);
         pgFileCode.appendChild(aboveRow);
@@ -3223,7 +3284,7 @@ function renderLab() {
             highlightLines: hlLines,
             lineMetadata: lineMetadata,
             firstLineNumber: firstLineNum,
-            skipScrollIntoView: sg > 0,
+            skipScrollIntoView: sg > 0 || !!skipHighlightScroll,
           });
         }
       }
@@ -3237,7 +3298,16 @@ function renderLab() {
         (function(fp) {
           belowRow.addEventListener("click", function() {
             pgExpandState[fp].below += PG_EXPAND_STEP;
-            showPgFile(fp);
+            showPgFile(fp, true);
+            const rows = pgFileCode.querySelectorAll(".code-expand-row");
+            const anchor = rows.length > 0 ? rows[rows.length - 1] : pgFileCode;
+            anchor.scrollIntoView({ block: "end" });
+            // The editors grow as CodeMirror measures; keep the anchor pinned until they settle.
+            const ro = new ResizeObserver(function() {
+              anchor.scrollIntoView({ block: "end" });
+            });
+            ro.observe(anchor.parentElement);
+            setTimeout(function() { ro.disconnect(); }, 1000);
           });
         })(filePath);
         pgFileCode.appendChild(belowRow);
@@ -3474,6 +3544,8 @@ var sCanvas, sCtx, sDpr, sW, sH;
 var sCamX = 0, sCamY = 0, sZoom = 1;
 var sDragging = null, sPanning = false, sPanStart = {x: 0, y: 0};
 var sDragMoved = false;
+var sPressStart = {x: 0, y: 0};
+var sDragOffset = {x: 0, y: 0};
 var sHoveredEntity = null, sHoveredRelation = null;
 var sSelectedEntity = null;
 var sNodes = [];
@@ -3674,21 +3746,19 @@ function sRouteManhattan(fromNode, toNode) {
     return sSimplifyPath([portA, stepA, {x: midX2, y: midY2}, stepB, portB]);
   }
 
-  // U-shaped detour: find best detour direction
+  // U-shaped detour along a shared horizontal or vertical line
   var bestPath = null;
   var bestLen = Infinity;
-  var offsets = [
-    { dx: 0, dy: -80 },
-    { dx: 0, dy: 80 },
-    { dx: -80, dy: 0 },
-    { dx: 80, dy: 0 }
+  var rails = [
+    { axis: "y", v: Math.min(stepA.y, stepB.y) - 80 },
+    { axis: "y", v: Math.max(stepA.y, stepB.y) + 80 },
+    { axis: "x", v: Math.min(stepA.x, stepB.x) - 80 },
+    { axis: "x", v: Math.max(stepA.x, stepB.x) + 80 }
   ];
-  for (var o = 0; o < offsets.length; o++) {
-    var midAx = stepA.x + offsets[o].dx;
-    var midAy = stepA.y + offsets[o].dy;
-    var midBx = stepB.x + offsets[o].dx;
-    var midBy = stepB.y + offsets[o].dy;
-    var path = [portA, stepA, {x: midAx, y: midAy}, {x: midBx, y: midBy}, stepB, portB];
+  for (var o = 0; o < rails.length; o++) {
+    var path = rails[o].axis === "y"
+      ? [portA, stepA, {x: stepA.x, y: rails[o].v}, {x: stepB.x, y: rails[o].v}, stepB, portB]
+      : [portA, stepA, {x: rails[o].v, y: stepA.y}, {x: rails[o].v, y: stepB.y}, stepB, portB];
     var blocked = false;
     for (var s = 0; s < path.length - 1; s++) {
       if (sSegmentHitsAnyBox(path[s].x, path[s].y, path[s + 1].x, path[s + 1].y, fromName, toName)) {
@@ -3727,9 +3797,304 @@ function sSimplifyPath(points) {
   return result;
 }
 
+// ── Schema: channel routing over the layered grid ──
+var S_LANE = 8;
+var sCompGrids = null;
+
+function sBuildGrids() {
+  sCompGrids = {};
+  var groups = {};
+  var i, m;
+  for (i = 0; i < sNodes.length; i++) {
+    var cid = sNodes[i]._comp;
+    if (cid === undefined || cid < 0) continue;
+    if (!groups[cid]) groups[cid] = [];
+    groups[cid].push(sNodes[i]);
+  }
+  for (var gKey in groups) {
+    if (!Object.prototype.hasOwnProperty.call(groups, gKey)) continue;
+    var nodes = groups[gKey];
+    var byX = {};
+    for (i = 0; i < nodes.length; i++) {
+      var cx = Math.round(nodes[i].x);
+      if (!byX[cx]) byX[cx] = [];
+      byX[cx].push(nodes[i]);
+    }
+    var xs = [];
+    for (var xk in byX) {
+      if (Object.prototype.hasOwnProperty.call(byX, xk)) xs.push(Number(xk));
+    }
+    xs.sort(function(a, b) { return a - b; });
+    var cols = [];
+    var colOf = {};
+    for (i = 0; i < xs.length; i++) {
+      var members = byX[xs[i]];
+      var boxes = [];
+      for (m = 0; m < members.length; m++) {
+        boxes.push({
+          top: members[m].y - members[m].h / 2 - 8,
+          bot: members[m].y + members[m].h / 2 + 8
+        });
+        colOf[members[m].name] = i;
+      }
+      boxes.sort(function(a, b) { return a.top - b.top; });
+      cols.push({ x: xs[i], left: xs[i] - 90, right: xs[i] + 90, boxes: boxes });
+    }
+    var gutters = [];
+    for (i = 0; i <= cols.length; i++) {
+      var gl = i === 0 ? cols[0].left - 60 : cols[i - 1].right;
+      var gr = i === cols.length ? cols[cols.length - 1].right + 60 : cols[i].left;
+      gutters.push({ left: gl, right: gr, center: (gl + gr) / 2, runs: [] });
+    }
+    sCompGrids[gKey] = { cols: cols, gutters: gutters, colOf: colOf };
+  }
+}
+
+/** One y clear across every given column: merged intervals, nearest gap. */
+function sCorridorY(colList, target) {
+  var iv = [];
+  var i;
+  for (i = 0; i < colList.length; i++) {
+    var bx = colList[i].boxes;
+    for (var j = 0; j < bx.length; j++) iv.push({ top: bx[j].top, bot: bx[j].bot });
+  }
+  if (iv.length === 0) return target;
+  iv.sort(function(a, b) { return a.top - b.top; });
+  var merged = [iv[0]];
+  for (i = 1; i < iv.length; i++) {
+    var last = merged[merged.length - 1];
+    if (iv[i].top <= last.bot + 12) {
+      if (iv[i].bot > last.bot) last.bot = iv[i].bot;
+    } else {
+      merged.push({ top: iv[i].top, bot: iv[i].bot });
+    }
+  }
+  var cands = [merged[0].top - 10];
+  for (i = 0; i + 1 < merged.length; i++) cands.push((merged[i].bot + merged[i + 1].top) / 2);
+  cands.push(merged[merged.length - 1].bot + 10);
+  var best = cands[0];
+  for (i = 1; i < cands.length; i++) {
+    if (Math.abs(cands[i] - target) < Math.abs(best - target)) best = cands[i];
+  }
+  return best;
+}
+
+/** A horizontal crossing of a column band picks the nearest box-free y. */
+function sClearY(col, y) {
+  var boxes = col.boxes;
+  var blocked = false;
+  for (var i = 0; i < boxes.length; i++) {
+    if (y > boxes[i].top && y < boxes[i].bot) { blocked = true; break; }
+  }
+  if (!blocked) return y;
+  var cands = [boxes[0].top - 10];
+  for (i = 0; i + 1 < boxes.length; i++) {
+    if (boxes[i + 1].top - boxes[i].bot > 12) cands.push((boxes[i].bot + boxes[i + 1].top) / 2);
+  }
+  cands.push(boxes[boxes.length - 1].bot + 10);
+  var best = cands[0];
+  for (i = 1; i < cands.length; i++) {
+    if (Math.abs(cands[i] - y) < Math.abs(best - y)) best = cands[i];
+  }
+  return best;
+}
+
+/** Row centre of a named column when visible; header centre otherwise. */
+function sPortRowY(node, colName) {
+  var top = node.y - node.h / 2;
+  var showCols = sColumnsShown(sNodes.length);
+  var visible = sVisibleColCount(node, showCols);
+  if (colName) {
+    var key = sKeyName(colName);
+    for (var i = 0; i < node.entity.columns.length && i < visible; i++) {
+      if (sKeyName(node.entity.columns[i].name) === key) return top + 24 + i * 16 + 8;
+    }
+  }
+  return top + 12;
+}
+
+/** Guesses the FK column on the child and the PK column on the parent. */
+function sRelPortNames(rel) {
+  var child = sNodeMap[rel.fromEntity];
+  var fkName = null;
+  if (child && rel.propertyName) {
+    var base = sKeyName(rel.propertyName);
+    for (var i = 0; i < child.entity.columns.length; i++) {
+      var kn = sKeyName(child.entity.columns[i].name);
+      if (kn === base || kn === base + "id") { fkName = child.entity.columns[i].name; break; }
+    }
+  }
+  var parent = sNodeMap[rel.toEntity];
+  var pkName = null;
+  if (parent) {
+    for (i = 0; i < parent.entity.columns.length; i++) {
+      if (parent.entity.columns[i].isPrimary) { pkName = parent.entity.columns[i].name; break; }
+    }
+  }
+  return { fk: fkName, pk: pkName };
+}
+
+function sChannelRouteAll() {
+  var i, j, r;
+  var jobs = [];
+  var seen = {};
+  for (i = 0; i < schema.relations.length; i++) {
+    var rel = schema.relations[i];
+    if (rel.fromEntity === rel.toEntity) continue;
+    var a = sNodeMap[rel.fromEntity];
+    var b = sNodeMap[rel.toEntity];
+    if (!a || !b) continue;
+    var key = sEdgeKey(rel.fromEntity, rel.toEntity);
+    if (seen[key]) continue;
+    seen[key] = true;
+    var grid = a._comp !== undefined && a._comp === b._comp ? sCompGrids[a._comp] : null;
+    if (!grid || grid.colOf[a.name] === undefined || grid.colOf[b.name] === undefined) {
+      sEdgeRoutes[key] = sRouteManhattan(a, b);
+      sEdgeKeys.push(key);
+      continue;
+    }
+    var names = sRelPortNames(rel);
+    var ca = grid.colOf[a.name];
+    var cb = grid.colOf[b.name];
+    var sideA, sideB;
+    if (ca === cb) {
+      sideA = "right";
+      sideB = "right";
+    } else {
+      sideA = ca < cb ? "right" : "left";
+      sideB = ca < cb ? "left" : "right";
+    }
+    jobs.push({
+      key: key, a: a, b: b, grid: grid, ca: ca, cb: cb,
+      sideA: sideA, sideB: sideB,
+      ya: sPortRowY(a, names.fk), yb: sPortRowY(b, names.pk)
+    });
+  }
+
+  // Spread ports so a hub's edges fan out instead of stacking on one point
+  var byPort = {};
+  for (i = 0; i < jobs.length; i++) {
+    var jb = jobs[i];
+    var ka = jb.a.name + "|" + jb.sideA;
+    var kb = jb.b.name + "|" + jb.sideB;
+    if (!byPort[ka]) byPort[ka] = [];
+    if (!byPort[kb]) byPort[kb] = [];
+    byPort[ka].push({ job: jb, end: "a" });
+    byPort[kb].push({ job: jb, end: "b" });
+  }
+  for (var pk in byPort) {
+    if (!Object.prototype.hasOwnProperty.call(byPort, pk)) continue;
+    var ends = byPort[pk];
+    if (ends.length < 2) continue;
+    ends.sort(function(u, v) {
+      var uy = u.end === "a" ? u.job.b.y : u.job.a.y;
+      var vy = v.end === "a" ? v.job.b.y : v.job.a.y;
+      return uy - vy;
+    });
+    var node = ends[0].end === "a" ? ends[0].job.a : ends[0].job.b;
+    var spread = Math.min(S_LANE, (node.h - 16) / ends.length);
+    for (j = 0; j < ends.length; j++) {
+      var off = (j - (ends.length - 1) / 2) * spread;
+      var lo = node.y - node.h / 2 + 8;
+      var hi = node.y + node.h / 2 - 8;
+      if (ends[j].end === "a") {
+        ends[j].job.ya = Math.max(lo, Math.min(hi, ends[j].job.ya + off));
+      } else {
+        ends[j].job.yb = Math.max(lo, Math.min(hi, ends[j].job.yb + off));
+      }
+    }
+  }
+
+  // Build gutter runs for every edge
+  var corridorUse = {};
+  for (i = 0; i < jobs.length; i++) {
+    jb = jobs[i];
+    var runs = [];
+    if (jb.ca === jb.cb) {
+      runs.push({ g: jb.grid.gutters[jb.ca + 1], fromY: jb.ya, toY: jb.yb });
+    } else {
+      var step = jb.ca < jb.cb ? 1 : -1;
+      var between = [];
+      for (var c = jb.ca + step; c !== jb.cb; c += step) between.push(jb.grid.cols[c]);
+      var gFirst = jb.grid.gutters[step === 1 ? jb.ca + 1 : jb.ca];
+      var gLast = jb.grid.gutters[step === 1 ? jb.cb : jb.cb + 1];
+      if (between.length === 0) {
+        runs.push({ g: gLast, fromY: jb.ya, toY: jb.yb });
+      } else {
+        var yCorr = sCorridorY(between, (jb.ya + jb.yb) / 2);
+        var bucket = String(Math.round(yCorr / 4));
+        var used = corridorUse[bucket] || 0;
+        corridorUse[bucket] = used + 1;
+        yCorr += (used % 2 === 0 ? 1 : -1) * Math.ceil(used / 2) * 5;
+        runs.push({ g: gFirst, fromY: jb.ya, toY: yCorr });
+        runs.push({ g: gLast, fromY: yCorr, toY: jb.yb });
+      }
+    }
+    jb.runs = runs;
+    for (r = 0; r < runs.length; r++) runs[r].g.runs.push(runs[r]);
+  }
+
+  // Lane assignment: spread the vertical runs sharing a gutter
+  for (i = 0; i < jobs.length; i++) {
+    for (r = 0; r < jobs[i].runs.length; r++) jobs[i].runs[r].g._done = false;
+  }
+  for (i = 0; i < jobs.length; i++) {
+    for (r = 0; r < jobs[i].runs.length; r++) {
+      var gut = jobs[i].runs[r].g;
+      if (gut._done) continue;
+      gut._done = true;
+      var live = [];
+      for (j = 0; j < gut.runs.length; j++) {
+        if (Math.abs(gut.runs[j].fromY - gut.runs[j].toY) >= 0.5) live.push(gut.runs[j]);
+      }
+      live.sort(function(u, v) {
+        return (u.fromY + u.toY) / 2 - (v.fromY + v.toY) / 2;
+      });
+      var lane = live.length > 1
+        ? Math.min(S_LANE, (gut.right - gut.left - 12) / (live.length - 1))
+        : 0;
+      for (j = 0; j < live.length; j++) {
+        live[j].x = gut.center + (j - (live.length - 1) / 2) * lane;
+      }
+    }
+  }
+
+  // Materialize the polylines
+  for (i = 0; i < jobs.length; i++) {
+    jb = jobs[i];
+    var pts = [{
+      x: jb.sideA === "right" ? jb.a.x + jb.a.w / 2 : jb.a.x - jb.a.w / 2,
+      y: jb.ya
+    }];
+    var curY = jb.ya;
+    for (r = 0; r < jb.runs.length; r++) {
+      var rn = jb.runs[r];
+      if (Math.abs(rn.fromY - rn.toY) < 0.5) continue;
+      pts.push({ x: rn.x, y: curY });
+      pts.push({ x: rn.x, y: rn.toY });
+      curY = rn.toY;
+    }
+    pts.push({
+      x: jb.sideB === "right" ? jb.b.x + jb.b.w / 2 : jb.b.x - jb.b.w / 2,
+      y: jb.yb
+    });
+    sEdgeRoutes[jb.key] = sSimplifyPath(pts);
+    sEdgeKeys.push(jb.key);
+  }
+  // Runs accumulate per routing pass; reset for the next relayout
+  for (var gk in sCompGrids) {
+    if (!Object.prototype.hasOwnProperty.call(sCompGrids, gk)) continue;
+    for (i = 0; i < sCompGrids[gk].gutters.length; i++) sCompGrids[gk].gutters[i].runs = [];
+  }
+}
+
 function sRouteAllEdges() {
   sEdgeRoutes = {};
   sEdgeKeys = [];
+  if (!sFocusedMode && sCompGrids) {
+    sChannelRouteAll();
+    return;
+  }
   var seen = {};
   for (var i = 0; i < schema.relations.length; i++) {
     var rel = schema.relations[i];
@@ -3826,66 +4191,148 @@ function sComputeComponents(nodes) {
   return out;
 }
 
-/** Positions one component from its own origin, with dagre or a grid. */
+/** Positions one component from its own origin: layered left-to-right. */
+var S_COL_GAP = 110;
+var S_ROW_GAP = 44;
+var S_COL_CAP = 2400;
+
 function sLayoutComponent(nodes) {
-  var i;
-  if (nodes.length === 1 || typeof dagre === "undefined") {
-    var cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
-    var cellW = 0, cellH = 0;
-    for (i = 0; i < nodes.length; i++) {
-      if (nodes[i].w > cellW) cellW = nodes[i].w;
-      if (nodes[i].h > cellH) cellH = nodes[i].h;
-    }
-    var rows = Math.ceil(nodes.length / cols);
-    for (i = 0; i < nodes.length; i++) {
-      nodes[i].x = (i % cols) * (cellW + 60) + cellW / 2;
-      nodes[i].y = Math.floor(i / cols) * (cellH + 60) + cellH / 2;
-    }
-    return {
-      w: cols * cellW + (cols - 1) * 60,
-      h: rows * cellH + (rows - 1) * 60
-    };
+  var i, j, t, p, q;
+  if (nodes.length === 1) {
+    nodes[0].x = nodes[0].w / 2;
+    nodes[0].y = nodes[0].h / 2;
+    return { w: nodes[0].w, h: nodes[0].h };
   }
-
-  var g = new dagre.graphlib.Graph();
-  g.setGraph({ rankdir: "LR", nodesep: 60, ranksep: 120, marginx: 0, marginy: 0 });
-  g.setDefaultEdgeLabel(function() { return {}; });
-
-  var present = {};
-  for (i = 0; i < nodes.length; i++) {
-    present[nodes[i].name] = true;
-    g.setNode(nodes[i].name, { width: nodes[i].w, height: nodes[i].h });
-  }
-
-  var seenEdge = {};
+  var idx = {};
+  for (i = 0; i < nodes.length; i++) idx[nodes[i].name] = i;
+  var n = nodes.length;
+  var out = [], und = [];
+  for (i = 0; i < n; i++) { out.push([]); und.push([]); }
+  var seenE = {};
   for (i = 0; i < schema.relations.length; i++) {
-    var edge = schema.relations[i];
-    if (edge.fromEntity === edge.toEntity) continue;
-    if (!present[edge.fromEntity] || !present[edge.toEntity]) continue;
-    var ek = sEdgeKey(edge.fromEntity, edge.toEntity);
-    if (seenEdge[ek]) continue;
-    seenEdge[ek] = true;
-    g.setEdge(edge.fromEntity, edge.toEntity);
+    var rel = schema.relations[i];
+    if (rel.fromEntity === rel.toEntity) continue;
+    var ea = idx[rel.fromEntity], eb = idx[rel.toEntity];
+    if (ea === undefined || eb === undefined) continue;
+    var ek = ea < eb ? ea + "|" + eb : eb + "|" + ea;
+    if (seenE[ek]) continue;
+    seenE[ek] = true;
+    out[ea].push(eb);
+    und[ea].push(eb); und[eb].push(ea);
   }
 
-  dagre.layout(g);
+  // Break cycles: depth-first, back edges are dropped from the working copy
+  var color = [], acyc = [];
+  for (i = 0; i < n; i++) { color.push(0); acyc.push([]); }
+  function dfsBreak(u) {
+    color[u] = 1;
+    for (var e = 0; e < out[u].length; e++) {
+      var v = out[u][e];
+      if (color[v] === 1) continue;
+      acyc[u].push(v);
+      if (color[v] === 0) dfsBreak(v);
+    }
+    color[u] = 2;
+  }
+  for (i = 0; i < n; i++) if (color[i] === 0) dfsBreak(i);
 
+  // Layer by longest path from sinks: referenced hubs land in column 0
+  var layer = [];
+  for (i = 0; i < n; i++) layer.push(-1);
+  function assignLayer(u) {
+    if (layer[u] >= 0) return layer[u];
+    layer[u] = 0;
+    var best = 0;
+    for (var e = 0; e < acyc[u].length; e++) {
+      var d = assignLayer(acyc[u][e]) + 1;
+      if (d > best) best = d;
+    }
+    layer[u] = best;
+    return best;
+  }
+  for (i = 0; i < n; i++) assignLayer(i);
+
+  // Order each column by neighbor barycenter, four alternating sweeps
+  var maxLayer = 0;
+  for (i = 0; i < n; i++) if (layer[i] > maxLayer) maxLayer = layer[i];
+  var cols = [];
+  for (i = 0; i <= maxLayer; i++) cols.push([]);
+  for (i = 0; i < n; i++) cols[layer[i]].push(i);
+  function sweepPair(fixed, moving) {
+    var pos = {};
+    for (p = 0; p < fixed.length; p++) pos[fixed[p]] = p;
+    var keyed = [];
+    for (p = 0; p < moving.length; p++) {
+      var u = moving[p], sum = 0, cnt = 0;
+      for (q = 0; q < und[u].length; q++) {
+        if (pos[und[u][q]] !== undefined) { sum += pos[und[u][q]]; cnt++; }
+      }
+      keyed.push({ u: u, k: cnt ? sum / cnt : p, o: p });
+    }
+    keyed.sort(function(x, y) { return x.k - y.k || x.o - y.o; });
+    for (p = 0; p < keyed.length; p++) moving[p] = keyed[p].u;
+  }
+  for (t = 0; t < 4; t++) {
+    for (i = 1; i < cols.length; i++) sweepPair(cols[i - 1], cols[i]);
+    for (i = cols.length - 2; i >= 0; i--) sweepPair(cols[i + 1], cols[i]);
+  }
+
+  // Split an over-tall column into side-by-side runs, keeping the order
+  var phys = [];
+  for (i = 0; i < cols.length; i++) {
+    var run = [], runH = 0;
+    for (j = 0; j < cols[i].length; j++) {
+      var u2 = cols[i][j];
+      var hh = nodes[u2].h + S_ROW_GAP;
+      if (runH > 0 && runH + hh > S_COL_CAP) { phys.push(run); run = []; runH = 0; }
+      run.push(u2);
+      runH += hh;
+    }
+    if (run.length > 0) phys.push(run);
+  }
+
+  // Coordinates: fixed-width columns, stacked rows, then three relax passes
+  var xCur = 0;
+  for (i = 0; i < phys.length; i++) {
+    var yCur = 0;
+    for (j = 0; j < phys[i].length; j++) {
+      var nd = nodes[phys[i][j]];
+      nd.x = xCur + nd.w / 2;
+      nd.y = yCur + nd.h / 2;
+      yCur += nd.h + S_ROW_GAP;
+    }
+    xCur += 180 + S_COL_GAP;
+  }
+  for (t = 0; t < 3; t++) {
+    for (i = 0; i < phys.length; i++) {
+      var want = [];
+      for (j = 0; j < phys[i].length; j++) {
+        var u3 = phys[i][j];
+        var s2 = 0, c2 = 0;
+        for (q = 0; q < und[u3].length; q++) { s2 += nodes[und[u3][q]].y; c2++; }
+        want.push(c2 > 0 ? s2 / c2 : nodes[u3].y);
+      }
+      for (j = 0; j < phys[i].length; j++) nodes[phys[i][j]].y = want[j];
+      // The top-down sweep resolves overlaps without reordering the column
+      var floorY = -Infinity;
+      for (j = 0; j < phys[i].length; j++) {
+        var nd2 = nodes[phys[i][j]];
+        var top = Math.max(nd2.y - nd2.h / 2, floorY);
+        nd2.y = top + nd2.h / 2;
+        floorY = top + nd2.h + S_ROW_GAP;
+      }
+    }
+  }
+
+  // Normalize to origin and report the extent
   var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-  for (i = 0; i < nodes.length; i++) {
-    var laid = g.node(nodes[i].name);
-    if (!laid) continue;
-    nodes[i].x = laid.x;
-    nodes[i].y = laid.y;
-    minX = Math.min(minX, laid.x - nodes[i].w / 2);
-    maxX = Math.max(maxX, laid.x + nodes[i].w / 2);
-    minY = Math.min(minY, laid.y - nodes[i].h / 2);
-    maxY = Math.max(maxY, laid.y + nodes[i].h / 2);
+  for (i = 0; i < n; i++) {
+    minX = Math.min(minX, nodes[i].x - nodes[i].w / 2);
+    maxX = Math.max(maxX, nodes[i].x + nodes[i].w / 2);
+    minY = Math.min(minY, nodes[i].y - nodes[i].h / 2);
+    maxY = Math.max(maxY, nodes[i].y + nodes[i].h / 2);
   }
-  if (minX === Infinity) return { w: 0, h: 0 };
-  for (i = 0; i < nodes.length; i++) {
-    nodes[i].x -= minX;
-    nodes[i].y -= minY;
-  }
+  for (i = 0; i < n; i++) { nodes[i].x -= minX; nodes[i].y -= minY; }
   return { w: maxX - minX, h: maxY - minY };
 }
 
@@ -3934,9 +4381,11 @@ function sComputeOverviewLayout() {
 
   for (i = 0; i < components.length; i++) {
     if (components[i].length === 1) {
+      components[i][0]._comp = -1;
       isolated.push(components[i][0]);
       continue;
     }
+    for (var ci = 0; ci < components[i].length; ci++) components[i][ci]._comp = i;
     var size = sLayoutComponent(components[i]);
     boxes.push({ nodes: components[i], w: size.w, h: size.h });
   }
@@ -3961,6 +4410,7 @@ function sComputeOverviewLayout() {
     }
   }
 
+  sBuildGrids();
   sRouteAllEdges();
 }
 
@@ -4149,17 +4599,17 @@ function sCacheNodeLabels(nodes) {
   }
   for (var i = 0; i < nodes.length; i++) {
     var n = nodes[i];
-    sCtx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+    sCtx.font = "bold 12px " + RPT_FONT;
     n.nameStr = clip(n.name, maxNameW);
-    sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+    sCtx.font = "11px " + RPT_FONT;
     n.metaStr = clip(n.entity.columns.length + " cols  \\u00b7  " + n.sizeLabel, maxMetaW);
-    sCtx.font = "10px monospace";
+    sCtx.font = "10px " + RPT_FONT;
     n.colTypes = [];
     for (var c = 0; c < n.entity.columns.length; c++) {
       n.colTypes.push(clip(n.entity.columns[c].type, 60));
     }
     var foreignKeys = sForeignKeyColumns(n.entity);
-    sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+    sCtx.font = "11px " + RPT_FONT;
     n.colNames = [];
     n.colKinds = [];
     for (var k = 0; k < n.entity.columns.length; k++) {
@@ -4319,7 +4769,7 @@ function schemaDraw() {
     if (sZoom >= 0.35) {
       var mid = sPolylineMidpoint(points);
       var labelStr = sRelLabel(rel.type);
-      sCtx.font = (10 / sZoom) + "px monospace";
+      sCtx.font = (10 / sZoom) + "px " + RPT_FONT;
       sCtx.textAlign = "center";
       sCtx.textBaseline = "bottom";
       sCtx.fillStyle = isHovered ? "#ffffff" : "#666";
@@ -4330,7 +4780,7 @@ function schemaDraw() {
 
   // Draw entity boxes
   var BOX_W = 180;
-  var R = 6;
+  var R = 0;
   var HDR_H = 24;
   var COL_ROW_H = 16;
   var showCols = sApplyNodeSizes(sNodes);
@@ -4404,7 +4854,7 @@ function schemaDraw() {
     // Entity name (after icon). Below this zoom the glyphs are sub-pixel mush.
     if (sZoom >= 0.15) {
       sCtx.fillStyle = "#e0e0e0";
-      sCtx.font = "bold 12px -apple-system, BlinkMacSystemFont, sans-serif";
+      sCtx.font = "bold 12px " + RPT_FONT;
       sCtx.textAlign = "left";
       sCtx.textBaseline = "middle";
       sCtx.fillText(n.nameStr || n.name, iconX + iconSize + 6, y + HDR_H / 2);
@@ -4423,13 +4873,13 @@ function schemaDraw() {
           sDrawColumnIcon(sCtx, kind, x + 13, colY + COL_ROW_H / 2);
         }
         sCtx.fillStyle = kind === "pk" ? "#e0e0e0" : "#ccc";
-        sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+        sCtx.font = "11px " + RPT_FONT;
         sCtx.textAlign = "left";
         sCtx.textBaseline = "middle";
         sCtx.fillText(n.colNames ? n.colNames[c] : col.name, x + 21, colY + COL_ROW_H / 2);
         // Column type (right-aligned, dimmer)
         sCtx.fillStyle = "#3b82f6";
-        sCtx.font = "10px monospace";
+        sCtx.font = "10px " + RPT_FONT;
         sCtx.textAlign = "right";
         sCtx.fillText(n.colTypes ? n.colTypes[c] : col.type, x + BOX_W - 10, colY + COL_ROW_H / 2);
         colY += COL_ROW_H;
@@ -4437,14 +4887,14 @@ function schemaDraw() {
       // "+N more" indicator
       if (hasMore) {
         sCtx.fillStyle = "#666";
-        sCtx.font = "10px -apple-system, BlinkMacSystemFont, sans-serif";
+        sCtx.font = "10px " + RPT_FONT;
         sCtx.textAlign = "left";
         sCtx.fillText("+" + (cols.length - visibleColCount) + " more", x + 10, colY + COL_ROW_H / 2);
       }
     } else if (!showCols && showBodyText) {
       // Meta line: "N cols · ~X KB"
       sCtx.fillStyle = "#666";
-      sCtx.font = "11px -apple-system, BlinkMacSystemFont, sans-serif";
+      sCtx.font = "11px " + RPT_FONT;
       sCtx.fillText(n.metaStr || "", x + 8, y + HDR_H + (BOX_H - HDR_H) / 2);
     }
   }
@@ -4905,6 +5355,24 @@ function renderSchema() {
     });
   }
 
+  var schemaSearchEl = document.getElementById("schema-search");
+  if (schemaSearchEl) {
+    schemaSearchEl.addEventListener("input", function() {
+      var q = this.value.trim().toLowerCase();
+      var entityRows = entityListEl.querySelectorAll(".st-row[data-entity]");
+      for (var er = 0; er < entityRows.length; er++) {
+        var row = entityRows[er];
+        var label = row.querySelector(".st-label").textContent.toLowerCase();
+        var show = q === "" || label.indexOf(q) >= 0 || row.dataset.entity.toLowerCase().indexOf(q) >= 0;
+        row.style.display = show ? "" : "none";
+        var kids = row.nextElementSibling;
+        if (kids && kids.classList.contains("st-children")) {
+          kids.style.display = show ? "" : "none";
+        }
+      }
+    });
+  }
+
   var sidebarCollapseBtn = document.getElementById("schema-sidebar-collapse");
   var sidebarShowBtn = document.getElementById("schema-sidebar-show");
   var schemaTab = document.getElementById("tab-schema");
@@ -5125,8 +5593,10 @@ function renderSchema() {
     var pos = sScreenToWorld(sx, sy);
     var hit = sHitTestEntity(pos.x, pos.y);
     sDragMoved = false;
+    sPressStart = { x: e.clientX, y: e.clientY };
     if (hit) {
       sDragging = hit;
+      sDragOffset = { x: hit.x - pos.x, y: hit.y - pos.y };
       sHideTooltip();
       sHideRelBadge();
     } else {
@@ -5142,14 +5612,20 @@ function renderSchema() {
     var pos = sScreenToWorld(sx, sy);
 
     if (sDragging) {
+      if (!sDragMoved &&
+          Math.abs(e.clientX - sPressStart.x) < 4 &&
+          Math.abs(e.clientY - sPressStart.y) < 4) return;
       sDragMoved = true;
-      sDragging.x = pos.x;
-      sDragging.y = pos.y;
+      sDragging.x = pos.x + sDragOffset.x;
+      sDragging.y = pos.y + sDragOffset.y;
       sRerouteEdgesForNode(sDragging.name);
       sScheduleRedraw();
       sHideTooltip();
       sHideRelBadge();
     } else if (sPanning) {
+      if (!sDragMoved &&
+          Math.abs(e.clientX - sPressStart.x) < 4 &&
+          Math.abs(e.clientY - sPressStart.y) < 4) return;
       sDragMoved = true;
       sCamX += (e.clientX - sPanStart.x) / sZoom;
       sCamY += (e.clientY - sPanStart.y) / sZoom;
@@ -5619,7 +6095,7 @@ function epDraw() {
 
     // Class name
     epCtx.fillStyle = "#e0e0e0";
-    epCtx.font = "bold 11px -apple-system, BlinkMacSystemFont, sans-serif";
+    epCtx.font = "bold 11px " + RPT_FONT;
     epCtx.textAlign = "left";
     epCtx.textBaseline = "middle";
     var nameStr = n.className;
@@ -5635,7 +6111,7 @@ function epDraw() {
     var infoY = y + HDR_H + 8;
 
     // Type badge
-    epCtx.font = "bold 9px -apple-system, BlinkMacSystemFont, sans-serif";
+    epCtx.font = "bold 9px " + RPT_FONT;
     var typeLabel = n.type.toUpperCase();
     var badgeW = epCtx.measureText(typeLabel).width + 10;
     epRoundRect(epCtx, x + 8, infoY - 1, badgeW, 14, 3);
@@ -5653,7 +6129,7 @@ function epDraw() {
     var orderW = 0;
     if (n.order >= 0) {
       var orderLabel = "#" + (n.order + 1);
-      epCtx.font = "bold 8px -apple-system, BlinkMacSystemFont, sans-serif";
+      epCtx.font = "bold 8px " + RPT_FONT;
       orderW = epCtx.measureText(orderLabel).width + 8;
       epRoundRect(epCtx, badgeRight + 4, infoY, orderW, 12, 3);
       epCtx.fillStyle = "rgba(255,255,255,0.08)";
@@ -5665,7 +6141,7 @@ function epDraw() {
 
     // Repeat marker, right-aligned so it fits whatever the type badge is wide
     if (n.expandedElsewhere) {
-      epCtx.font = "bold 10px -apple-system, BlinkMacSystemFont, sans-serif";
+      epCtx.font = "bold 10px " + RPT_FONT;
       epCtx.fillStyle = "#888";
       epCtx.textAlign = "right";
       epCtx.textBaseline = "middle";
@@ -5676,7 +6152,7 @@ function epDraw() {
     // Method name
     if (n.methodName) {
       var methodY = infoY + 18;
-      epCtx.font = "9px monospace";
+      epCtx.font = "9px " + RPT_FONT;
       epCtx.textAlign = "left";
       epCtx.fillStyle = isCond ? "#f59e0b" : "#888";
       var mText = n.methodName + (isCond ? "?()" : "()");

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1,12 +1,13 @@
 export function getReportStyles(): string {
 	return `
 :root {
-  --bg: #0a0a0a;
-  --surface: #111111;
-  --surface-hover: #1a1a1a;
-  --border: rgba(255,255,255,0.08);
-  --border-hover: rgba(255,255,255,0.15);
-  --text: #e0e0e0;
+  --bg: #000;
+  --surface: #000;
+  --surface-hover: rgba(255,255,255,0.05);
+  --border: rgba(255,255,255,0.15);
+  --border-hover: rgba(255,255,255,0.3);
+  --border-strong: rgba(255,255,255,0.3);
+  --text: #e8e8e8;
   --text-muted: #888;
   --text-dim: #666;
   --white: #fff;
@@ -25,9 +26,27 @@ export function getReportStyles(): string {
   --header-h: 96px;
   --row1-h: 56px;
   --row2-h: 40px;
-  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
+
+/* ── Scrollbars ── */
+html { scrollbar-color: #333 transparent; scrollbar-width: thin; }
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-corner { background: transparent; }
+::-webkit-scrollbar-thumb { background: #333; }
+::-webkit-scrollbar-thumb:hover { background: #4a4a4a; }
+#diagnosis-sidebar::-webkit-scrollbar,
+#schema-sidebar::-webkit-scrollbar,
+#endpoints-sidebar::-webkit-scrollbar,
+#mg-tree::-webkit-scrollbar,
+#mg-problems-list::-webkit-scrollbar,
+#mg-trace-body::-webkit-scrollbar,
+#mg-info-pop::-webkit-scrollbar,
+.playground-editor::-webkit-scrollbar,
+.playground-results::-webkit-scrollbar,
+.cm-scroller::-webkit-scrollbar { width: 6px; height: 6px; }
 body { background: var(--bg); color: var(--text); font-family: var(--font); overflow: hidden; }
 canvas { display: block; cursor: grab; }
 canvas:active { cursor: grabbing; }
@@ -35,34 +54,38 @@ canvas:active { cursor: grabbing; }
 /* ── Header Row 1 ── */
 #header-row1 {
   position: fixed; top: 0; left: 0; right: 0; height: var(--row1-h);
-  padding: 0 20px;
-  background: rgba(10,10,10,0.95);
-  border-bottom: 1px solid var(--border);
-  display: flex; align-items: center; gap: 14px;
+  padding: 0 24px;
+  background: #000;
+  border-bottom: 1px solid var(--border-strong);
+  display: flex; align-items: center; gap: 16px;
   z-index: 20;
-  backdrop-filter: blur(12px);
 }
 #header-row1 .brand {
-  display: flex; align-items: center; gap: 8px;
-  font-size: 15px; font-weight: 700; color: var(--white);
+  display: flex; align-items: center; gap: 12px;
+  font-size: 13px; font-weight: 700; color: #f2f1ef;
+  letter-spacing: 0.08em; text-transform: uppercase;
   white-space: nowrap; flex-shrink: 0;
 }
 #header-row1 .brand svg { flex-shrink: 0; }
 #header-row1 .meta { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
 #header-row1 .meta-badge {
-  font-size: 11px; padding: 2px 8px; border-radius: 4px;
-  background: rgba(255,255,255,0.06); border: 1px solid var(--border);
+  font-size: 11px; padding: 3px 8px;
+  background: none; border: 1px solid var(--border);
   color: var(--text-muted); white-space: nowrap;
+  letter-spacing: 0.04em;
 }
 #header-row1 .spacer { flex: 1; min-width: 0; }
-#header-row1 .github-link {
-  display: flex; align-items: center;
-  text-decoration: none; color: #ccc;
-  padding: 6px; border-radius: 6px;
-  transition: background 0.15s, color 0.15s; flex-shrink: 0;
+#header-row1 .nav-actions { display: flex; gap: 8px; flex-shrink: 0; }
+#header-row1 .nav-btn {
+  display: inline-flex; align-items: center;
+  text-decoration: none; color: rgba(255,255,255,0.75);
+  border: 1px solid var(--border-strong);
+  padding: 5px 14px;
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  transition: background 0.15s, color 0.15s, border-color 0.15s; flex-shrink: 0;
 }
-#header-row1 .github-link:hover { background: rgba(255,255,255,0.08); color: var(--white); }
-#header-row1 .github-link svg { fill: currentColor; }
+#header-row1 .nav-btn:hover { background: var(--white); border-color: var(--white); color: #000; }
 @media (max-width: 640px) {
   #header-row1 .meta { display: none; }
 }
@@ -70,35 +93,35 @@ canvas:active { cursor: grabbing; }
 /* ── Header Row 2 (Tab bar) ── */
 #header-row2 {
   position: fixed; top: var(--row1-h); left: 0; right: 0; height: var(--row2-h);
-  padding: 0 20px;
-  background: rgba(10,10,10,0.95);
-  border-bottom: 1px solid var(--border);
+  padding: 0 24px;
+  background: #000;
+  border-bottom: 1px solid var(--border-strong);
   display: flex; align-items: center; gap: 0;
   z-index: 20;
-  backdrop-filter: blur(12px);
 }
 .tab-btn {
-  background: none; border: none; color: var(--text-muted);
-  font-size: 13px; font-family: var(--font); font-weight: 500;
+  background: none; border: none; color: rgba(255,255,255,0.6);
+  font-size: 11px; font-family: var(--font); font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em;
   padding: 0 16px; height: 100%; cursor: pointer;
   border-bottom: 2px solid transparent;
   transition: color 0.15s, border-color 0.15s;
-  display: flex; align-items: center; gap: 6px;
+  display: flex; align-items: center; gap: 8px;
 }
 .tab-icon { width: 15px; height: 15px; flex-shrink: 0; opacity: 0.75; }
 .tab-btn:hover .tab-icon, .tab-btn.active .tab-icon { opacity: 1; }
 .tab-btn:hover { color: var(--text); }
 .tab-btn.active { color: var(--white); border-bottom-color: var(--nest-red); }
 .tab-btn .count-badge {
-  font-size: 10px; padding: 1px 6px; border-radius: 10px;
+  font-size: 10px; padding: 1px 6px;
   background: rgba(239,68,68,0.15); color: var(--sev-error);
-  font-weight: 600; line-height: 1.4;
+  font-weight: 700; line-height: 1.4; letter-spacing: 0;
 }
 .tab-btn .count-badge.clean {
   background: rgba(74,222,128,0.15); color: var(--score-green);
 }
 .tab-btn .beta-badge {
-  font-size: 9px; padding: 1px 5px; border-radius: 4px;
+  font-size: 9px; padding: 1px 5px;
   background: rgba(251,191,36,0.15); color: #fbbf24;
   font-weight: 600; line-height: 1.4; text-transform: uppercase; letter-spacing: 0.5px;
 }
@@ -134,25 +157,25 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 #tab-modules.mg-sidebar-collapsed #mg-sidebar-show {
   display: flex; position: absolute; top: 12px; left: 12px; z-index: 10;
   width: 28px; height: 28px; justify-content: center;
-  background: rgba(50,50,50,0.9);
-  backdrop-filter: blur(4px);
-  border: 1px solid rgba(255,255,255,0.22);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
   color: rgba(255,255,255,0.7);
 }
 #tab-modules.mg-sidebar-collapsed #mg-sidebar-show:hover {
-  background: rgba(70,70,70,0.95); color: #fff;
+  background: rgba(255,255,255,0.08); color: #fff;
 }
 #mg-sidebar-show:is(:hover, :focus-visible)::after { left: 0; right: auto; }
 .mg-side-search { padding: 8px 16px 0; }
 .mg-side-search input {
   width: 100%; box-sizing: border-box;
   background: rgba(255,255,255,0.05); border: 1px solid var(--border);
-  border-radius: 5px; padding: 5px 9px; font-size: 12px; color: var(--text);
+  padding: 5px 9px; font-size: 12px; color: var(--text);
+  font-family: var(--font);
   outline: none;
 }
 .mg-side-search input:focus { border-color: rgba(59,130,246,0.5); }
-.mg-toggle-row { display: flex; border-bottom: 1px solid var(--border); }
-.mg-toggle-row .schema-sync { padding: 10px 6px 10px 16px; white-space: nowrap; }
+.mg-toggle-row { display: flex; flex-wrap: wrap; padding: 6px 0; border-bottom: 1px solid var(--border); }
+.mg-toggle-row .schema-sync { padding: 4px 6px 4px 16px; white-space: nowrap; }
 #mg-tree { flex: 1; overflow-y: auto; padding: 4px 0; }
 .mg-tree-project .st-icon { color: var(--white); }
 #mg-main {
@@ -224,20 +247,18 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .mg-dock-tab:hover { color: var(--white); }
 #mg-dock[data-active="problems"] #mg-dock-tab-problems,
 #mg-dock[data-active="trace"] #mg-dock-tab-trace { color: var(--white); background: rgba(255,255,255,0.06); }
-.mg-trace-legend {
-  display: none; font-size: 10px; color: var(--text-dim); min-width: 0;
-}
-#mg-dock.open[data-active="trace"] .mg-trace-legend { display: inline; }
+.mg-trace-legend { display: none; }
+#mg-dock.open[data-active="trace"] .mg-trace-legend { display: inline-flex; align-items: center; }
+.mg-trace-info { color: var(--text-dim); cursor: help; display: inline-flex; }
+.mg-trace-info:hover, .mg-trace-info:focus-visible { color: var(--white); outline: none; }
+
 #mg-float-tip {
   position: fixed; z-index: 100; display: none;
   pointer-events: none; max-width: 380px;
+  white-space: pre-line;
 }
 #detail-timings-btn { cursor: pointer; }
 #detail-timings-btn:hover { text-decoration: underline; }
-.mg-trace-legend-self {
-  display: inline-block; width: 14px; height: 8px; border-radius: 2px;
-  background: #fbbf24; vertical-align: middle;
-}
 #mg-trace-phases { display: none; padding: 8px 14px 2px; border-top: 1px solid var(--border); }
 #mg-dock.open[data-active="trace"] #mg-trace-phases:not(:empty) { display: block; }
 #mg-trace-phases .mg-trace-note { padding: 4px 0 0; }
@@ -375,7 +396,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .md-verb.md-put, .md-verb.md-patch { background: rgba(245,158,11,0.15); color: var(--cat-performance); }
 .md-verb.md-delete { background: rgba(239,68,68,0.15); color: var(--sev-error); }
 .md-verb.md-verb-multi { background: rgba(255,255,255,0.08); color: var(--text-muted); }
-.md-route { font-family: monospace; font-size: 11px; color: var(--text); overflow-wrap: anywhere; }
+.md-route { font-family: var(--font); font-size: 11px; color: var(--text); overflow-wrap: anywhere; }
 .md-tree { list-style: none; padding: 0; margin: 2px 0 0; }
 .md-tree li { padding: 1px 0; font-size: 11px; color: #bbb; }
 .md-tree-row { display: flex; align-items: baseline; gap: 4px; }
@@ -448,8 +469,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   position: absolute; left: 0; top: 0; bottom: 0; width: 360px;
   overflow-y: auto;
   border-right: 1px solid var(--border);
-  background: rgba(17,17,17,0.95);
-  backdrop-filter: blur(8px);
+  background: var(--surface);
   z-index: 5;
 }
 #diagnosis-main {
@@ -459,13 +479,32 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .diagnosis-toolbar {
   position: sticky; top: 0; z-index: 5;
-  background: rgba(17,17,17,0.95);
-  backdrop-filter: blur(8px);
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
   display: flex; flex-direction: column; align-items: stretch;
 }
-.filter-rows { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; padding: 10px 16px 12px; }
-.sev-filters, .scope-filters { display: flex; flex-wrap: wrap; gap: 6px; }
+.diag-filters-toggle {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; padding: 9px 16px;
+  background: none; border: none; border-bottom: 1px solid var(--border);
+  font-size: 11px; font-family: var(--font); font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.6); cursor: pointer;
+  transition: color 0.15s;
+}
+.diag-filters-toggle:hover { color: var(--white); }
+.diag-filters-toggle svg { width: 13px; height: 13px; flex-shrink: 0; }
+.diag-filters-count {
+  font-size: 10px; padding: 1px 6px;
+  background: rgba(255,255,255,0.08); color: var(--white);
+  font-weight: 700; line-height: 1.4; letter-spacing: 0;
+}
+.diag-filters-caret { margin-left: auto; font-size: 10px; transition: transform 0.15s; }
+.diagnosis-toolbar.filters-open .diag-filters-caret { transform: rotate(90deg); }
+#diag-filters-body { display: none; }
+.diagnosis-toolbar.filters-open #diag-filters-body { display: flex; border-bottom: 1px solid var(--border); }
+.filter-rows { flex-direction: column; gap: 8px; flex: 1; min-width: 0; padding: 10px 16px 12px; }
+.sev-filters, .scope-filters, .cat-filters { display: flex; flex-wrap: wrap; gap: 6px; }
 .filter-label {
   font-size: 10px;
   color: var(--text-dim);
@@ -473,14 +512,14 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   letter-spacing: 0.5px;
   width: 100%;
 }
-.sev-pill, .scope-pill {
-  font-size: 11px; padding: 4px 12px; border-radius: 12px;
-  border: 1px solid var(--border); background: transparent;
+.sev-pill, .scope-pill, .cat-pill {
+  font-size: 11px; padding: 4px 12px;
+  border: 1px solid var(--border); background: none;
   color: var(--text-muted); cursor: pointer; font-family: var(--font);
-  transition: all 0.15s;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-.sev-pill:hover, .scope-pill:hover { border-color: var(--border-hover); color: var(--text); }
-.sev-pill.active, .scope-pill.active { background: rgba(255,255,255,0.08); color: var(--white); border-color: var(--border-hover); }
+.sev-pill:hover, .scope-pill:hover, .cat-pill:hover { background: rgba(255,255,255,0.08); border-color: var(--border-hover); color: var(--white); }
+.sev-pill.active, .scope-pill.active, .cat-pill.active { background: rgba(255,255,255,0.08); color: var(--white); border-color: var(--border-hover); }
 
 /* ── File Tree ── */
 .tree-folder, .tree-file { border-bottom: 1px solid rgba(255,255,255,0.03); }
@@ -489,9 +528,17 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .tree-folder-header, .tree-file-header {
   display: flex; align-items: center; gap: 6px;
   padding: 6px 14px; cursor: pointer; user-select: none;
-  transition: background 0.15s; font-size: 12px;
+  transition: background-color 0.15s; font-size: 12px;
+  background-image: repeating-linear-gradient(to right, var(--guide-color, transparent) 0, var(--guide-color, transparent) 1px, transparent 1px, transparent 12px);
+  background-position: 19px 0;
+  background-repeat: no-repeat;
+  background-size: var(--guides, 0px) 100%;
 }
-.tree-folder-header:hover, .tree-file-header:hover { background: var(--surface-hover); }
+#diagnosis-rule-list:hover .tree-folder-header,
+#diagnosis-rule-list:hover .tree-file-header,
+#pg-result-list:hover .tree-folder-header,
+#pg-result-list:hover .tree-file-header { --guide-color: rgba(255,255,255,0.14); }
+.tree-folder-header:hover, .tree-file-header:hover { background-color: rgba(255,255,255,0.1); }
 
 .tree-chevron {
   color: var(--text-dim); font-size: 10px;
@@ -503,6 +550,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .tree-folder-icon, .tree-file-icon {
   flex-shrink: 0; color: var(--text-muted); display: flex; align-items: center;
 }
+.tree-folder:not(.collapsed) > .tree-folder-header .tree-folder-icon { color: var(--white); }
 .sev-indicator-error { color: var(--sev-error); }
 .sev-indicator-warning { color: var(--sev-warning); }
 .sev-indicator-info { color: var(--sev-info); }
@@ -517,14 +565,15 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 
 .tree-count {
-  font-size: 10px; padding: 1px 7px; border-radius: 10px;
-  background: rgba(255,255,255,0.08); color: var(--text-muted); font-weight: 600; flex-shrink: 0;
+  font-size: 10px; padding: 1px 7px;
+  background: rgba(255,255,255,0.08); color: var(--text-muted); font-weight: 700; flex-shrink: 0;
 }
+.tree-folder:not(.collapsed) > .tree-folder-header .tree-count { display: none; }
 
 .tree-folder-body { display: block; }
 .tree-folder.collapsed .tree-folder-body { display: none; }
 
-.tree-file.active { background: rgba(234,40,69,0.08); border-left: 3px solid var(--nest-red); }
+.tree-file.active { background: rgba(234,40,69,0.08); box-shadow: inset 3px 0 0 var(--nest-red); }
 
 /* Lab: standalone items (project-scope findings with no filePath) */
 .pg-standalone-item {
@@ -533,8 +582,8 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   border-bottom: 1px solid rgba(255,255,255,0.04);
   display: flex; gap: 8px; align-items: flex-start; font-size: 12px;
 }
-.pg-standalone-item:hover { background: var(--surface-hover); }
-.pg-standalone-item.active { background: rgba(234,40,69,0.08); border-left: 3px solid var(--nest-red); }
+.pg-standalone-item:hover { background: rgba(255,255,255,0.1); }
+.pg-standalone-item.active { background: rgba(234,40,69,0.08); box-shadow: inset 3px 0 0 var(--nest-red); }
 .pg-standalone-item .sev-dot {
   width: 6px; height: 6px; border-radius: 50%; margin-top: 5px; flex-shrink: 0;
 }
@@ -566,7 +615,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   margin-bottom: 2px;
 }
 #diagnosis-file-header .file-view-dir {
-  font-size: 11px; font-family: monospace; color: var(--text-dim);
+  font-size: 11px; font-family: var(--font); color: var(--text-dim);
   margin-bottom: 8px;
 }
 #diagnosis-file-header .file-view-counts {
@@ -579,8 +628,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 /* ── Diagnosis: Unified code viewer container ── */
 #diagnosis-file-code {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border: 1px solid var(--border-strong);
   overflow: hidden;
   margin-bottom: 20px;
 }
@@ -590,7 +638,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   display: flex; align-items: center; justify-content: center;
   gap: 8px; padding: 4px 12px;
   font-size: 12px;
-  font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+  font-family: var(--font);
   color: var(--text-dim);
   background: rgba(255,255,255,0.02);
   border-top: 1px dashed var(--border);
@@ -614,7 +662,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .diag-info-item .diag-info-header .code-sev-badge {
   display: inline-block; font-size: 11px; font-weight: 600;
-  padding: 2px 8px; border-radius: 4px; text-transform: capitalize;
+  padding: 2px 8px; text-transform: capitalize;
 }
 .diag-info-item .diag-info-header .code-sev-badge.error {
   background: rgba(239,68,68,0.15); color: var(--sev-error); border: 1px solid rgba(239,68,68,0.25);
@@ -626,8 +674,8 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   background: rgba(59,130,246,0.15); color: var(--sev-info); border: 1px solid rgba(59,130,246,0.25);
 }
 .diag-info-item .diag-info-header .code-rule-badge {
-  display: inline-block; font-size: 11px; font-family: monospace;
-  padding: 2px 8px; border-radius: 4px;
+  display: inline-block; font-size: 11px; font-family: var(--font);
+  padding: 2px 8px;
   background: rgba(255,255,255,0.06); color: var(--text-muted);
   border: 1px solid var(--border);
 }
@@ -655,13 +703,12 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .code-notscored-badge {
   padding: 2px 6px;
   border: 1px solid rgba(255,255,255,0.15);
-  border-radius: 4px;
   font-size: 11px;
   color: rgba(255,255,255,0.45);
   white-space: nowrap;
 }
 .diag-info-item .diag-info-header .diag-linecol {
-  font-size: 11px; font-family: monospace; color: var(--text-dim);
+  font-size: 11px; font-family: var(--font); color: var(--text-dim);
 }
 .diag-info-item .diag-info-msg {
   font-size: 13px; font-weight: 500; color: var(--text); line-height: 1.5;
@@ -669,7 +716,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .diag-info-item .diag-info-help {
   background: rgba(255,255,255,0.03);
-  border-radius: 6px;
+  border: 1px solid var(--border);
   padding: 10px 12px;
   font-size: 13px;
   color: var(--text-muted);
@@ -677,15 +724,15 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   margin-top: 8px;
 }
 .diag-info-item .diag-info-help .section-label {
-  font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-dim); margin-bottom: 6px; font-weight: 600;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--text-dim); margin-bottom: 6px; font-weight: 700;
 }
 .diag-info-item .diag-info-examples {
   margin-top: 10px;
 }
 .diag-info-item .diag-info-examples .section-label {
-  font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-dim); margin-bottom: 8px; font-weight: 600;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--text-dim); margin-bottom: 8px; font-weight: 700;
 }
 
 /* ── Lab: file view ── */
@@ -695,7 +742,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   font-size: 15px; font-weight: 600; color: var(--white); margin-bottom: 2px;
 }
 #pg-file-header .file-view-dir {
-  font-size: 11px; font-family: monospace; color: var(--text-dim); margin-bottom: 8px;
+  font-size: 11px; font-family: var(--font); color: var(--text-dim); margin-bottom: 8px;
 }
 #pg-file-header .file-view-counts {
   display: flex; align-items: center; gap: 12px; font-size: 12px; color: var(--text-muted);
@@ -705,22 +752,21 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 #pg-file-code {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border: 1px solid var(--border-strong);
   overflow: hidden;
   margin-bottom: 16px;
 }
 #pg-file-code .cm-editor { background: var(--surface); }
 #pg-file-code .cm-scroller { overflow: auto; }
 .playground-results .section-label {
-  font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-dim); margin-bottom: 8px; font-weight: 600;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--text-dim); margin-bottom: 8px; font-weight: 700;
 }
 .examples-group { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-.example-block { border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+.example-block { border: 1px solid var(--border-strong); overflow: hidden; }
 .example-tag {
-  font-size: 10px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: 0.5px; padding: 6px 12px; border-bottom: 1px solid var(--border);
+  font-size: 10px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.08em; padding: 6px 12px; border-bottom: 1px solid var(--border-strong);
 }
 .example-tag.bad { color: var(--sev-error); background: rgba(239,68,68,0.06); }
 .example-tag.good { color: var(--score-green); background: rgba(74,222,128,0.06); }
@@ -734,7 +780,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .code-expand-row {
   display: flex; align-items: center; gap: 8px;
   padding: 4px 12px; font-size: 12px;
-  font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+  font-family: var(--font);
   color: var(--text-dim); cursor: pointer;
   background: rgba(255,255,255,0.02);
   border-top: 1px solid var(--border);
@@ -751,7 +797,6 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 /* ── Diagnosis: Line hover tooltip (wrapper) ── */
 .cm-tooltip.cm-tooltip-hover {
   border: 1px solid rgba(255,255,255,0.12);
-  border-radius: 6px;
   background: #1a1a1a;
   box-shadow: 0 4px 12px rgba(0,0,0,0.5);
   max-width: 400px;
@@ -762,7 +807,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 /* ── Diagnosis: Line hover tooltip (content) ── */
 .cm-line-tooltip {
   padding: 6px 10px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: var(--font);
   font-size: 12px;
 }
 .cm-line-tooltip-entry {
@@ -780,7 +825,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   flex-shrink: 0;
 }
 .cm-line-tooltip-rule {
-  font-family: "SF Mono", "Fira Code", monospace;
+  font-family: var(--font);
   font-size: 11px; color: var(--text-muted);
   background: rgba(255,255,255,0.06);
   padding: 1px 6px; border-radius: 3px;
@@ -794,8 +839,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 /* ── Diagnosis: no-source fallback ── */
 .no-source-msg {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border: 1px solid var(--border-strong);
   padding: 24px;
   text-align: center;
   color: var(--text-dim);
@@ -807,27 +851,29 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .summary-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 16px;
-  max-width: 1200px;
+  gap: 20px;
+  max-width: 1320px;
   margin: 0 auto;
 }
 .ov-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 20px;
+  background: #000;
+  border: 1px solid var(--border-strong);
+  display: flex; flex-direction: column;
 }
 .ov-card.full-width { grid-column: 1 / -1; }
 .ov-card h3 {
-  font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-muted); margin-bottom: 14px;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+  font-weight: 700; color: rgba(255,255,255,0.75);
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--border-strong);
 }
+.ov-card-body { padding: 20px 16px; }
 .ov-score-row {
-  display: flex; align-items: center; gap: 24px; flex-wrap: wrap;
+  display: flex; align-items: center; gap: 28px; flex-wrap: wrap;
 }
 .ov-score-ring { flex-shrink: 0; }
 .ov-score-details { flex: 1; min-width: 200px; }
-.ov-score-label { font-size: 20px; font-weight: 700; color: var(--white); }
+.ov-score-label { font-size: 22px; font-weight: 700; color: #f2f1ef; letter-spacing: -0.01em; }
 .ov-score-sublabel { font-size: 13px; color: var(--text-muted); margin-top: 2px; }
 .ov-stars { margin-top: 6px; font-size: 16px; letter-spacing: 2px; }
 .ov-breakdown {
@@ -845,8 +891,8 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   gap: 10px 20px;
 }
 .ov-info-item label {
-  font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-dim); display: block;
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
+  font-weight: 700; color: var(--text-dim); display: block;
 }
 .ov-info-item span {
   font-size: 14px; color: var(--text); font-weight: 500;
@@ -879,7 +925,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .playground-editor {
   width: 50%; height: 100%; overflow-y: auto;
   border-right: 1px solid var(--border);
-  background: rgba(17,17,17,0.95);
+  background: var(--surface);
   padding: 20px;
   display: flex; flex-direction: column;
 }
@@ -889,12 +935,12 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   display: flex; flex-direction: column;
 }
 .playground-section-label {
-  font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-muted); font-weight: 600; margin-bottom: 12px;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.75); font-weight: 700; margin-bottom: 12px;
   display: flex; align-items: center; gap: 8px;
 }
 .playground-section-label.playground-title {
-  font-size: 14px; letter-spacing: 1px;
+  font-size: 13px; letter-spacing: 0.08em;
 }
 .playground-subtitle {
   font-size: 12px; color: var(--text-dim); line-height: 1.5;
@@ -909,13 +955,13 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .playground-subtitle code {
   font-size: 11px; background: rgba(255,255,255,0.08); padding: 1px 5px;
-  border-radius: 3px; font-family: "SF Mono", "Fira Code", monospace;
+  font-family: var(--font);
   color: var(--text);
 }
 .playground-section-label span {
-  font-size: 10px; padding: 1px 7px; border-radius: 10px;
+  font-size: 10px; padding: 1px 7px;
   background: rgba(255,255,255,0.08); color: var(--text-muted);
-  font-weight: 600;
+  font-weight: 700; letter-spacing: 0;
 }
 .playground-preset {
   display: flex; align-items: center; gap: 10px;
@@ -939,13 +985,13 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .playground-field { display: flex; flex-direction: column; gap: 4px; }
 .playground-field label {
-  font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-dim); font-weight: 600;
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--text-dim); font-weight: 700;
 }
 .playground-field input,
 .playground-field select {
-  font-size: 12px; padding: 6px 10px; border-radius: 6px;
-  background: rgba(255,255,255,0.06); border: 1px solid var(--border);
+  font-size: 12px; padding: 6px 10px;
+  background: rgba(255,255,255,0.05); border: 1px solid var(--border);
   color: var(--text); font-family: var(--font);
   outline: none; min-width: 120px;
 }
@@ -957,35 +1003,35 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .playground-field-wide input { width: 100%; }
 .pg-cm-wrap {
   flex: 1; min-height: 200px;
-  border-radius: 8px; overflow: hidden;
-  border: 1px solid var(--border);
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
 }
 .pg-cm-wrap:focus-within { border-color: var(--border-hover); }
 .pg-context-hint {
   font-size: 10px; color: var(--text-dim); margin-top: 4px;
-  font-family: "SF Mono", "Fira Code", monospace;
+  font-family: var(--font);
 }
 .pg-cm-wrap .cm-editor { height: 100%; background: var(--surface); }
 .pg-cm-wrap .cm-scroller {
-  font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+  font-family: var(--font);
   font-size: 12px; line-height: 1.6;
 }
 .playground-actions {
   display: flex; justify-content: flex-end; margin-top: 12px;
 }
 #pg-run-btn {
-  font-size: 13px; padding: 8px 20px; border-radius: 8px;
-  background: rgba(234,40,69,0.15); border: 1px solid var(--nest-red);
-  color: var(--nest-red); cursor: pointer; font-family: var(--font);
-  font-weight: 600;
-  transition: background 0.15s, color 0.15s;
+  font-size: 11px; padding: 8px 20px;
+  text-transform: uppercase; letter-spacing: 0.08em; font-weight: 700;
+  background: var(--nest-red); border: 1px solid var(--nest-red);
+  color: #fff; cursor: pointer; font-family: var(--font);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-#pg-run-btn:hover { background: rgba(234,40,69,0.25); color: #fff; }
+#pg-run-btn:hover { background: var(--white); border-color: var(--white); color: #000; }
 .playground-error {
-  margin-top: 10px; padding: 10px 14px; border-radius: 8px;
+  margin-top: 10px; padding: 10px 14px;
   background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.3);
   color: var(--sev-error);
-  font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+  font-family: var(--font);
   font-size: 12px; line-height: 1.5; white-space: pre-wrap;
 }
 .playground-empty {
@@ -1002,8 +1048,8 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   border-bottom: 1px solid rgba(255,255,255,0.04);
   display: flex; gap: 8px; align-items: flex-start;
 }
-.pg-result-item:hover { background: var(--surface-hover); }
-.pg-result-item.active { background: rgba(234,40,69,0.08); border-left: 3px solid var(--nest-red); padding-left: 9px; }
+.pg-result-item:hover { background: rgba(255,255,255,0.1); }
+.pg-result-item.active { background: rgba(234,40,69,0.08); box-shadow: inset 3px 0 0 var(--nest-red); }
 .pg-result-item .sev-dot {
   width: 6px; height: 6px; border-radius: 50%;
   margin-top: 5px; flex-shrink: 0;
@@ -1019,8 +1065,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .playground-code-body {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border: 1px solid var(--border-strong);
   overflow: hidden;
   margin-bottom: 16px;
 }
@@ -1044,11 +1089,12 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .schema-sidebar-title { font-weight: 600; font-size: 13px; color: var(--white); }
 .st-btn {
-  background: none; border: 1px solid rgba(255,255,255,0.1);
-  border-radius: 4px; padding: 2px 4px; cursor: pointer;
+  background: none; border: 1px solid var(--border);
+  padding: 2px 4px; cursor: pointer;
   color: var(--text-dim); display: flex; align-items: center;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-.st-btn:hover { background: rgba(255,255,255,0.08); color: var(--white); }
+.st-btn:hover { background: rgba(255,255,255,0.08); border-color: var(--border-hover); color: var(--white); }
 .st-btn svg { width: 16px; height: 16px; }
 .schema-entity-count {
   font-size: 11px; color: var(--text-muted); background: rgba(255,255,255,0.06);
@@ -1083,17 +1129,17 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   opacity: 0.7; flex-shrink: 0;
 }
 .st-col-type {
-  font-size: 11px; color: var(--cat-correctness); font-family: monospace;
+  font-size: 11px; color: var(--cat-correctness); font-family: var(--font);
   margin-left: 6px; flex-shrink: 0;
 }
 .st-rel-type {
   font-size: 9px; font-weight: 600; color: var(--cat-architecture);
   background: rgba(139,92,246,0.1); padding: 1px 5px; border-radius: 3px;
-  margin-left: 6px; font-family: monospace; flex-shrink: 0;
+  margin-left: 6px; font-family: var(--font); flex-shrink: 0;
 }
 .st-col-default {
   font-size: 10px; color: var(--text-dim); margin-left: 4px;
-  font-family: monospace; max-width: 120px;
+  font-family: var(--font); max-width: 120px;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   display: inline-block; vertical-align: middle; flex-shrink: 0;
 }
@@ -1125,13 +1171,12 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 #tab-schema.sidebar-collapsed #schema-sidebar-show {
   display: flex; position: absolute; top: 12px; left: 12px; z-index: 10;
   width: 28px; height: 28px; justify-content: center;
-  background: rgba(50,50,50,0.9);
-  backdrop-filter: blur(4px);
-  border: 1px solid rgba(255,255,255,0.22);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
   color: rgba(255,255,255,0.7);
 }
 #tab-schema.sidebar-collapsed #schema-sidebar-show:hover {
-  background: rgba(70,70,70,0.95); color: #fff;
+  background: rgba(255,255,255,0.08); color: #fff;
 }
 #schema-sidebar-show:is(:hover, :focus-visible)::after { left: 0; right: auto; }
 .schema-sync {
@@ -1148,7 +1193,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   position: absolute; top: calc(100% + 6px); right: 0; z-index: 40;
   white-space: nowrap; pointer-events: none;
   background: #1a1a1a; border: 1px solid rgba(255,255,255,0.12);
-  border-radius: 4px; padding: 4px 8px;
+  padding: 4px 8px;
   font-size: 11px; font-family: var(--font); color: var(--text);
   box-shadow: 0 4px 12px rgba(0,0,0,0.5);
 }
@@ -1176,14 +1221,13 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .schema-diagram-btn {
   width: 28px; height: 28px; justify-content: center;
-  background: rgba(50,50,50,0.9);
-  backdrop-filter: blur(4px);
-  border: 1px solid rgba(255,255,255,0.22);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
   color: rgba(255,255,255,0.7);
 }
 .schema-diagram-btn:hover {
-  background: rgba(70,70,70,0.95);
-  border-color: rgba(255,255,255,0.35);
+  background: rgba(255,255,255,0.08);
+  border-color: var(--border-hover);
   color: #fff;
 }
 .schema-diagram-btn.active {
@@ -1193,10 +1237,9 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 #schema-zoombar, #mg-zoombar {
   display: flex; align-items: center; gap: 6px;
-  height: 28px; padding: 0 8px; border-radius: 6px;
-  background: rgba(50,50,50,0.9);
-  backdrop-filter: blur(4px);
-  border: 1px solid rgba(255,255,255,0.22);
+  height: 28px; padding: 0 8px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
 }
 .schema-zoom-btn {
   width: 20px; height: 20px; justify-content: center; padding: 0;
@@ -1206,16 +1249,16 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .schema-zoom-btn svg { width: 14px; height: 14px; }
 #schema-zoom-range, #mg-zoom-range {
   -webkit-appearance: none; appearance: none;
-  width: 110px; height: 3px; border-radius: 2px;
+  width: 110px; height: 3px;
   background: rgba(255,255,255,0.25); outline: none; cursor: pointer;
 }
 #schema-zoom-range::-webkit-slider-thumb, #mg-zoom-range::-webkit-slider-thumb {
   -webkit-appearance: none; appearance: none;
-  width: 11px; height: 11px; border-radius: 50%;
+  width: 11px; height: 11px;
   background: var(--nest-red); cursor: pointer;
 }
 #schema-zoom-range::-moz-range-thumb, #mg-zoom-range::-moz-range-thumb {
-  width: 11px; height: 11px; border: none; border-radius: 50%;
+  width: 11px; height: 11px; border: none;
   background: var(--nest-red); cursor: pointer;
 }
 .schema-zoom-value {
@@ -1227,7 +1270,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .schema-tooltip {
   position: absolute; z-index: 20; pointer-events: none;
   background: #1a1a1a; border: 1px solid rgba(255,255,255,0.12);
-  border-radius: 6px; padding: 8px 10px;
+  padding: 8px 10px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.5);
   max-width: 280px; font-size: 12px; color: var(--text);
   font-family: var(--font);
@@ -1237,13 +1280,13 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .schema-tooltip .tt-cols { margin: 0; padding: 0; list-style: none; }
 .schema-tooltip .tt-cols li { padding: 1px 0; display: flex; gap: 6px; font-size: 11px; }
 .schema-tooltip .tt-cols li .col-name { color: var(--text); }
-.schema-tooltip .tt-cols li .col-type { color: var(--text-dim); font-family: monospace; font-size: 10px; }
+.schema-tooltip .tt-cols li .col-type { color: var(--text-dim); font-family: var(--font); font-size: 10px; }
 .schema-tooltip .tt-size { margin-top: 4px; font-size: 10px; color: var(--text-dim); }
 .schema-size-badge { color: var(--text-dim); }
 .schema-rel-badge {
   position: absolute; z-index: 20; pointer-events: none;
   background: #1a1a1a; border: 1px solid rgba(255,255,255,0.25);
-  border-radius: 6px; padding: 6px 10px;
+  padding: 6px 10px;
   box-shadow: 0 0 8px rgba(255,255,255,0.15), 0 4px 12px rgba(0,0,0,0.5);
   font-size: 11px; color: var(--text); font-family: var(--font);
   white-space: nowrap;
@@ -1306,7 +1349,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   margin-top: 5px; flex-shrink: 0;
 }
 .sd-rule {
-  font-size: 10px; font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 10px; font-family: var(--font);
   color: var(--text-dim); background: rgba(255,255,255,0.06);
   padding: 1px 5px; border-radius: 3px; flex-shrink: 0;
   white-space: nowrap;
@@ -1395,7 +1438,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 }
 .ep-code-panel-method { color: var(--text-muted); font-weight: 400; }
 .ep-code-panel-path {
-  font-size: 11px; font-family: monospace; color: var(--text-dim);
+  font-size: 11px; font-family: var(--font); color: var(--text-dim);
   word-break: break-all;
 }
 .ep-code-panel-close {

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -131,8 +131,10 @@ canvas:active { cursor: grabbing; }
 .tab-spacer { flex: 1; }
 .tab-controls { display: flex; align-items: center; gap: 8px; height: 100%; }
 .tab-controls select {
-  font-size: 11px; padding: 4px 10px; border-radius: 4px;
-  background: rgba(255,255,255,0.06); border: 1px solid var(--border);
+  font-size: 11px; padding: 4px 24px 4px 10px;
+  appearance: none; -webkit-appearance: none;
+  background: rgba(255,255,255,0.06) url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='1.5'/%3E%3C/svg%3E") no-repeat right 8px center;
+  border: 1px solid var(--border);
   color: var(--text-muted); cursor: pointer; font-family: var(--font);
   outline: none; display: none;
 }
@@ -997,6 +999,13 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   background: rgba(255,255,255,0.05); border: 1px solid var(--border);
   color: var(--text); font-family: var(--font);
   outline: none; min-width: 120px;
+}
+.playground-field select {
+  appearance: none; -webkit-appearance: none;
+  padding-right: 28px;
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='1.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
 }
 .playground-field input:focus,
 .playground-field select:focus {

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -1,9 +1,12 @@
+export const REPORT_FONT_STACK =
+	'"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+
 export function getReportStyles(): string {
 	return `
 :root {
   --bg: #000;
   --surface: #000;
-  --surface-hover: rgba(255,255,255,0.05);
+  --surface-hover: rgba(255,255,255,0.1);
   --border: rgba(255,255,255,0.15);
   --border-hover: rgba(255,255,255,0.3);
   --border-strong: rgba(255,255,255,0.3);
@@ -26,7 +29,7 @@ export function getReportStyles(): string {
   --header-h: 96px;
   --row1-h: 56px;
   --row2-h: 40px;
-  --font: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --font: ${REPORT_FONT_STACK};
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -55,7 +58,7 @@ canvas:active { cursor: grabbing; }
 #header-row1 {
   position: fixed; top: 0; left: 0; right: 0; height: var(--row1-h);
   padding: 0 24px;
-  background: #000;
+  background: var(--surface);
   border-bottom: 1px solid var(--border-strong);
   display: flex; align-items: center; gap: 16px;
   z-index: 20;
@@ -94,7 +97,7 @@ canvas:active { cursor: grabbing; }
 #header-row2 {
   position: fixed; top: var(--row1-h); left: 0; right: 0; height: var(--row2-h);
   padding: 0 24px;
-  background: #000;
+  background: var(--surface);
   border-bottom: 1px solid var(--border-strong);
   display: flex; align-items: center; gap: 0;
   z-index: 20;
@@ -247,9 +250,8 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .mg-dock-tab:hover { color: var(--white); }
 #mg-dock[data-active="problems"] #mg-dock-tab-problems,
 #mg-dock[data-active="trace"] #mg-dock-tab-trace { color: var(--white); background: rgba(255,255,255,0.06); }
-.mg-trace-legend { display: none; }
-#mg-dock.open[data-active="trace"] .mg-trace-legend { display: inline-flex; align-items: center; }
-.mg-trace-info { color: var(--text-dim); cursor: help; display: inline-flex; }
+.mg-trace-info { color: var(--text-dim); cursor: help; display: none; }
+#mg-dock.open[data-active="trace"] .mg-trace-info { display: inline-flex; }
 .mg-trace-info:hover, .mg-trace-info:focus-visible { color: var(--white); outline: none; }
 
 #mg-float-tip {
@@ -518,8 +520,8 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   color: var(--text-muted); cursor: pointer; font-family: var(--font);
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-.sev-pill:hover, .scope-pill:hover, .cat-pill:hover { background: rgba(255,255,255,0.08); border-color: var(--border-hover); color: var(--white); }
-.sev-pill.active, .scope-pill.active, .cat-pill.active { background: rgba(255,255,255,0.08); color: var(--white); border-color: var(--border-hover); }
+.sev-pill:hover, .scope-pill:hover, .cat-pill:hover,
+.sev-pill.active, .scope-pill.active, .cat-pill.active { background: rgba(255,255,255,0.08); border-color: var(--border-hover); color: var(--white); }
 
 /* ── File Tree ── */
 .tree-folder, .tree-file { border-bottom: 1px solid rgba(255,255,255,0.03); }
@@ -538,7 +540,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 #diagnosis-rule-list:hover .tree-file-header,
 #pg-result-list:hover .tree-folder-header,
 #pg-result-list:hover .tree-file-header { --guide-color: rgba(255,255,255,0.14); }
-.tree-folder-header:hover, .tree-file-header:hover { background-color: rgba(255,255,255,0.1); }
+.tree-folder-header:hover, .tree-file-header:hover { background-color: var(--surface-hover); }
 
 .tree-chevron {
   color: var(--text-dim); font-size: 10px;
@@ -550,6 +552,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
 .tree-folder-icon, .tree-file-icon {
   flex-shrink: 0; color: var(--text-muted); display: flex; align-items: center;
 }
+/* An open folder shows a neutral icon; the severity color appears only while collapsed. */
 .tree-folder:not(.collapsed) > .tree-folder-header .tree-folder-icon { color: var(--white); }
 .sev-indicator-error { color: var(--sev-error); }
 .sev-indicator-warning { color: var(--sev-warning); }
@@ -582,7 +585,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   border-bottom: 1px solid rgba(255,255,255,0.04);
   display: flex; gap: 8px; align-items: flex-start; font-size: 12px;
 }
-.pg-standalone-item:hover { background: rgba(255,255,255,0.1); }
+.pg-standalone-item:hover { background: var(--surface-hover); }
 .pg-standalone-item.active { background: rgba(234,40,69,0.08); box-shadow: inset 3px 0 0 var(--nest-red); }
 .pg-standalone-item .sev-dot {
   width: 6px; height: 6px; border-radius: 50%; margin-top: 5px; flex-shrink: 0;
@@ -856,7 +859,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   margin: 0 auto;
 }
 .ov-card {
-  background: #000;
+  background: var(--surface);
   border: 1px solid var(--border-strong);
   display: flex; flex-direction: column;
 }
@@ -1048,7 +1051,7 @@ body.mg-resizing { cursor: col-resize; user-select: none; }
   border-bottom: 1px solid rgba(255,255,255,0.04);
   display: flex; gap: 8px; align-items: flex-start;
 }
-.pg-result-item:hover { background: rgba(255,255,255,0.1); }
+.pg-result-item:hover { background: var(--surface-hover); }
 .pg-result-item.active { background: rgba(234,40,69,0.08); box-shadow: inset 3px 0 0 var(--nest-red); }
 .pg-result-item .sev-dot {
   width: 6px; height: 6px; border-radius: 50%;

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -35,52 +35,12 @@ function edgeKey(from: string, to: string): string {
 	return from < to ? `${from}|${to}` : `${to}|${from}`;
 }
 
-/** Fake dagre that ranks nodes along a diagonal, enough to exercise packing. */
-const fakeDagre = {
-	graphlib: {
-		Graph: class {
-			private readonly nodes = new Map<
-				string,
-				{ width: number; height: number; x: number; y: number }
-			>();
-			private order = 0;
-			setGraph() {
-				return this;
-			}
-			setDefaultEdgeLabel() {
-				return this;
-			}
-			setNode(id: string, value: { width: number; height: number }) {
-				this.order += 1;
-				this.nodes.set(id, {
-					...value,
-					x: this.order * 400,
-					y: this.order * 200,
-				});
-			}
-			setEdge() {
-				return this;
-			}
-			node(id: string) {
-				return this.nodes.get(id);
-			}
-		},
-	},
-	layout() {
-		// Positions are assigned in setNode.
-	},
-};
-
 /**
  * Pulls the layout functions out of the emitted script and runs them against a
  * synthetic schema. The report has no DOM harness, so this executes the real
  * emitted source rather than a copy.
  */
-function runOverviewLayout(
-	relations: Relation[],
-	nodes: Node[],
-	dagreImpl: unknown
-): void {
+function runOverviewLayout(relations: Relation[], nodes: Node[]): void {
 	const scripts = getReportScripts(EMPTY);
 	const start = scripts.indexOf("function sComputeComponents");
 	const end = scripts.indexOf("function sComputeStarLayout");
@@ -94,7 +54,6 @@ function runOverviewLayout(
 		"sEdgeKey",
 		"sRouteAllEdges",
 		"sBuildGrids",
-		"dagre",
 		`${scripts.slice(start, end)}\nreturn sComputeOverviewLayout;`
 	);
 	factory(
@@ -106,8 +65,7 @@ function runOverviewLayout(
 		},
 		() => {
 			// Grid building is not under test.
-		},
-		dagreImpl
+		}
 	)();
 }
 
@@ -156,24 +114,17 @@ function buildSchema(): { nodes: Node[]; relations: Relation[] } {
 }
 
 describe("schema overview layout", () => {
-	it("separates every table when dagre is available", () => {
+	it("separates every table", () => {
 		const { nodes, relations } = buildSchema();
-		runOverviewLayout(relations, nodes, fakeDagre);
+		runOverviewLayout(relations, nodes);
 
 		expect(nodes).toHaveLength(34);
 		expect(findOverlap(nodes)).toBeNull();
 	});
 
-	it("still separates every table with no dagre on the page", () => {
-		const { nodes, relations } = buildSchema();
-		runOverviewLayout(relations, nodes, undefined);
-
-		expect(findOverlap(nodes)).toBeNull();
-	});
-
 	it("groups unrelated tables instead of stringing them out", () => {
 		const { nodes, relations } = buildSchema();
-		runOverviewLayout(relations, nodes, fakeDagre);
+		runOverviewLayout(relations, nodes);
 
 		const isolated = nodes.filter((n) => n.name.startsWith("isolated"));
 		const rows = new Set(isolated.map((n) => n.y));
@@ -219,7 +170,7 @@ describe("schema overview layout", () => {
 			{ fromEntity: "a", toEntity: "b" },
 			{ fromEntity: "b", toEntity: "c" },
 		];
-		runOverviewLayout(relations, nodes, fakeDagre);
+		runOverviewLayout(relations, nodes);
 
 		expect(findOverlap(nodes)).toBeNull();
 	});

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -93,6 +93,7 @@ function runOverviewLayout(
 		"sNodes",
 		"sEdgeKey",
 		"sRouteAllEdges",
+		"sBuildGrids",
 		"dagre",
 		`${scripts.slice(start, end)}\nreturn sComputeOverviewLayout;`
 	);
@@ -102,6 +103,9 @@ function runOverviewLayout(
 		edgeKey,
 		() => {
 			// Edge routing is not under test.
+		},
+		() => {
+			// Grid building is not under test.
 		},
 		dagreImpl
 	)();

--- a/packages/website/src/components/landing/graph-and-schema.tsx
+++ b/packages/website/src/components/landing/graph-and-schema.tsx
@@ -272,8 +272,7 @@ export const GraphAndSchema = () => (
 						>
 							<code>--timings</code>
 						</Link>{" "}
-						overlays the real construction times. The 800ms hiding in an{" "}
-						<code>onModuleInit</code> becomes a bar.
+						overlays the real construction times.
 					</p>
 				),
 				figure: <ModuleGraph />,
@@ -284,7 +283,7 @@ export const GraphAndSchema = () => (
 				},
 			},
 			{
-				title: "The ER diagram you never drew.",
+				title: "An ER diagram from your source code.",
 				copy: (
 					<p>
 						Entities and relations from{" "}

--- a/packages/website/src/components/landing/pr-review.tsx
+++ b/packages/website/src/components/landing/pr-review.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { CommandBlock } from "./command-block";
 import { Figure, Section } from "./primitives";
 
 const G = {
@@ -360,12 +361,25 @@ const PullRequestMock = () => (
 
 export const PrReview = () => (
 	<Section
-		command="npx nestjs-doctor@latest ci install"
 		copy={
 			<>
 				<p>
-					Runs as a required check. It comments on the issues the pull request
-					introduces, and blocks at the severity you choose.
+					It comments on the issues a pull request introduces, using the{" "}
+					<b>built-in rules</b> and the{" "}
+					<Link
+						className="text-nest-red underline underline-offset-4"
+						href="/docs/custom-rules"
+					>
+						custom rules
+					</Link>{" "}
+					you write. Enforce hexagonal architecture, DDD layers, or any
+					convention your team cares about.
+				</p>
+				<p>Install it with one command:</p>
+				<CommandBlock command="npx nestjs-doctor@latest ci install" />
+				<p>
+					Comments, score only, or hard gate: you choose how much it does on
+					each PR.
 				</p>
 				<p>
 					<Link
@@ -379,6 +393,6 @@ export const PrReview = () => (
 		}
 		figure={<PullRequestMock />}
 		figureLeft
-		title="Reviews only what the PR introduced."
+		title="A deterministic code reviewer."
 	/>
 );

--- a/packages/website/src/components/landing/pr-review.tsx
+++ b/packages/website/src/components/landing/pr-review.tsx
@@ -364,7 +364,7 @@ export const PrReview = () => (
 		copy={
 			<>
 				<p>
-					It comments on the issues a pull request introduces, using the{" "}
+					It comments on the findings a pull request introduces, using the{" "}
 					<b>built-in rules</b> and the{" "}
 					<Link
 						className="text-nest-red underline underline-offset-4"

--- a/packages/website/src/components/landing/primitives.tsx
+++ b/packages/website/src/components/landing/primitives.tsx
@@ -87,13 +87,11 @@ export const Section = ({
 	copy,
 	figure,
 	figureLeft = false,
-	command,
 }: {
 	title: string;
 	copy: ReactNode;
 	figure: ReactNode;
 	figureLeft?: boolean;
-	command?: string;
 }) => (
 	<section className="border-white/15 border-b py-10">
 		<div
@@ -103,7 +101,6 @@ export const Section = ({
 				<h2 className="mt-0 mb-5 max-w-[40ch] text-balance font-bold text-2xl text-[#f2f1ef] leading-tight tracking-[-0.01em]">
 					{title}
 				</h2>
-				{command ? <CommandBlock command={command} /> : null}
 				<div className="mt-4 space-y-4 text-[13px] text-white/[0.92] leading-relaxed [&_b]:text-white [&_p_code]:bg-white/10 [&_p_code]:px-1.5 [&_p_code]:py-px [&_p_code]:text-white">
 					{copy}
 				</div>

--- a/packages/website/src/components/landing/primitives.tsx
+++ b/packages/website/src/components/landing/primitives.tsx
@@ -68,7 +68,7 @@ export const SectionPair = ({
 					{item.title}
 				</h2>
 				<CommandBlock command={item.command} />
-				<div className="mt-3 max-w-[52ch] text-[13px] text-white/[0.92] leading-relaxed [&_b]:text-white [&_code]:bg-white/10 [&_code]:px-1.5 [&_code]:py-px [&_code]:text-white">
+				<div className="mt-3 max-w-[52ch] text-[13px] text-white/[0.92] leading-relaxed [&_b]:text-white [&_p_code]:bg-white/10 [&_p_code]:px-1.5 [&_p_code]:py-px [&_p_code]:text-white">
 					{item.copy}
 				</div>
 				<a
@@ -104,7 +104,7 @@ export const Section = ({
 					{title}
 				</h2>
 				{command ? <CommandBlock command={command} /> : null}
-				<div className="mt-4 space-y-4 text-[13px] text-white/[0.92] leading-relaxed [&_b]:text-white [&_code]:bg-white/10 [&_code]:px-1.5 [&_code]:py-px [&_code]:text-white">
+				<div className="mt-4 space-y-4 text-[13px] text-white/[0.92] leading-relaxed [&_b]:text-white [&_p_code]:bg-white/10 [&_p_code]:px-1.5 [&_p_code]:py-px [&_p_code]:text-white">
 					{copy}
 				</div>
 			</div>


### PR DESCRIPTION
## Context

The HTML report grew its own look: system sans font, rounded grey cards, a nav unlike the site. The docs site and landing settled on a design language months ago: IBM Plex Mono, black surfaces, square corners, `white/30` borders, uppercase caption strips. The schema tab laid tables out with dagre and fell back to diagonal edge routes.

## Problem

On a 51-table schema (crocova) the diagram was unreadable: long diagonal lines crossing boxes, tables scattered without visible structure. On top of that, clicking a table often failed to select it and nudged it instead — any 1px mouse jitter counted as a drag, and the drag handler snapped the table's center under the cursor. Visually, the report looked like a different product than the site.

## Possible flows

| Path into the changed code | Affected |
|---|---|
| `--report` → open report → any tab | Yes: fonts, nav, tabs, cards, tooltips, scrollbars |
| Findings tab → sidebar | Yes: search, collapsible filters + category filter, indent guides |
| Findings/Lab → code viewer expanders | Yes: top expander keeps viewport, bottom follows the new lines |
| Schema tab → "Show all tables" | Yes: layered layout + orthogonal channel routing |
| Schema tab → focused star view | Routing only: orthogonal U-detours (was diagonal) |
| Schema tab → drag a table | Yes: 4px click threshold, grab-offset drag |
| Module graph / endpoints tabs | Style only: fonts, square corners; layout untouched |
| Landing page PR-review + graph sections | Copy only |

## Solution

Restyled every report surface with the site tokens (one `--font`, `--border-strong`, square corners everywhere) and rebuilt the schema diagram: a layered left-to-right layout (referenced hubs in the left column, barycenter-ordered rows, over-tall columns wrapped) replaces dagre, and every relation routes orthogonally through the gutters between columns — FK-row ports, lane-spread verticals, one shared clear corridor per long edge, fan-out on hub tables. Deliberately not done: horizontal nudging beyond corridor spreading, and the endpoints tab's rounded nodes.

## Before vs after

| | Before | After |
|---|---|---|
| Schema edges | Diagonal fallbacks crossing boxes | 90° only, routed in gutters |
| Table placement | dagre from a CDN, grid fallback offline | Deterministic layered layout, no CDN |
| Click on table | Lost to 1px jitter; box teleports to cursor | Selects; drags need 4px and keep grab offset |
| Findings sidebar | Severity/scope pills always visible, no search | Search + collapsible filters with category |
| Report typography | System sans, rounded cards | IBM Plex Mono, square, site borders |
| Score/weights/diagnostics | Unchanged | Unchanged |

## Example

```
npx nestjs-doctor . --report
```

Before, crocova's 51-table schema rendered with straight diagonal relation lines through unrelated tables (`sRouteManhattan`'s U-detour connected two offset midpoints directly). After, the same scan renders columns of tables with Z-shaped orthogonal runs; `CareerPageVersion → User` routes as `(2900,950) → (2813,950) → (2813,198) → (480,198) → (480,363) → (470,363)` — six points, every segment horizontal or vertical.
