### PR TITLE
fix(ci): keep the action release marked as the repository's latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
-      # The Marketplace listing mirrors the repository's "latest" release, and a
-      # changesets release (nestjs-doctor@X.Y.Z, nestjs-doctor-lsp@X.Y.Z) takes
-      # that flag on publish. Hand it back to the newest action release.
       - name: Keep the action release marked as latest
         if: steps.changesets.outputs.published == 'true'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,25 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
+      # The Marketplace listing mirrors the repository's "latest" release, and a
+      # changesets release (nestjs-doctor@X.Y.Z, nestjs-doctor-lsp@X.Y.Z) takes
+      # that flag on publish. Hand it back to the newest action release.
+      - name: Keep the action release marked as latest
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="$(gh api "repos/${{ github.repository }}/releases" --paginate \
+            --jq '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(.created_at) | last | .tag_name')"
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "No action release exists; leaving latest alone."
+            exit 0
+          fi
+          rid="$(gh api "repos/${{ github.repository }}/releases/tags/$tag" --jq .id)"
+          gh api -X PATCH "repos/${{ github.repository }}/releases/$rid" -f make_latest=true > /dev/null
+          echo "Marked $tag as the latest release."
+
   publish-vscode:
     name: Publish VS Code Extension
     needs: release


### PR DESCRIPTION
## Context

The GitHub Marketplace listing for the action mirrors the repository's "latest" release. This is a monorepo: changesets creates a GitHub release per npm package (`nestjs-doctor@X.Y.Z`, `nestjs-doctor-lsp@X.Y.Z`), and each publish marks its newest release as the repository's latest. The action's own releases use plain `vX.Y.Z` tags (`v1.0.0` exists since July).

## Problem

After the last publish the repo's latest release was `nestjs-doctor-lsp@4.0.0`, so the Marketplace advertised `uses: RoloBits/nestjs-doctor@nestjs-doctor-lsp@4.0.0` as the install snippet — a language server version as the action version.

## Possible flows

| Path into the latest-release flag | Affected |
|---|---|
| changesets publish on push to main | Yes: stole "latest" on every release |
| Manual `vX.Y.Z` action release | Correct at creation, then overwritten by the next publish |
| `action-tag.yml` moving `v1` | Unaffected: tags only, no releases |

## Solution

After a successful changesets publish, the release workflow finds the newest `vX.Y.Z` release and PATCHes it back to `make_latest=true`. No action release existing is a no-op. The current listing was repaired by hand (`v1.0.0` re-marked latest) since the workflow only guards future publishes.

## Before vs after

| | Before | After |
|---|---|---|
| Marketplace "Latest" after a publish | Whichever package published last | Newest `vX.Y.Z` action release |
| Marketplace install snippet | `@nestjs-doctor-lsp@4.0.0` | `@v1.0.0` |
| npm releases on the Releases page | Listed | Unchanged, listed |

## Example

```
gh api repos/RoloBits/nestjs-doctor/releases/latest -q .tag_name
```

Before: `nestjs-doctor-lsp@4.0.0`. After: `v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGVR6E5GSeEBp6fVGAc9CS
