### PR TITLE
docs: split custom rules into configuration and authoring pages

### DIFF
--- a/.changeset/rule-lab-docs-link.md
+++ b/.changeset/rule-lab-docs-link.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Point the Rule Lab's custom-rules link at the rule-authoring docs page, which moved to /docs/rules/custom.

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -113,7 +113,7 @@ The same shape works as `.nestjs-doctor.json`, or as a `"nestjs-doctor"` key in
 `package.json`.
 
 [Configuration →](https://nestjs.doctor/docs/configuration) ·
-[Custom rules →](https://nestjs.doctor/docs/custom-rules)
+[Custom rule configuration →](https://nestjs.doctor/docs/custom-rules)
 
 ## Rules
 

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -113,7 +113,7 @@ export function getReportHtml(): string {
 <div class="tab-content" id="tab-lab">
   <div class="playground-editor">
     <div class="playground-section-label playground-title">RULE LAB</div>
-    <p class="playground-subtitle">Write and test <a href="https://www.nestjs.doctor/docs/custom-rules" target="_blank" rel="noopener">custom rules</a> against your project. Use <code>/nestjs-doctor-create-rule</code> with an AI agent to <a href="https://www.nestjs.doctor/docs/coding-agents" target="_blank" rel="noopener">scaffold rules automatically</a>.</p>
+    <p class="playground-subtitle">Write and test <a href="https://www.nestjs.doctor/docs/rules/custom" target="_blank" rel="noopener">custom rules</a> against your project. Use <code>/nestjs-doctor-create-rule</code> with an AI agent to <a href="https://www.nestjs.doctor/docs/coding-agents" target="_blank" rel="noopener">scaffold rules automatically</a>.</p>
     <div class="playground-form">
       <div class="playground-form-row">
         <div class="playground-field">

--- a/packages/website/src/app/docs/ci/gates/page.mdx
+++ b/packages/website/src/app/docs/ci/gates/page.mdx
@@ -44,9 +44,9 @@ whatever `scope` says. Set a number and the run fails whenever the score falls
 below it.
 
 The two gates measure different things: `blocking` sees the reported scope,
-`min-score` the whole project, so a pull request touching one file can fail on
-debt somewhere else. Use `blocking` alone for new code, and add `min-score` for
-a floor on the repository as a whole.
+`min-score` the whole project. A pull request touching one file can fail on
+debt somewhere else. Use `blocking` alone for new code, and add `min-score`
+for a floor on the repository as a whole.
 
 ## Setting the threshold in config instead
 

--- a/packages/website/src/app/docs/ci/gates/page.mdx
+++ b/packages/website/src/app/docs/ci/gates/page.mdx
@@ -37,23 +37,16 @@ Because it follows the scope, a repository with a thousand pre-existing findings
 can adopt `blocking: error` on day one. The gate only ever sees what each pull
 request adds, so nobody inherits somebody else's backlog.
 
-The CLI's `--blocking` default varies by output mode. The action always passes
-the flag explicitly, so its own default is `none` either way.
-
 ## `min-score`: gate on the score
 
-Gates on the 0-100 project health score. Unset by default. Set it to a number
-and the run fails whenever the score falls below it.
+Gates on the 0-100 health score, which always reflects the whole project,
+whatever `scope` says. Set a number and the run fails whenever the score falls
+below it.
 
-The score always reflects the whole project, whatever `scope` says. Narrowing a
-report must never make a codebase look healthier than it is.
-
-So the two gates measure different things. `blocking` sees the reported scope,
+The two gates measure different things: `blocking` sees the reported scope,
 `min-score` the whole project, so a pull request touching one file can fail on
-debt somewhere else.
-
-Use `blocking` alone for new code. Add `min-score` for a floor on the repository
-as a whole.
+debt somewhere else. Use `blocking` alone for new code, and add `min-score` for
+a floor on the repository as a whole.
 
 ## Setting the threshold in config instead
 
@@ -67,26 +60,22 @@ agree on it:
 }
 ```
 
-The action's `min-score` input overrides that when set, which holds CI to a
-higher bar than a local run. Leave the input empty and the config value
-applies.
+The action's `min-score` input overrides the config value when set. Leave it
+empty and the config value applies.
 
 ## Which findings count
 
-Both gates count what the run reports, with one exception: a rule can be
-report-only. Those appear in the report and count toward neither gate. A project
-that wants one enforced can say so per rule.
+Both gates count what the run reports. Three levers take a finding out of the
+count:
 
-Whether such a rule also comments on the pull request is a separate surface.
-A house-style rule declares neither, while `security/no-advisory-nestjs-packages`
-comments and still cannot fail a build. See
-[Surfaces](/docs/custom-rules#surfaces).
-
-The config file is the third lever. Disable a rule or a whole category and it
-stops counting toward either gate. See [Configuration](/docs/configuration).
-
-Inline `nestjs-doctor-ignore` comments work the same way. A suppressed finding
-is not reported, so it cannot fail a gate.
+- A report-only rule appears in the report and counts toward neither gate.
+  `security/no-advisory-nestjs-packages` works this way, commenting on the pull
+  request while never failing a build. See
+  [Surfaces](/docs/custom-rules#surfaces).
+- A rule or category disabled in the config file stops counting toward either
+  gate. See [Configuration](/docs/configuration).
+- An inline `nestjs-doctor-ignore` comment suppresses the finding entirely, so
+  it is never reported.
 
 Point the action at a CI-specific file with the `config` input to hold CI
 stricter than local runs. Both gates are CLI flags too. See

--- a/packages/website/src/app/docs/ci/page.mdx
+++ b/packages/website/src/app/docs/ci/page.mdx
@@ -17,23 +17,15 @@ Run this from anywhere inside the repository:
 npx nestjs-doctor@latest ci install
 ```
 
-It writes `.github/workflows/nestjs-doctor.yml`.
+It writes `.github/workflows/nestjs-doctor.yml` at the git repository root, so
+running it from `apps/api` in a monorepo still lands the file in the right
+place. The push trigger uses the branch `origin/HEAD` points at, then
+`origin/main`, `origin/master`, and finally the branch you have checked out.
+The command prints its pick.
 
-**Where it writes:** always the git repository root, so running it from
-`apps/api` in a monorepo still lands the file in the right place. Outside a git
-repository it refuses rather than dropping a `.github/` tree into the current
-directory.
-
-**What it will not touch:** an existing workflow, unless you pass `--force`. A
-symlink anywhere on the path (`.github`, `.github/workflows`, or the file
-itself) is refused outright, so the write cannot escape the repository.
-
-**Which branch the push trigger uses:** the branch `origin/HEAD` points at,
-verified to still exist. Then `origin/main`, then `origin/master`, then the
-branch you have checked out.
-
-A clone made with `--single-branch` has no `origin/HEAD`, and neither does a
-remote added by hand. The command prints the branch it picked.
+Three cases make it refuse instead of write: outside a git repository, an
+existing workflow (replace it with `--force`), and a symlink anywhere on the
+path, so the write cannot escape the repository.
 
 A minimal `.github/workflows/nestjs-doctor.yml`:
 
@@ -60,16 +52,17 @@ jobs:
       - uses: RoloBits/nestjs-doctor@v1
 ```
 
-`ci install` writes a fuller version of that file. It adds `ready_for_review` to
-the pull request types, a concurrency guard that cancels superseded runs, and
-the common inputs commented out.
+`ci install` writes a fuller version of that file: `ready_for_review` among the
+pull request types, a concurrency guard that cancels superseded runs, and the
+common inputs commented out.
 
 The check never fails until you uncomment `blocking` or `min-score`.
 
-On a pull request the action reports in three places. A sticky summary comment
-is rewritten in place on every push, and inline review comments land on the
-changed lines. A commit status carries the score, and the job summary mirrors
-the full report.
+## What a pull request gets
+
+The action reports in three places. A sticky summary comment is rewritten in
+place on every push, and inline review comments land on the changed lines. A
+commit status carries the score, and the job summary mirrors the full report.
 
 `fetch-depth: 0` matters for the default scope. The action compares against the
 merge base of your branch and its target, which a shallow checkout cannot

--- a/packages/website/src/app/docs/ci/page.mdx
+++ b/packages/website/src/app/docs/ci/page.mdx
@@ -19,13 +19,14 @@ npx nestjs-doctor@latest ci install
 
 It writes `.github/workflows/nestjs-doctor.yml` at the git repository root, so
 running it from `apps/api` in a monorepo still lands the file in the right
-place. The push trigger uses the branch `origin/HEAD` points at, then
-`origin/main`, `origin/master`, and finally the branch you have checked out.
-The command prints its pick.
+place. The push trigger uses the branch `origin/HEAD` points at, verified to
+still exist, then `origin/main`, `origin/master`, and finally the branch you
+have checked out. A `--single-branch` clone or a remote added by hand has no
+`origin/HEAD`. The command prints its pick.
 
-Three cases make it refuse instead of write: outside a git repository, an
-existing workflow (replace it with `--force`), and a symlink anywhere on the
-path, so the write cannot escape the repository.
+It refuses in three cases: outside a git repository, an existing workflow
+(replace it with `--force`), and a symlink anywhere on the path. The refusals
+keep the write from escaping the repository.
 
 A minimal `.github/workflows/nestjs-doctor.yml`:
 

--- a/packages/website/src/app/docs/coding-agents/page.mdx
+++ b/packages/website/src/app/docs/coding-agents/page.mdx
@@ -75,4 +75,4 @@ boot, overlays the real times on the module graph, and puts `main.ts` back. See
 choosing the scope, matching the AST, and verifying the rule loads.
 Use it when the convention you want enforced is specific to your codebase.
 
-See [Custom rules](/docs/custom-rules) for the interface it writes against.
+See [Custom rules](/docs/rules/custom) for the interface it writes against.

--- a/packages/website/src/app/docs/custom-rules/page.mdx
+++ b/packages/website/src/app/docs/custom-rules/page.mdx
@@ -4,33 +4,13 @@ export const metadata = docsMetadata["/docs/custom-rules"];
 
 <BreadcrumbJsonLd path="/docs/custom-rules" />
 
-# Custom rules
+# Custom rule configuration
 
-Extend the built-in rule set with project-specific checks. Custom rules encode domain conventions, team standards, or patterns the built-in rules don't cover.
-
-## Let an agent do it
-
-Writing a rule is mostly matching an AST, and an agent can do it:
-
-```bash
-npx nestjs-doctor@latest --init
-```
-
-That installs a `nestjs-doctor-create-rule` skill. Describe the convention you
-want enforced and the agent checks static analysis can see it, picks file or
-project scope, writes the `.ts` file, points `customRulesDir` at it, and runs a
-scan to confirm the rule loads. It works in Claude Code, Cursor, Codex, and the
-other agents on [Coding agents](/docs/coding-agents).
-
-A rule it cannot detect statically is worth knowing about early. The skill says
-so instead of writing something that never fires.
-
-The rest of this page is the same work by hand.
+How a project wires custom rules into the scan: where the files live, how they load, and how their findings are scoped. Writing the rules themselves is covered on [Custom rules](/docs/rules/custom).
 
 ## Setup
 
-1. Create a directory for your rules (e.g. `rules/` at your project root).
-2. Set `customRulesDir` in your config file:
+Point `customRulesDir` at a directory of rule files in `nestjs-doctor.config.json`:
 
 ```json
 {
@@ -38,45 +18,22 @@ The rest of this page is the same work by hand.
 }
 ```
 
-3. Add `.ts` files to that directory. Each file exports a rule object.
+The path resolves against the scanned directory. Every `.ts` file in it exports one rule; other extensions and subdirectories are ignored. Rules load through `jiti` at scan time, so CI needs no build step, no `ts-node`, and no `tsconfig` for them.
 
-Only `.ts` files are loaded. Subdirectories are ignored.
+## Loading and ids
 
-## Rule shape
+Rule ids are prefixed with `custom/`, so `id: "no-todo-comments"` reports as `custom/no-todo-comments` and can never collide with a built-in rule. A custom rule is toggled by that prefixed id through the same `rules` and `ignore.rules` keys built-in rules use, described on [Configuration](/docs/configuration).
 
-Every custom rule exports an object with two properties, `meta` (a descriptor) and `check` (the inspection function):
+An invalid rule produces a warning and never crashes the scan. The warnings appear in CLI output, and the usual causes are:
 
-```typescript
-import type { RuleContext } from "nestjs-doctor";
+- Missing or non-function `check` export
+- Invalid `category` or `severity` values
+- Missing required `meta` fields
+- Syntax errors in the rule file
 
-export const myRule = {
-  meta: {
-    id: "my-rule-id",
-    category: "correctness",
-    severity: "warning",
-    description: "Short explanation of what this rule checks",
-    help: "Actionable advice on how to fix it.",
-  },
-  check(context: RuleContext) {
-    // inspect context.sourceFile, call context.report() per diagnostic
-  },
-};
-```
+Fix the warning and re-run. The rest of the scan continues unaffected.
 
-### `meta` fields
-
-| Field         | Type       | Required | Description                                                             |
-| ------------- | ---------- | -------- | ----------------------------------------------------------------------- |
-| `id`          | `string`   | Yes      | Unique identifier for the rule                                          |
-| `category`    | `string`   | Yes      | One of `"security"`, `"performance"`, `"correctness"`, `"architecture"` |
-| `severity`    | `string`   | Yes      | One of `"error"`, `"warning"`, `"info"`                                 |
-| `description` | `string`   | Yes      | Short summary shown in the report                                       |
-| `help`        | `string`   | Yes      | Fix guidance shown alongside diagnostics                                |
-| `scope`       | `string`   | No       | `"file"` (default) or `"project"`                                       |
-| `tags`        | `string[]` | No       | Labels stamped onto every diagnostic the rule emits                     |
-| `surfaces`    | `string[]` | No       | Where the rule may appear. Omitted means everywhere                     |
-
-### Surfaces
+## Surfaces
 
 A rule appears on four surfaces by default:
 
@@ -90,9 +47,9 @@ A rule appears on four surfaces by default:
 `--format json` is the exception: it carries every finding, with `surfaces` on
 each one, so a consumer filters however it wants.
 
-Naming a subset narrows it:
+Naming a subset in the rule's `meta` narrows it:
 
-```ts
+```typescript
 surfaces: ["cli"],
 ```
 
@@ -116,128 +73,3 @@ rule declares:
 
 That is how a team that does want a house style enforced puts it back on the
 score and the build.
-
-### Tags
-
-The one tag with behavior today is `"module-graph"`. Diagnostics carrying it appear in the Modules Graph tab's problems drawer, beside the built-in module-wiring ones:
-
-```typescript
-meta: {
-  id: "no-untagged-feature-module",
-  category: "architecture",
-  severity: "warning",
-  description: "Feature modules must follow the naming convention",
-  help: "Rename the module to end with FeatureModule.",
-  tags: ["module-graph"],
-},
-```
-
-A `tags` value that is not an array of strings is dropped with a warning, and the rule still runs.
-
-### The `check` function
-
-The `check` function receives a `RuleContext`. The first three members are what most rules need, and the rest carry facts a single file cannot see:
-
-| Member | What it is |
-|---|---|
-| `sourceFile` | The ts-morph `SourceFile` for the file being analyzed |
-| `filePath` | The absolute path to that file |
-| `report(diagnostic)` | Emits a diagnostic with `filePath`, `message`, `help`, `line`, and `column` |
-| `config` | The resolved config for the project |
-| `diProviders` | Class names NestJS instantiates itself |
-| `guards` | Composed guard decorators, globally registered guards, and guarded base classes |
-| `moduleDirectories` | Directories that hold a module file, for boundary checks |
-
-Every member after `report` is optional. Absent means the fact was not determined, which is not the same as empty.
-
-For project-scoped rules (`scope: "project"`), the context carries the whole project instead of a single file:
-
-| Member | What it holds |
-| ------ | ------------- |
-| `project` | The ts-morph `Project`, every parsed file |
-| `files` | Paths of the scanned files |
-| `moduleGraph` | Modules, their imports and exports |
-| `providers` | Every provider and the module that declares it |
-| `config` | The resolved config for the project |
-| `targetPath` | The directory being scanned, for reading a file the scan did not parse |
-| `installRoot` | Where to resolve `node_modules` from, when that is not `targetPath` |
-
-`targetPath` is what a rule uses to reach something outside the TypeScript it
-was given, such as the project's `package.json`. Read it when the rule runs
-rather than caching it: the language server keeps one context alive for the
-whole editing session.
-
-`installRoot` is absent unless the two differ, which happens under
-`--scope changed`. That mode scans a base revision in a throwaway checkout with
-no install, so a rule reading `node_modules` should prefer it:
-
-```typescript
-const root = context.installRoot ?? context.targetPath;
-```
-
-Reading `targetPath` there finds nothing installed. The rule then reports
-against the base revision what it would never report against the working tree.
-
-## Example
-
-A rule that flags unresolved TODO comments:
-
-```typescript
-import type { RuleContext } from "nestjs-doctor";
-
-export const noTodoComments = {
-  meta: {
-    id: "no-todo-comments",
-    category: "correctness",
-    severity: "warning",
-    description: "TODO comments should be resolved before merging",
-    help: "Replace the TODO with an implementation or open an issue.",
-  },
-  check(context: RuleContext) {
-    const text = context.sourceFile.getFullText();
-    const regex = /\/\/\s*TODO/gi;
-    let match: RegExpExecArray | null;
-    while ((match = regex.exec(text)) !== null) {
-      const pos = context.sourceFile.getLineAndColumnAtPos(match.index);
-      context.report({
-        message: "Unresolved TODO comment",
-        help: "Replace the TODO with an implementation or open an issue.",
-        filePath: context.filePath,
-        line: pos.line,
-        column: pos.column,
-      });
-    }
-  },
-};
-```
-
-The line and column come from ts-morph: `getLineAndColumnAtPos` turns a character offset into the 1-indexed position a diagnostic expects.
-
-## ID prefixing
-
-Rule IDs are automatically prefixed with `custom/`, so `id: "no-todo-comments"` reports as `custom/no-todo-comments`. The prefix avoids collisions with built-in rules.
-
-## When a rule fails to load
-
-Invalid rules produce warnings but never crash the scan. Common causes are surfaced in CLI output:
-
-- Missing or non-function `check` export
-- Invalid `category` or `severity` values
-- Missing required `meta` fields
-- Syntax errors in the rule file
-
-Fix the warning and re-run. The rest of the scan continues unaffected.
-
-## Disabling custom rules
-
-Toggle a custom rule by its prefixed id, through the same `rules` and `ignore.rules` keys built-in rules use. See [Configuration](/docs/configuration).
-
-## The Rule Lab tab
-
-The HTML report has a Rule Lab tab for writing and testing custom rules in the browser:
-
-```bash
-npx nestjs-doctor . --report
-```
-
-Scaffold a rule with `/nestjs-doctor-create-rule`, test it in the Rule Lab, then save the `.ts` file to your `customRulesDir`.

--- a/packages/website/src/app/docs/custom-rules/page.mdx
+++ b/packages/website/src/app/docs/custom-rules/page.mdx
@@ -6,7 +6,7 @@ export const metadata = docsMetadata["/docs/custom-rules"];
 
 # Custom rule configuration
 
-How a project wires custom rules into the scan: where the files live, how they load, and how their findings are scoped. Writing the rules themselves is covered on [Custom rules](/docs/rules/custom).
+How a project wires custom rules into the scan: where the files live, how they load, and the surfaces their findings appear on. Writing the rules themselves is covered on [Custom rules](/docs/rules/custom).
 
 ## Setup
 
@@ -18,7 +18,7 @@ Point `customRulesDir` at a directory of rule files in `nestjs-doctor.config.jso
 }
 ```
 
-The path resolves against the scanned directory. Every `.ts` file in it exports one rule; other extensions and subdirectories are ignored. Rules load through `jiti` at scan time, so CI needs no build step, no `ts-node`, and no `tsconfig` for them.
+The path resolves against the scanned directory. Rule files export rule objects, one or several per file; other extensions and subdirectories are ignored. Rules load through `jiti` at scan time, so CI needs no build step, no `ts-node`, and no `tsconfig` for them.
 
 ## Loading and ids
 

--- a/packages/website/src/app/docs/pipeline/scoring/page.mdx
+++ b/packages/website/src/app/docs/pipeline/scoring/page.mdx
@@ -35,7 +35,7 @@ A rule declares which surfaces it appears on. Only diagnostics carrying the
 `score` surface reach the formula below. A rule marked `surfaces: ["cli"]`
 still reports every finding in the console and the HTML report, and weighs
 nothing, which keeps a matter of taste from moving a number meant to track
-defects. See [Custom rules](/docs/custom-rules#surfaces).
+defects. See [Surfaces](/docs/custom-rules#surfaces).
 
 ## Formula
 

--- a/packages/website/src/app/docs/report/boot-trace/page.mdx
+++ b/packages/website/src/app/docs/report/boot-trace/page.mdx
@@ -14,8 +14,8 @@ being a guess and becomes a bar with a number on it.
 
 ## Why it needs a change to your code
 
-A scan reads source files. It never runs your application, so construction time
-does not exist for it to measure.
+nestjs-doctor is a scanner that reads source files. It never runs your
+application, so construction time does not exist for it to measure.
 
 NestJS measures it already. Booting with `{ snapshot: true }` records an
 `initTime` for every class and assembles a `SerializedGraph`. Writing that

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -18,12 +18,14 @@ no server, no build step. Commit it or attach it to a pull request.
 `--output` names a different path, which keeps the file out of the repository
 being scanned.
 
-Three things load from the network when opened. The graph layout library and
-the logo are one request each. The code viewer is a CodeMirror import map, so
-it pulls 18 modules from esm.sh.
+Four things load from the network when opened. The graph layout library and
+the logo are one request each, the IBM Plex Mono font is a stylesheet plus the
+font files it names, and the code viewer is a CodeMirror import map, so it
+pulls 18 modules from esm.sh.
 
-Offline, the module graph falls back to a plain grid and the code viewers do
-not load. Everything else works.
+Offline, the module graph falls back to a plain grid, the code viewers do not
+load, and the text falls back to the system monospace font. Everything else
+works, including the schema diagram's layout.
 
 ![Module graph](/module-graph.png)
 

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -19,12 +19,12 @@ no server, no build step. Commit it or attach it to a pull request.
 being scanned.
 
 Four things load from the network when opened. The graph layout library and
-the logo are one request each, the IBM Plex Mono font is a stylesheet plus the
-font files it names, and the code viewer is a CodeMirror import map, so it
-pulls 18 modules from esm.sh.
+the logo are one request each. The IBM Plex Mono font is a stylesheet plus the
+font files it names. The code viewer is a CodeMirror import map, so it pulls
+18 modules from esm.sh.
 
-Offline, the module graph falls back to a plain grid, the code viewers do not
-load, and the text falls back to the system monospace font. Everything else
+Offline, the module graph falls back to a plain grid and the code viewers do
+not load. The text falls back to the system monospace font. Everything else
 works, including the schema diagram's layout.
 
 ![Module graph](/module-graph.png)
@@ -55,7 +55,7 @@ findings behind a **Show not scored** checkbox above the severity filters, and
 badges each one `not scored` beside its rule id when you turn it on.
 
 Which rules those are is up to the rule and your config. See
-[Custom rules](/docs/custom-rules#surfaces).
+[Surfaces](/docs/custom-rules#surfaces).
 
 ## Boot trace
 

--- a/packages/website/src/app/docs/rules/custom/page.mdx
+++ b/packages/website/src/app/docs/rules/custom/page.mdx
@@ -1,0 +1,173 @@
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { docsMetadata } from "@/lib/docs-metadata";
+export const metadata = docsMetadata["/docs/rules/custom"];
+
+<BreadcrumbJsonLd path="/docs/rules/custom" />
+
+# Custom rules
+
+Extend the built-in rule set with project-specific checks. Custom rules encode domain conventions, team standards, or patterns the built-in rules don't cover. Wiring them into a project is covered on [Custom rule configuration](/docs/custom-rules).
+
+## Let an agent do it
+
+Writing a rule is mostly matching an AST, and an agent can do it:
+
+```bash
+npx nestjs-doctor@latest --init
+```
+
+That installs a `nestjs-doctor-create-rule` skill. Describe the convention you
+want enforced and the agent checks static analysis can see it, picks file or
+project scope, writes the `.ts` file, points
+[`customRulesDir`](/docs/custom-rules) at it, and runs a scan to confirm the
+rule loads. It works in Claude Code, Cursor, Codex, and the other agents on
+[Coding agents](/docs/coding-agents).
+
+A rule it cannot detect statically is worth knowing about early. The skill says
+so instead of writing something that never fires.
+
+The rest of this page is the same work by hand.
+
+## Rule shape
+
+Every custom rule exports an object with two properties, `meta` (a descriptor) and `check` (the inspection function):
+
+```typescript
+import type { RuleContext } from "nestjs-doctor";
+
+export const myRule = {
+  meta: {
+    id: "my-rule-id",
+    category: "correctness",
+    severity: "warning",
+    description: "Short explanation of what this rule checks",
+    help: "Actionable advice on how to fix it.",
+  },
+  check(context: RuleContext) {
+    // inspect context.sourceFile, call context.report() per diagnostic
+  },
+};
+```
+
+### `meta` fields
+
+| Field         | Type       | Required | Description                                                             |
+| ------------- | ---------- | -------- | ----------------------------------------------------------------------- |
+| `id`          | `string`   | Yes      | Unique identifier for the rule                                          |
+| `category`    | `string`   | Yes      | One of `"security"`, `"performance"`, `"correctness"`, `"architecture"` |
+| `severity`    | `string`   | Yes      | One of `"error"`, `"warning"`, `"info"`                                 |
+| `description` | `string`   | Yes      | Short summary shown in the report                                       |
+| `help`        | `string`   | Yes      | Fix guidance shown alongside diagnostics                                |
+| `scope`       | `string`   | No       | `"file"` (default) or `"project"`                                       |
+| `tags`        | `string[]` | No       | Labels stamped onto every diagnostic the rule emits                     |
+| `surfaces`    | `string[]` | No       | Where the rule may appear, described on [Surfaces](/docs/custom-rules#surfaces) |
+
+Custom rules come in the two code scopes, `file` and `project`. The schema
+scope the built-in [schema rules](/docs/rules/schema) use is not available to
+them, and `"schema"` is not a valid category.
+
+### Tags
+
+The one tag with behavior today is `"module-graph"`. Diagnostics carrying it appear in the Modules Graph tab's problems drawer, beside the built-in module-wiring ones:
+
+```typescript
+meta: {
+  id: "no-untagged-feature-module",
+  category: "architecture",
+  severity: "warning",
+  description: "Feature modules must follow the naming convention",
+  help: "Rename the module to end with FeatureModule.",
+  tags: ["module-graph"],
+},
+```
+
+A `tags` value that is not an array of strings is dropped with a warning, and the rule still runs.
+
+### The `check` function
+
+The `check` function receives a `RuleContext`. The first three members are what most rules need, and the rest carry facts a single file cannot see:
+
+| Member | What it is |
+|---|---|
+| `sourceFile` | The ts-morph `SourceFile` for the file being analyzed |
+| `filePath` | The absolute path to that file |
+| `report(diagnostic)` | Emits a diagnostic with `filePath`, `message`, `help`, `line`, and `column` |
+| `config` | The resolved config for the project |
+| `diProviders` | Class names NestJS instantiates itself |
+| `guards` | Composed guard decorators, globally registered guards, and guarded base classes |
+| `moduleDirectories` | Directories that hold a module file, for boundary checks |
+
+Every member after `report` is optional. Absent means the fact was not determined, which is not the same as empty.
+
+For project-scoped rules (`scope: "project"`), the context carries the whole project instead of a single file:
+
+| Member | What it holds |
+| ------ | ------------- |
+| `project` | The ts-morph `Project`, every parsed file |
+| `files` | Paths of the scanned files |
+| `moduleGraph` | Modules, their imports and exports |
+| `providers` | Every provider and the module that declares it |
+| `config` | The resolved config for the project |
+| `targetPath` | The directory being scanned, for reading a file the scan did not parse |
+| `installRoot` | Where to resolve `node_modules` from, when that is not `targetPath` |
+
+`targetPath` is what a rule uses to reach something outside the TypeScript it
+was given, such as the project's `package.json`. Read it when the rule runs
+rather than caching it: the language server keeps one context alive for the
+whole editing session.
+
+`installRoot` is absent unless the two differ, which happens under
+`--scope changed`. That mode scans a base revision in a throwaway checkout with
+no install, so a rule reading `node_modules` should prefer it:
+
+```typescript
+const root = context.installRoot ?? context.targetPath;
+```
+
+Reading `targetPath` there finds nothing installed. The rule then reports
+against the base revision what it would never report against the working tree.
+
+## Example
+
+A rule that flags unresolved TODO comments:
+
+```typescript
+import type { RuleContext } from "nestjs-doctor";
+
+export const noTodoComments = {
+  meta: {
+    id: "no-todo-comments",
+    category: "correctness",
+    severity: "warning",
+    description: "TODO comments should be resolved before merging",
+    help: "Replace the TODO with an implementation or open an issue.",
+  },
+  check(context: RuleContext) {
+    const text = context.sourceFile.getFullText();
+    const regex = /\/\/\s*TODO/gi;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(text)) !== null) {
+      const pos = context.sourceFile.getLineAndColumnAtPos(match.index);
+      context.report({
+        message: "Unresolved TODO comment",
+        help: "Replace the TODO with an implementation or open an issue.",
+        filePath: context.filePath,
+        line: pos.line,
+        column: pos.column,
+      });
+    }
+  },
+};
+```
+
+The line and column come from ts-morph: `getLineAndColumnAtPos` turns a character offset into the 1-indexed position a diagnostic expects.
+
+## The Rule Lab tab
+
+The HTML report has a Rule Lab tab for writing and testing custom rules in the browser:
+
+```bash
+npx nestjs-doctor . --report
+```
+
+Scaffold a rule with `/nestjs-doctor-create-rule`, test it in the Rule Lab, then save the `.ts` file to your [`customRulesDir`](/docs/custom-rules).

--- a/packages/website/src/app/docs/rules/page.mdx
+++ b/packages/website/src/app/docs/rules/page.mdx
@@ -31,5 +31,5 @@ Rules have one of three scopes:
 
 ## Writing your own
 
-See [Custom rules](/docs/custom-rules) for the rule interface, the three
+See [Custom rules](/docs/rules/custom) for the rule interface, the two
 contexts, and a worked example.

--- a/packages/website/src/app/globals.css
+++ b/packages/website/src/app/globals.css
@@ -24,6 +24,12 @@ html {
 	background: #000;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+	html {
+		scroll-behavior: smooth;
+	}
+}
+
 body {
 	height: 100%;
 }

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({
 	children: React.ReactNode;
 }>) {
 	return (
-		<html lang="en">
+		<html data-scroll-behavior="smooth" lang="en">
 			<body
 				className={`${ibmPlexMono.variable} antialiased`}
 				suppressHydrationWarning

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -52,9 +52,9 @@ export const docsMetadata: Record<string, Metadata> = {
 			"Configure nestjs-doctor with nestjs-doctor.config.json. Customize file patterns, enable or disable rules, ignore specific diagnostics, and suppress rules inline with comments.",
 	},
 	"/docs/custom-rules": {
-		title: "Custom rules",
+		title: "Custom rule configuration",
 		description:
-			"Extend nestjs-doctor with project-specific checks. Encode domain conventions, enforce team standards, or flag patterns unique to your codebase.",
+			"Wire custom rules into a nestjs-doctor scan: customRulesDir, how rule files load, custom/ id prefixing, and the surfaces a rule's findings appear on.",
 	},
 	"/docs/ci": {
 		title: "GitHub Actions setup",
@@ -155,5 +155,10 @@ export const docsMetadata: Record<string, Metadata> = {
 		title: "Schema rules",
 		description:
 			"3 rules that validate database schema design: primary keys, timestamps, and relation configuration.",
+	},
+	"/docs/rules/custom": {
+		title: "Custom rules",
+		description:
+			"Write project-specific nestjs-doctor rules: the rule shape, file and project scopes, the check function's context, and the report's Rule Lab.",
 	},
 };

--- a/packages/website/src/lib/docs-navigation.ts
+++ b/packages/website/src/lib/docs-navigation.ts
@@ -38,7 +38,7 @@ export const DOCS_NAV: NavSection[] = [
 		title: "Configuration",
 		items: [
 			{ title: "Config files", href: "/docs/configuration" },
-			{ title: "Custom rules", href: "/docs/custom-rules" },
+			{ title: "Custom rule configuration", href: "/docs/custom-rules" },
 		],
 	},
 	{
@@ -50,6 +50,7 @@ export const DOCS_NAV: NavSection[] = [
 			{ title: "Architecture", href: "/docs/rules/architecture" },
 			{ title: "Performance", href: "/docs/rules/performance" },
 			{ title: "Schema", href: "/docs/rules/schema" },
+			{ title: "Custom rules", href: "/docs/rules/custom" },
 		],
 	},
 	{


### PR DESCRIPTION
## Context

`/docs/custom-rules` sat under the Configuration nav section but mixed two audiences: someone wiring rules into a repo (`customRulesDir`, loading, surfaces) and someone writing a rule (the shape, contexts, examples).

## Problem

The page's title said "Custom rules" while its nav section said Configuration, and the Rules section had no entry for authoring at all. Six pages deep-link `/docs/custom-rules#surfaces`, the published npm READMEs link `/docs/custom-rules`, and every generated HTML report bakes that URL into its Rule Lab tab, so the URL cannot move.

## Possible flows

| Path into the page | After the split |
|---|---|
| Nav → Configuration → Custom rule configuration | Config half at `/docs/custom-rules`, unchanged URL |
| Nav → Rules → Custom rules | New authoring page at `/docs/rules/custom` |
| `#surfaces` anchors (6 in-repo pages) | Unchanged, section stays on the config page |
| npm README / already-generated reports | Unchanged URL still resolves to config content |
| Rule Lab subtitle in new reports | Retargeted to `/docs/rules/custom` (changeset added) |
| `rules/page.mdx`, `coding-agents` links | Retargeted to `/docs/rules/custom` |

## Solution

Split the page. `/docs/custom-rules` becomes "Custom rule configuration": setup, jiti loading, `custom/` prefixing, load warnings, and the surfaces tables. `/docs/rules/custom` is "Custom rules": the agent path, rule shape, `meta` fields, tags, both check contexts, the worked example, and the Rule Lab. Each links to the other instead of restating. Also stated on the authoring page: custom rules take only the `file` and `project` scopes, matching the loader's `VALID_SCOPES`/`VALID_CATEGORIES`. Deliberately not done: moving Surfaces to `/docs/configuration` (six anchor edits, separate change).

## Before vs after

| | Before | After |
|---|---|---|
| Configuration nav | "Custom rules" (mixed page) | "Custom rule configuration" (config only) |
| Rules nav | No authoring entry | "Custom rules" → `/docs/rules/custom` |
| `#surfaces` anchor | `/docs/custom-rules#surfaces` | Unchanged |
| `noTodoComments` example | Verified by nd-docs: loads warning-free, fires at line 2 | Unchanged, moved |

## Example

```
curl -s https://www.nestjs.doctor/docs/rules/custom
```

Before: 404. After: the authoring page, with the sidebar's Rules section showing Custom rules after Schema.