### PR TITLE
feat(cli): end a terminal scan with an interactive menu

### DIFF
--- a/.changeset/interactive-menu.md
+++ b/.changeset/interactive-menu.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+A console scan in a terminal now ends with a menu: open the HTML report built from the scan that just ran, scaffold the GitHub Actions workflow when it is missing, or copy the findings as markdown. The menu is skipped in CI, inside coding agents, in pipes, and in every machine-readable mode, and quitting keeps the run's exit code. Opening a report from the browser no longer holds the process open, and the Windows open command quotes the path correctly.

--- a/packages/nestjs-doctor/package.json
+++ b/packages/nestjs-doctor/package.json
@@ -57,6 +57,7 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
+    "@clack/prompts": "^1.7.0",
     "citty": "^0.2.2",
     "jiti": "^2.7.0",
     "ora": "^9.4.1",

--- a/packages/nestjs-doctor/src/cli/ci-install.ts
+++ b/packages/nestjs-doctor/src/cli/ci-install.ts
@@ -1,4 +1,4 @@
-import { lstatSync } from "node:fs";
+import { existsSync, lstatSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { findGitRepo, runGit } from "../engine/git.js";
@@ -111,6 +111,12 @@ jobs:
 `;
 
 /** Writes the pull request workflow into the repository that contains `targetPath`. */
+/** True when the repository already carries the scaffolded workflow file. */
+export const ciWorkflowExists = (targetPath: string): boolean => {
+	const repo = findGitRepo(targetPath);
+	return repo !== null && existsSync(join(repo.root, WORKFLOW_FILE));
+};
+
 export const installCiWorkflow = async (
 	targetPath: string,
 	force: boolean

--- a/packages/nestjs-doctor/src/cli/ci-install.ts
+++ b/packages/nestjs-doctor/src/cli/ci-install.ts
@@ -110,13 +110,13 @@ jobs:
         #   version: "1.2.3"          # Pin the nestjs-doctor version (default: latest)
 `;
 
-/** Writes the pull request workflow into the repository that contains `targetPath`. */
 /** True when the repository already carries the scaffolded workflow file. */
 export const ciWorkflowExists = (targetPath: string): boolean => {
 	const repo = findGitRepo(targetPath);
 	return repo !== null && existsSync(join(repo.root, WORKFLOW_FILE));
 };
 
+/** Writes the pull request workflow into the repository that contains `targetPath`. */
 export const installCiWorkflow = async (
 	targetPath: string,
 	force: boolean

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -6,8 +6,13 @@ import {
 } from "../engine/project-detector.js";
 import { flags } from "./flags.js";
 import { setCliVersion } from "./output.js";
-import { MonorepoPipeline, SingleProjectPipeline } from "./pipeline.js";
+import {
+	type InteractiveArtifacts,
+	MonorepoPipeline,
+	SingleProjectPipeline,
+} from "./pipeline.js";
 import { type CliArgs, CliSetup } from "./setup.js";
+import { canPrompt } from "./ui/environment.js";
 import { logger } from "./ui/logger.js";
 
 const CONFIG_ERROR_EXIT_CODE = 2;
@@ -61,9 +66,18 @@ async function scan(args: CliArgs): Promise<void> {
 
 	const { targetPath, options } = ctx;
 
+	const runMenu = async (artifacts: InteractiveArtifacts) => {
+		if (!canPrompt(options)) {
+			return;
+		}
+		const { runInteractiveMenu } = await import("./interactive/menu.js");
+		await runInteractiveMenu({ ...artifacts, targetPath, version });
+	};
+
 	const monorepo = await detectMonorepo(targetPath);
 	if (monorepo) {
-		await new MonorepoPipeline(targetPath, monorepo, options)
+		const pipeline = new MonorepoPipeline(targetPath, monorepo, options);
+		await pipeline
 			.resolveConfig()
 			.buildContext()
 			.runRules()
@@ -72,6 +86,7 @@ async function scan(args: CliArgs): Promise<void> {
 			.warnCustomRules()
 			.output()
 			.run();
+		await runMenu(pipeline.interactiveArtifacts);
 		return;
 	}
 
@@ -81,7 +96,8 @@ async function scan(args: CliArgs): Promise<void> {
 		);
 	}
 
-	await new SingleProjectPipeline(targetPath, options)
+	const pipeline = new SingleProjectPipeline(targetPath, options);
+	await pipeline
 		.resolveConfig()
 		.buildContext()
 		.runRules()
@@ -90,6 +106,7 @@ async function scan(args: CliArgs): Promise<void> {
 		.warnCustomRules()
 		.output()
 		.run();
+	await runMenu(pipeline.interactiveArtifacts);
 }
 
 runMain(main);

--- a/packages/nestjs-doctor/src/cli/interactive/clipboard.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/clipboard.ts
@@ -1,0 +1,45 @@
+import { spawn } from "node:child_process";
+
+const resolveClipboardCommands = (): [string, string[]][] => {
+	if (process.platform === "darwin") {
+		return [["pbcopy", []]];
+	}
+	if (process.platform === "win32") {
+		return [["clip", []]];
+	}
+	return [
+		["wl-copy", []],
+		["xclip", ["-selection", "clipboard"]],
+		["xsel", ["--clipboard", "--input"]],
+	];
+};
+
+const CLIPBOARD_COMMANDS = resolveClipboardCommands();
+
+const tryCommand = (
+	command: string,
+	commandArgs: string[],
+	text: string
+): Promise<boolean> => {
+	return new Promise((resolvePromise) => {
+		const child = spawn(command, commandArgs, {
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+		child.on("error", () => resolvePromise(false));
+		child.on("close", (code) => resolvePromise(code === 0));
+		child.stdin.on("error", () => {
+			// A missing binary also surfaces here; the close handler answers.
+		});
+		child.stdin.end(text);
+	});
+};
+
+/** Copies text to the system clipboard; false when no clipboard tool works. */
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+	for (const [command, commandArgs] of CLIPBOARD_COMMANDS) {
+		if (await tryCommand(command, commandArgs, text)) {
+			return true;
+		}
+	}
+	return false;
+};

--- a/packages/nestjs-doctor/src/cli/interactive/menu.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/menu.ts
@@ -82,10 +82,10 @@ export const runInteractiveMenu = async (
 
 	// What the console report showed. The markdown copy narrows itself.
 	const shown = withSurface(context.result, "cli");
+	const findingCount = shown.summary.total;
 
 	for (;;) {
 		const offerCi = !ciWorkflowExists(context.targetPath);
-		const findingCount = shown.summary.total;
 
 		const choice = await select<MenuAction>({
 			message: "What next?",

--- a/packages/nestjs-doctor/src/cli/interactive/menu.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/menu.ts
@@ -1,5 +1,6 @@
 import { intro, isCancel, log, outro, select, spinner } from "@clack/prompts";
 import type { DiagnoseResult } from "../../common/result.js";
+import { withSurface } from "../../engine/result-builder.js";
 import { buildMarkdownReport } from "../../formatters/markdown-report.js";
 import { openReportInBrowser, writeReportFile } from "../../report/output.js";
 import { ciWorkflowExists, installCiWorkflow } from "../ci-install.js";
@@ -79,9 +80,12 @@ export const runInteractiveMenu = async (
 ): Promise<void> => {
 	intro("nestjs-doctor");
 
+	// What the console report showed. The markdown copy narrows itself.
+	const shown = withSurface(context.result, "cli");
+
 	for (;;) {
 		const offerCi = !ciWorkflowExists(context.targetPath);
-		const findingCount = context.result.summary.total;
+		const findingCount = shown.summary.total;
 
 		const choice = await select<MenuAction>({
 			message: "What next?",

--- a/packages/nestjs-doctor/src/cli/interactive/menu.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/menu.ts
@@ -1,0 +1,125 @@
+import { intro, isCancel, log, outro, select, spinner } from "@clack/prompts";
+import type { DiagnoseResult } from "../../common/result.js";
+import { buildMarkdownReport } from "../../formatters/markdown-report.js";
+import { openReportInBrowser, writeReportFile } from "../../report/output.js";
+import { ciWorkflowExists, installCiWorkflow } from "../ci-install.js";
+import { copyToClipboard } from "./clipboard.js";
+
+interface InteractiveContext {
+	buildReportHtml: () => string;
+	result: DiagnoseResult;
+	targetPath: string;
+	version: string;
+}
+
+type MenuAction = "report" | "ci" | "markdown" | "quit";
+
+const openReport = async (context: InteractiveContext): Promise<void> => {
+	const working = spinner();
+	working.start("Generating the HTML report");
+	let reportPath: string;
+	try {
+		const html = context.buildReportHtml();
+		reportPath = await writeReportFile(context.targetPath, html);
+	} catch (error) {
+		working.stop("Report generation failed");
+		log.error(error instanceof Error ? error.message : String(error));
+		return;
+	}
+	working.stop(`Report written to ${reportPath}`);
+	openReportInBrowser(reportPath);
+	log.info("Opened in your browser.");
+};
+
+const addCiWorkflow = async (context: InteractiveContext): Promise<void> => {
+	const outcome = await installCiWorkflow(context.targetPath, false);
+	switch (outcome.status) {
+		case "created":
+			log.success(
+				`Workflow written to ${outcome.workflowPath}. Push trigger keyed to the ${outcome.branch} branch.`
+			);
+			log.info(
+				"The check never fails until you set blocking or min-score in the workflow."
+			);
+			break;
+		case "exists":
+			log.info(
+				`${outcome.workflowPath} already exists. Run "nestjs-doctor ci install --force" to replace it.`
+			);
+			break;
+		case "no-repo":
+			log.warn("Not a git repository; nothing was written.");
+			break;
+		case "symlink":
+			log.warn(
+				`${outcome.workflowPath} is a symlink; refusing to write through it.`
+			);
+			break;
+		default:
+			log.error(`Could not write the workflow (${outcome.status}).`);
+	}
+};
+
+const copyMarkdown = async (context: InteractiveContext): Promise<void> => {
+	const markdown = buildMarkdownReport(context.result, {
+		targetPath: context.targetPath,
+		version: context.version,
+	});
+	if (await copyToClipboard(markdown)) {
+		log.success("Markdown summary copied to the clipboard.");
+		return;
+	}
+	log.warn("No clipboard tool found; printing instead.");
+	process.stdout.write(`\n${markdown}\n\n`);
+};
+
+/** The post-scan menu. Never changes process.exitCode: the gates own it. */
+export const runInteractiveMenu = async (
+	context: InteractiveContext
+): Promise<void> => {
+	intro("nestjs-doctor");
+
+	for (;;) {
+		const offerCi = !ciWorkflowExists(context.targetPath);
+		const findingCount = context.result.summary.total;
+
+		const choice = await select<MenuAction>({
+			message: "What next?",
+			options: [
+				{
+					hint: `${findingCount} finding${findingCount === 1 ? "" : "s"} in an interactive page`,
+					label: "Open the HTML report",
+					value: "report",
+				},
+				...(offerCi
+					? [
+							{
+								hint: "Scaffold .github/workflows/nestjs-doctor.yml",
+								label: "Add to GitHub Actions",
+								value: "ci" as const,
+							},
+						]
+					: []),
+				{
+					hint: "The pull request summary, for pasting anywhere",
+					label: "Copy findings as markdown",
+					value: "markdown",
+				},
+				{ label: "Quit", value: "quit" },
+			],
+		});
+
+		if (isCancel(choice) || choice === "quit") {
+			outro("Done.");
+			return;
+		}
+
+		if (choice === "report") {
+			await openReport(context);
+		} else if (choice === "ci") {
+			await addCiWorkflow(context);
+		} else if (choice === "markdown") {
+			await copyMarkdown(context);
+		}
+	}
+};

--- a/packages/nestjs-doctor/src/cli/interactive/menu.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/menu.ts
@@ -28,7 +28,7 @@ const openReport = async (context: InteractiveContext): Promise<void> => {
 		return;
 	}
 	working.stop(`Report written to ${reportPath}`);
-	openReportInBrowser(reportPath);
+	openReportInBrowser(reportPath, log.warn);
 	log.info("Opened in your browser.");
 };
 

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -45,7 +45,7 @@ const resolveRunUrl = (): string | undefined => {
 	return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
 };
 
-/** Applies both gates, exiting when either fails. */
+/** Applies both gates, marking the process failed when either trips. */
 function enforceGates(
 	result: DiagnoseResult,
 	resolvedMinimumScore: number | undefined,
@@ -59,11 +59,12 @@ function enforceGates(
 				`Score ${score} is below the minimum threshold of ${resolvedMinimumScore}.`
 			);
 		}
-		process.exit(FAILURE_EXIT_CODE);
+		process.exitCode = FAILURE_EXIT_CODE;
+		return;
 	}
 
 	if (shouldBlock(result.diagnostics, options.blocking)) {
-		process.exit(FAILURE_EXIT_CODE);
+		process.exitCode = FAILURE_EXIT_CODE;
 	}
 }
 

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -3,7 +3,10 @@ import type { Diagnostic } from "../common/diagnostic.js";
 import type { DiagnoseResult } from "../common/result.js";
 import { computeBaselineDelta } from "../engine/baseline.js";
 import { collectEntryModules } from "../engine/graph/entry-points.js";
-import { detachModuleGraph } from "../engine/graph/module-graph.js";
+import {
+	detachModuleGraph,
+	mergeModuleGraphs,
+} from "../engine/graph/module-graph.js";
 import { pruneCrossProjectOrphans } from "../engine/orphan-prune.js";
 import type { MonorepoInfo } from "../engine/project-detector.js";
 import { withScopedDiagnostics } from "../engine/result-builder.js";
@@ -27,6 +30,11 @@ import {
 	type ResolvedScope,
 	resolveScope,
 } from "../engine/scope.js";
+import {
+	type ReportProvider,
+	toReportProvider,
+} from "../report/formatters/report-data.js";
+import { buildHtmlReport } from "../report/html-report.js";
 import { getEcosystem, resetEcosystem } from "../telemetry/ecosystem.js";
 import { generatedIn } from "../telemetry/environment.js";
 import { resolveIdentity } from "../telemetry/install-id.js";
@@ -46,6 +54,12 @@ import { logger } from "./ui/logger.js";
 import { spinner } from "./ui/spinner.js";
 
 type PipelineStep = () => void | Promise<void>;
+
+/** Handed to the post-scan menu so its actions reuse the finished scan. */
+export interface InteractiveArtifacts {
+	buildReportHtml: () => string;
+	result: DiagnoseResult;
+}
 
 const displayCustomRuleWarnings = (
 	warnings: string[],
@@ -247,8 +261,30 @@ export class MonorepoPipeline extends ScanPipeline {
 	private readonly monorepo: MonorepoInfo;
 	private scanResults!: Map<string, EngineResult>;
 	private readonly bootstrapRoots: string[] = [];
+	private readonly allFiles: string[] = [];
+	private readonly allProviders: ReportProvider[] = [];
 	private result!: MonorepoEngineResult;
 	private scanStartTime!: number;
+
+	/** What the post-scan menu needs, without re-scanning. */
+	get interactiveArtifacts(): InteractiveArtifacts {
+		return {
+			buildReportHtml: () => {
+				const { moduleGraphs, result } = this.result;
+				return buildHtmlReport(
+					mergeModuleGraphs(moduleGraphs),
+					result.combined,
+					{
+						bootstrapRoots: this.bootstrapRoots,
+						files: this.allFiles,
+						projects: [...moduleGraphs.keys()],
+						providers: this.allProviders,
+					}
+				);
+			},
+			result: this.result.result.combined,
+		};
+	}
 
 	constructor(
 		targetPath: string,
@@ -276,12 +312,24 @@ export class MonorepoPipeline extends ScanPipeline {
 					if (context.config?.telemetry === false) {
 						this.subProjectOptOut = true;
 					}
+					this.allFiles.push(...context.files);
 					for (const root of collectEntryModules(
 						context.astProject,
 						context.files,
 						context.moduleGraph
 					)) {
 						this.bootstrapRoots.push(`${name}/${root}`);
+					}
+					for (const provider of context.providers.values()) {
+						const owner = context.moduleGraph.providerToModule.get(
+							provider.name
+						);
+						this.allProviders.push(
+							toReportProvider(provider, {
+								project: name,
+								module: owner ? `${name}/${owner.name}` : undefined,
+							})
+						);
 					}
 					const scanResult = buildResult(context, diagnose(context));
 					return {
@@ -363,6 +411,27 @@ export class SingleProjectPipeline extends ScanPipeline {
 	private context!: AnalysisContext;
 	private rawOutput!: RawDiagnosticOutput;
 	private result!: EngineResult;
+
+	/** What the post-scan menu needs, without re-scanning. */
+	get interactiveArtifacts(): InteractiveArtifacts {
+		return {
+			buildReportHtml: () => {
+				const { moduleGraph, files, providers } = this.result;
+				return buildHtmlReport(moduleGraph, this.result.result, {
+					bootstrapRoots: [
+						...collectEntryModules(this.context.astProject, files, moduleGraph),
+					],
+					files,
+					providers: [...providers.values()].map((provider) =>
+						toReportProvider(provider, {
+							module: moduleGraph.providerToModule.get(provider.name)?.name,
+						})
+					),
+				});
+			},
+			result: this.result.result,
+		};
+	}
 
 	buildContext(): this {
 		this.steps.push(async () => {

--- a/packages/nestjs-doctor/src/cli/ui/environment.ts
+++ b/packages/nestjs-doctor/src/cli/ui/environment.ts
@@ -1,0 +1,66 @@
+const CI_ENV_VARS = [
+	"CI",
+	"GITHUB_ACTIONS",
+	"GITLAB_CI",
+	"BUILDKITE",
+	"JENKINS_URL",
+	"TF_BUILD",
+	"CODEBUILD_BUILD_ID",
+	"TEAMCITY_VERSION",
+	"BITBUCKET_BUILD_NUMBER",
+	"CIRCLECI",
+	"TRAVIS",
+	"DRONE",
+];
+
+const AGENT_ENV_VARS = [
+	"CLAUDECODE",
+	"CLAUDE_CODE",
+	"CURSOR_AGENT",
+	"CODEX_SANDBOX",
+	"OPENCODE",
+	"AMP_THREAD_ID",
+	"CLINE_ACTIVE",
+	"AUGMENT_AGENT",
+	"GOOSE_TERMINAL",
+	"AGENT_SESSION_ID",
+	"AGENT_THREAD_ID",
+];
+
+/** True in CI or inside a coding agent, where a prompt would hang the run. */
+export const isNonInteractiveEnvironment = (
+	env: NodeJS.ProcessEnv = process.env
+): boolean => {
+	return [...CI_ENV_VARS, ...AGENT_ENV_VARS].some((name) => env[name]);
+};
+
+interface PromptGate {
+	format: string;
+	score: boolean;
+}
+
+interface PromptStreams {
+	stdin: { isTTY?: boolean; setRawMode?: unknown };
+	stdout: { isTTY?: boolean };
+}
+
+/** Whether the run may show the post-scan menu. */
+export const canPrompt = (
+	options: PromptGate,
+	env: NodeJS.ProcessEnv = process.env,
+	streams: PromptStreams = process
+): boolean => {
+	if (options.format !== "console" || options.score) {
+		return false;
+	}
+	if (!(streams.stdin.isTTY && streams.stdout.isTTY)) {
+		return false;
+	}
+	if (typeof streams.stdin.setRawMode !== "function") {
+		return false;
+	}
+	if (env.TERM === "dumb") {
+		return false;
+	}
+	return !isNonInteractiveEnvironment(env);
+};

--- a/packages/nestjs-doctor/src/report/output.ts
+++ b/packages/nestjs-doctor/src/report/output.ts
@@ -37,11 +37,14 @@ export const openCommand = (filePath: string): [string, string[]] => {
 	return ["xdg-open", [filePath]];
 };
 
-export const openReportInBrowser = (filePath: string): void => {
+export const openReportInBrowser = (
+	filePath: string,
+	onError: (message: string) => void = logger.warn
+): void => {
 	const [command, args] = openCommand(filePath);
 	const child = spawn(command, args, { detached: true, stdio: "ignore" });
 	child.on("error", () => {
-		logger.warn(`Could not open ${filePath} in a browser.`);
+		onError(`Could not open ${filePath} in a browser.`);
 	});
 	child.unref();
 };

--- a/packages/nestjs-doctor/src/report/output.ts
+++ b/packages/nestjs-doctor/src/report/output.ts
@@ -29,14 +29,14 @@ export const writeReportFile = async (
 
 export const openReportInBrowser = (filePath: string): void => {
 	if (process.platform === "darwin") {
-		exec(`open "${filePath}"`);
+		exec(`open "${filePath}"`).unref();
 		return;
 	}
 	if (process.platform === "win32") {
-		exec(`start "${filePath}"`);
+		exec(`start "" "${filePath}"`).unref();
 		return;
 	}
-	exec(`xdg-open "${filePath}"`);
+	exec(`xdg-open "${filePath}"`).unref();
 };
 
 export const logSingleProjectSummary = (scanResult: EngineResult): void => {

--- a/packages/nestjs-doctor/src/report/output.ts
+++ b/packages/nestjs-doctor/src/report/output.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { highlighter } from "../cli/ui/highlighter.js";
@@ -23,20 +23,28 @@ export const writeReportFile = async (
 		: join(targetPath, "nestjs-doctor-report.html");
 	await mkdir(dirname(outPath), { recursive: true });
 	await writeFile(outPath, html, "utf-8");
-	logger.info(`Report written to ${highlighter.info(outPath)}`);
 	return outPath;
 };
 
-export const openReportInBrowser = (filePath: string): void => {
+const openCommand = (filePath: string): [string, string[]] => {
 	if (process.platform === "darwin") {
-		exec(`open "${filePath}"`).unref();
-		return;
+		return ["open", [filePath]];
 	}
 	if (process.platform === "win32") {
-		exec(`start "" "${filePath}"`).unref();
-		return;
+		return ["cmd", ["/c", "start", "", filePath]];
 	}
-	exec(`xdg-open "${filePath}"`).unref();
+	return ["xdg-open", [filePath]];
+};
+
+export const openReportInBrowser = (filePath: string): void => {
+	const [command, args] = openCommand(filePath);
+	// Detached with no pipes: an inherited stdio pipe keeps the event loop
+	// alive until the browser exits.
+	const child = spawn(command, args, { detached: true, stdio: "ignore" });
+	child.on("error", () => {
+		logger.warn(`Could not open ${filePath} in a browser.`);
+	});
+	child.unref();
 };
 
 export const logSingleProjectSummary = (scanResult: EngineResult): void => {

--- a/packages/nestjs-doctor/src/report/output.ts
+++ b/packages/nestjs-doctor/src/report/output.ts
@@ -26,7 +26,8 @@ export const writeReportFile = async (
 	return outPath;
 };
 
-const openCommand = (filePath: string): [string, string[]] => {
+/** The platform's file opener, as a command and its arguments. */
+export const openCommand = (filePath: string): [string, string[]] => {
 	if (process.platform === "darwin") {
 		return ["open", [filePath]];
 	}
@@ -38,8 +39,6 @@ const openCommand = (filePath: string): [string, string[]] => {
 
 export const openReportInBrowser = (filePath: string): void => {
 	const [command, args] = openCommand(filePath);
-	// Detached with no pipes: an inherited stdio pipe keeps the event loop
-	// alive until the browser exits.
 	const child = spawn(command, args, { detached: true, stdio: "ignore" });
 	child.on("error", () => {
 		logger.warn(`Could not open ${filePath} in a browser.`);

--- a/packages/nestjs-doctor/src/report/setup.ts
+++ b/packages/nestjs-doctor/src/report/setup.ts
@@ -1,3 +1,4 @@
+import { highlighter } from "../cli/ui/highlighter.js";
 import { logger } from "../cli/ui/logger.js";
 import { detectMonorepo } from "../engine/project-detector.js";
 import {
@@ -52,6 +53,7 @@ export const runReport = async (
 			pipeline.generatedHtml,
 			outputPath
 		);
+		logger.info(`Report written to ${highlighter.info(outPath)}`);
 		openReportInBrowser(outPath);
 		return;
 	}
@@ -75,5 +77,6 @@ export const runReport = async (
 		pipeline.generatedHtml,
 		outputPath
 	);
+	logger.info(`Report written to ${highlighter.info(outPath)}`);
 	openReportInBrowser(outPath);
 };

--- a/packages/nestjs-doctor/src/report/setup.ts
+++ b/packages/nestjs-doctor/src/report/setup.ts
@@ -23,6 +23,12 @@ export const runReport = async (
 ): Promise<void> => {
 	const monorepo = await detectMonorepo(targetPath);
 
+	const writeAndOpen = async (html: string): Promise<void> => {
+		const outPath = await writeReportFile(targetPath, html, outputPath);
+		logger.info(`Report written to ${highlighter.info(outPath)}`);
+		openReportInBrowser(outPath);
+	};
+
 	let bootTimings: BootstrapTimings | undefined;
 	if (timingsPath) {
 		const { timings, warnings } = loadBootstrapTimings(targetPath, timingsPath);
@@ -48,13 +54,7 @@ export const runReport = async (
 			.generateHtml()
 			.run();
 		logMonorepoSummary(pipeline.monoResult, pipeline.mergedGraph);
-		const outPath = await writeReportFile(
-			targetPath,
-			pipeline.generatedHtml,
-			outputPath
-		);
-		logger.info(`Report written to ${highlighter.info(outPath)}`);
-		openReportInBrowser(outPath);
+		await writeAndOpen(pipeline.generatedHtml);
 		return;
 	}
 
@@ -72,11 +72,5 @@ export const runReport = async (
 		.generateHtml()
 		.run();
 	logSingleProjectSummary(pipeline.scanResult);
-	const outPath = await writeReportFile(
-		targetPath,
-		pipeline.generatedHtml,
-		outputPath
-	);
-	logger.info(`Report written to ${highlighter.info(outPath)}`);
-	openReportInBrowser(outPath);
+	await writeAndOpen(pipeline.generatedHtml);
 };

--- a/packages/nestjs-doctor/tests/unit/interactive-environment.test.ts
+++ b/packages/nestjs-doctor/tests/unit/interactive-environment.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+	canPrompt,
+	isNonInteractiveEnvironment,
+} from "../../src/cli/ui/environment.js";
+
+const CONSOLE = { format: "console", score: false };
+
+const tty = {
+	stdin: { isTTY: true, setRawMode: () => undefined },
+	stdout: { isTTY: true },
+};
+
+describe("isNonInteractiveEnvironment", () => {
+	it("is false for an empty environment", () => {
+		expect(isNonInteractiveEnvironment({})).toBe(false);
+	});
+
+	it.each([
+		"CI",
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"JENKINS_URL",
+		"BUILDKITE",
+	])("detects the %s CI marker", (name) => {
+		expect(isNonInteractiveEnvironment({ [name]: "1" })).toBe(true);
+	});
+
+	it.each([
+		"CLAUDECODE",
+		"CURSOR_AGENT",
+		"CODEX_SANDBOX",
+		"AMP_THREAD_ID",
+	])("detects the %s coding-agent marker", (name) => {
+		expect(isNonInteractiveEnvironment({ [name]: "1" })).toBe(true);
+	});
+});
+
+describe("canPrompt", () => {
+	it("refuses every non-console format", () => {
+		for (const format of ["json", "sarif", "gitlab", "markdown", "github"]) {
+			expect(canPrompt({ format, score: false }, {}, tty)).toBe(false);
+		}
+	});
+
+	it("refuses score-only output", () => {
+		expect(canPrompt({ format: "console", score: true }, {}, tty)).toBe(false);
+	});
+
+	it("refuses without a TTY on both ends", () => {
+		expect(canPrompt(CONSOLE, {}, { ...tty, stdout: { isTTY: false } })).toBe(
+			false
+		);
+	});
+
+	it("refuses when raw mode is unavailable", () => {
+		expect(canPrompt(CONSOLE, {}, { ...tty, stdin: { isTTY: true } })).toBe(
+			false
+		);
+	});
+
+	it("refuses a dumb terminal", () => {
+		expect(canPrompt(CONSOLE, { TERM: "dumb" }, tty)).toBe(false);
+	});
+
+	it("refuses inside CI and coding agents", () => {
+		expect(canPrompt(CONSOLE, { CI: "true" }, tty)).toBe(false);
+		expect(canPrompt(CONSOLE, { CLAUDECODE: "1" }, tty)).toBe(false);
+	});
+
+	it("allows an interactive console run", () => {
+		expect(canPrompt(CONSOLE, { TERM: "xterm-256color" }, tty)).toBe(true);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/report-output.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-output.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { writeReportFile } from "../../src/report/output.js";
+import { openCommand, writeReportFile } from "../../src/report/output.js";
 
 const roots: string[] = [];
 const scratch = (): string => {
@@ -54,5 +54,23 @@ describe("writeReportFile", () => {
 		} finally {
 			process.chdir(cwd);
 		}
+	});
+});
+
+describe("openCommand", () => {
+	const platform = process.platform;
+	const setPlatform = (value: string): void => {
+		Object.defineProperty(process, "platform", { value });
+	};
+	afterAll(() => setPlatform(platform));
+
+	it("passes the path as one argument on every platform", () => {
+		const path = "/tmp/a b/report.html";
+		setPlatform("darwin");
+		expect(openCommand(path)).toEqual(["open", [path]]);
+		setPlatform("linux");
+		expect(openCommand(path)).toEqual(["xdg-open", [path]]);
+		setPlatform("win32");
+		expect(openCommand(path)).toEqual(["cmd", ["/c", "start", "", path]]);
 	});
 });

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -77,6 +77,17 @@ and every format except `console` and `github`. A custom rule that failed to
 load is silent, and a run below `--min-score` exits `1` with no message on
 either stream.
 
+## The menu
+
+A console scan in a terminal ends with a short menu: open the HTML report,
+scaffold the GitHub Actions workflow when it is missing, or copy the findings
+as markdown. The report comes from the scan that just ran, so nothing is
+scanned twice.
+
+The menu never appears where it could hang a machine. It is skipped in CI,
+inside coding agents, in pipes, in `dumb` terminals, and in every mode other
+than plain `console` output. Quitting keeps the run's exit code.
+
 ## Gates
 
 | Flag | Does |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   packages/nestjs-doctor:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.7.0
+        version: 1.7.0
       citty:
         specifier: ^0.2.2
         version: 0.2.2
@@ -389,8 +392,16 @@ packages:
   '@clack/core@1.1.0':
     resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
 
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
   '@clack/prompts@1.1.0':
     resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
@@ -2409,8 +2420,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4268,9 +4288,21 @@ snapshots:
     dependencies:
       sisteransi: 1.0.5
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@clack/prompts@1.1.0':
     dependencies:
       '@clack/core': 1.1.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@emnapi/core@1.11.2':
@@ -5918,7 +5950,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.5: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
## Context

react-doctor ends a terminal scan with a menu of next actions. Ours printed the report and exited, leaving the HTML report, the workflow scaffold, and the markdown summary behind flags most users never find. This is PR 1 of the interactive-CLI plan: the gate, the menu, and three actions. The finding detail view and agent handoff follow separately.

Unlike react-doctor, nothing here touches the network: no score API, no metrics, no crash reporting. The menu spawns local commands only.

## Problem

Two structural blockers stood in front of any menu: `enforceGates` called `process.exit(1)` inline, so a failing run (the common interactive case under the default `blocking: error`) would die before a menu could draw; and the codebase had no TTY or CI detection at all, so nothing could tell a terminal from a pipe.

## Possible flows

| Path into the changed code | After |
|---|---|
| Console scan in a terminal | Menu appears after the report |
| Console scan in CI, a coding agent, a pipe, or TERM=dumb | No menu, byte-identical output |
| `--json` / `--score` / `--format *` | No menu; the interactive chunk is never loaded |
| Gate failure, any mode | `process.exitCode = 1` instead of `process.exit(1)`; observable behavior unchanged |
| `--report` flag | Unchanged (separate mode) |
| Menu → Open the HTML report | Built from the finished scan's artifacts; no second scan |
| Menu → Add to GitHub Actions | Shown only when the workflow file is missing; reuses `installCiWorkflow` |
| Menu → Copy findings as markdown | The PR-comment builder → clipboard, print fallback |

## Solution

A `canPrompt` gate in `src/cli/ui/environment.ts` (console format, both TTYs, raw mode, not TERM=dumb, no CI/agent env markers — the marker lists mirror react-doctor's fencing). The menu is a lazily imported `@clack/prompts` module running after `pipeline.run()`, fed by a new `interactiveArtifacts` getter on both pipelines; the monorepo pipeline now collects files/providers during its reduce the way the report pipeline does. Also fixed while touching: `openReportInBrowser` leaks an un-unref'd child (kept the process alive), and the win32 `start "<path>"` treated the path as a window title.

Deliberately not done: finding detail view, agent handoff, any persisted state, any `--yes` flag.

## Before vs after

| | Before | After |
|---|---|---|
| Terminal scan | Report, exit | Report, menu (report / CI / markdown / quit) |
| CI and machine formats | Report/payload, exit | Unchanged |
| Gate failure | `process.exit(1)` | `process.exitCode = 1`, same codes observed |
| Menu report | n/a (`--report` re-scans) | Reuses the finished scan |
| `dist` | — | Menu is its own lazy chunk; `--json` never loads it |

## Example

```
node dist/cli/index.mjs tests/fixtures/bad-security
```

Before: report prints, process exits 0. After (in a TTY): the same report, then `What next?` with four options; selecting Copy findings as markdown puts "Score 66/100 — Fair · 3 findings" on the clipboard; Quit exits 0. Verified under a pty with expect; `--blocking warning` still exits 1, `--json` still emits pure JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGVR6E5GSeEBp6fVGAc9CS
