### PR TITLE
feat(cli): browse findings from the post-scan menu

### DIFF
--- a/.changeset/interactive-detail.md
+++ b/.changeset/interactive-detail.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+The post-scan menu gains a finding browser: rule groups ordered worst first, a per-finding view with the code frame, the fix guidance and the docs link, and a copyable agent-ready fix prompt per rule.

--- a/packages/nestjs-doctor/src/cli/interactive/code-frame.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/code-frame.ts
@@ -3,7 +3,7 @@ import { highlighter } from "../ui/highlighter.js";
 
 /**
  * Renders the diagnostic's source window with the offending line marked and a
- * caret under the column. Pure ASCII, so it needs no unicode fallback.
+ * caret under the column. Pure ASCII.
  */
 export const renderCodeFrame = (
 	sourceLines: SourceLine[],

--- a/packages/nestjs-doctor/src/cli/interactive/code-frame.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/code-frame.ts
@@ -1,0 +1,32 @@
+import type { SourceLine } from "../../common/diagnostic.js";
+import { highlighter } from "../ui/highlighter.js";
+
+/**
+ * Renders the diagnostic's source window with the offending line marked and a
+ * caret under the column. Pure ASCII, so it needs no unicode fallback.
+ */
+export const renderCodeFrame = (
+	sourceLines: SourceLine[],
+	line: number,
+	column: number
+): string => {
+	const gutterWidth = String(
+		Math.max(...sourceLines.map((entry) => entry.line))
+	).length;
+
+	const rows: string[] = [];
+	for (const entry of sourceLines) {
+		const isTarget = entry.line === line;
+		const marker = isTarget ? ">" : " ";
+		const gutter = String(entry.line).padStart(gutterWidth);
+		const text =
+			entry.text.length > 200 ? entry.text.slice(0, 200) : entry.text;
+		const row = `${marker} ${gutter} | ${text}`;
+		rows.push(isTarget ? row : highlighter.dim(row));
+		if (isTarget && column > 0) {
+			const caretIndent = " ".repeat(2 + gutterWidth + 3 + (column - 1));
+			rows.push(highlighter.error(`${caretIndent}^`));
+		}
+	}
+	return rows.join("\n");
+};

--- a/packages/nestjs-doctor/src/cli/interactive/detail.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/detail.ts
@@ -1,0 +1,208 @@
+import { isCancel, log, select } from "@clack/prompts";
+import {
+	type Diagnostic,
+	isCodeDiagnostic,
+	type Severity,
+} from "../../common/diagnostic.js";
+import { highlighter } from "../ui/highlighter.js";
+import { copyToClipboard } from "./clipboard.js";
+import { renderCodeFrame } from "./code-frame.js";
+
+interface RuleGroup {
+	diagnostics: Diagnostic[];
+	rule: string;
+	severity: Severity;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+	error: 0,
+	warning: 1,
+	info: 2,
+};
+
+const SEVERITY_MARK: Record<Severity, string> = {
+	error: highlighter.error("x"),
+	warning: highlighter.warn("!"),
+	info: highlighter.info("i"),
+};
+
+/** Groups by rule, worst severity first, then by how often the rule fired. */
+export const groupFindings = (diagnostics: Diagnostic[]): RuleGroup[] => {
+	const groups = new Map<string, RuleGroup>();
+	for (const diagnostic of diagnostics) {
+		const group = groups.get(diagnostic.rule);
+		if (group) {
+			group.diagnostics.push(diagnostic);
+		} else {
+			groups.set(diagnostic.rule, {
+				diagnostics: [diagnostic],
+				rule: diagnostic.rule,
+				severity: diagnostic.severity,
+			});
+		}
+	}
+	return [...groups.values()].sort(
+		(a, b) =>
+			SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] ||
+			b.diagnostics.length - a.diagnostics.length ||
+			a.rule.localeCompare(b.rule)
+	);
+};
+
+const locate = (diagnostic: Diagnostic): string => {
+	if (isCodeDiagnostic(diagnostic)) {
+		return `${diagnostic.filePath}:${diagnostic.line}:${diagnostic.column}`;
+	}
+	return `entity ${diagnostic.entity}`;
+};
+
+const docsUrl = (rule: string): string | undefined => {
+	const [category] = rule.split("/");
+	if (rule.startsWith("custom/")) {
+		return;
+	}
+	return `https://nestjs.doctor/docs/rules/${category}`;
+};
+
+/** One agent-ready prompt for a single rule's findings. */
+export const buildFixPrompt = (
+	group: RuleGroup,
+	targetPath: string
+): string => {
+	const first = group.diagnostics[0];
+	const locations = group.diagnostics
+		.slice(0, 10)
+		.map((diagnostic) => `- ${locate(diagnostic)}`)
+		.join("\n");
+	const overflow =
+		group.diagnostics.length > 10
+			? `\n…and ${group.diagnostics.length - 10} more; run npx nestjs-doctor@latest . --json for the full list.`
+			: "";
+
+	return [
+		`Fix the ${group.rule} findings reported by nestjs-doctor in ${targetPath}.`,
+		"",
+		`Finding: ${first.message}`,
+		`Fix guidance: ${first.help}`,
+		"",
+		`Locations (${group.diagnostics.length}):`,
+		`${locations}${overflow}`,
+		"",
+		"Fix the root cause; do not suppress the rule or delete the check.",
+		"Verify by re-running: npx nestjs-doctor@latest .",
+	].join("\n");
+};
+
+const printDetail = (
+	diagnostic: Diagnostic,
+	group: RuleGroup,
+	position: number
+): void => {
+	const header = `${SEVERITY_MARK[diagnostic.severity]} ${diagnostic.rule} ${highlighter.dim(
+		`(${position + 1}/${group.diagnostics.length})`
+	)}`;
+	const lines = [
+		header,
+		highlighter.dim(`${diagnostic.category} · ${locate(diagnostic)}`),
+		"",
+		diagnostic.message,
+	];
+
+	if (isCodeDiagnostic(diagnostic) && diagnostic.sourceLines?.length) {
+		lines.push(
+			"",
+			renderCodeFrame(
+				diagnostic.sourceLines,
+				diagnostic.line,
+				diagnostic.column
+			)
+		);
+	}
+
+	lines.push("", `Fix: ${diagnostic.help}`);
+	const url = docsUrl(diagnostic.rule);
+	if (url) {
+		lines.push(highlighter.dim(`Docs: ${url}`));
+	}
+
+	process.stdout.write(`\n${lines.join("\n")}\n\n`);
+};
+
+type DetailAction = "next" | "previous" | "copy" | "back";
+
+const reviewGroup = async (
+	group: RuleGroup,
+	targetPath: string
+): Promise<"back" | "cancel"> => {
+	let position = 0;
+	for (;;) {
+		const diagnostic = group.diagnostics[position];
+		printDetail(diagnostic, group, position);
+
+		const options: { label: string; value: DetailAction }[] = [];
+		if (position < group.diagnostics.length - 1) {
+			options.push({ label: "Next finding", value: "next" });
+		}
+		if (position > 0) {
+			options.push({ label: "Previous finding", value: "previous" });
+		}
+		options.push(
+			{ label: "Copy a fix prompt for this rule", value: "copy" },
+			{ label: "Back to the rule list", value: "back" }
+		);
+
+		const choice = await select<DetailAction>({
+			message: group.rule,
+			options,
+		});
+
+		if (isCancel(choice)) {
+			return "cancel";
+		}
+		if (choice === "back") {
+			return "back";
+		}
+		if (choice === "next") {
+			position += 1;
+		} else if (choice === "previous") {
+			position -= 1;
+		} else if (choice === "copy") {
+			const prompt = buildFixPrompt(group, targetPath);
+			if (await copyToClipboard(prompt)) {
+				log.success("Fix prompt copied. Paste it into any agent.");
+			} else {
+				log.warn("No clipboard tool found; printing instead.");
+				process.stdout.write(`\n${prompt}\n\n`);
+			}
+		}
+	}
+};
+
+/** The finding browser: rule groups, then finding-by-finding detail. */
+export const reviewFindings = async (
+	diagnostics: Diagnostic[],
+	targetPath: string
+): Promise<void> => {
+	const groups = groupFindings(diagnostics);
+
+	for (;;) {
+		const choice = await select<RuleGroup | "back">({
+			message: "Which rule?",
+			options: [
+				...groups.map((group) => ({
+					hint: group.diagnostics[0].message,
+					label: `${SEVERITY_MARK[group.severity]} ${group.rule} (${group.diagnostics.length})`,
+					value: group,
+				})),
+				{ label: "Back", value: "back" as const },
+			],
+		});
+
+		if (isCancel(choice) || choice === "back") {
+			return;
+		}
+		if ((await reviewGroup(choice, targetPath)) === "cancel") {
+			return;
+		}
+	}
+};

--- a/packages/nestjs-doctor/src/cli/interactive/menu.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/menu.ts
@@ -129,7 +129,7 @@ export const runInteractiveMenu = async (
 		}
 
 		if (choice === "review") {
-			await reviewFindings(context.result.diagnostics, context.targetPath);
+			await reviewFindings(shown.diagnostics, context.targetPath);
 		} else if (choice === "report") {
 			await openReport(context);
 		} else if (choice === "ci") {

--- a/packages/nestjs-doctor/src/cli/interactive/menu.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/menu.ts
@@ -5,6 +5,7 @@ import { buildMarkdownReport } from "../../formatters/markdown-report.js";
 import { openReportInBrowser, writeReportFile } from "../../report/output.js";
 import { ciWorkflowExists, installCiWorkflow } from "../ci-install.js";
 import { copyToClipboard } from "./clipboard.js";
+import { reviewFindings } from "./detail.js";
 
 interface InteractiveContext {
 	buildReportHtml: () => string;
@@ -13,7 +14,7 @@ interface InteractiveContext {
 	version: string;
 }
 
-type MenuAction = "report" | "ci" | "markdown" | "quit";
+type MenuAction = "review" | "report" | "ci" | "markdown" | "quit";
 
 const openReport = async (context: InteractiveContext): Promise<void> => {
 	const working = spinner();
@@ -90,6 +91,15 @@ export const runInteractiveMenu = async (
 		const choice = await select<MenuAction>({
 			message: "What next?",
 			options: [
+				...(findingCount > 0
+					? [
+							{
+								hint: "Finding by finding, with the code",
+								label: `Review ${findingCount} finding${findingCount === 1 ? "" : "s"}`,
+								value: "review" as const,
+							},
+						]
+					: []),
 				{
 					hint: `${findingCount} finding${findingCount === 1 ? "" : "s"} in an interactive page`,
 					label: "Open the HTML report",
@@ -118,7 +128,9 @@ export const runInteractiveMenu = async (
 			return;
 		}
 
-		if (choice === "report") {
+		if (choice === "review") {
+			await reviewFindings(context.result.diagnostics, context.targetPath);
+		} else if (choice === "report") {
 			await openReport(context);
 		} else if (choice === "ci") {
 			await addCiWorkflow(context);

--- a/packages/nestjs-doctor/tests/unit/interactive-detail.test.ts
+++ b/packages/nestjs-doctor/tests/unit/interactive-detail.test.ts
@@ -35,13 +35,13 @@ describe("renderCodeFrame", () => {
 	it("marks the offending line and no other", () => {
 		const marked = frame
 			.split("\n")
-			.filter((row) => row.replace(/\[\d+m/g, "").startsWith(">"));
+			.filter((row) => row.replace(/\x1b\[\d+m/g, "").startsWith(">"));
 		expect(marked).toHaveLength(1);
 		expect(marked[0]).toContain("findAll() {");
 	});
 
 	it("puts the caret under the column", () => {
-		const rows = frame.split("\n").map((row) => row.replace(/\[\d+m/g, ""));
+		const rows = frame.split("\n").map((row) => row.replace(/\x1b\[\d+m/g, ""));
 		const target = rows.findIndex((row) => row.startsWith(">"));
 		const caretRow = rows[target + 1];
 		const caretColumn = caretRow.indexOf("^");
@@ -50,7 +50,7 @@ describe("renderCodeFrame", () => {
 	});
 
 	it("keeps every gutter number right-aligned", () => {
-		const rows = frame.split("\n").map((row) => row.replace(/\[\d+m/g, ""));
+		const rows = frame.split("\n").map((row) => row.replace(/\x1b\[\d+m/g, ""));
 		const pipes = new Set(
 			rows.filter((row) => row.includes("|")).map((row) => row.indexOf("|"))
 		);

--- a/packages/nestjs-doctor/tests/unit/interactive-detail.test.ts
+++ b/packages/nestjs-doctor/tests/unit/interactive-detail.test.ts
@@ -9,6 +9,8 @@ import type {
 	Diagnostic,
 } from "../../src/common/diagnostic.js";
 
+const ANSI_RE = /\u001B\[[0-9;]*m/g;
+
 const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
 	category: "security",
 	column: 3,
@@ -35,13 +37,13 @@ describe("renderCodeFrame", () => {
 	it("marks the offending line and no other", () => {
 		const marked = frame
 			.split("\n")
-			.filter((row) => row.replace(/\x1b\[\d+m/g, "").startsWith(">"));
+			.filter((row) => row.replace(ANSI_RE, "").startsWith(">"));
 		expect(marked).toHaveLength(1);
 		expect(marked[0]).toContain("findAll() {");
 	});
 
 	it("puts the caret under the column", () => {
-		const rows = frame.split("\n").map((row) => row.replace(/\x1b\[\d+m/g, ""));
+		const rows = frame.split("\n").map((row) => row.replace(ANSI_RE, ""));
 		const target = rows.findIndex((row) => row.startsWith(">"));
 		const caretRow = rows[target + 1];
 		const caretColumn = caretRow.indexOf("^");
@@ -50,7 +52,7 @@ describe("renderCodeFrame", () => {
 	});
 
 	it("keeps every gutter number right-aligned", () => {
-		const rows = frame.split("\n").map((row) => row.replace(/\x1b\[\d+m/g, ""));
+		const rows = frame.split("\n").map((row) => row.replace(ANSI_RE, ""));
 		const pipes = new Set(
 			rows.filter((row) => row.includes("|")).map((row) => row.indexOf("|"))
 		);

--- a/packages/nestjs-doctor/tests/unit/interactive-detail.test.ts
+++ b/packages/nestjs-doctor/tests/unit/interactive-detail.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { renderCodeFrame } from "../../src/cli/interactive/code-frame.js";
+import {
+	buildFixPrompt,
+	groupFindings,
+} from "../../src/cli/interactive/detail.js";
+import type {
+	CodeDiagnostic,
+	Diagnostic,
+} from "../../src/common/diagnostic.js";
+
+const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
+	category: "security",
+	column: 3,
+	filePath: "/app/src/users.controller.ts",
+	help: "Add @UseGuards to the controller.",
+	line: 12,
+	message: "Endpoint has no guard.",
+	rule: "security/require-auth-guards",
+	severity: "warning",
+	...overrides,
+});
+
+describe("renderCodeFrame", () => {
+	const frame = renderCodeFrame(
+		[
+			{ line: 11, text: "@Get()" },
+			{ line: 12, text: "findAll() {" },
+			{ line: 13, text: "  return [];" },
+		],
+		12,
+		3
+	);
+
+	it("marks the offending line and no other", () => {
+		const marked = frame
+			.split("\n")
+			.filter((row) => row.replace(/\[\d+m/g, "").startsWith(">"));
+		expect(marked).toHaveLength(1);
+		expect(marked[0]).toContain("findAll() {");
+	});
+
+	it("puts the caret under the column", () => {
+		const rows = frame.split("\n").map((row) => row.replace(/\[\d+m/g, ""));
+		const target = rows.findIndex((row) => row.startsWith(">"));
+		const caretRow = rows[target + 1];
+		const caretColumn = caretRow.indexOf("^");
+		// "> 12 | " is 7 characters, then column 3 means 2 more.
+		expect(caretColumn).toBe(rows[target].indexOf("|") + 2 + 3 - 1);
+	});
+
+	it("keeps every gutter number right-aligned", () => {
+		const rows = frame.split("\n").map((row) => row.replace(/\[\d+m/g, ""));
+		const pipes = new Set(
+			rows.filter((row) => row.includes("|")).map((row) => row.indexOf("|"))
+		);
+		expect(pipes.size).toBe(1);
+	});
+});
+
+describe("groupFindings", () => {
+	it("orders by severity, then count, then rule id", () => {
+		const diagnostics: Diagnostic[] = [
+			code({ rule: "performance/b", severity: "info" }),
+			code({ rule: "correctness/a", severity: "error" }),
+			code({ rule: "security/c", severity: "warning" }),
+			code({ rule: "security/c", severity: "warning", line: 20 }),
+			code({ rule: "architecture/d", severity: "warning" }),
+		];
+		const groups = groupFindings(diagnostics);
+		expect(groups.map((group) => group.rule)).toEqual([
+			"correctness/a",
+			"security/c",
+			"architecture/d",
+			"performance/b",
+		]);
+		expect(groups[1].diagnostics).toHaveLength(2);
+	});
+});
+
+describe("buildFixPrompt", () => {
+	it("carries the rule, the locations, and the verification command", () => {
+		const prompt = buildFixPrompt(
+			{
+				diagnostics: [code({}), code({ line: 40, column: 1 })],
+				rule: "security/require-auth-guards",
+				severity: "warning",
+			},
+			"/app"
+		);
+		expect(prompt).toContain("security/require-auth-guards");
+		expect(prompt).toContain("/app/src/users.controller.ts:12:3");
+		expect(prompt).toContain("/app/src/users.controller.ts:40:1");
+		expect(prompt).toContain("do not suppress");
+		expect(prompt).toContain("npx nestjs-doctor@latest .");
+	});
+
+	it("caps the location list at ten and says how many more", () => {
+		const many = Array.from({ length: 14 }, (_, index) =>
+			code({ line: index + 1 })
+		);
+		const prompt = buildFixPrompt(
+			{ diagnostics: many, rule: "r/x", severity: "info" },
+			"/app"
+		);
+		expect(prompt.match(/^- \//gm)).toHaveLength(10);
+		expect(prompt).toContain("and 4 more");
+	});
+});

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -79,10 +79,14 @@ either stream.
 
 ## The menu
 
-A console scan in a terminal ends with a short menu: open the HTML report,
-scaffold the GitHub Actions workflow when it is missing, or copy the findings
-as markdown. The report comes from the scan that just ran, so nothing is
-scanned twice.
+A console scan in a terminal ends with a short menu: review the findings one
+by one, open the HTML report, scaffold the GitHub Actions workflow when it is
+missing, or copy the findings as markdown. The report comes from the scan that
+just ran, so nothing is scanned twice.
+
+Reviewing walks rule by rule, worst first. Each finding shows its code frame,
+the fix guidance, and the docs link, and one keystroke copies an agent-ready
+fix prompt for the whole rule.
 
 The menu never appears where it could hang a machine. It is skipped in CI,
 inside coding agents, in pipes, in `dumb` terminals, and in every mode other


### PR DESCRIPTION
## Context

Stacked on #262 (merge that first). The console report is deliberately lossy: it prints one message per rule group. Every diagnostic already carries an 11-line `sourceLines` window that only the HTML report used.

Stacked-PR note: `pull_request: branches: [main]` means this PR shows no checks at all until #262 merges and the base retargets — not a failure, just absent.

## Problem

Reading a finding in the terminal meant `--verbose` for file:line, then opening the file yourself. The per-diagnostic messages after the first were unreachable in every console mode.

## Possible flows

| Path | After |
|---|---|
| Menu → Review N findings | Rule list, worst severity first, count and first message per rule |
| Rule → finding pages | Real per-diagnostic messages, code frame from `sourceLines`, no file reads |
| Schema finding | Entity + guidance, no frame (no line exists) |
| Copy a fix prompt | Rule + guidance + up to 10 locations + re-verify command, to the clipboard |
| Custom rules | No docs link (nothing published to link) |
| Non-TTY / CI / machine formats | Unchanged, gate from #262 |

## Solution

Three additions inside the lazy interactive chunk: a pure ASCII code-frame renderer, a grouped finding browser (Next/Previous/Copy/Back), and a per-rule fix-prompt builder with the standing orders (root cause, no suppressions, re-verify). Grouping is by rule id, ordered severity → count → id.

## Before vs after

| | Before | After |
|---|---|---|
| Per-finding messages in the terminal | First per group only | All, paged |
| Code context in the terminal | None | `sourceLines` frame with marker and caret |
| Fix prompt | Hand-written | One keystroke, per rule |
| Console report, machine formats | Unchanged | Unchanged |

## Example

```
node dist/cli/index.mjs tests/fixtures/bad-security
```

Menu → Review 3 findings → `security/require-guards-on-endpoints (3)` → page 1/3 shows `orders.controller.ts:5:1`, the frame with `>  5 |   @Get()` marked, the guidance, and the docs link. Verified under a pty with expect; 6 new unit tests pin the frame geometry, group ordering, and prompt content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGVR6E5GSeEBp6fVGAc9CS