### PR TITLE
feat(cli): stream scan progress through the spinner

### DIFF
--- a/.changeset/interactive-scan-progress.md
+++ b/.changeset/interactive-scan-progress.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-The scan now shows live progress: the spinner animates instead of freezing on one frame, a progress bar fills through the parse and rule phases, and monorepo scans label each sub-project. The rule pass yields to the event loop between file batches, so terminal output streams during the scan instead of appearing all at once at the end.
+The scan now shows live progress: the spinner animates instead of freezing on one frame, a progress bar fills through the parse and rule phases, and monorepo scans label each sub-project. The rule pass yields to the event loop between file batches, so terminal output streams during the scan instead of appearing all at once at the end. Interactive runs now stop at the score box instead of dumping every finding; the menu owns the findings, and `--verbose` still prints them.

--- a/.changeset/interactive-scan-progress.md
+++ b/.changeset/interactive-scan-progress.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-The scan now shows live progress: the spinner animates instead of freezing on one frame, the text advances through parsing and rules with a per-file count, and monorepo scans label each sub-project. The rule pass yields to the event loop between file batches, so terminal output streams during the scan instead of appearing all at once at the end.
+The scan now shows live progress: the spinner animates instead of freezing on one frame, a progress bar fills through the parse and rule phases, and monorepo scans label each sub-project. The rule pass yields to the event loop between file batches, so terminal output streams during the scan instead of appearing all at once at the end.

--- a/.changeset/interactive-scan-progress.md
+++ b/.changeset/interactive-scan-progress.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+The scan now shows live progress: the spinner animates instead of freezing on one frame, the text advances through parsing and rules with a per-file count, and monorepo scans label each sub-project. The rule pass yields to the event loop between file batches, so terminal output streams during the scan instead of appearing all at once at the end.

--- a/.changeset/interactive-scan-progress.md
+++ b/.changeset/interactive-scan-progress.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-The scan now shows live progress: the spinner animates instead of freezing on one frame, a progress bar fills through the parse and rule phases, and monorepo scans label each sub-project. The rule pass yields to the event loop between file batches, so terminal output streams during the scan instead of appearing all at once at the end. Interactive runs now stop at the score box instead of dumping every finding; the menu owns the findings, and `--verbose` still prints them.
+The scan now shows live progress: the spinner animates instead of freezing on one frame, a progress bar fills through the parse, analysis and rule phases, and monorepo scans label each sub-project. The rule pass yields to the event loop between file batches, so terminal output streams during the scan instead of appearing all at once at the end. Interactive runs now stop at the score box instead of dumping every finding; the menu owns the findings, and `--verbose` still prints them.

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -167,7 +167,7 @@ export async function diagnose(
 	const targetPath = validatePath(path);
 	const scanConfig = await resolveScanConfig(targetPath, options.config);
 	const context = await buildAnalysisContext(targetPath, scanConfig);
-	const rawOutput = runDiagnosis(context);
+	const rawOutput = await runDiagnosis(context);
 	const { result } = buildResult(
 		context,
 		rawOutput,
@@ -197,7 +197,7 @@ export async function diagnoseMonorepo(
 
 	if (!monorepo) {
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = runDiagnosis(context);
+		const rawOutput = await runDiagnosis(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -99,6 +99,7 @@ export type {
 } from "../engine/rules/types.js";
 export type {
 	AnalysisContext,
+	AnalysisProgress,
 	AutoScanResult,
 	RawDiagnosticOutput,
 	ScanConfig,

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -99,6 +99,7 @@ export type {
 } from "../engine/rules/types.js";
 export type {
 	AnalysisContext,
+	AnalysisPhase,
 	AnalysisProgress,
 	AutoScanResult,
 	RawDiagnosticOutput,

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -99,7 +99,6 @@ export type {
 } from "../engine/rules/types.js";
 export type {
 	AnalysisContext,
-	AnalysisPhase,
 	AnalysisProgress,
 	AutoScanResult,
 	RawDiagnosticOutput,

--- a/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
@@ -232,7 +232,8 @@ const printDiagnostics = (
 
 export function printConsoleReport(
 	fullResult: DiagnoseResult,
-	verbose: boolean
+	verbose: boolean,
+	summaryOnly = false
 ): void {
 	const result = withSurface(fullResult, "cli");
 	const { score, diagnostics, project, summary, elapsedMs } = result;
@@ -334,7 +335,7 @@ export function printConsoleReport(
 	logger.dim(`  ${projectInfoParts.join(" | ")}`);
 	logger.break();
 
-	if (diagnostics.length === 0) {
+	if (diagnostics.length === 0 || summaryOnly) {
 		return;
 	}
 
@@ -359,10 +360,11 @@ export function printConsoleReport(
 
 export function printMonorepoReport(
 	monorepoResult: MonorepoResult,
-	verbose: boolean
+	verbose: boolean,
+	summaryOnly = false
 ): void {
 	// Print combined report first
-	printConsoleReport(monorepoResult.combined, verbose);
+	printConsoleReport(monorepoResult.combined, verbose, summaryOnly);
 
 	// Then print per-project summaries
 	logger.log("  Sub-project breakdown:");

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -65,9 +65,10 @@ async function scan(args: CliArgs): Promise<void> {
 	}
 
 	const { targetPath, options } = ctx;
+	options.interactive = canPrompt(options);
 
 	const runMenu = async (artifacts: InteractiveArtifacts) => {
-		if (!canPrompt(options)) {
+		if (!options.interactive) {
 			return;
 		}
 		const { runInteractiveMenu } = await import("./interactive/menu.js");

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -122,11 +122,13 @@ function emit(
 
 	// `console` and `github` still print the human-readable report; every other
 	// format replaces it.
+	// The menu owns the findings in an interactive run; --verbose still dumps.
+	const summaryOnly = options.interactive && !options.verbose;
 	if (options.format === "console" || options.format === "github") {
 		if (monorepo) {
-			printMonorepoReport(monorepo, options.verbose);
+			printMonorepoReport(monorepo, options.verbose, summaryOnly);
 		} else {
-			printConsoleReport(result, options.verbose);
+			printConsoleReport(result, options.verbose, summaryOnly);
 		}
 	}
 }

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -51,9 +51,24 @@ import {
 } from "./output.js";
 import type { PipelineOptions } from "./setup.js";
 import { logger } from "./ui/logger.js";
+import { renderProgressBar } from "./ui/progress-bar.js";
 import { spinner } from "./ui/spinner.js";
 
 type PipelineStep = () => void | Promise<void>;
+
+const analysisText = (
+	phase: "collecting" | "parsing" | "analyzing",
+	parsed?: number,
+	total?: number
+): string => {
+	if (phase === "collecting") {
+		return "Collecting files";
+	}
+	if (phase === "parsing") {
+		return `Parsing files ${renderProgressBar(parsed ?? 0, total ?? 0)}`;
+	}
+	return "Analyzing the project structure";
+};
 
 /** Handed to the post-scan menu so its actions reuse the finished scan. */
 export interface InteractiveArtifacts {
@@ -300,6 +315,8 @@ export class MonorepoPipeline extends ScanPipeline {
 		this.monorepo = monorepo;
 	}
 
+	private projectLabel = "";
+
 	buildContext(): this {
 		this.steps.push(() => {
 			this.scanStartTime = performance.now();
@@ -317,6 +334,7 @@ export class MonorepoPipeline extends ScanPipeline {
 					if (context.config?.telemetry === false) {
 						this.subProjectOptOut = true;
 					}
+					const label = this.projectLabel || name;
 					this.allFiles.push(...context.files);
 					for (const root of collectEntryModules(
 						context.astProject,
@@ -338,7 +356,7 @@ export class MonorepoPipeline extends ScanPipeline {
 					}
 					const rawOutput = await diagnose(context, (checked, total) => {
 						this.progress?.update(
-							`${name} — running rules (${checked}/${total} files)`
+							`${label} — running rules ${renderProgressBar(checked, total)}`
 						);
 					});
 					const scanResult = buildResult(context, rawOutput);
@@ -349,8 +367,12 @@ export class MonorepoPipeline extends ScanPipeline {
 					};
 				},
 				(name, index, total) => {
+					this.projectLabel = `${name} (${index}/${total})`;
+					this.progress?.update(`${this.projectLabel} — collecting files`);
+				},
+				(_name, phase, parsed, total) => {
 					this.progress?.update(
-						`${name} (${index}/${total}) — collecting and parsing files`
+						`${this.projectLabel} — ${analysisText(phase, parsed, total).toLowerCase()}`
 					);
 				}
 			);
@@ -450,10 +472,12 @@ export class SingleProjectPipeline extends ScanPipeline {
 
 	buildContext(): this {
 		this.steps.push(async () => {
-			this.progress?.update("Collecting and parsing files");
 			this.context = await buildAnalysisContext(
 				this.targetPath,
-				this.scanConfig
+				this.scanConfig,
+				(phase, parsed, total) => {
+					this.progress?.update(analysisText(phase, parsed, total));
+				}
 			);
 		});
 		return this;
@@ -462,7 +486,9 @@ export class SingleProjectPipeline extends ScanPipeline {
 	runRules(): this {
 		this.steps.push(async () => {
 			this.rawOutput = await diagnose(this.context, (checked, total) => {
-				this.progress?.update(`Running rules — ${checked}/${total} files`);
+				this.progress?.update(
+					`Running rules ${renderProgressBar(checked, total)}`
+				);
 			});
 		});
 		return this;

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -67,7 +67,10 @@ const analysisText = (
 	if (phase === "parsing") {
 		return `Parsing files ${renderProgressBar(parsed ?? 0, total ?? 0)}`;
 	}
-	return "Analyzing the project structure";
+	if (total) {
+		return `Analyzing the project ${renderProgressBar(parsed ?? 0, total)}`;
+	}
+	return "Analyzing the project";
 };
 
 /** Handed to the post-scan menu so its actions reuse the finished scan. */

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -13,6 +13,7 @@ import { withScopedDiagnostics } from "../engine/result-builder.js";
 import { allRules } from "../engine/rules/index.js";
 import {
 	type AnalysisContext,
+	type AnalysisPhase,
 	buildAnalysisContext,
 	buildMonorepoResult,
 	buildResult,
@@ -57,7 +58,7 @@ import { spinner } from "./ui/spinner.js";
 type PipelineStep = () => void | Promise<void>;
 
 const analysisText = (
-	phase: "collecting" | "parsing" | "analyzing",
+	phase: AnalysisPhase,
 	parsed?: number,
 	total?: number
 ): string => {

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -78,6 +78,8 @@ abstract class ScanPipeline {
 	protected readonly options: PipelineOptions;
 	protected resolvedMinimumScore: number | undefined;
 	protected scanConfig!: ScanConfig;
+	/** Live spinner handle while `run` is in flight; steps update its text. */
+	protected progress: { update(text: string): void } | null = null;
 	/** Set when any scanned sub-project declares its own opt-out. */
 	protected subProjectOptOut = false;
 	/** Warnings raised while narrowing the scope; surfaced alongside the report. */
@@ -185,6 +187,7 @@ abstract class ScanPipeline {
 			return result;
 		}
 
+		this.progress?.update("Comparing against the base revision");
 		const scope: ResolvedScope = resolveScope({
 			base: this.options.base,
 			changedFilesFrom: this.options.changedFilesFrom,
@@ -233,11 +236,13 @@ abstract class ScanPipeline {
 		const progress = this.options.isMachineReadable
 			? null
 			: spinner("Scanning...").start();
+		this.progress = progress;
 
 		for (const step of this.steps) {
 			await step();
 		}
 
+		this.progress = null;
 		progress?.succeed("Scan complete");
 	}
 }
@@ -308,7 +313,7 @@ export class MonorepoPipeline extends ScanPipeline {
 				this.targetPath,
 				this.scanConfig,
 				this.monorepo,
-				(name, context: AnalysisContext) => {
+				async (name, context: AnalysisContext) => {
 					if (context.config?.telemetry === false) {
 						this.subProjectOptOut = true;
 					}
@@ -331,12 +336,22 @@ export class MonorepoPipeline extends ScanPipeline {
 							})
 						);
 					}
-					const scanResult = buildResult(context, diagnose(context));
+					const rawOutput = await diagnose(context, (checked, total) => {
+						this.progress?.update(
+							`${name} — running rules (${checked}/${total} files)`
+						);
+					});
+					const scanResult = buildResult(context, rawOutput);
 					return {
 						...scanResult,
 						moduleGraph: detachModuleGraph(scanResult.moduleGraph),
 						providers: new Map(),
 					};
+				},
+				(name, index, total) => {
+					this.progress?.update(
+						`${name} (${index}/${total}) — collecting and parsing files`
+					);
 				}
 			);
 		});
@@ -435,6 +450,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 
 	buildContext(): this {
 		this.steps.push(async () => {
+			this.progress?.update("Collecting and parsing files");
 			this.context = await buildAnalysisContext(
 				this.targetPath,
 				this.scanConfig
@@ -444,8 +460,10 @@ export class SingleProjectPipeline extends ScanPipeline {
 	}
 
 	runRules(): this {
-		this.steps.push(() => {
-			this.rawOutput = diagnose(this.context);
+		this.steps.push(async () => {
+			this.rawOutput = await diagnose(this.context, (checked, total) => {
+				this.progress?.update(`Running rules — ${checked}/${total} files`);
+			});
 		});
 		return this;
 	}

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -94,7 +94,10 @@ abstract class ScanPipeline {
 	protected resolvedMinimumScore: number | undefined;
 	protected scanConfig!: ScanConfig;
 	/** Live spinner handle while `run` is in flight; steps update its text. */
-	protected progress: { update(text: string): void } | null = null;
+	protected progress: {
+		succeed(text: string): void;
+		update(text: string): void;
+	} | null = null;
 	/** Set when any scanned sub-project declares its own opt-out. */
 	protected subProjectOptOut = false;
 	/** Warnings raised while narrowing the scope; surfaced alongside the report. */
@@ -185,6 +188,7 @@ abstract class ScanPipeline {
 
 	warnCustomRules(): this {
 		this.steps.push(() => {
+			this.stopProgress();
 			displayCustomRuleWarnings(
 				this.scanConfig.customRuleWarnings,
 				this.options.isMachineReadable
@@ -247,18 +251,22 @@ abstract class ScanPipeline {
 		);
 	}
 
+	/** Ends the spinner so nothing prints through an active frame. */
+	protected stopProgress(): void {
+		this.progress?.succeed("Scan complete");
+		this.progress = null;
+	}
+
 	async run(): Promise<void> {
-		const progress = this.options.isMachineReadable
+		this.progress = this.options.isMachineReadable
 			? null
 			: spinner("Scanning...").start();
-		this.progress = progress;
 
 		for (const step of this.steps) {
 			await step();
 		}
 
-		this.progress = null;
-		progress?.succeed("Scan complete");
+		this.stopProgress();
 	}
 }
 

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -20,6 +20,8 @@ export interface PipelineOptions {
 	changedFilesFrom: string | undefined;
 	configPath: string | undefined;
 	format: OutputFormat;
+	/** True when the run ends in the menu; set after setup from `canPrompt`. */
+	interactive: boolean;
 	isMachineReadable: boolean;
 	json: boolean;
 	jsonCompact: boolean;
@@ -260,6 +262,7 @@ export class CliSetup {
 				changedFilesFrom: this.args["changed-files-from"],
 				configPath: this.args.config,
 				format,
+				interactive: false,
 				isMachineReadable,
 				json: format === "json",
 				jsonCompact: this.args["json-compact"] ?? false,

--- a/packages/nestjs-doctor/src/cli/ui/progress-bar.ts
+++ b/packages/nestjs-doctor/src/cli/ui/progress-bar.ts
@@ -1,0 +1,8 @@
+const BAR_WIDTH = 20;
+
+/** A fixed-width unicode bar with the running count: `████░░░… 132/354`. */
+export const renderProgressBar = (done: number, total: number): string => {
+	const filled =
+		total > 0 ? Math.min(BAR_WIDTH, Math.round((done / total) * BAR_WIDTH)) : 0;
+	return `${"█".repeat(filled)}${"░".repeat(BAR_WIDTH - filled)} ${done}/${total}`;
+};

--- a/packages/nestjs-doctor/src/cli/ui/spinner.ts
+++ b/packages/nestjs-doctor/src/cli/ui/spinner.ts
@@ -43,6 +43,11 @@ export const spinner = (text: string) => ({
 		return {
 			succeed: (displayText: string) => finalize("succeed", text, displayText),
 			fail: (displayText: string) => finalize("fail", text, displayText),
+			update: (displayText: string) => {
+				if (sharedInstance) {
+					sharedInstance.text = displayText;
+				}
+			},
 		};
 	},
 });

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -59,9 +59,11 @@ export interface AnalysisContext {
 	targetPath: string;
 }
 
-/** Reports where the context build is: `parsed`/`total` only during "parsing". */
+export type AnalysisPhase = "collecting" | "parsing" | "analyzing";
+
+/** Reports where the context build is. Counts come with "parsing" and "analyzing". */
 export type AnalysisProgress = (
-	phase: "collecting" | "parsing" | "analyzing",
+	phase: AnalysisPhase,
 	parsed?: number,
 	total?: number
 ) => void;
@@ -255,7 +257,7 @@ export async function reduceSubProjects<T>(
 	onProject?: (name: string, index: number, total: number) => void,
 	onAnalysis?: (
 		name: string,
-		phase: "collecting" | "parsing" | "analyzing",
+		phase: AnalysisPhase,
 		parsed?: number,
 		total?: number
 	) => void

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -39,6 +39,7 @@ import {
 	ormReadsFromTargetPath,
 	updateSchemaForFile,
 } from "./schema/extract.js";
+import { yieldToEventLoop } from "./yield.js";
 
 export interface AnalysisContext {
 	astProject: Project;
@@ -58,21 +59,41 @@ export interface AnalysisContext {
 	targetPath: string;
 }
 
+/** Reports where the context build is: `parsed`/`total` only during "parsing". */
+export type AnalysisProgress = (
+	phase: "collecting" | "parsing" | "analyzing",
+	parsed?: number,
+	total?: number
+) => void;
+
 export async function buildAnalysisContext(
 	targetPath: string,
-	scanConfig: ScanConfig
+	scanConfig: ScanConfig,
+	onProgress?: AnalysisProgress
 ): Promise<AnalysisContext> {
 	const { config, fileRules, projectRules, schemaRules } = scanConfig;
+	onProgress?.("collecting");
 	const [files, project] = await Promise.all([
 		collectFiles(targetPath, config),
 		detectProject(targetPath),
 	]);
 	const { aliases: pathAliases, baseUrl } = loadTsconfigResolution(targetPath);
-	const astProject = createAstParser(files, pathAliases, baseUrl);
+	const astProject = await createAstParser(
+		files,
+		pathAliases,
+		baseUrl,
+		(parsed, total) => onProgress?.("parsing", parsed, total)
+	);
+	onProgress?.("analyzing");
+	await yieldToEventLoop();
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
+	await yieldToEventLoop();
 	const providers = resolveProviders(astProject, files);
+	await yieldToEventLoop();
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);
+	await yieldToEventLoop();
 	const schemaGraph = extractSchema(astProject, files, project.orm, targetPath);
+	await yieldToEventLoop();
 
 	return {
 		astProject,
@@ -156,7 +177,8 @@ async function buildSubProjectContext(
 	monorepo: MonorepoInfo,
 	name: string,
 	files: string[],
-	rootSchemaFor: RootSchemaLookup
+	rootSchemaFor: RootSchemaLookup,
+	onProgress?: AnalysisProgress
 ): Promise<AnalysisContext> {
 	const { config: rootConfig, combinedRules } = scanConfig;
 	const projectPath = join(targetPath, monorepo.projects.get(name)!);
@@ -166,10 +188,20 @@ async function buildSubProjectContext(
 	]);
 
 	const { aliases: pathAliases, baseUrl } = loadTsconfigResolution(projectPath);
-	const astProject = createAstParser(files, pathAliases, baseUrl);
+	const astProject = await createAstParser(
+		files,
+		pathAliases,
+		baseUrl,
+		(parsed, total) => onProgress?.("parsing", parsed, total)
+	);
+	onProgress?.("analyzing");
+	await yieldToEventLoop();
 	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
+	await yieldToEventLoop();
 	const providers = resolveProviders(astProject, files);
+	await yieldToEventLoop();
 	const endpointGraph = buildEndpointGraph(astProject, files, providers);
+	await yieldToEventLoop();
 	let schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
 	// Falls back to the workspace root, where a monorepo usually keeps its schema.
 	if (
@@ -210,7 +242,13 @@ export async function reduceSubProjects<T>(
 	scanConfig: ScanConfig,
 	monorepo: MonorepoInfo,
 	consume: (name: string, context: AnalysisContext) => T | Promise<T>,
-	onProject?: (name: string, index: number, total: number) => void
+	onProject?: (name: string, index: number, total: number) => void,
+	onAnalysis?: (
+		name: string,
+		phase: "collecting" | "parsing" | "analyzing",
+		parsed?: number,
+		total?: number
+	) => void
 ): Promise<Map<string, T>> {
 	const filesByProject = await collectMonorepoFiles(
 		targetPath,
@@ -248,7 +286,8 @@ export async function reduceSubProjects<T>(
 			monorepo,
 			name,
 			files,
-			rootSchemaFor
+			rootSchemaFor,
+			(phase, parsed, total) => onAnalysis?.(name, phase, parsed, total)
 		);
 		results.set(name, await consume(name, context));
 	}

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -9,7 +9,7 @@ import { resolveScanConfig, type ScanConfig } from "./config/scan-config.js";
 import { collectFiles, collectMonorepoFiles } from "./file-collector.js";
 import { createAstParser } from "./graph/ast-parser.js";
 import {
-	buildEndpointGraph,
+	buildEndpointGraphWithProgress,
 	updateEndpointGraphForFile,
 } from "./graph/endpoint-graph.js";
 import {
@@ -90,7 +90,12 @@ export async function buildAnalysisContext(
 	await yieldToEventLoop();
 	const providers = resolveProviders(astProject, files);
 	await yieldToEventLoop();
-	const endpointGraph = buildEndpointGraph(astProject, files, providers);
+	const endpointGraph = await buildEndpointGraphWithProgress(
+		astProject,
+		files,
+		providers,
+		(traced, total) => onProgress?.("analyzing", traced, total)
+	);
 	await yieldToEventLoop();
 	const schemaGraph = extractSchema(astProject, files, project.orm, targetPath);
 	await yieldToEventLoop();
@@ -200,7 +205,12 @@ async function buildSubProjectContext(
 	await yieldToEventLoop();
 	const providers = resolveProviders(astProject, files);
 	await yieldToEventLoop();
-	const endpointGraph = buildEndpointGraph(astProject, files, providers);
+	const endpointGraph = await buildEndpointGraphWithProgress(
+		astProject,
+		files,
+		providers,
+		(traced, total) => onProgress?.("analyzing", traced, total)
+	);
 	await yieldToEventLoop();
 	let schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
 	// Falls back to the workspace root, where a monorepo usually keeps its schema.

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -209,7 +209,8 @@ export async function reduceSubProjects<T>(
 	targetPath: string,
 	scanConfig: ScanConfig,
 	monorepo: MonorepoInfo,
-	consume: (name: string, context: AnalysisContext) => T
+	consume: (name: string, context: AnalysisContext) => T | Promise<T>,
+	onProject?: (name: string, index: number, total: number) => void
 ): Promise<Map<string, T>> {
 	const filesByProject = await collectMonorepoFiles(
 		targetPath,
@@ -231,10 +232,16 @@ export async function reduceSubProjects<T>(
 	};
 
 	const results = new Map<string, T>();
+	const total = [...filesByProject.values()].filter(
+		(files) => files.length > 0
+	).length;
+	let index = 0;
 	for (const [name, files] of filesByProject) {
 		if (files.length === 0) {
 			continue;
 		}
+		index++;
+		onProject?.(name, index, total);
 		const context = await buildSubProjectContext(
 			targetPath,
 			scanConfig,
@@ -243,7 +250,7 @@ export async function reduceSubProjects<T>(
 			files,
 			rootSchemaFor
 		);
-		results.set(name, consume(name, context));
+		results.set(name, await consume(name, context));
 	}
 	return results;
 }

--- a/packages/nestjs-doctor/src/engine/baseline.ts
+++ b/packages/nestjs-doctor/src/engine/baseline.ts
@@ -28,13 +28,13 @@ async function scanBaseline(
 			baseTargetPath,
 			scanConfig,
 			monorepo,
-			(_name, context) => diagnose(context).diagnostics
+			async (_name, context) => (await diagnose(context)).diagnostics
 		);
 		return [...perProject.values()].flat();
 	}
 
 	const context = await buildAnalysisContext(baseTargetPath, scanConfig);
-	return diagnose(context).diagnostics;
+	return (await diagnose(context)).diagnostics;
 }
 
 /**

--- a/packages/nestjs-doctor/src/engine/diagnostician.ts
+++ b/packages/nestjs-doctor/src/engine/diagnostician.ts
@@ -16,6 +16,7 @@ import {
 	runProjectRules,
 	runSchemaRules,
 } from "./rule-runner.js";
+import { YIELD_INTERVAL, yieldToEventLoop } from "./yield.js";
 
 function formatRuleError(error: unknown): string {
 	if (error instanceof Error) {
@@ -255,12 +256,6 @@ export function checkSchema(context: AnalysisContext): {
 	const result = runSchemaRules(context.schemaGraph, context.schemaRules);
 	return processResults(result.diagnostics, result.errors, context);
 }
-
-// Yields to the event loop between batches so a spinner can repaint.
-const YIELD_INTERVAL = 25;
-
-const yieldToEventLoop = (): Promise<void> =>
-	new Promise((resolve) => setImmediate(resolve));
 
 export async function diagnose(
 	context: AnalysisContext,

--- a/packages/nestjs-doctor/src/engine/diagnostician.ts
+++ b/packages/nestjs-doctor/src/engine/diagnostician.ts
@@ -256,9 +256,37 @@ export function checkSchema(context: AnalysisContext): {
 	return processResults(result.diagnostics, result.errors, context);
 }
 
-export function diagnose(context: AnalysisContext): RawDiagnosticOutput {
+// Yields to the event loop between batches so a spinner can repaint.
+const YIELD_INTERVAL = 25;
+
+const yieldToEventLoop = (): Promise<void> =>
+	new Promise((resolve) => setImmediate(resolve));
+
+export async function diagnose(
+	context: AnalysisContext,
+	onFileChecked?: (checked: number, total: number) => void
+): Promise<RawDiagnosticOutput> {
 	const startTime = performance.now();
-	const fileResult = checkAllFiles(context);
+	const facts = fileRuleFacts(context);
+	const rawDiagnostics: Diagnostic[] = [];
+	const errors: { ruleId: string; error: unknown }[] = [];
+	const total = context.files.length;
+	for (let index = 0; index < total; index++) {
+		const result = runFileRules(
+			context.astProject,
+			[context.files[index]],
+			context.fileRules,
+			context.config,
+			facts
+		);
+		rawDiagnostics.push(...result.diagnostics);
+		errors.push(...result.errors);
+		onFileChecked?.(index + 1, total);
+		if ((index + 1) % YIELD_INTERVAL === 0) {
+			await yieldToEventLoop();
+		}
+	}
+	const fileResult = processResults(rawDiagnostics, errors, context);
 	const projectResult = checkProject(context);
 	const elapsedMs = performance.now() - startTime;
 	return {

--- a/packages/nestjs-doctor/src/engine/graph/ast-parser.ts
+++ b/packages/nestjs-doctor/src/engine/graph/ast-parser.ts
@@ -1,11 +1,13 @@
 import { Project } from "ts-morph";
+import { YIELD_INTERVAL, yieldToEventLoop } from "../yield.js";
 import type { PathAliasMap } from "./tsconfig-paths.js";
 
-export function createAstParser(
+export async function createAstParser(
 	files: string[],
 	pathAliases?: PathAliasMap,
-	baseUrl?: string
-): Project {
+	baseUrl?: string,
+	onFileParsed?: (parsed: number, total: number) => void
+): Promise<Project> {
 	const project = new Project({
 		compilerOptions: {
 			strict: true,
@@ -21,8 +23,12 @@ export function createAstParser(
 		skipAddingFilesFromTsConfig: true,
 	});
 
-	for (const file of files) {
-		project.addSourceFileAtPath(file);
+	for (let index = 0; index < files.length; index++) {
+		project.addSourceFileAtPath(files[index]);
+		onFileParsed?.(index + 1, files.length);
+		if ((index + 1) % YIELD_INTERVAL === 0) {
+			await yieldToEventLoop();
+		}
 	}
 
 	return project;

--- a/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
@@ -2043,13 +2043,7 @@ export function buildEndpointGraph(
 	files: string[],
 	providers: Map<string, ProviderInfo>
 ): EndpointGraph {
-	const endpoints: EndpointNode[] = [];
-
-	for (const traced of traceFiles(project, files, providers)) {
-		endpoints.push(...traced);
-	}
-
-	return { endpoints };
+	return { endpoints: [...traceFiles(project, files, providers)].flat() };
 }
 
 /** Same graph, yielding to the event loop after every file it traces. */
@@ -2060,12 +2054,11 @@ export async function buildEndpointGraphWithProgress(
 	onFile?: (traced: number, total: number) => void
 ): Promise<EndpointGraph> {
 	const endpoints: EndpointNode[] = [];
-	let index = 0;
+	let traced = 0;
 
-	for (const traced of traceFiles(project, files, providers)) {
-		endpoints.push(...traced);
-		index++;
-		onFile?.(index, files.length);
+	for (const fromFile of traceFiles(project, files, providers)) {
+		endpoints.push(...fromFile);
+		onFile?.(++traced, files.length);
 		await yieldToEventLoop();
 	}
 

--- a/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
@@ -2022,23 +2022,31 @@ function extractEndpointsFromFile(
 	return endpoints;
 }
 
+/** One file's endpoints at a time, over a cache shared across the walk. */
+function* traceFiles(
+	project: Project,
+	files: string[],
+	providers: Map<string, ProviderInfo>
+): Generator<EndpointNode[]> {
+	const cache = new ScanCache();
+
+	for (const filePath of files) {
+		const sourceFile = project.getSourceFile(filePath);
+		yield sourceFile
+			? extractEndpointsFromFile(sourceFile, filePath, providers, cache)
+			: [];
+	}
+}
+
 export function buildEndpointGraph(
 	project: Project,
 	files: string[],
 	providers: Map<string, ProviderInfo>
 ): EndpointGraph {
 	const endpoints: EndpointNode[] = [];
-	const cache = new ScanCache();
 
-	for (const filePath of files) {
-		const sourceFile = project.getSourceFile(filePath);
-		if (!sourceFile) {
-			continue;
-		}
-
-		endpoints.push(
-			...extractEndpointsFromFile(sourceFile, filePath, providers, cache)
-		);
+	for (const traced of traceFiles(project, files, providers)) {
+		endpoints.push(...traced);
 	}
 
 	return { endpoints };
@@ -2052,16 +2060,12 @@ export async function buildEndpointGraphWithProgress(
 	onFile?: (traced: number, total: number) => void
 ): Promise<EndpointGraph> {
 	const endpoints: EndpointNode[] = [];
-	const cache = new ScanCache();
+	let index = 0;
 
-	for (let index = 0; index < files.length; index++) {
-		const sourceFile = project.getSourceFile(files[index]);
-		if (sourceFile) {
-			endpoints.push(
-				...extractEndpointsFromFile(sourceFile, files[index], providers, cache)
-			);
-		}
-		onFile?.(index + 1, files.length);
+	for (const traced of traceFiles(project, files, providers)) {
+		endpoints.push(...traced);
+		index++;
+		onFile?.(index, files.length);
 		await yieldToEventLoop();
 	}
 

--- a/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/endpoint-graph.ts
@@ -29,6 +29,7 @@ import {
 	isController,
 	resolveDecoratorWrapper,
 } from "../nest-class-inspector.js";
+import { yieldToEventLoop } from "../yield.js";
 import { extractSimpleTypeName, type ProviderInfo } from "./type-resolver.js";
 
 const MAX_TRACE_DEPTH = 10;
@@ -2038,6 +2039,30 @@ export function buildEndpointGraph(
 		endpoints.push(
 			...extractEndpointsFromFile(sourceFile, filePath, providers, cache)
 		);
+	}
+
+	return { endpoints };
+}
+
+/** Same graph, yielding to the event loop after every file it traces. */
+export async function buildEndpointGraphWithProgress(
+	project: Project,
+	files: string[],
+	providers: Map<string, ProviderInfo>,
+	onFile?: (traced: number, total: number) => void
+): Promise<EndpointGraph> {
+	const endpoints: EndpointNode[] = [];
+	const cache = new ScanCache();
+
+	for (let index = 0; index < files.length; index++) {
+		const sourceFile = project.getSourceFile(files[index]);
+		if (sourceFile) {
+			endpoints.push(
+				...extractEndpointsFromFile(sourceFile, files[index], providers, cache)
+			);
+		}
+		onFile?.(index + 1, files.length);
+		await yieldToEventLoop();
 	}
 
 	return { endpoints };

--- a/packages/nestjs-doctor/src/engine/scanner.ts
+++ b/packages/nestjs-doctor/src/engine/scanner.ts
@@ -13,6 +13,7 @@ import {
 // biome-ignore lint/performance/noBarrelFile: re-exports preserve backward compatibility for all consumers
 export {
 	type AnalysisContext,
+	type AnalysisProgress,
 	buildAnalysisContext,
 	prepareAnalysis,
 	reduceSubProjects,

--- a/packages/nestjs-doctor/src/engine/scanner.ts
+++ b/packages/nestjs-doctor/src/engine/scanner.ts
@@ -56,8 +56,8 @@ export async function scanMonorepo(
 		targetPath,
 		scanConfig,
 		monorepo,
-		(_name, context) => {
-			const scanResult = buildResult(context, diagnose(context));
+		async (_name, context) => {
+			const scanResult = buildResult(context, await diagnose(context));
 			return {
 				...scanResult,
 				moduleGraph: detachModuleGraph(scanResult.moduleGraph),
@@ -84,7 +84,7 @@ export async function autoScan(
 		return { isMonorepo: true, monorepo: result };
 	}
 	const context = await buildAnalysisContext(targetPath, scanConfig);
-	const rawOutput = diagnose(context);
+	const rawOutput = await diagnose(context);
 	const result = buildResult(context, rawOutput, scanConfig.customRuleWarnings);
 	return { isMonorepo: false, single: result };
 }

--- a/packages/nestjs-doctor/src/engine/scanner.ts
+++ b/packages/nestjs-doctor/src/engine/scanner.ts
@@ -13,6 +13,7 @@ import {
 // biome-ignore lint/performance/noBarrelFile: re-exports preserve backward compatibility for all consumers
 export {
 	type AnalysisContext,
+	type AnalysisPhase,
 	type AnalysisProgress,
 	buildAnalysisContext,
 	prepareAnalysis,

--- a/packages/nestjs-doctor/src/engine/yield.ts
+++ b/packages/nestjs-doctor/src/engine/yield.ts
@@ -1,0 +1,5 @@
+// Yields to the event loop between work batches so a spinner can repaint.
+export const YIELD_INTERVAL = 25;
+
+export const yieldToEventLoop = (): Promise<void> =>
+	new Promise((resolve) => setImmediate(resolve));

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -117,8 +117,8 @@ export class SingleProjectReportPipeline extends ReportPipeline {
 	}
 
 	runRules(): this {
-		this.steps.push(() => {
-			this.rawOutput = diagnose(this.context);
+		this.steps.push(async () => {
+			this.rawOutput = await diagnose(this.context);
 		});
 		return this;
 	}
@@ -198,7 +198,7 @@ export class MonorepoReportPipeline extends ReportPipeline {
 				this.targetPath,
 				this.scanConfig,
 				this.monorepo,
-				(name, context: AnalysisContext) => {
+				async (name, context: AnalysisContext) => {
 					this.allFiles.push(...context.files);
 					for (const root of collectEntryModules(
 						context.astProject,
@@ -218,7 +218,7 @@ export class MonorepoReportPipeline extends ReportPipeline {
 							})
 						);
 					}
-					const scanResult = buildResult(context, diagnose(context));
+					const scanResult = buildResult(context, await diagnose(context));
 					return {
 						...scanResult,
 						moduleGraph: detachModuleGraph(scanResult.moduleGraph),

--- a/packages/nestjs-doctor/tests/integration/advisories.test.ts
+++ b/packages/nestjs-doctor/tests/integration/advisories.test.ts
@@ -30,7 +30,7 @@ describe("the vulnerable-deps fixture", () => {
 		const context = await buildAnalysisContext(FIXTURE, scanConfig);
 		result = buildResult(
 			context,
-			diagnose(context),
+			await diagnose(context),
 			scanConfig.customRuleWarnings
 		).result;
 		advisories = result.diagnostics.filter((d) =>
@@ -115,7 +115,7 @@ describe("what each surface sees of the fixture", () => {
 		const context = await buildAnalysisContext(FIXTURE, scanConfig);
 		result = buildResult(
 			context,
-			diagnose(context),
+			await diagnose(context),
 			scanConfig.customRuleWarnings
 		).result;
 	});

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -33,7 +33,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "basic-app/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -54,7 +54,7 @@ describe("scanner integration", () => {
 		const configFiles = context.files.filter((f) => f.endsWith(".config.ts"));
 		expect(configFiles).toHaveLength(0);
 
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -67,7 +67,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-practices/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -100,7 +100,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-practices/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -121,7 +121,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-practices/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -144,7 +144,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-practices/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -159,7 +159,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-architecture/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -197,7 +197,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-architecture/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -215,7 +215,7 @@ describe("scanner integration", () => {
 			const targetPath = resolve(fixtureRoot, "src");
 			const scanConfig = await resolveScanConfig(targetPath);
 			const context = await buildAnalysisContext(targetPath, scanConfig);
-			const rawOutput = diagnose(context);
+			const rawOutput = await diagnose(context);
 			const { result } = buildResult(
 				context,
 				rawOutput,
@@ -233,7 +233,7 @@ describe("scanner integration", () => {
 			const configPath = resolve(fixtureRoot, "nestjs-doctor.config.json");
 			const scanConfig = await resolveScanConfig(targetPath, configPath);
 			const context = await buildAnalysisContext(targetPath, scanConfig);
-			const rawOutput = diagnose(context);
+			const rawOutput = await diagnose(context);
 			const { result } = buildResult(
 				context,
 				rawOutput,
@@ -487,7 +487,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "config-disable-rules/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -513,7 +513,7 @@ describe("scanner integration", () => {
 		);
 		const scanConfig = await resolveScanConfig(targetPath, configPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -535,7 +535,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "graphql-app/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -572,7 +572,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "graphql-app/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -587,7 +587,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "dynamic-modules/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -614,7 +614,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "dynamic-modules/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -632,7 +632,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "cross-file-imports/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -664,7 +664,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "cross-file-monorepo/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -705,7 +705,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "cross-file-path-aliases/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -1100,7 +1100,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-correctness/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -1129,7 +1129,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-security/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -1151,7 +1151,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "bad-performance/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -1182,7 +1182,7 @@ describe("scanner integration", () => {
 		const targetPath = resolve(FIXTURES, "false-positives/src");
 		const scanConfig = await resolveScanConfig(targetPath);
 		const context = await buildAnalysisContext(targetPath, scanConfig);
-		const rawOutput = diagnose(context);
+		const rawOutput = await diagnose(context);
 		const { result } = buildResult(
 			context,
 			rawOutput,
@@ -1204,7 +1204,7 @@ describe("scanner integration", () => {
 		beforeAll(async () => {
 			const scanConfig = await resolveScanConfig(targetPath);
 			context = await buildAnalysisContext(targetPath, scanConfig);
-			const rawOutput = diagnose(context);
+			const rawOutput = await diagnose(context);
 			({ result } = buildResult(
 				context,
 				rawOutput,
@@ -1271,7 +1271,7 @@ describe("scanner integration", () => {
 		beforeAll(async () => {
 			const scanConfig = await resolveScanConfig(targetPath);
 			context = await buildAnalysisContext(targetPath, scanConfig);
-			const rawOutput = diagnose(context);
+			const rawOutput = await diagnose(context);
 			({ result } = buildResult(
 				context,
 				rawOutput,
@@ -1339,7 +1339,7 @@ describe("scanner integration", () => {
 		beforeAll(async () => {
 			const scanConfig = await resolveScanConfig(targetPath);
 			context = await buildAnalysisContext(targetPath, scanConfig);
-			const rawOutput = diagnose(context);
+			const rawOutput = await diagnose(context);
 			({ result } = buildResult(
 				context,
 				rawOutput,

--- a/packages/nestjs-doctor/tests/integration/global-guards.test.ts
+++ b/packages/nestjs-doctor/tests/integration/global-guards.test.ts
@@ -13,7 +13,7 @@ async function scan(fixture: string) {
 	const targetPath = resolve(FIXTURES, fixture);
 	const scanConfig = await resolveScanConfig(targetPath);
 	const context = await buildAnalysisContext(targetPath, scanConfig);
-	return { context, output: diagnose(context) };
+	return { context, output: await diagnose(context) };
 }
 
 describe("global guard detection", () => {

--- a/packages/nestjs-doctor/tests/integration/inline-suppressions.test.ts
+++ b/packages/nestjs-doctor/tests/integration/inline-suppressions.test.ts
@@ -15,7 +15,7 @@ async function analyze(fixture: string): Promise<Result> {
 	const targetPath = resolve(FIXTURES, fixture);
 	const scanConfig = await resolveScanConfig(targetPath);
 	const context = await buildAnalysisContext(targetPath, scanConfig);
-	const raw = diagnose(context);
+	const raw = await diagnose(context);
 	return buildResult(context, raw, scanConfig.customRuleWarnings).result;
 }
 

--- a/packages/nestjs-doctor/tests/integration/module-boundaries.test.ts
+++ b/packages/nestjs-doctor/tests/integration/module-boundaries.test.ts
@@ -13,7 +13,7 @@ async function boundaryFindings(fixture: string) {
 	const targetPath = resolve(FIXTURES, fixture);
 	const scanConfig = await resolveScanConfig(targetPath);
 	const context = await buildAnalysisContext(targetPath, scanConfig);
-	return diagnose(context).diagnostics.filter(
+	return (await diagnose(context)).diagnostics.filter(
 		(diagnostic) => diagnostic.rule === BOUNDARY_RULE
 	);
 }

--- a/packages/nestjs-doctor/tests/integration/schema-alias.test.ts
+++ b/packages/nestjs-doctor/tests/integration/schema-alias.test.ts
@@ -11,7 +11,7 @@ const FIXTURE = resolve(import.meta.dirname, "../fixtures/typeorm-alias-app");
 async function scan() {
 	const scanConfig = await resolveScanConfig(FIXTURE);
 	const context = await buildAnalysisContext(FIXTURE, scanConfig);
-	return { context, output: diagnose(context) };
+	return { context, output: await diagnose(context) };
 }
 
 describe("alias-imported base entities", () => {

--- a/packages/nestjs-doctor/tests/integration/scope.test.ts
+++ b/packages/nestjs-doctor/tests/integration/scope.test.ts
@@ -51,7 +51,7 @@ ${body}
 const scanHead = async (targetPath: string) => {
 	const scanConfig = await resolveScanConfig(targetPath);
 	const context = await buildAnalysisContext(targetPath, scanConfig);
-	return { diagnostics: diagnose(context).diagnostics, scanConfig };
+	return { diagnostics: (await diagnose(context)).diagnostics, scanConfig };
 };
 
 const rulesIn = (diagnostics: Diagnostic[]): string[] =>
@@ -272,11 +272,12 @@ describe("advisory findings under changed scope", () => {
 							root,
 							scanConfig,
 							info,
-							(_n, context) => diagnose(context).diagnostics
+							async (_n, context) => (await diagnose(context)).diagnostics
 						)
 					).values(),
 				].flat()
-			: diagnose(await buildAnalysisContext(root, scanConfig)).diagnostics;
+			: (await diagnose(await buildAnalysisContext(root, scanConfig)))
+					.diagnostics;
 		const scope = resolveScope({
 			mode: "changed",
 			targetPath: root,

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -84,6 +84,9 @@ by one, open the HTML report, scaffold the GitHub Actions workflow when it is
 missing, hand off to a coding agent, or copy the findings as markdown. The report comes from the scan that
 just ran, so nothing is scanned twice.
 
+An interactive run prints the score box and stops there. The findings list
+lives behind the review entry; pass `--verbose` to print it anyway.
+
 Reviewing walks rule by rule, worst first. Each finding shows its code frame,
 the fix guidance, and the docs link, and one keystroke copies an agent-ready
 fix prompt for the whole rule.


### PR DESCRIPTION
## Context

The interactive CLI (#262–#264) put the scan in front of a person watching a terminal. The scan runs ts-morph parsing and 49 rules as synchronous CPU work on the main thread.

## Problem

The spinner froze on its first frame and every line of output appeared at once when the scan finished. Synchronous work blocks the event loop, so ora's render timer never fired — a 10-second scan was indistinguishable from a hang. react-doctor does not have this problem because its heavy work (oxlint) runs in a separate process.

## Possible flows

| Path into `diagnose` | Affected |
|---|---|
| CLI single-project scan | Yes — per-file counts on the spinner |
| CLI monorepo scan | Yes — per-project labels plus per-file counts |
| `--scope changed` base-revision rescan | Labelled "Comparing against the base revision", no per-file ticks |
| `--report` pipeline | Awaits the async engine, keeps its own static spinner text |
| Public API `diagnose(path)` / `autoScan` | Already async, behaviour unchanged |
| LSP scan worker | Untouched — it calls the sync `checkAllFiles`, which did not change |

## Solution

- Engine `diagnose` (internal) is now async: it runs the file-rule loop itself, yields to the event loop every 25 files, and takes an optional per-file callback. Output order and content are byte-identical to before.
- `createAstParser` yields and reports per parsed file, and `buildAnalysisContext` yields between the graph phases and takes an optional progress callback (`AnalysisProgress`, additive third parameter on the public function, re-exported from the API).
- The endpoint trace — 5.3s of a 5.5s analysis phase on a 354-file project, while every other graph build took milliseconds — runs through an async variant that yields after every traced file and drives its own bar. The sync `buildEndpointGraph` stays for its ~90 existing callers.
- The shared spinner handle gained `update(text)`; it sets the live text without touching the overlap bookkeeping.
- The CLI pipeline renders a fixed-width bar through the parse and rule phases and names the rest: "Collecting files", "Analyzing the project structure", "Comparing against the base revision", with `apps/api (2/7)` prefixes in monorepos.
- `reduceSubProjects` accepts optional `onProject` and `onAnalysis` callbacks so the label leads each sub-project instead of trailing it.
- Interactive runs end the spinner before anything prints and stop at the framed score box: the menu's review entry owns the findings, `--verbose` still prints the full list, and non-interactive runs keep the dump.

Deliberately not done: per-file progress inside the four graph builders (four more signatures for phases that yield between each other already), and per-diagnostic live counts (they fire before suppression filtering, so the number would tick up and then drop).

## Before vs after

| | Before | After |
|---|---|---|
| Spinner during scan | One frozen frame | Animates from the first parsed file |
| Spinner text | "Scanning..." throughout | Progress bar through parse and rules, phase names elsewhere |
| Output | Everything at once at the end | Streams as phases finish |
| Interactive console run | Full findings dump, then the menu | Score box, then the menu; `--verbose` restores the dump |
| `--json` / `--score` | No spinner | No spinner (unchanged) |
| `checkAllFiles` public API | Sync | Sync (unchanged) |
| `elapsedMs` in results | Pure rule time | Includes the yields, a few ms on hundreds of files |

## Example

`node dist/cli/index.mjs ~/RoloBits/crocova/apps/api` (354 files, real pty)

Before: `⠋ Scanning...` frozen for ~7s, then the report, gate, and menu burst out together.

After, captured from the pty log — the glyph cycles and the bar fills from the start:

```
⠙ Parsing files ███░░░░░░░░░░░░░░░░░ 50/354
⠸ Parsing files ████████████████░░░░ 275/354
⠹ Analyzing the project ████████░░░░░░░░░░░░ 134/354
⠴ Running rules █░░░░░░░░░░░░░░░░░░░ 25/354
⠹ Running rules ██████████████░░░░░░ 250/354
⠴ Running rules ████████████████████ 354/354
✔ Scan complete
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
