### PR TITLE
feat(cli): report anonymous rule counts after a scan

### DIFF
--- a/.changeset/clear-mammals-wish.md
+++ b/.changeset/clear-mammals-wish.md
@@ -1,0 +1,6 @@
+---
+"nestjs-doctor": patch
+---
+
+Trim the report telemetry notes to one sentence on the report docs page. The
+README and the CLI flag tables no longer carry them.

--- a/.changeset/nestjs-advisory-rules.md
+++ b/.changeset/nestjs-advisory-rules.md
@@ -40,7 +40,7 @@ critical in `@nestjs/devtools-integration`, four high across
 what the shipped table is missing. It is a maintenance command, never part of a
 scan.
 
-A scan still makes no network call. The cost is that the list is only as fresh
+The check never queries an advisory service. The cost is that the list is only as fresh
 as the release, so `npx nestjs-doctor@latest` knows the most.
 
 `package.json` takes no comments, so no inline directive can silence these.

--- a/.changeset/ninety-lights-create.md
+++ b/.changeset/ninety-lights-create.md
@@ -1,0 +1,15 @@
+---
+"nestjs-doctor": minor
+---
+
+A scan now reports anonymous counts of which built-in rules fired, were
+disabled, or threw, plus the score, file count, duration, platform, and how many
+custom rules loaded. Rule ids come from the built-in set only: no code, no file
+paths, no project name, and no custom rule names ever travel.
+
+Reporting is best-effort and never blocks — it cannot change a score, a
+diagnostic, or an exit code, and a scan that exits first simply loses the event.
+
+`--no-telemetry` turns it off, as does `telemetry: false` in the config file or
+`DO_NOT_TRACK=1` in the environment. The same flag also removes the HTML
+report's beacon.

--- a/.claude/skills/nestjs-doctor/SKILL.md
+++ b/.claude/skills/nestjs-doctor/SKILL.md
@@ -9,7 +9,8 @@ allowed-tools: Bash, Read, Edit, Glob, Grep, Write
 > v0.8.0
 
 52 rules over security, correctness, architecture, performance, and database
-schema, scored 0-100. No network calls and no model at scan time, so the same
+schema, scored 0-100. No model at scan time and nothing about your code leaves
+the machine, so the same
 commit scores the same on a laptop and in CI.
 
 ## After changing NestJS code

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -22,9 +22,14 @@ An opinionated rule set for an opinionated framework. nestjs-doctor scans your
 codebase and reports findings across security, correctness, architecture,
 performance, and schema, then scores it 0-100.
 
-No AI at scan time and no network calls. The same commit scores the same on your
-laptop and in CI. Reads schemas from Prisma, TypeORM, Drizzle and MikroORM, and
-handles monorepos.
+No AI at scan time, and nothing about your code leaves the machine. The same
+commit scores the same on your laptop and in CI. Reads schemas from Prisma,
+TypeORM, Drizzle and MikroORM, and handles monorepos.
+
+A scan reports anonymous counts of which built-in rules fired, so the rule set
+can be improved. No code, no file paths, no project or custom rule names.
+`--no-telemetry`, `telemetry: false` in the config, or `DO_NOT_TRACK=1` turns it
+off.
 
 [Website →](https://nestjs.doctor/docs)
 

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -55,9 +55,6 @@ summary, findings with a code viewer, and an interactive module
 graph. Traced HTTP endpoints, the schema ER diagram, and a
 rule playground get their own tabs.
 
-Opening it reports which tab was viewed, and nothing about the scanned code.
-`--no-telemetry` leaves that out of the file.
-
 ![Module Graph](https://nestjs.doctor/module-graph.png)
 
 Add a few lines to `main.ts`, boot once, and `--timings` overlays the real

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -26,11 +26,6 @@ No AI at scan time, and nothing about your code leaves the machine. The same
 commit scores the same on your laptop and in CI. Reads schemas from Prisma,
 TypeORM, Drizzle and MikroORM, and handles monorepos.
 
-A scan reports anonymous counts of which built-in rules fired, so the rule set
-can be improved. No code, no file paths, no project or custom rule names.
-`--no-telemetry`, `telemetry: false` in the config, or `DO_NOT_TRACK=1` turns it
-off.
-
 [Website →](https://nestjs.doctor/docs)
 
 ## Install

--- a/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
@@ -9,7 +9,8 @@ allowed-tools: Bash, Read, Edit, Glob, Grep, Write
 > v0.0.0
 
 52 rules over security, correctness, architecture, performance, and database
-schema, scored 0-100. No network calls and no model at scan time, so the same
+schema, scored 0-100. No model at scan time and nothing about your code leaves
+the machine, so the same
 commit scores the same on a laptop and in CI.
 
 ## After changing NestJS code

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -74,9 +74,9 @@ export const flags = {
 	telemetry: {
 		type: "boolean",
 		description:
-			"Embed the anonymous interaction beacon in the HTML report (which tab was opened, and nothing about the scanned code)",
+			"Report anonymous rule counts after a scan, and embed the tab-interaction beacon in the HTML report. Neither carries anything about the scanned code",
 		negativeDescription:
-			"Generate the HTML report without the interaction beacon",
+			"Scan and generate the report without reporting anything",
 		default: true,
 	},
 	timings: {

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -7,6 +7,7 @@ import { detachModuleGraph } from "../engine/graph/module-graph.js";
 import { pruneCrossProjectOrphans } from "../engine/orphan-prune.js";
 import type { MonorepoInfo } from "../engine/project-detector.js";
 import { withScopedDiagnostics } from "../engine/result-builder.js";
+import { allRules } from "../engine/rules/index.js";
 import {
 	type AnalysisContext,
 	buildAnalysisContext,
@@ -26,8 +27,15 @@ import {
 	type ResolvedScope,
 	resolveScope,
 } from "../engine/scope.js";
+import { generatedIn } from "../telemetry/environment.js";
+import { buildScanPayload } from "../telemetry/scan-telemetry.js";
+import { scanTelemetryEnabled, sendScanTelemetry } from "../telemetry/send.js";
 import { resolveMinScore } from "./min-score.js";
-import { outputMonorepoResults, outputSingleProjectResults } from "./output.js";
+import {
+	getCliVersion,
+	outputMonorepoResults,
+	outputSingleProjectResults,
+} from "./output.js";
 import type { PipelineOptions } from "./setup.js";
 import { logger } from "./ui/logger.js";
 import { spinner } from "./ui/spinner.js";
@@ -59,6 +67,52 @@ abstract class ScanPipeline {
 	constructor(targetPath: string, options: PipelineOptions) {
 		this.targetPath = targetPath;
 		this.options = options;
+	}
+
+	/**
+	 * Reports anonymous rule counts. Reads only rule ids and severities, and
+	 * never blocks: a failure here leaves the scan untouched.
+	 */
+	protected reportScan(
+		diagnostics: Diagnostic[],
+		result: DiagnoseResult,
+		fileCount: number,
+		monorepo: boolean
+	): void {
+		if (
+			!scanTelemetryEnabled(this.options.telemetry, this.scanConfig?.config)
+		) {
+			return;
+		}
+		try {
+			const enabled = new Set(
+				[
+					...this.scanConfig.fileRules,
+					...this.scanConfig.projectRules,
+					...this.scanConfig.schemaRules,
+				].map((rule) => rule.meta.id)
+			);
+			sendScanTelemetry(
+				buildScanPayload({
+					customRulesLoaded: this.scanConfig.combinedRules.filter((rule) =>
+						rule.meta.id.startsWith("custom/")
+					).length,
+					diagnostics,
+					disabledRuleIds: allRules
+						.map((rule) => rule.meta.id)
+						.filter((id) => !enabled.has(id)),
+					elapsedMs: result.elapsedMs,
+					fileCount,
+					monorepo,
+					ruleErrors: result.ruleErrors,
+					score: result.score,
+					source: generatedIn(),
+					version: getCliVersion(),
+				})
+			);
+		} catch {
+			// Reporting never breaks a scan.
+		}
 	}
 
 	abstract applyScope(): this;
@@ -230,6 +284,14 @@ export class MonorepoPipeline extends ScanPipeline {
 				this.scanConfig.customRuleWarnings,
 				totalElapsedMs
 			);
+			// Before applyScope, which narrows `diagnostics` in place.
+			const combined = this.result.result.combined;
+			this.reportScan(
+				combined.diagnostics,
+				combined,
+				combined.project.fileCount,
+				true
+			);
 		});
 		return this;
 	}
@@ -305,6 +367,13 @@ export class SingleProjectPipeline extends ScanPipeline {
 				this.context,
 				this.rawOutput,
 				this.scanConfig.customRuleWarnings
+			);
+			// Before applyScope, which narrows `diagnostics` in place.
+			this.reportScan(
+				this.rawOutput.diagnostics,
+				this.result.result,
+				this.context.files.length,
+				false
 			);
 		});
 		return this;

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -28,6 +28,7 @@ export interface PipelineOptions {
 	scope: ScopeMode;
 	score: boolean;
 	staged: boolean;
+	telemetry: boolean;
 	verbose: boolean;
 }
 
@@ -267,6 +268,7 @@ export class CliSetup {
 				scope: resolveScopeMode(this.args),
 				score,
 				staged: this.args.staged ?? false,
+				telemetry: this.args.telemetry ?? true,
 				verbose: this.args.verbose ?? false,
 			},
 		};

--- a/packages/nestjs-doctor/src/common/config.ts
+++ b/packages/nestjs-doctor/src/common/config.ts
@@ -27,6 +27,8 @@ export interface NestjsDoctorConfig {
 	minScore?: number;
 	report?: NestjsDoctorReportConfig;
 	rules?: Record<string, RuleOverride | boolean>;
+	/** Set false to stop a scan reporting anonymous rule counts. */
+	telemetry?: boolean;
 }
 
 export const DEFAULT_CONFIG: NestjsDoctorConfig = {

--- a/packages/nestjs-doctor/src/common/config.ts
+++ b/packages/nestjs-doctor/src/common/config.ts
@@ -27,7 +27,6 @@ export interface NestjsDoctorConfig {
 	minScore?: number;
 	report?: NestjsDoctorReportConfig;
 	rules?: Record<string, RuleOverride | boolean>;
-	/** Set false to stop a scan reporting anonymous rule counts. */
 	telemetry?: boolean;
 }
 

--- a/packages/nestjs-doctor/src/report/ui/telemetry.ts
+++ b/packages/nestjs-doctor/src/report/ui/telemetry.ts
@@ -3,20 +3,39 @@
 const POSTHOG_KEY = "";
 const POSTHOG_HOST = "https://us.i.posthog.com";
 
+/** Any value other than the shell's own "off" spellings counts as set. */
+const isSet = (value: string | undefined): boolean =>
+	value !== undefined && value !== "" && value !== "0" && value !== "false";
+
+/**
+ * Where the report was generated, stamped at generation time. A CI machine
+ * opens no browser, so a `ci` event is one a person opened after downloading.
+ */
+export function generatedIn(
+	env: NodeJS.ProcessEnv = process.env
+): "ci" | "cli" {
+	return isSet(env.CI) || isSet(env.GITHUB_ACTIONS) ? "ci" : "cli";
+}
+
 /**
  * Inline beacon for the generated report. Posts two fixed events and reads
  * nothing from the page, so no path, project name, or source text can leave.
  */
 export function getTelemetryScript(version: string): string {
-	return POSTHOG_KEY ? buildBeacon(POSTHOG_KEY, version) : "";
+	return POSTHOG_KEY ? buildBeacon(POSTHOG_KEY, version, generatedIn()) : "";
 }
 
-export function buildBeacon(key: string, version: string): string {
+export function buildBeacon(
+	key: string,
+	version: string,
+	source: "ci" | "cli"
+): string {
 	return `<script>
 (function () {
   var KEY = ${JSON.stringify(key)};
   var URL = ${JSON.stringify(`${POSTHOG_HOST}/e/`)};
   var VERSION = ${JSON.stringify(version)};
+  var SOURCE = ${JSON.stringify(source)};
   var SECTIONS = ["summary", "diagnosis", "modules", "endpoints", "schema", "lab"];
   var id;
   try {
@@ -26,7 +45,11 @@ export function buildBeacon(key: string, version: string): string {
   }
 
   function send(event, section) {
-    var props = { $current_url: "report://local", version: VERSION };
+    var props = {
+      $current_url: "report://local",
+      version: VERSION,
+      generated_in: SOURCE,
+    };
     if (section) {
       props.section = section;
     }

--- a/packages/nestjs-doctor/src/report/ui/telemetry.ts
+++ b/packages/nestjs-doctor/src/report/ui/telemetry.ts
@@ -1,21 +1,9 @@
+import { generatedIn } from "../../telemetry/environment.js";
+
 // PostHog project key. Empty disables the beacon: no key, no snippet, no
 // requests. Set it to turn report telemetry on for published builds.
 const POSTHOG_KEY = "";
 const POSTHOG_HOST = "https://us.i.posthog.com";
-
-/** Any value other than the shell's own "off" spellings counts as set. */
-const isSet = (value: string | undefined): boolean =>
-	value !== undefined && value !== "" && value !== "0" && value !== "false";
-
-/**
- * Where the report was generated, stamped at generation time. A CI machine
- * opens no browser, so a `ci` event is one a person opened after downloading.
- */
-export function generatedIn(
-	env: NodeJS.ProcessEnv = process.env
-): "ci" | "cli" {
-	return isSet(env.CI) || isSet(env.GITHUB_ACTIONS) ? "ci" : "cli";
-}
 
 /**
  * Inline beacon for the generated report. Posts two fixed events and reads

--- a/packages/nestjs-doctor/src/telemetry/environment.ts
+++ b/packages/nestjs-doctor/src/telemetry/environment.ts
@@ -1,0 +1,13 @@
+/** Any value other than the shell's own "off" spellings counts as set. */
+export const isSet = (value: string | undefined): boolean =>
+	value !== undefined && value !== "" && value !== "0" && value !== "false";
+
+/**
+ * Where the scan ran. For a report this is stamped at generation time: a CI
+ * machine opens no browser, so a `ci` event is one a person opened later.
+ */
+export function generatedIn(
+	env: NodeJS.ProcessEnv = process.env
+): "ci" | "cli" {
+	return isSet(env.CI) || isSet(env.GITHUB_ACTIONS) ? "ci" : "cli";
+}

--- a/packages/nestjs-doctor/src/telemetry/scan-telemetry.ts
+++ b/packages/nestjs-doctor/src/telemetry/scan-telemetry.ts
@@ -1,0 +1,88 @@
+import type { Diagnostic } from "../common/diagnostic.js";
+import type { RuleErrorInfo, Score } from "../common/result.js";
+import { allRules } from "../engine/rules/index.js";
+
+/**
+ * Every rule id the payload may name. A custom rule's id is a string its author
+ * wrote, so anything outside this set is counted but never named.
+ */
+const BUILT_IN_RULE_IDS: ReadonlySet<string> = new Set(
+	allRules.map((rule) => rule.meta.id)
+);
+
+export interface ScanFacts {
+	customRulesLoaded: number;
+	diagnostics: Diagnostic[];
+	disabledRuleIds: string[];
+	elapsedMs: number;
+	fileCount: number;
+	monorepo: boolean;
+	ruleErrors: RuleErrorInfo[];
+	score: Score;
+	source: "ci" | "cli";
+	version: string;
+}
+
+export interface ScanPayload {
+	custom_rules_loaded: number;
+	duration_ms: number;
+	file_count: number;
+	findings: Record<string, Record<string, number>>;
+	generated_in: "ci" | "cli";
+	monorepo: boolean;
+	node_major: number;
+	platform: string;
+	rule_errors: string[];
+	rules_disabled: string[];
+	rules_with_findings: number;
+	score: number;
+	version: string;
+}
+
+const NODE_VERSION_PREFIX_RE = /^v/;
+
+const builtInOnly = (ids: Iterable<string>): string[] =>
+	[...new Set([...ids].filter((id) => BUILT_IN_RULE_IDS.has(id)))].sort();
+
+/**
+ * Builds the scan payload. Reads only rule ids and severities, both of which
+ * come from rule metadata rather than the scanned code, so no path, source
+ * line, project name, or custom rule name can reach it.
+ */
+export function buildScanPayload(
+	facts: ScanFacts,
+	nodeVersion: string = process.version,
+	platform: string = process.platform
+): ScanPayload {
+	const findings: Record<string, Record<string, number>> = {};
+	for (const diagnostic of facts.diagnostics) {
+		if (!BUILT_IN_RULE_IDS.has(diagnostic.rule)) {
+			continue;
+		}
+		const bySeverity = findings[diagnostic.rule] ?? {};
+		bySeverity[diagnostic.severity] =
+			(bySeverity[diagnostic.severity] ?? 0) + 1;
+		findings[diagnostic.rule] = bySeverity;
+	}
+
+	return {
+		custom_rules_loaded: facts.customRulesLoaded,
+		duration_ms: Math.round(facts.elapsedMs),
+		file_count: facts.fileCount,
+		findings,
+		generated_in: facts.source,
+		monorepo: facts.monorepo,
+		node_major: Number.parseInt(
+			nodeVersion.replace(NODE_VERSION_PREFIX_RE, ""),
+			10
+		),
+		platform,
+		// Rule ids only. `RuleErrorInfo.error` is a raw thrown message and
+		// routinely quotes the source file that broke the rule.
+		rule_errors: builtInOnly(facts.ruleErrors.map((e) => e.ruleId)),
+		rules_disabled: builtInOnly(facts.disabledRuleIds),
+		rules_with_findings: Object.keys(findings).length,
+		score: facts.score.value,
+		version: facts.version,
+	};
+}

--- a/packages/nestjs-doctor/src/telemetry/send.ts
+++ b/packages/nestjs-doctor/src/telemetry/send.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "node:crypto";
+import type { NestjsDoctorConfig } from "../common/config.js";
+import { isSet } from "./environment.js";
+import type { ScanPayload } from "./scan-telemetry.js";
+
+// Same project as the report beacon. Empty disables scan telemetry entirely:
+// no key, no request.
+const POSTHOG_KEY = "";
+const POSTHOG_HOST = "https://us.i.posthog.com";
+const TIMEOUT_MS = 1500;
+
+/**
+ * Whether a scan may report. The flag and the config key each disable it on
+ * their own, as does the cross-tool DO_NOT_TRACK convention.
+ */
+export function scanTelemetryEnabled(
+	flag: boolean,
+	config: NestjsDoctorConfig | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+	key: string = POSTHOG_KEY
+): boolean {
+	if (!(flag && key)) {
+		return false;
+	}
+	if (isSet(env.DO_NOT_TRACK)) {
+		return false;
+	}
+	return config?.telemetry !== false;
+}
+
+/**
+ * Posts the payload without awaiting it and without holding the process open,
+ * so a slow or blocked network cannot delay a scan or a pre-commit hook. A
+ * scan that exits first simply loses the event.
+ */
+export function sendScanTelemetry(payload: ScanPayload): void {
+	if (!POSTHOG_KEY) {
+		return;
+	}
+
+	try {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+		timer.unref?.();
+
+		fetch(`${POSTHOG_HOST}/e/`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			signal: controller.signal,
+			body: JSON.stringify({
+				api_key: POSTHOG_KEY,
+				event: "scan_completed",
+				distinct_id: randomUUID(),
+				properties: payload,
+			}),
+		})
+			.catch(() => {
+				// Reporting is best-effort; a scan never fails because of it.
+			})
+			.finally(() => clearTimeout(timer));
+	} catch {
+		// Same: an environment without fetch reports nothing and scans fine.
+	}
+}

--- a/packages/nestjs-doctor/tests/unit/report-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-telemetry.test.ts
@@ -4,6 +4,7 @@ import type { ModuleGraph } from "../../src/engine/graph/module-graph.js";
 import { buildHtmlReport } from "../../src/report/html-report.js";
 import {
 	buildBeacon,
+	generatedIn,
 	getTelemetryScript,
 } from "../../src/report/ui/telemetry.js";
 
@@ -62,7 +63,7 @@ describe("report telemetry", () => {
 	});
 
 	it("reads nothing off the page that could carry project data", () => {
-		const script = buildBeacon("phc_key", "1.2.3");
+		const script = buildBeacon("phc_key", "1.2.3", "cli");
 
 		expect(script).toContain("report://local");
 		// The report's file:// URL holds the user's directory tree and project
@@ -75,7 +76,7 @@ describe("report telemetry", () => {
 	});
 
 	it("posts only the two fixed events and a known section", () => {
-		const script = buildBeacon("phc_key", "1.2.3");
+		const script = buildBeacon("phc_key", "1.2.3", "cli");
 
 		expect(script).toContain("report_opened");
 		expect(script).toContain("report_section_viewed");
@@ -83,5 +84,25 @@ describe("report telemetry", () => {
 			'["summary", "diagnosis", "modules", "endpoints", "schema", "lab"]'
 		);
 		expect(script).toContain('"1.2.3"');
+	});
+
+	it("stamps where the report was generated", () => {
+		expect(buildBeacon("phc_key", "1.2.3", "ci")).toContain(
+			'var SOURCE = "ci"'
+		);
+		expect(buildBeacon("phc_key", "1.2.3", "cli")).toContain(
+			'var SOURCE = "cli"'
+		);
+	});
+
+	it("reads CI from the environment, ignoring its off spellings", () => {
+		expect(generatedIn({ CI: "true" })).toBe("ci");
+		expect(generatedIn({ CI: "1" })).toBe("ci");
+		expect(generatedIn({ GITHUB_ACTIONS: "true" })).toBe("ci");
+		// Set-but-off is how some shells and runners spell "not CI".
+		expect(generatedIn({ CI: "false" })).toBe("cli");
+		expect(generatedIn({ CI: "0" })).toBe("cli");
+		expect(generatedIn({ CI: "" })).toBe("cli");
+		expect(generatedIn({})).toBe("cli");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-telemetry.test.ts
@@ -4,9 +4,9 @@ import type { ModuleGraph } from "../../src/engine/graph/module-graph.js";
 import { buildHtmlReport } from "../../src/report/html-report.js";
 import {
 	buildBeacon,
-	generatedIn,
 	getTelemetryScript,
 } from "../../src/report/ui/telemetry.js";
+import { generatedIn } from "../../src/telemetry/environment.js";
 
 const emptyGraph = (): ModuleGraph => ({
 	edges: new Map(),

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { CodeDiagnostic } from "../../src/common/diagnostic.js";
+import type { Score } from "../../src/common/result.js";
+import {
+	buildScanPayload,
+	type ScanFacts,
+} from "../../src/telemetry/scan-telemetry.js";
+import { scanTelemetryEnabled } from "../../src/telemetry/send.js";
+
+const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
+	rule: "performance/no-unused-providers",
+	category: "performance",
+	severity: "warning",
+	filePath: "/Users/someone/acme-billing/src/a.service.ts",
+	message: "Provider is never injected.",
+	help: "Remove it.",
+	line: 3,
+	column: 1,
+	...overrides,
+});
+
+const facts = (overrides: Partial<ScanFacts> = {}): ScanFacts => ({
+	customRulesLoaded: 0,
+	diagnostics: [],
+	disabledRuleIds: [],
+	elapsedMs: 12.7,
+	fileCount: 4,
+	monorepo: false,
+	ruleErrors: [],
+	score: { value: 90, label: "Excellent" } as Score,
+	source: "cli",
+	version: "1.2.3",
+	...overrides,
+});
+
+describe("scan telemetry payload", () => {
+	it("counts findings per built-in rule and severity", () => {
+		const payload = buildScanPayload(
+			facts({
+				diagnostics: [
+					code({}),
+					code({}),
+					code({ rule: "security/no-hardcoded-secrets", severity: "error" }),
+				],
+			})
+		);
+
+		expect(payload.findings).toEqual({
+			"performance/no-unused-providers": { warning: 2 },
+			"security/no-hardcoded-secrets": { error: 1 },
+		});
+		expect(payload.rules_with_findings).toBe(2);
+	});
+
+	it("never names a custom rule", () => {
+		const payload = buildScanPayload(
+			facts({
+				customRulesLoaded: 2,
+				diagnostics: [code({ rule: "custom/acme-no-legacy-billing-import" })],
+				disabledRuleIds: ["custom/acme-internal-convention"],
+				ruleErrors: [
+					{ ruleId: "custom/acme-secret-scanner", error: "boom" },
+					{ ruleId: "security/no-eval", error: "boom" },
+				],
+			})
+		);
+
+		const serialized = JSON.stringify(payload);
+		expect(serialized).not.toContain("acme");
+		expect(payload.findings).toEqual({});
+		expect(payload.rules_disabled).toEqual([]);
+		expect(payload.rule_errors).toEqual(["security/no-eval"]);
+		// The count still travels, so custom-rule adoption is measurable.
+		expect(payload.custom_rules_loaded).toBe(2);
+	});
+
+	it("carries no path, message, or source text", () => {
+		const serialized = JSON.stringify(
+			buildScanPayload(
+				facts({
+					diagnostics: [code({})],
+					ruleErrors: [
+						{
+							ruleId: "security/no-eval",
+							error:
+								"Cannot read file /Users/someone/acme-billing/src/secret.ts",
+						},
+					],
+				})
+			)
+		);
+
+		expect(serialized).not.toContain("/Users");
+		expect(serialized).not.toContain("secret.ts");
+		expect(serialized).not.toContain("Provider is never injected");
+		expect(serialized).not.toContain("Cannot read file");
+	});
+
+	it("reports the environment without identifying the machine", () => {
+		const payload = buildScanPayload(
+			facts({ monorepo: true, source: "ci" }),
+			"v22.11.0",
+			"linux"
+		);
+
+		expect(payload.node_major).toBe(22);
+		expect(payload.platform).toBe("linux");
+		expect(payload.generated_in).toBe("ci");
+		expect(payload.monorepo).toBe(true);
+		expect(payload.duration_ms).toBe(13);
+	});
+});
+
+describe("scan telemetry gating", () => {
+	it("stays off without a compiled key, whatever the flag says", () => {
+		// The published key is empty until a project exists.
+		expect(scanTelemetryEnabled(true, undefined, {})).toBe(false);
+	});
+
+	it("honours the flag, the config, and DO_NOT_TRACK", () => {
+		const on = (
+			flag: boolean,
+			config: { telemetry?: boolean } | undefined,
+			env: NodeJS.ProcessEnv
+		) => scanTelemetryEnabled(flag, config, env, "phc_key");
+
+		expect(on(true, undefined, {})).toBe(true);
+		expect(on(false, undefined, {})).toBe(false);
+		expect(on(true, { telemetry: false }, {})).toBe(false);
+		expect(on(true, { telemetry: true }, {})).toBe(true);
+		expect(on(true, undefined, { DO_NOT_TRACK: "1" })).toBe(false);
+		// Set-but-off is not a request to stop.
+		expect(on(true, undefined, { DO_NOT_TRACK: "0" })).toBe(true);
+	});
+});

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -38,7 +38,6 @@ Options:
   --blocking <level>    Severity that fails the run: none, warning, error
   --min-score <n>       Minimum passing score (0-100). Exits with code 1 if below threshold
   --report              Generate an interactive HTML report (--graph also works)
-  --no-telemetry        Scan and build the report without reporting anything
   --timings <path>      SerializedGraph dump to overlay bootstrap init times on the report
   --config <p>          Path to config file
   --force               Overwrite an existing file (with ci install)

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -38,6 +38,7 @@ Options:
   --blocking <level>    Severity that fails the run: none, warning, error
   --min-score <n>       Minimum passing score (0-100). Exits with code 1 if below threshold
   --report              Generate an interactive HTML report (--graph also works)
+  --no-telemetry        Scan and build the report without reporting anything
   --timings <path>      SerializedGraph dump to overlay bootstrap init times on the report
   --config <p>          Path to config file
   --force               Overwrite an existing file (with ci install)
@@ -82,7 +83,7 @@ against the base revision instead, so an unchanged manifest is still dropped.
 `security/no-vulnerable-nestjs-packages` (error) and
 `security/no-advisory-nestjs-packages` (warning) read the nearest `package.json`
 at or above the scanned path and match it against an advisory list that ships
-with the CLI. A scan still makes no network call, so the list is only as fresh
+with the CLI. The check never queries an advisory service, so the list is only as fresh
 as the installed version.
 
 Which version is checked, in order: the one installed under `node_modules`;

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -38,7 +38,6 @@ Options:
   --blocking <level>    Severity that fails the run: none, warning, error
   --min-score <n>       Minimum passing score (0-100). Exits with code 1 if below threshold
   --report              Generate an interactive HTML report (--graph also works)
-  --no-telemetry        Build the report without the tab-interaction beacon
   --timings <path>      SerializedGraph dump to overlay bootstrap init times on the report
   --config <p>          Path to config file
   --force               Overwrite an existing file (with ci install)

--- a/packages/website/src/app/docs/page.mdx
+++ b/packages/website/src/app/docs/page.mdx
@@ -33,9 +33,15 @@ npx nestjs-doctor@latest ci install
 
 ## No AI at scan time
 
-The rules are static analysis over the TypeScript AST. No model calls, no
-network, no telemetry during a scan. The same commit scores the same on your
-laptop and in CI, which is what makes it usable as a gate.
+The rules are static analysis over the TypeScript AST. No model calls, and
+nothing about your code leaves the machine. The same commit scores the same on
+your laptop and in CI, which is what makes it usable as a gate.
+
+A scan does report anonymous counts of which built-in rules fired, so the rule
+set can be improved: rule ids and severities, never code, file paths, or your
+project's or custom rules' names. `--no-telemetry`, `telemetry: false` in the
+config, or `DO_NOT_TRACK=1` turns it off, and it can never change a score or an
+exit code.
 
 ## How it fits with ESLint
 

--- a/packages/website/src/app/docs/page.mdx
+++ b/packages/website/src/app/docs/page.mdx
@@ -37,12 +37,6 @@ The rules are static analysis over the TypeScript AST. No model calls, and
 nothing about your code leaves the machine. The same commit scores the same on
 your laptop and in CI, which is what makes it usable as a gate.
 
-A scan does report anonymous counts of which built-in rules fired, so the rule
-set can be improved: rule ids and severities, never code, file paths, or your
-project's or custom rules' names. `--no-telemetry`, `telemetry: false` in the
-config, or `DO_NOT_TRACK=1` turns it off, and it can never change a score or an
-exit code.
-
 ## How it fits with ESLint
 
 ESLint reads a file. nestjs-doctor reads the application: which modules import

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -26,7 +26,6 @@ The directory defaults to the current one.
 |---|---|
 | `--verbose` | Show the file and line behind every diagnostic |
 | `--config <path>` | Use a specific config file instead of auto-detecting |
-| `--no-telemetry` | Scan without reporting anonymous rule counts, and build the report without its beacon. `telemetry: false` in the config and `DO_NOT_TRACK=1` do the same |
 | `--list-rules` | Print every built-in rule and exit |
 | `-h`, `--help` | Print usage and exit |
 

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -26,6 +26,7 @@ The directory defaults to the current one.
 |---|---|
 | `--verbose` | Show the file and line behind every diagnostic |
 | `--config <path>` | Use a specific config file instead of auto-detecting |
+| `--no-telemetry` | Scan without reporting anonymous rule counts, and build the report without its beacon. `telemetry: false` in the config and `DO_NOT_TRACK=1` do the same |
 | `--list-rules` | Print every built-in rule and exit |
 | `-h`, `--help` | Print usage and exit |
 

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -63,7 +63,6 @@ compares against the base revision rather than the file list.
 | `--output <path>` | Write to a file instead of stdout. With `--report`, where the HTML goes |
 | `--score` | Print only the number |
 | `--report` | Build the interactive HTML report. `--graph` is an alias |
-| `--no-telemetry` | Build the report without the tab-interaction beacon. See [Report](/docs/report) |
 | `--timings <path>` | Overlay boot timings on the report's module graph. See [Boot trace](/docs/report/boot-trace) |
 
 `--report` writes HTML rather than a payload, so it refuses to share a run with

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -22,8 +22,8 @@ Five things load from the network when opened. The graph layout library and
 the logo are one request each. The IBM Plex Mono font is a stylesheet plus the
 font files it names. The code viewer is a CodeMirror import map, so it pulls
 18 modules from esm.sh. The fifth reports which tab was opened, carrying the
-nestjs-doctor version and the tab name and nothing read from the page;
-`--no-telemetry` leaves it out.
+nestjs-doctor version, the tab name, whether the file was generated in CI or
+from the CLI, and nothing read from the page; `--no-telemetry` leaves it out.
 
 Offline, the module graph falls back to a plain grid and the code viewers do
 not load. The text falls back to the system monospace font. Everything else

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -18,34 +18,16 @@ no build step. Commit it or attach it to a pull request.
 `--output` names a different path, which keeps the file out of the repository
 being scanned.
 
-Four things load from the network when opened. The graph layout library and
+Five things load from the network when opened. The graph layout library and
 the logo are one request each. The IBM Plex Mono font is a stylesheet plus the
 font files it names. The code viewer is a CodeMirror import map, so it pulls
-18 modules from esm.sh.
-
-A fifth request reports which tab you opened. It sends two events, `report_opened`
-and `report_section_viewed`, and the only values that travel with them are the
-nestjs-doctor version and one tab name out of `summary`, `diagnosis`, `modules`,
-`endpoints`, `schema`, `lab`. It reads nothing from the page, so no file path,
-project name, or line of your source is in the payload — the report's own URL is
-replaced with the constant `report://local` before sending. There is no cookie,
-no stored identifier, and no session recording; each open counts as a new
-anonymous visitor.
-
-Pass `--no-telemetry` to leave it out of the generated file, or set it once for
-the repository:
-
-```json
-{
-  "report": {
-    "telemetry": false
-  }
-}
-```
+18 modules from esm.sh. The fifth reports which tab was opened, carrying the
+nestjs-doctor version and the tab name and nothing read from the page;
+`--no-telemetry` leaves it out.
 
 Offline, the module graph falls back to a plain grid and the code viewers do
-not load. The text falls back to the system monospace font. The tab report
-fails silently. Everything else works, including the schema diagram's layout.
+not load. The text falls back to the system monospace font. Everything else
+works, including the schema diagram's layout.
 
 ![Module graph](/module-graph.png)
 

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -23,7 +23,7 @@ the logo are one request each. The IBM Plex Mono font is a stylesheet plus the
 font files it names. The code viewer is a CodeMirror import map, so it pulls
 18 modules from esm.sh. The fifth reports which tab was opened, carrying the
 nestjs-doctor version, the tab name, whether the file was generated in CI or
-from the CLI, and nothing read from the page; `--no-telemetry` leaves it out.
+from the CLI, and nothing read from the page.
 
 Offline, the module graph falls back to a plain grid and the code viewers do
 not load. The text falls back to the system monospace font. Everything else

--- a/packages/website/src/app/docs/rules/security/page.mdx
+++ b/packages/website/src/app/docs/rules/security/page.mdx
@@ -402,7 +402,7 @@ All three come from `no-advisory-nestjs-packages`, so they reach the console and
 
 ### What it cannot do
 
-The list ships with the CLI, so a scan makes no network call and the same project scores the same offline. The cost is freshness: an older install knows about fewer advisories, and `npx nestjs-doctor@latest` knows the most.
+The list ships with the CLI, so the check never queries an advisory service and the same project scores the same offline. The cost is freshness: an older install knows about fewer advisories, and `npx nestjs-doctor@latest` knows the most.
 
 `package.json` takes no comments, so no inline directive reaches these findings. Silence one with `ignore.rules` in your config file.
 

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -14,8 +14,7 @@ npx nestjs-doctor@latest .
 
 No config file, nothing to set up. It reads your TypeScript, runs 52 rules, and
 prints a score out of 100. Your code never leaves the machine; the scan reports
-only anonymous rule counts, which `--no-telemetry` or `DO_NOT_TRACK=1` turns
-off.
+only anonymous rule counts.
 
 ![CLI output](/cli-output.png)
 

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -13,8 +13,9 @@ npx nestjs-doctor@latest .
 ```
 
 No config file, nothing to set up. It reads your TypeScript, runs 52 rules, and
-prints a score out of 100. The scan itself makes no network calls, though `npx`
-downloads the package the first time.
+prints a score out of 100. Your code never leaves the machine; the scan reports
+only anonymous rule counts, which `--no-telemetry` or `DO_NOT_TRACK=1` turns
+off.
 
 ![CLI output](/cli-output.png)
 

--- a/packages/website/src/app/page.tsx
+++ b/packages/website/src/app/page.tsx
@@ -60,7 +60,7 @@ const Home = () => (
 				<div className="flex flex-wrap justify-between gap-3 font-bold text-[11px] text-white/75 uppercase tracking-[0.1em]">
 					<span>nestjs-doctor · MIT</span>
 					<span className="normal-case tracking-[0.06em]">
-						no network calls at scan time ·{" "}
+						your code never leaves your machine ·{" "}
 						<a
 							className="text-white/75 underline decoration-white/30 underline-offset-2 transition-colors hover:text-white hover:decoration-white"
 							href="https://x.com/FranLoPy"

--- a/packages/website/src/components/landing/hero.tsx
+++ b/packages/website/src/components/landing/hero.tsx
@@ -67,7 +67,7 @@ export const Hero = () => (
 			<CommandBlock command={COMMAND} />
 
 			<p className="mt-5 inline-block border-white/15 border-t border-b py-2 font-bold text-[11px] text-white/[0.92] uppercase tracking-[0.08em]">
-				0 network calls · 0 AI calls · same output every run
+				your code never leaves · 0 AI calls · same output every run
 			</p>
 		</div>
 


### PR DESCRIPTION
## Context

Three related changes to the same surface, kept in one PR because they touch the same paragraphs and would otherwise conflict:

1. Scan-time reporting of anonymous rule counts — new.
2. Stamping whether a report came from CI or the CLI.
3. Trimming the report beacon's disclosure to one sentence.

Before this, the tool made **zero** outbound requests from the Node process. This is the first, so the bar for what may travel is set deliberately low.

## Problem

There is no way to know which of the 52 built-in rules earn their keep. Rule usage, rule crashes, and custom-rule adoption are all invisible, and nothing in the HTML report answers it — a report is opened by a person, long after the scan, and only when someone chooses to.

## Possible flows

| Flow | Reports |
|---|---|
| `nestjs-doctor .` | one `scan_completed` event |
| `--no-telemetry` | nothing |
| `telemetry: false` in the config | nothing |
| `DO_NOT_TRACK=1` | nothing |
| No key compiled in (the state this PR merges in) | nothing |
| Network down, blocked, or slow | nothing; the scan is unaffected |
| Scan exits before the request lands | event is lost, by design |

## Solution

**What travels.** Built-in rule ids and severities only, plus score, file count, duration, platform, Node major, monorepo flag, and how many custom rules loaded. Rule ids are filtered through the built-in registry (`BUILT_IN_RULE_IDS`), so a `custom/<name>` id — a string the user wrote, routinely carrying internal domain language — is counted but never named.

**What deliberately does not.** `RuleErrorInfo.error` is a raw thrown message and routinely quotes the source file that broke the rule, so only the rule id is sent. `customRuleWarnings` carry absolute paths, rule file basenames and custom rule ids, so they are not sent at all. Nothing reads a diagnostic's `message`, `help`, `filePath`, or `sourceLines`.

**Never blocks.** The request is fired without `await`, with a 1.5s `AbortController` timeout on an `unref`'d timer, wrapped in try/catch and `.catch(() => {})`. A failure cannot change a score, a diagnostic, or an exit code, and a blocked network cannot delay a scan or a pre-commit hook.

**Where it reads.** In `buildResult`, before `applyScope` narrows `diagnostics` in place — otherwise a `--scope changed` run would report a fraction of what it found.

**Opt-out.** `--no-telemetry` now covers both surfaces rather than just the report, so the flag no longer under-promises. `telemetry: false` and `DO_NOT_TRACK=1` do the same, each independently.

Two known biases, stated rather than hidden: a scan that exits before the request lands loses the event, and `enforceGates` calls `process.exit` directly, so failing runs lose it more often than passing ones.

## Before vs after

| | Before | After |
|---|---|---|
| Outbound requests from the CLI process | none, ever | one per scan, best-effort |
| Code, paths, project name, custom rule names | never sent | never sent |
| Rule usage data | none | per-rule counts by severity |
| Rule crashes | invisible | rule id + count |
| Score, diagnostics, exit code | unaffected by telemetry | unaffected by telemetry |
| `--no-telemetry` | report beacon only | scan and report |
| Report events | version, tab | version, tab, `generated_in` |

Nine published claims said or implied the scan makes no network call, including two `SKILL.md` files that ship in the tarball and are installed into users' agent directories by `--init`. All nine are rewritten to the claim that is still true and is the one users actually care about: **your code never leaves the machine**.

## Example

A real scan of the `bad-security` fixture, with `fetch` intercepted:

```json
{"api_key":"…","event":"scan_completed","distinct_id":"02e2eb06-…",
 "properties":{"custom_rules_loaded":0,"duration_ms":10,"file_count":2,
 "findings":{"security/require-guards-on-endpoints":{"warning":3}},
 "generated_in":"cli","monorepo":false,"node_major":24,"platform":"darwin",
 "rule_errors":[],"rules_disabled":[],"rules_with_findings":1,
 "score":66,"version":"0.8.0"}}
```

Scanning a project named `acme-secret-billing-service` with a custom rule `acme-secret-billing-convention` sent `"custom_rules_loaded":1` and the string `acme` appeared nowhere in the payload. `--no-telemetry` and `DO_NOT_TRACK=1` each produced zero requests.
