### PR TITLE
feat(cli): switch on telemetry, sent from a detached child

### DIFF
--- a/.changeset/legal-tables-heal.md
+++ b/.changeset/legal-tables-heal.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+Turn on the anonymous rule-count reporting and the HTML report's beacon, both of
+which shipped inert. `--no-telemetry`, `telemetry: false` in the config file, and
+`DO_NOT_TRACK=1` each switch them back off.

--- a/packages/nestjs-doctor/src/report/ui/telemetry.ts
+++ b/packages/nestjs-doctor/src/report/ui/telemetry.ts
@@ -2,7 +2,7 @@ import { generatedIn } from "../../telemetry/environment.js";
 
 // PostHog project key. Empty disables the beacon: no key, no snippet, no
 // requests. Set it to turn report telemetry on for published builds.
-const POSTHOG_KEY = "";
+const POSTHOG_KEY = "phc_BGjn97jvL862fdhHAKzJ7mhuXBZm8CEe83ENuMvpCgdD";
 const POSTHOG_HOST = "https://us.i.posthog.com";
 
 /**

--- a/packages/nestjs-doctor/src/telemetry/send.ts
+++ b/packages/nestjs-doctor/src/telemetry/send.ts
@@ -5,7 +5,7 @@ import type { ScanPayload } from "./scan-telemetry.js";
 
 // Same project as the report beacon. Empty disables scan telemetry entirely:
 // no key, no request.
-const POSTHOG_KEY = "";
+const POSTHOG_KEY = "phc_BGjn97jvL862fdhHAKzJ7mhuXBZm8CEe83ENuMvpCgdD";
 const POSTHOG_HOST = "https://us.i.posthog.com";
 const TIMEOUT_MS = 1500;
 

--- a/packages/nestjs-doctor/src/telemetry/send.ts
+++ b/packages/nestjs-doctor/src/telemetry/send.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import type { NestjsDoctorConfig } from "../common/config.js";
 import { isSet } from "./environment.js";
@@ -7,7 +8,7 @@ import type { ScanPayload } from "./scan-telemetry.js";
 // no key, no request.
 const POSTHOG_KEY = "phc_BGjn97jvL862fdhHAKzJ7mhuXBZm8CEe83ENuMvpCgdD";
 const POSTHOG_HOST = "https://us.i.posthog.com";
-const TIMEOUT_MS = 1500;
+const TIMEOUT_MS = 3000;
 
 /**
  * Whether a scan may report. The flag and the config key each disable it on
@@ -29,36 +30,48 @@ export function scanTelemetryEnabled(
 }
 
 /**
- * Posts the payload without awaiting it and without holding the process open,
- * so a slow or blocked network cannot delay a scan or a pre-commit hook. A
- * scan that exits first simply loses the event.
+ * Runs in a detached child. An in-process request keeps the event loop alive
+ * until it settles, which on a network that drops the connection delayed the
+ * scan by ten seconds.
  */
+const CHILD_SCRIPT = `
+const body = process.argv[1];
+const req = require("node:https").request(${JSON.stringify(`${POSTHOG_HOST}/e/`)}, {
+  method: "POST",
+  headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(body) },
+  timeout: ${TIMEOUT_MS},
+}, (res) => res.resume());
+req.on("error", () => {});
+req.on("timeout", () => req.destroy());
+req.end(body);
+`;
+
+/** Hands the payload to a detached child, so the scan never waits on the network. */
 export function sendScanTelemetry(payload: ScanPayload): void {
 	if (!POSTHOG_KEY) {
 		return;
 	}
 
 	try {
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-		timer.unref?.();
-
-		fetch(`${POSTHOG_HOST}/e/`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			signal: controller.signal,
-			body: JSON.stringify({
-				api_key: POSTHOG_KEY,
-				event: "scan_completed",
-				distinct_id: randomUUID(),
-				properties: payload,
-			}),
-		})
-			.catch(() => {
-				// Reporting is best-effort; a scan never fails because of it.
-			})
-			.finally(() => clearTimeout(timer));
+		const child = spawn(
+			process.execPath,
+			[
+				"-e",
+				CHILD_SCRIPT,
+				JSON.stringify({
+					api_key: POSTHOG_KEY,
+					event: "scan_completed",
+					distinct_id: randomUUID(),
+					properties: payload,
+				}),
+			],
+			{ detached: true, stdio: "ignore", windowsHide: true }
+		);
+		child.on("error", () => {
+			// Reporting is best-effort; a scan never fails because of it.
+		});
+		child.unref();
 	} catch {
-		// Same: an environment without fetch reports nothing and scans fine.
+		// Same: an environment that cannot spawn reports nothing and scans fine.
 	}
 }

--- a/packages/nestjs-doctor/tests/unit/report-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-telemetry.test.ts
@@ -56,10 +56,11 @@ describe("report telemetry", () => {
 		expect(html).not.toContain("window.__ndTrack =");
 	});
 
-	it("sends no event before a key is configured", () => {
-		// The published key is empty until a project exists, so the default
-		// build stays silent rather than posting to a missing project.
-		expect(getTelemetryScript("1.2.3")).toBe("");
+	it("embeds the beacon with the configured key", () => {
+		const script = getTelemetryScript("1.2.3");
+
+		expect(script).toContain("window.__ndTrack =");
+		expect(script).toContain('var VERSION = "1.2.3"');
 	});
 
 	it("reads nothing off the page that could carry project data", () => {

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
@@ -113,8 +113,11 @@ describe("scan telemetry payload", () => {
 
 describe("scan telemetry gating", () => {
 	it("stays off without a compiled key, whatever the flag says", () => {
-		// The published key is empty until a project exists.
-		expect(scanTelemetryEnabled(true, undefined, {})).toBe(false);
+		expect(scanTelemetryEnabled(true, undefined, {}, "")).toBe(false);
+	});
+
+	it("is on by default with a key compiled in", () => {
+		expect(scanTelemetryEnabled(true, undefined, {})).toBe(true);
 	});
 
 	it("honours the flag, the config, and DO_NOT_TRACK", () => {


### PR DESCRIPTION
## Context

#272 and #273 shipped both telemetry surfaces with an empty key, so they compiled to nothing and sent nothing. The PostHog project now exists and the website already reports through it.

## Problem

Two problems, one of them serious.

**The key was never set**, so the scan reporter and the report beacon were dead code.

**And the sender blocked the scan.** The original implementation fired `fetch` without awaiting it, on the assumption that an unawaited request cannot delay the process. That assumption is wrong: Node keeps the event loop alive until the request settles, and `unref()` on the abort timer does not cover the socket. Measured on the `bad-security` fixture, three runs each:

| Network | `--no-telemetry` | Telemetry on |
|---|---|---|
| Normal | 0.30s | **0.58s** |
| Connection dropped | 0.30s | **10.5s** |

The 10.5s is the one that matters. `AbortController` fires at 1.5s but undici's TCP connect timeout ignores it, so a corporate firewall that silently drops traffic to posthog.com would add ten seconds to every scan and every pre-commit hook.

## Possible flows

| Flow | Scan time | Event |
|---|---|---|
| Normal network | unchanged | delivered |
| Endpoint dropping packets | unchanged | abandoned after 3s |
| Offline | unchanged | abandoned |
| `--no-telemetry` / `telemetry: false` / `DO_NOT_TRACK=1` | unchanged | never sent |
| A machine that cannot spawn | unchanged | never sent |

## Solution

Hand the payload to a **detached child process** and `unref()` it, which is what Next.js does for the same reason. The parent exits immediately; the child outlives it and completes the POST on its own. No in-process request can then hold the CLI open.

The child runs via `node -e` with the body passed as an argument, so nothing extra is added to the tarball and no build config changes. `stdio: "ignore"` and `windowsHide: true` keep it invisible. The timeout moves to 3s, which now costs the user nothing because they are not waiting for it.

Also sets the project key in both compiled constants. It is a PostHog **project** key: a public, write-only client token, already visible in the website bundle, and unable to read the project's data. It is committed because the CLI has no build-time secret mechanism.

An in-process `node:https` request with `socket.unref()` was tried first and rejected: it still blocked for 1.5s on a dropped connection, because the connect attempt stays referenced regardless.

Two tests asserted the old inert state and now assert the live one.

## Before vs after

| | Before | After |
|---|---|---|
| Scan, normal network | 0.58s | **0.29s** |
| Scan, connection dropped | 10.5s | **0.30s** |
| Scan, `--no-telemetry` | 0.30s | 0.30s |
| Event delivery | in-process | detached child |
| Payload contents | unchanged | unchanged |
| Extra files in the tarball | — | none |

## Example

Delivery confirmed against a local receiver, which the child reached *after* the parent had exited:

```
RECEIVED POST /e/
{"api_key":"phc_BGjn…","event":"scan_completed","distinct_id":"d037887d-…",
 "properties":{"custom_rules_loaded":0,"duration_ms":14,"file_count":2,
 "findings":{"security/require-guards-on-endpoints":{"warning":3}},
 "generated_in":"cli","monorepo":false,"node_major":24,"platform":"darwin",
 "rule_errors":[],"rules_disabled":[],"rules_with_findings":1,
 "score":66,"version":"0.8.0"}}
```

And against a black-holed endpoint (`203.0.113.1`, TEST-NET-3), three runs: `0.34s`, `0.30s`, `0.28s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9kBJmRBY36sDV4JmFbE27
