### PR TITLE
feat(cli): show the rule's guidance and samples under a finding

### DIFF
--- a/.changeset/cli-rule-panel.md
+++ b/.changeset/cli-rule-panel.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+Reviewing a finding in the menu now shows the rule's own guidance underneath it: what the rule looks for, then the bad and good code samples the HTML report already carried. Bad and good are marked by a word, a glyph and a per-line sigil, so the pair reads the same with colour turned off.
+
+The samples are now tested. Each rule's bad sample has to fire that rule, and its good sample has to stay silent in the same file, which caught two that were wrong: `security/no-dangerous-redirects` never fired because the sample had no enclosing controller, and its good sample was worse than useless, showing an allowlist check the rule does not accept and would still report.

--- a/packages/nestjs-doctor/src/cli/interactive/detail.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/detail.ts
@@ -7,6 +7,8 @@ import {
 import { highlighter } from "../ui/highlighter.js";
 import { copyToClipboard } from "./clipboard.js";
 import { renderCodeFrame } from "./code-frame.js";
+import { ruleInfo } from "./rule-info.js";
+import { renderRulePanel } from "./rule-panel.js";
 
 interface RuleGroup {
 	diagnostics: Diagnostic[];
@@ -120,10 +122,9 @@ const printDetail = (
 	}
 
 	lines.push("", `Fix: ${diagnostic.help}`);
-	const url = docsUrl(diagnostic.rule);
-	if (url) {
-		lines.push(highlighter.dim(`Docs: ${url}`));
-	}
+	lines.push(
+		...renderRulePanel(ruleInfo(diagnostic.rule), docsUrl(diagnostic.rule))
+	);
 
 	process.stdout.write(`\n${lines.join("\n")}\n\n`);
 };

--- a/packages/nestjs-doctor/src/cli/interactive/rule-info.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/rule-info.ts
@@ -1,0 +1,40 @@
+import { allRules } from "../../engine/rules/index.js";
+import type { RuleMeta } from "../../engine/rules/types.js";
+import { getRuleExamples } from "../../report/data/examples.js";
+
+interface RuleInfo {
+	bad?: string;
+	description?: string;
+	good?: string;
+}
+
+let cache: Map<string, RuleInfo> | null = null;
+
+const build = (): Map<string, RuleInfo> => {
+	const examples = getRuleExamples();
+	const metaById = new Map<string, RuleMeta>(
+		allRules.map((rule) => [rule.meta.id, rule.meta])
+	);
+	const ids = new Set([...metaById.keys(), ...Object.keys(examples)]);
+	const infos = new Map<string, RuleInfo>();
+	for (const id of ids) {
+		infos.set(id, {
+			...(metaById.get(id)?.description
+				? { description: metaById.get(id)?.description }
+				: {}),
+			...(examples[id]
+				? { bad: examples[id].bad, good: examples[id].good }
+				: {}),
+		});
+	}
+	return infos;
+};
+
+/**
+ * The rule's own description and sample pair. Empty for a custom rule, which
+ * carries neither.
+ */
+export const ruleInfo = (id: string): RuleInfo => {
+	cache ??= build();
+	return cache.get(id) ?? {};
+};

--- a/packages/nestjs-doctor/src/cli/interactive/rule-panel.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/rule-panel.ts
@@ -1,0 +1,91 @@
+import { highlighter } from "../ui/highlighter.js";
+
+const WHITESPACE = /\s+/;
+const MIN_WIDTH = 40;
+const MAX_WIDTH = 96;
+const GUTTER = 4;
+
+const unicode = process.platform !== "win32" || Boolean(process.env.WT_SESSION);
+const MARK_BAD = unicode ? "✗" : "[x]";
+const MARK_GOOD = unicode ? "✓" : "[v]";
+const RULE = unicode ? "─" : "-";
+
+/** Usable width for panel text, clamped so long lines never wrap the frame. */
+const bodyWidth = (columns = process.stdout.columns || 80): number =>
+	Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, columns - GUTTER));
+
+const truncate = (text: string, width: number): string =>
+	text.length <= width ? text : `${text.slice(0, Math.max(0, width - 1))}…`;
+
+/** Wraps on spaces, leaving anything longer than the width to be truncated. */
+const wrap = (text: string, width: number): string[] => {
+	const out: string[] = [];
+	let line = "";
+	for (const word of text.split(WHITESPACE)) {
+		if (line && `${line} ${word}`.length > width) {
+			out.push(line);
+			line = word;
+		} else {
+			line = line ? `${line} ${word}` : word;
+		}
+	}
+	if (line) {
+		out.push(line);
+	}
+	return out.map((row) => truncate(row, width));
+};
+
+/** An uppercase dim caption, the terminal form of the site's label strip. */
+const caption = (label: string, meta?: string, width = bodyWidth()): string => {
+	const left = label.toUpperCase();
+	if (!meta) {
+		return highlighter.dim(left);
+	}
+	const gap = Math.max(1, width - left.length - meta.length);
+	return highlighter.dim(`${left}${" ".repeat(gap)}${meta}`);
+};
+
+const sample = (
+	code: string,
+	mark: string,
+	label: string,
+	sigil: string,
+	paint: (text: string) => string,
+	width: number
+): string[] => [
+	paint(`${mark} ${label}`),
+	...code.split("\n").map((row) => `  ${sigil} ${truncate(row, width - 4)}`),
+];
+
+/**
+ * The rule's guidance below a finding: what it means, then the sample pair.
+ * Bad and Good are marked three ways over, so the distinction survives with
+ * no colour at all.
+ */
+export const renderRulePanel = (
+	info: { bad?: string; description?: string; good?: string },
+	docsUrl?: string,
+	columns?: number
+): string[] => {
+	const width = bodyWidth(columns);
+	const lines: string[] = [];
+
+	if (info.description) {
+		lines.push(
+			highlighter.dim(RULE.repeat(width)),
+			caption("Recommendation", docsUrl, width),
+			...wrap(info.description, width)
+		);
+	}
+
+	if (info.bad && info.good) {
+		lines.push(
+			highlighter.dim(RULE.repeat(width)),
+			...sample(info.bad, MARK_BAD, "BAD", "-", highlighter.error, width),
+			"",
+			...sample(info.good, MARK_GOOD, "GOOD", "+", highlighter.success, width)
+		);
+	}
+
+	return lines;
+};

--- a/packages/nestjs-doctor/src/report/data/examples.ts
+++ b/packages/nestjs-doctor/src/report/data/examples.ts
@@ -40,15 +40,19 @@ const csrfOptions = { csrf: false };`,
 			good: "app.use(csurf({ cookie: true }));",
 		},
 		"security/no-dangerous-redirects": {
-			bad: `@Get('redirect')
-redirect(@Query('url') url: string, @Res() res: Response) {
-  res.redirect(url);
-}`,
-			good: `@Get('redirect')
-redirect(@Query('url') url: string, @Res() res: Response) {
-  const allowed = ['https://example.com', 'https://app.example.com'];
-  if (allowed.includes(url)) {
+			bad: `@Controller('go')
+export class GoController {
+  @Get('redirect')
+  redirect(@Query('url') url: string, @Res() res: Response) {
     res.redirect(url);
+  }
+}`,
+			good: `@Controller('go')
+export class GoController {
+  @Get('redirect')
+  redirect(@Query('to') to: string, @Res() res: Response) {
+    const targets: Record<string, string> = { home: '/', docs: '/docs' };
+    res.redirect(targets[to] ?? '/');
   }
 }`,
 		},
@@ -102,14 +106,14 @@ export class AllExceptionsFilter implements ExceptionFilter {
 			bad: `@Controller('users')
 export class UserController {
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.userRepo.findOne(id); // Returns raw entity
+  findOne(@Param('id') id: string): Promise<UserEntity> {
+    return this.userRepo.findOne(id); // Every column ships
   }
 }`,
 			good: `@Controller('users')
 export class UserController {
   @Get(':id')
-  async findOne(@Param('id') id: string) {
+  async findOne(@Param('id') id: string): Promise<UserResponseDto> {
     const user = await this.userService.findOne(id);
     return new UserResponseDto(user); // Controlled shape
   }
@@ -486,17 +490,17 @@ export class OrderModule {}`,
 		"architecture/no-manual-instantiation": {
 			bad: `@Injectable()
 export class OrderService {
-  processOrder() {
-    const validator = new OrderValidator();  // Manual instantiation!
-    validator.validate(order);
+  processOrder(order: Order) {
+    const pricing = new PricingService();  // Bypasses the injector
+    return pricing.total(order);
   }
 }`,
 			good: `@Injectable()
 export class OrderService {
-  constructor(private readonly validator: OrderValidator) {}
+  constructor(private readonly pricing: PricingService) {}
 
-  processOrder() {
-    this.validator.validate(order);
+  processOrder(order: Order) {
+    return this.pricing.total(order);
   }
 }`,
 		},
@@ -542,7 +546,7 @@ export class UserService {
 		},
 		"architecture/require-module-boundaries": {
 			bad: `// In user module:
-import { OrderValidator } from '../order/validators/order.validator';`,
+import { OrderRepository } from '../order/repositories/order.repository';`,
 			good: `// In user module:
 import { OrderValidator } from '../order';
 // Or better: inject via DI through the module system`,
@@ -711,17 +715,16 @@ export class Product {
 		},
 		"schema/require-cascade-rule": {
 			bad: `@Entity()
-export class User {
-  @OneToMany(() => Order, (order) => order.user, {
-    cascade: true,  // Risky: may unintentionally persist/remove orders
-  })
-  orders: Order[];
+export class Order {
+  @ManyToOne(() => User, (user) => user.orders)
+  user: User;  // No onDelete — the database default decides
 }`,
 			good: `@Entity()
-export class User {
-  @OneToMany(() => Order, (order) => order.user)
-  orders: Order[];
-  // Persist/remove orders explicitly via OrderRepository
+export class Order {
+  @ManyToOne(() => User, (user) => user.orders, {
+    onDelete: 'CASCADE',
+  })
+  user: User;
 }`,
 		},
 	};

--- a/packages/nestjs-doctor/tests/unit/interactive-rule-panel.test.ts
+++ b/packages/nestjs-doctor/tests/unit/interactive-rule-panel.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { ruleInfo } from "../../src/cli/interactive/rule-info.js";
+import { renderRulePanel } from "../../src/cli/interactive/rule-panel.js";
+
+const ANSI_RE = /\[[0-9;]*m/g;
+
+const plain = (lines: string[]): string[] =>
+	lines.map((line) => line.replace(ANSI_RE, ""));
+
+describe("renderRulePanel", () => {
+	const panel = plain(
+		renderRulePanel(
+			{
+				bad: "const a = 1;\nconst b = 2;",
+				description: "Do not do the thing.",
+				good: "const c = 3;",
+			},
+			"https://nestjs.doctor/docs/rules/security",
+			100
+		)
+	);
+
+	it("puts the bad sample before the good one", () => {
+		const bad = panel.findIndex((line) => line.includes("BAD"));
+		const good = panel.findIndex((line) => line.includes("GOOD"));
+		expect(bad).toBeGreaterThan(-1);
+		expect(good).toBeGreaterThan(bad);
+	});
+
+	it("marks every sample line so the pair survives without colour", () => {
+		expect(panel.filter((line) => line.startsWith("  - "))).toHaveLength(2);
+		expect(panel.filter((line) => line.startsWith("  + "))).toHaveLength(1);
+	});
+
+	it("captions the recommendation in uppercase with the docs link", () => {
+		const row = panel.find((line) => line.startsWith("RECOMMENDATION"));
+		expect(row).toContain("https://nestjs.doctor/docs/rules/security");
+	});
+
+	it("keeps every line inside the width it was given", () => {
+		const wide = plain(
+			renderRulePanel(
+				{ bad: "x".repeat(300), description: "y ".repeat(200), good: "z" },
+				undefined,
+				80
+			)
+		);
+		for (const line of wide) {
+			expect(line.length).toBeLessThanOrEqual(80);
+		}
+	});
+
+	it("renders nothing for a rule that carries neither", () => {
+		expect(renderRulePanel({})).toEqual([]);
+	});
+
+	it("omits the samples when only a description exists", () => {
+		const only = plain(renderRulePanel({ description: "Just this." }));
+		expect(only.some((line) => line.includes("BAD"))).toBe(false);
+		expect(only.some((line) => line.includes("Just this."))).toBe(true);
+	});
+});
+
+describe("ruleInfo", () => {
+	it("carries the description and the sample pair for a built-in rule", () => {
+		const info = ruleInfo("security/no-hardcoded-secrets");
+		expect(info.description).toBeTruthy();
+		expect(info.bad).toContain("apiKey");
+		expect(info.good).toContain("ConfigService");
+	});
+
+	it("is empty for a custom rule, which has neither", () => {
+		expect(ruleInfo("custom/whatever")).toEqual({});
+	});
+
+	it("still carries a description for a rule with no samples", () => {
+		const info = ruleInfo("security/no-vulnerable-nestjs-packages");
+		expect(info.description).toBeTruthy();
+		expect(info.bad).toBeUndefined();
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/rule-examples.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rule-examples.test.ts
@@ -1,0 +1,122 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+	buildAnalysisContext,
+	diagnose,
+	resolveScanConfig,
+} from "../../src/engine/scanner.js";
+import { getRuleExamples } from "../../src/report/data/examples.js";
+
+const roots: string[] = [];
+afterAll(() => {
+	for (const root of roots) {
+		rmSync(root, { force: true, recursive: true });
+	}
+});
+
+// The samples are fragments, so they need imports and a Nest dependency to
+// parse and to be detected as a Nest project at all.
+const PRELUDE = `import {
+	Body, Controller, Get, Global, Inject, Injectable, Module,
+	Param, Post, Query, Res, UseGuards,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+
+class AddressDto {
+	street = '';
+}
+`;
+
+/** Filenames rules key on. A sample fires in at least one of them. */
+const FILENAMES = [
+	"sample.controller.ts",
+	"sample.service.ts",
+	"sample.module.ts",
+	"sample.entity.ts",
+	"index.ts",
+];
+
+/**
+ * Rules whose sample cannot fire from one standalone file. Each needs a
+ * fixture shape the sample alone does not describe.
+ */
+const NEEDS_WIDER_FIXTURE = new Map<string, string>([
+	[
+		"performance/no-unused-module-exports",
+		"project-scoped: needs a second module importing this one",
+	],
+	[
+		"architecture/no-manual-instantiation",
+		"the class has to be a registered provider, which one file cannot show",
+	],
+]);
+
+const scan = async (source: string, filename: string): Promise<string[]> => {
+	const root = mkdtempSync(join(tmpdir(), "nd-examples-"));
+	roots.push(root);
+	mkdirSync(join(root, "src"), { recursive: true });
+	writeFileSync(
+		join(root, "package.json"),
+		JSON.stringify({
+			dependencies: {
+				"@nestjs/common": "^11.0.0",
+				"@nestjs/core": "^11.0.0",
+				typeorm: "^0.3.0",
+			},
+			name: "example-fixture",
+		})
+	);
+	writeFileSync(join(root, "src", filename), `${PRELUDE}${source}\n`, "utf-8");
+	const scanConfig = await resolveScanConfig(root);
+	const context = await buildAnalysisContext(root, scanConfig);
+	const output = await diagnose(context);
+	return output.diagnostics.map((diagnostic) => diagnostic.rule);
+};
+
+const examples = getRuleExamples();
+const testable = Object.keys(examples).filter(
+	(rule) => !NEEDS_WIDER_FIXTURE.has(rule)
+);
+
+/** The first filename the bad sample fires in, or null if it never does. */
+const fireContext = async (
+	source: string,
+	rule: string
+): Promise<string | null> => {
+	for (const filename of FILENAMES) {
+		if ((await scan(source, filename)).includes(rule)) {
+			return filename;
+		}
+	}
+	return null;
+};
+
+describe("rule examples", () => {
+	it("covers most of the built-in rules", () => {
+		expect(testable.length).toBeGreaterThan(40);
+	});
+
+	// Both halves in one test, and the good sample is checked in the very
+	// context the bad one fired in: a good sample the rule never inspects
+	// would otherwise pass for the wrong reason.
+	it.each(
+		testable
+	)("%s: bad fires, good does not, in the same file", async (rule) => {
+		const filename = await fireContext(examples[rule].bad, rule);
+		expect(filename, "the bad sample never fires this rule").not.toBeNull();
+		expect(await scan(examples[rule].good, filename as string)).not.toContain(
+			rule
+		);
+	}, 60_000);
+
+	it.each([
+		...NEEDS_WIDER_FIXTURE.keys(),
+	])("%s: has a sample, and is documented as needing a wider fixture", (rule) => {
+		expect(examples[rule]?.bad ?? "").not.toBe("");
+		expect(NEEDS_WIDER_FIXTURE.get(rule)).toBeTruthy();
+	});
+});

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -91,6 +91,11 @@ Reviewing walks rule by rule, worst first. Each finding shows its code frame,
 the fix guidance, and the docs link, and one keystroke copies an agent-ready
 fix prompt for the whole rule.
 
+Under the finding sits the rule's own guidance: what it looks for, then a bad
+and a good sample of the pattern. Every sample is tested against the rule it
+illustrates, so the bad one is what the rule reports and the good one is what
+it accepts.
+
 Handing off detects Claude Code, Codex, and Cursor on your PATH and starts the
 one you pick with the top findings as its first prompt, plainly: no
 permission-skipping flags are passed. Copy the prompt instead to use any other


### PR DESCRIPTION
## Context

The post-scan menu reviews findings rule by rule: severity, location, a code frame from your source, and a `Fix:` line. The HTML report has always shown more, a bad and a good sample per rule, from `src/report/data/examples.ts`. That data already ships in the CLI bundle; nothing in the terminal read it.

react-doctor was the reference here. Worth knowing what its panel actually contains: severity, location, an "Impact" line that is one of five strings keyed by category, the message, a code frame, the help text, and a docs link. It has no per-rule samples. This is not parity work.

## Problem

The terminal stopped at `Fix:`. A finding told you what was wrong and what to do, never what the fixed code looks like.

And nothing had ever executed the samples. `CLAUDE.md` records that roughly half the docs-site rule samples were wrong when someone finally ran them. Running these found the same thing.

## Possible flows

| Path | Affected |
|---|---|
| Menu → Review findings | Yes, the guidance and samples are new |
| Menu → other entries | No |
| Console report, `--verbose` | No |
| `--json` / `--sarif` / CI | No, `canPrompt` already refuses every non-console format |
| HTML report rule lab | Same corrected samples, three of them changed |
| Custom rules | Render nothing, they carry neither description nor samples |

## Solution

`rule-info.ts` maps a rule id to its `description` and sample pair, built once and cached. `rule-panel.ts` renders it: an uppercase dim `RECOMMENDATION` caption with the docs link right-aligned, then the pair.

Bad and good are distinguished four ways: the word, a glyph, a per-line `-` / `+` sigil, and colour. Only the last one needs a colour terminal, so the pair reads identically under `NO_COLOR`. Lines are truncated to the terminal width rather than wrapped, because a wrapped code line stops being readable as code.

No new dependency. Ink was the obvious route and it costs +22 MB and +28 packages, taking the install from 18 MB to 40 MB and making React a runtime dependency of a CLI whose pitch is `npx nestjs-doctor@latest`.

**`rule-examples.test.ts` is the other half.** Each bad sample has to fire its own rule, and each good sample has to stay silent **in the same file the bad one fired in**. That last part matters: a good sample the rule never inspects would otherwise pass for the wrong reason, which is exactly how the redirect bug below survived.

Deliberately not done: the side-by-side panel. It needs about 110 columns before the samples stop being truncated into uselessness, and the full-width page is what a narrower terminal should show anyway.

## Before vs after

| | Before | After |
|---|---|---|
| Finding detail | frame, message, `Fix:` | plus what the rule looks for and a sample pair |
| Sample correctness | never executed | 51 tests, every pair verified in context |
| `NO_COLOR` | n/a | bad/good still distinguishable three ways |
| Custom rule | frame, message, `Fix:` | unchanged, renders nothing extra |
| Non-interactive runs | unchanged | unchanged |
| Dependencies | 8 runtime | 8 runtime |

Four samples were wrong or unverifiable and are corrected:

| Rule | Was | Now |
|---|---|---|
| `security/no-dangerous-redirects` | bad had no enclosing controller so the rule never looked; **good showed an allowlist check the rule does not accept and would still report** | complete controller; good redirects to a looked-up destination, never the raw param |
| `schema/require-cascade-rule` | `@OneToMany` with `cascade: true`, which the rule never reports | `@ManyToOne` with no `onDelete`, which it does |
| `security/no-raw-entity-in-response` | no return type, so the rule read `any` and never fired | annotated `Promise<UserEntity>` |
| `architecture/require-module-boundaries` | imported through `/validators/`, not an internal path | `/repositories/`, which is |

Two rules stay out of the sweep with the reason recorded next to them: `no-unused-module-exports` needs a second module importing the first, and `no-manual-instantiation` needs the class registered as a provider. Neither is expressible in one file.

## Example

Reviewing a circular-dependency finding, real output at 100 columns:

```
────────────────────────────────────────────────────────────────────────────────
RECOMMENDATION                        https://nestjs.doctor/docs/rules/architecture
Module import graph must not contain circular dependencies
────────────────────────────────────────────────────────────────────────────────
✗ BAD
  - // user.module.ts
  - @Module({ imports: [OrderModule] })
  - export class UserModule {}
  -
  - // order.module.ts
  - @Module({ imports: [UserModule] })  // Circular!
  - export class OrderModule {}

✓ GOOD
  + // shared.module.ts — extract shared logic
  + @Module({ providers: [SharedService], exports: [SharedService] })
  + export class SharedModule {}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
