### PR TITLE
docs: add the module graph page, and make the docs indexable

### DIFF
--- a/.changeset/readme-module-graph-link.md
+++ b/.changeset/readme-module-graph-link.md
@@ -1,0 +1,9 @@
+---
+"nestjs-doctor": patch
+---
+
+Link the module graph docs from the readme's report section.
+
+The report section described the interactive module graph and then linked only
+to the boot trace, so the graph itself had no destination. It now points at
+`/docs/report/module-graph`, which covers reading the tab.

--- a/.changeset/registry-discovery-metadata.md
+++ b/.changeset/registry-discovery-metadata.md
@@ -1,0 +1,14 @@
+---
+"nestjs-doctor": patch
+"nestjs-doctor-lsp": patch
+---
+
+Point the npm `homepage` field at the docs site and widen the registry keywords.
+
+`nestjs-doctor` sent its homepage link back to the GitHub readme, so the most
+authoritative page linking to the project skipped the docs site entirely, and
+`nestjs-doctor-lsp` carried no homepage at all. Both now link to the docs. The
+keyword lists gain the terms people actually search for — `static-analysis`,
+`module-graph`, `dependency-graph`, `circular-dependency`, `code-quality` — and
+drop `health-check`, which collides with `@nestjs/terminus` health endpoints and
+attracts the wrong query.

--- a/.changeset/registry-discovery-metadata.md
+++ b/.changeset/registry-discovery-metadata.md
@@ -1,6 +1,7 @@
 ---
 "nestjs-doctor": patch
 "nestjs-doctor-lsp": patch
+"nestjs-doctor-vscode": patch
 ---
 
 Point the npm `homepage` field at the docs site and widen the registry keywords.

--- a/packages/nestjs-doctor-lsp/package.json
+++ b/packages/nestjs-doctor-lsp/package.json
@@ -23,9 +23,11 @@
   },
   "keywords": [
     "nestjs",
+    "nest",
     "lsp",
     "language-server",
-    "diagnostics"
+    "diagnostics",
+    "static-analysis"
   ],
   "author": "RoloBits",
   "license": "MIT",
@@ -34,6 +36,7 @@
     "url": "https://github.com/RoloBits/nestjs-doctor.git",
     "directory": "packages/nestjs-doctor-lsp"
   },
+  "homepage": "https://www.nestjs.doctor/docs/language-server",
   "dependencies": {
     "vscode-languageserver": "^9.0.0",
     "vscode-languageserver-textdocument": "^1.0.0"

--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -29,8 +29,7 @@
     "nestjs",
     "nest",
     "linter",
-    "diagnostics",
-    "static-analysis",
+    "circular-dependency",
     "code-quality"
   ],
   "categories": [

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -54,6 +54,7 @@ Writes to the project root, or wherever `--output` names. One file: score
 summary, findings with a code viewer, and an interactive module
 graph. Traced HTTP endpoints, the schema ER diagram, and a
 rule playground get their own tabs.
+[Module graph docs →](https://nestjs.doctor/docs/report/module-graph)
 
 ![Module Graph](https://nestjs.doctor/module-graph.png)
 

--- a/packages/nestjs-doctor/package.json
+++ b/packages/nestjs-doctor/package.json
@@ -34,11 +34,19 @@
   },
   "keywords": [
     "nestjs",
-    "diagnostic",
-    "lint",
-    "health-check",
+    "nest",
+    "static-analysis",
+    "code-quality",
+    "code-review",
+    "module-graph",
+    "dependency-graph",
+    "circular-dependency",
     "architecture",
     "security",
+    "diagnostic",
+    "lint",
+    "typescript",
+    "devtools",
     "best-practices"
   ],
   "author": "RoloBits",
@@ -48,7 +56,7 @@
     "url": "https://github.com/RoloBits/nestjs-doctor.git",
     "directory": "packages/nestjs-doctor"
   },
-  "homepage": "https://github.com/RoloBits/nestjs-doctor#readme",
+  "homepage": "https://www.nestjs.doctor",
   "bugs": {
     "url": "https://github.com/RoloBits/nestjs-doctor/issues"
   },

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -1,6 +1,6 @@
 # NestJS Doctor
 
-> Diagnose and fix your NestJS code in one command. 52 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics, plus an interactive HTML report that visualizes the module dependency graph with circular imports highlighted, traced HTTP endpoints, and an ER diagram of the database schema. Zero config. Monorepo support. Ships an official GitHub Action that reports only what a pull request introduced.
+> Diagnose and fix your NestJS code in one command. 52 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics. An interactive HTML report visualizes the module dependency graph with circular imports highlighted, traced HTTP endpoints, and an ER diagram of the database schema. Zero config. Monorepo support. Ships an official GitHub Action that reports only what a pull request introduced.
 
 ## Quick Start
 
@@ -96,7 +96,7 @@ directives cannot silence either rule; use `ignore.rules`.
 
 ## Module graph
 
-`--report` writes an interactive HTML report whose Modules Graph tab draws the module graph built from the project's `@Module()` decorators. Circular imports render red and are listed as chains with the fix guidance from `architecture/no-circular-module-deps`. Selecting a module gives its blast radius, meaning every module that transitively imports it, split into direct and indirect with the chain between them. Two toggles start off: `@Global()` reach draws the wiring Nest does implicitly, and external modules adds package modules as separate nodes. A monorepo produces one merged graph with a labelled cluster per sub-project and cross-package imports drawn in cyan.
+`--report` writes an interactive HTML report whose Modules Graph tab draws the module graph built from the project's `@Module()` decorators. Circular imports render red and are listed as chains with the fix guidance from `architecture/no-circular-module-deps`. Selecting a module gives its blast radius, meaning every module that transitively imports it, split into direct and indirect with the chain between them. Two toggles start off: `@Global()` reach draws the wiring Nest does implicitly, and external modules adds package modules as separate nodes. A monorepo produces one merged graph with a labeled cluster per sub-project and cross-project imports drawn in cyan.
 
 The graph is decorator text, not a running app. Two `@Module()` classes with the same name in different directories collapse into one node outside a monorepo. A module produced only by a factory returning a `DynamicModule` never becomes an edge. `--report` ignores `--scope`, `--base`, `--staged`, `--min-score`, and `--blocking`, and always exits 0.
 

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -1,6 +1,6 @@
 # NestJS Doctor
 
-> Diagnose and fix your NestJS code in one command. 52 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics. Zero config. Monorepo support. Ships an official GitHub Action that reports only what a pull request introduced.
+> Diagnose and fix your NestJS code in one command. 52 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics, plus an interactive HTML report that visualizes the module dependency graph with circular imports highlighted, traced HTTP endpoints, and an ER diagram of the database schema. Zero config. Monorepo support. Ships an official GitHub Action that reports only what a pull request introduced.
 
 ## Quick Start
 
@@ -93,6 +93,14 @@ version-less `package.json` is reported too, never silently skipped.
 The warning rule declares `surfaces: ["cli", "prComment"]`, so it never moves
 the score and never fails a build. `package.json` takes no comments, so inline
 directives cannot silence either rule; use `ignore.rules`.
+
+## Module graph
+
+`--report` writes an interactive HTML report whose Modules Graph tab draws the module graph built from the project's `@Module()` decorators. Circular imports render red and are listed as chains with the fix guidance from `architecture/no-circular-module-deps`. Selecting a module gives its blast radius, meaning every module that transitively imports it, split into direct and indirect with the chain between them. Two toggles start off: `@Global()` reach draws the wiring Nest does implicitly, and external modules adds package modules as separate nodes. A monorepo produces one merged graph with a labelled cluster per sub-project and cross-package imports drawn in cyan.
+
+The graph is decorator text, not a running app. Two `@Module()` classes with the same name in different directories collapse into one node outside a monorepo. A module produced only by a factory returning a `DynamicModule` never becomes an edge. `--report` ignores `--scope`, `--base`, `--staged`, `--min-score`, and `--blocking`, and always exits 0.
+
+Docs: https://nestjs.doctor/docs/report/module-graph
 
 ## Boot trace
 

--- a/packages/website/public/robots.txt
+++ b/packages/website/public/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
 Allow: /
-Disallow: /share
 
 Sitemap: https://www.nestjs.doctor/sitemap.xml

--- a/packages/website/src/app/docs/pipeline/module-graph/page.mdx
+++ b/packages/website/src/app/docs/pipeline/module-graph/page.mdx
@@ -4,7 +4,7 @@ export const metadata = docsMetadata["/docs/pipeline/module-graph"];
 
 <BreadcrumbJsonLd path="/docs/pipeline/module-graph" />
 
-# Module graph
+# Module graph building
 
 **Source:** `src/engine/graph/module-graph.ts`
 

--- a/packages/website/src/app/docs/pipeline/output/page.mdx
+++ b/packages/website/src/app/docs/pipeline/output/page.mdx
@@ -115,7 +115,7 @@ The report has up to six tabs:
 
 - **Summary:** health score overview with a category breakdown.
 - **Findings:** source-level diagnostics with a code viewer and fix examples.
-- **Modules Graph:** clustered module diagram with a searchable project sidebar and a per-module detail panel (used by, blast radius, providers, imports, exports, wiring). Selecting a module animates its edges, colored by direction, and the view offers cycle focus plus toggles for `@Global()` reach and external modules. A Module problems drawer lists module-wiring diagnostics from rules tagged `module-graph`, custom rules included.
+- **Modules Graph:** clustered module diagram with cycles in red and a per-module detail panel. See [Module graph](/docs/report/module-graph).
 - **Endpoints:** badged `Beta`, traced HTTP routes per controller with their dependency chains. Controllers and handlers behind a project wrapper decorator, meaning a custom decorator composing `@Controller()` or `@Get()`, are resolved and traced too.
 - **Relational Schema:** entity-relationship diagram of the database models.
 - **Lab:** custom rule playground for writing and testing your own rules.

--- a/packages/website/src/app/docs/pipeline/page.mdx
+++ b/packages/website/src/app/docs/pipeline/page.mdx
@@ -33,7 +33,7 @@ The pipeline has 10 stages. In a monorepo, stages 1-9 run once per sub-project.
 | 2 | [Project detection](/docs/pipeline/project-detection) | `src/engine/project-detector.ts` | Per project |
 | 3 | [File collection](/docs/pipeline/file-collection) | `src/engine/file-collector.ts` | Per project |
 | 4 | [AST parsing](/docs/pipeline/ast-parsing) | `src/engine/graph/ast-parser.ts` | Per project |
-| 5 | [Module graph](/docs/pipeline/module-graph) | `src/engine/graph/module-graph.ts` | Per project |
+| 5 | [Module graph building](/docs/pipeline/module-graph) | `src/engine/graph/module-graph.ts` | Per project |
 | 6 | [Provider resolution](/docs/pipeline/provider-resolution) | `src/engine/graph/type-resolver.ts` | Per project |
 | 7 | [Rule execution](/docs/pipeline/rule-execution) | `src/engine/rule-runner.ts` | Per project |
 | 8 | [Diagnostic filtering](/docs/pipeline/diagnostic-filtering) | `src/engine/filter-diagnostics.ts` | Per project |

--- a/packages/website/src/app/docs/report/module-graph/page.mdx
+++ b/packages/website/src/app/docs/report/module-graph/page.mdx
@@ -6,9 +6,8 @@ export const metadata = docsMetadata["/docs/report/module-graph"];
 
 # Module graph
 
-Every NestJS project has a module graph. Most teams have never seen theirs. The
-report draws it from the `@Module()` decorators in your source, so it shows the
-wiring that exists rather than the one on the whiteboard.
+The report draws your module graph from the `@Module()` decorators in your
+source.
 
 Scan a project and open the report:
 
@@ -16,14 +15,14 @@ Scan a project and open the report:
 npx nestjs-doctor@latest . --report
 ```
 
-The graph is a tab inside the report, not a separate file. See
-[The report](/docs/report) for where the file lands and what else is in it.
+The graph is one tab inside that report, and there is no separate graph file.
+See [The report](/docs/report) for where the file lands and what else is in it.
 
 ![Module graph](/module-graph.png)
 
 ## Reading the canvas
 
-Color carries the state of a module, and nothing else:
+Node color carries the state of a module, and nothing else:
 
 | Color | Meaning |
 |---|---|
@@ -39,13 +38,14 @@ and projects at once, filtering the tree and the canvas together.
 
 ## Cycles
 
-Circular imports are the reason most people open this tab. Modules in a cycle
-turn red, and the edges between them animate as red dashes.
+Modules in a cycle turn red, and the edges between them animate as red dashes.
 
-A **Circular dependencies** section lists each chain as `UsersModule →
+A Circular dependencies section lists each chain as `UsersModule →
 OrdersModule → UsersModule`. Clicking a chain zooms to it and drops everything
 else to 15% opacity. A cycle buried in 200 modules becomes the only thing on
-screen. Each entry carries the fix guidance from
+screen.
+
+Each entry carries the fix guidance from
 [`no-circular-module-deps`](/docs/rules/architecture).
 
 `forwardRef()` does not hide a cycle. The import resolves, the edge is drawn,
@@ -53,9 +53,8 @@ and the chain still reports.
 
 ## Picking a module
 
-Selecting a node dims everything except its neighbors. Imports draw blue,
-importers draw green, both with moving dashes so direction is readable at a
-glance.
+Selecting a node dims everything except its neighbors. Imports draw blue and
+importers draw green. Both use moving dashes, so direction reads at a glance.
 
 The detail panel then covers seven things, in order: used by, blast radius,
 providers, imports, exports, wiring, and circular dependencies.
@@ -84,15 +83,15 @@ scanner, and the note names that case.
 A dock at the bottom of the canvas lists findings from rules tagged
 `module-graph`, custom rules included. Clicking one flies to the module that
 owns it. Code-level findings stay on the Findings tab, so this dock holds
-wiring problems only.
+wiring findings only.
 
-## Two toggles worth knowing
+## Toggles
 
-Both sit above the canvas and both start off:
+Two toggles sit above the canvas, and both start off:
 
 - **Show `@Global()` reach:** draws a dotted yellow line from every `@Global()`
-  module to each module that uses it without importing it. This is the wiring
-  Nest does for you, which is otherwise invisible.
+  module to every module that does not already import it. A global is available in every
+  module without an import, whether or not that module injects anything from it.
 - **Show external modules:** adds package modules like `ConfigModule` as gray
   dashed nodes in their own cluster. They are never edges in the underlying
   graph, so they only appear here.
@@ -102,21 +101,21 @@ module, and the cost grows with both.
 
 ## Monorepos
 
-A monorepo produces one merged graph, not one per package. Each sub-project
+A monorepo produces one merged graph covering every sub-project. Each sub-project
 becomes a labeled cluster with its own color and module count.
 
-Cross-package imports draw in cyan dashes at reduced opacity, so they read as
-secondary to the edges inside a package. Blast radius counts projects alongside
-modules, and anything crossing a package boundary carries a project badge.
+Cross-project imports draw in cyan dashes at reduced opacity, so they read as
+secondary to the edges inside a sub-project. Blast radius counts projects alongside
+modules, and anything crossing a sub-project boundary carries a project badge.
 
 One case produces no edge. A module imported by a bare name that is ambiguous
-across the workspace stays unresolved, because the scanner will not guess which
-package meant it.
+across the workspace stays unresolved. The scanner will not guess which sub-project
+meant it.
 
 ## Boot times on the graph
 
 `--timings` overlays how long each class took to construct during one real boot.
-Node subtitles gain the slowest class in milliseconds, and a **Boot trace** tab
+Node subtitles gain the slowest class in milliseconds, and a Boot trace tab
 appears in the bottom dock.
 
 That needs one change to `main.ts`, because a scan never runs your application.
@@ -125,9 +124,8 @@ result.
 
 ## Limits
 
-The graph is built from decorator text, not from a running application. Types
-are never resolved. Four consequences are worth knowing before you trust a
-drawing:
+The graph is built from decorator text alone, and types are never resolved.
+Four consequences follow:
 
 - **Same-named modules collide.** Two `@Module()` classes named `SharedModule`
   in different directories become one node, and the second one collected wins.
@@ -136,13 +134,12 @@ drawing:
   factory returning a `DynamicModule` yields no edge.
 - **`forwardRef()` imports look like plain imports.** The edge is correct, but
   the drawing does not mark which side used it.
-- **Offline the layout degrades.** The graph falls back to a plain grid with no
-  hierarchy, as [The report](/docs/report) covers.
+- **Offline the layout degrades.** See [The report](/docs/report).
 
 `--report` also ignores the flags that narrow or gate a scan. `--scope`,
 `--base`, `--staged`, `--min-score`, and `--blocking` have no effect on it, and
 a report always exits `0`. Run a gating scan as a separate command, which
 [Failing the build](/docs/ci/gates) covers.
 
-The graph is a view, not an export. There is no PNG, SVG, or DOT output, no
-alternative layout, and no comparison against a previous run.
+There is no PNG, SVG, or DOT output, no alternative layout, and no comparison
+against a previous run.

--- a/packages/website/src/app/docs/report/module-graph/page.mdx
+++ b/packages/website/src/app/docs/report/module-graph/page.mdx
@@ -1,0 +1,148 @@
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { docsMetadata } from "@/lib/docs-metadata";
+export const metadata = docsMetadata["/docs/report/module-graph"];
+
+<BreadcrumbJsonLd path="/docs/report/module-graph" />
+
+# Module graph
+
+Every NestJS project has a module graph. Most teams have never seen theirs. The
+report draws it from the `@Module()` decorators in your source, so it shows the
+wiring that exists rather than the one on the whiteboard.
+
+Scan a project and open the report:
+
+```bash
+npx nestjs-doctor@latest . --report
+```
+
+The graph is a tab inside the report, not a separate file. See
+[The report](/docs/report) for where the file lands and what else is in it.
+
+![Module graph](/module-graph.png)
+
+## Reading the canvas
+
+Color carries the state of a module, and nothing else:
+
+| Color | Meaning |
+|---|---|
+| Green | A root module: nothing imports it, or `NestFactory` boots it |
+| Yellow | Marked `@Global()`, with a halo around the node |
+| Red | Part of a circular import chain |
+| Gray, dashed | An external module from a package, hidden by default |
+
+Red wins over yellow. A `@Global()` module inside a cycle renders as a cycle.
+
+Drag or scroll to pan, pinch or hold ctrl to zoom. The sidebar searches modules
+and projects at once, filtering the tree and the canvas together.
+
+## Cycles
+
+Circular imports are the reason most people open this tab. Modules in a cycle
+turn red, and the edges between them animate as red dashes.
+
+A **Circular dependencies** section lists each chain as `UsersModule →
+OrdersModule → UsersModule`. Clicking a chain zooms to it and drops everything
+else to 15% opacity. A cycle buried in 200 modules becomes the only thing on
+screen. Each entry carries the fix guidance from
+[`no-circular-module-deps`](/docs/rules/architecture).
+
+`forwardRef()` does not hide a cycle. The import resolves, the edge is drawn,
+and the chain still reports.
+
+## Picking a module
+
+Selecting a node dims everything except its neighbors. Imports draw blue,
+importers draw green, both with moving dashes so direction is readable at a
+glance.
+
+The detail panel then covers seven things, in order: used by, blast radius,
+providers, imports, exports, wiring, and circular dependencies.
+
+**Blast radius** answers what breaks if you change this module. It walks the
+import graph backwards and counts every module that reaches the selected one,
+splitting them into direct importers and indirect ones. Each indirect module
+shows the chain that connects it, as `via AuthModule → UsersModule`.
+
+That number is import reachability, not runtime traffic. A module with a blast
+radius of 40 is imported by 40 modules. It says nothing about how often the code
+runs.
+
+## Wiring
+
+The wiring section walks from a module's controllers to its routes, then into
+the providers each handler calls. A route reads `GET /users · findAll`, and
+expands into the collaborators that handler injects.
+
+When tracing finds nothing, the panel says so instead of showing an empty tree.
+A custom decorator that composes `@Controller()` can hide handlers from the
+scanner, and the note names that case.
+
+## Module problems
+
+A dock at the bottom of the canvas lists findings from rules tagged
+`module-graph`, custom rules included. Clicking one flies to the module that
+owns it. Code-level findings stay on the Findings tab, so this dock holds
+wiring problems only.
+
+## Two toggles worth knowing
+
+Both sit above the canvas and both start off:
+
+- **Show `@Global()` reach:** draws a dotted yellow line from every `@Global()`
+  module to each module that uses it without importing it. This is the wiring
+  Nest does for you, which is otherwise invisible.
+- **Show external modules:** adds package modules like `ConfigModule` as gray
+  dashed nodes in their own cluster. They are never edges in the underlying
+  graph, so they only appear here.
+
+Leave `@Global()` reach off on a large project. It draws one line per global per
+module, and the cost grows with both.
+
+## Monorepos
+
+A monorepo produces one merged graph, not one per package. Each sub-project
+becomes a labeled cluster with its own color and module count.
+
+Cross-package imports draw in cyan dashes at reduced opacity, so they read as
+secondary to the edges inside a package. Blast radius counts projects alongside
+modules, and anything crossing a package boundary carries a project badge.
+
+One case produces no edge. A module imported by a bare name that is ambiguous
+across the workspace stays unresolved, because the scanner will not guess which
+package meant it.
+
+## Boot times on the graph
+
+`--timings` overlays how long each class took to construct during one real boot.
+Node subtitles gain the slowest class in milliseconds, and a **Boot trace** tab
+appears in the bottom dock.
+
+That needs one change to `main.ts`, because a scan never runs your application.
+[Boot trace](/docs/report/boot-trace) covers the change and how to read the
+result.
+
+## Limits
+
+The graph is built from decorator text, not from a running application. Types
+are never resolved. Four consequences are worth knowing before you trust a
+drawing:
+
+- **Same-named modules collide.** Two `@Module()` classes named `SharedModule`
+  in different directories become one node, and the second one collected wins.
+  Monorepos are exempt, because module names are prefixed per project.
+- **A module never named as an identifier is missing.** One produced only by a
+  factory returning a `DynamicModule` yields no edge.
+- **`forwardRef()` imports look like plain imports.** The edge is correct, but
+  the drawing does not mark which side used it.
+- **Offline the layout degrades.** The graph falls back to a plain grid with no
+  hierarchy, as [The report](/docs/report) covers.
+
+`--report` also ignores the flags that narrow or gate a scan. `--scope`,
+`--base`, `--staged`, `--min-score`, and `--blocking` have no effect on it, and
+a report always exits `0`. Run a gating scan as a separate command, which
+[Failing the build](/docs/ci/gates) covers.
+
+The graph is a view, not an export. There is no PNG, SVG, or DOT output, no
+alternative layout, and no comparison against a previous run.

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -46,8 +46,8 @@ Endpoints and Relational Schema stay hidden until there is data. A project with
 no controllers and no ORM entities sees four tabs. The Endpoints tab is badged
 `Beta`.
 
-Pick a module in the graph. The detail panel lists what it imports, exports,
-provides, and what breaks if you change it.
+[Module graph](/docs/report/module-graph) covers reading that tab: cycles,
+blast radius, and the toggles.
 
 ## Findings that do not score
 

--- a/packages/website/src/app/docs/rules/architecture/page.mdx
+++ b/packages/website/src/app/docs/rules/architecture/page.mdx
@@ -204,7 +204,7 @@ Set the option in the rule config:
 
 Aliased imports (`import { forwardRef as fr }`) and namespace access (`Nest.forwardRef(...)`) are not recognized. Use the bare imported name to get the opt-out.
 
-Dynamic module patterns are resolved during graph construction: `ConfigModule.forRoot()`, `forwardRef()`, spread syntax, and helper function calls. Cycle detection is accurate without restructuring the code into plain identifiers. See [Module graph: import resolution](/docs/pipeline/module-graph) for the full list of supported patterns.
+Dynamic module patterns are resolved during graph construction: `ConfigModule.forRoot()`, `forwardRef()`, spread syntax, and helper function calls. Cycle detection is accurate without restructuring the code into plain identifiers. See [Module graph building: import resolution](/docs/pipeline/module-graph) for the full list of supported patterns.
 
 ---
 

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono } from "next/font/google";
 import { SiteAnalytics } from "@/components/site-analytics";
+import { OG_IMAGE_ALT, OG_IMAGE_PATH, SITE_NAME, SITE_URL } from "@/lib/site";
 import "./globals.css";
 
 const ibmPlexMono = IBM_Plex_Mono({
@@ -9,35 +10,37 @@ const ibmPlexMono = IBM_Plex_Mono({
 	weight: ["200", "400", "500", "700"],
 });
 
-const SITE_URL = "https://www.nestjs.doctor";
-const TWITTER_IMAGE_PATH = "/nestjs-doctor-og-banner.png";
+const HOME_TITLE = "NestJS Doctor - Diagnose and Fix Your NestJS Code";
+const HOME_DESCRIPTION = "Diagnose and fix your NestJS code in one command.";
 
 export const metadata: Metadata = {
 	metadataBase: new URL(SITE_URL),
 	title: {
-		default: "NestJS Doctor - Diagnose and Fix Your NestJS Code",
-		template: "%s | NestJS Doctor",
+		default: HOME_TITLE,
+		template: `%s | ${SITE_NAME}`,
 	},
-	description: "Diagnose and fix your NestJS code in one command.",
+	description: HOME_DESCRIPTION,
 	alternates: { canonical: "./" },
 	openGraph: {
-		title: "NestJS Doctor - Diagnose and Fix Your NestJS Code",
-		description: "Diagnose and fix your NestJS code in one command.",
+		title: HOME_TITLE,
+		description: HOME_DESCRIPTION,
 		url: SITE_URL,
-		siteName: "NestJS Doctor",
+		siteName: SITE_NAME,
 		type: "website",
 		images: [
 			{
-				url: TWITTER_IMAGE_PATH,
+				url: OG_IMAGE_PATH,
 				width: 1200,
 				height: 630,
-				alt: "NestJS Doctor - Diagnose and fix your NestJS code",
+				alt: OG_IMAGE_ALT,
 			},
 		],
 	},
 	twitter: {
 		card: "summary_large_image",
-		images: [TWITTER_IMAGE_PATH],
+		title: HOME_TITLE,
+		description: HOME_DESCRIPTION,
+		images: [OG_IMAGE_PATH],
 	},
 	icons: {
 		icon: [{ url: "/favicon.png", type: "image/png" }],

--- a/packages/website/src/app/leaderboard/page.tsx
+++ b/packages/website/src/app/leaderboard/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { pageMetadata } from "@/lib/site";
 import {
 	LEADERBOARD_ENTRIES,
 	type ResolvedLeaderboardEntry,
@@ -84,11 +85,11 @@ const LeaderboardRow = ({
 	);
 };
 
-export const metadata: Metadata = {
+export const metadata: Metadata = pageMetadata("/leaderboard", {
 	title: "Leaderboard",
 	description:
 		"Scores for popular open-source NestJS projects, diagnosed by NestJS Doctor.",
-};
+});
 
 const LeaderboardPage = () => {
 	const topScore = LEADERBOARD_ENTRIES[0]?.score ?? 0;

--- a/packages/website/src/app/share/page.tsx
+++ b/packages/website/src/app/share/page.tsx
@@ -2,13 +2,14 @@
 
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
+import { SITE_URL } from "@/lib/site";
 import AnimatedScore from "./animated-score";
 
 const PERFECT_SCORE = 100;
 const SCORE_GOOD_THRESHOLD = 75;
 const SCORE_OK_THRESHOLD = 50;
 const COMMAND = "npx -y nestjs-doctor@latest .";
-const SHARE_BASE_URL = "https://www.nestjs.doctor/share";
+const SHARE_BASE_URL = `${SITE_URL}/share`;
 const X_ICON_PATH =
 	"M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z";
 const LINKEDIN_ICON_PATH =

--- a/packages/website/src/app/sitemap.ts
+++ b/packages/website/src/app/sitemap.ts
@@ -1,9 +1,8 @@
 import type { MetadataRoute } from "next";
 import { DOCS_NAV } from "@/lib/docs-navigation";
+import { SITE_URL } from "@/lib/site";
 
 export const dynamic = "force-static";
-
-const SITE_URL = "https://www.nestjs.doctor";
 
 export default function sitemap(): MetadataRoute.Sitemap {
 	const docRoutes = DOCS_NAV.flatMap((section) =>

--- a/packages/website/src/components/json-ld.tsx
+++ b/packages/website/src/components/json-ld.tsx
@@ -1,6 +1,5 @@
-import { DOCS_NAV } from "@/lib/docs-navigation";
-
-const SITE_URL = "https://www.nestjs.doctor";
+import { DOCS_PAGES } from "@/lib/docs-metadata";
+import { SITE_URL } from "@/lib/site";
 
 const HTML_UNSAFE = /[<>&\u2028\u2029]/g;
 const ESCAPES: Record<string, string> = {
@@ -39,20 +38,15 @@ export const BreadcrumbJsonLd = ({ path }: { path: string }) => {
 		{ name: "Docs", href: "/docs" },
 	];
 
-	if (path !== "/docs") {
-		for (const section of DOCS_NAV) {
-			for (const item of section.items) {
-				if (item.href === path) {
-					if (path.startsWith("/docs/pipeline") && path !== "/docs/pipeline") {
-						items.push({ name: "Pipeline", href: "/docs/pipeline" });
-					} else if (path.startsWith("/docs/rules") && path !== "/docs/rules") {
-						items.push({ name: "Rules", href: "/docs/rules" });
-					}
-					items.push({ name: item.title, href: item.href });
-					break;
-				}
-			}
-		}
+	const parent = path.slice(0, path.lastIndexOf("/"));
+	const parentPage = parent === "/docs" ? undefined : DOCS_PAGES[parent];
+
+	if (parentPage) {
+		items.push({ name: parentPage.title, href: parent });
+	}
+
+	if (path !== "/docs" && DOCS_PAGES[path]) {
+		items.push({ name: DOCS_PAGES[path].title, href: path });
 	}
 
 	const data = {

--- a/packages/website/src/components/landing/graph-and-schema.tsx
+++ b/packages/website/src/components/landing/graph-and-schema.tsx
@@ -278,7 +278,7 @@ export const GraphAndSchema = () => (
 				figure: <ModuleGraph />,
 				command: "npx nestjs-doctor@latest . --report",
 				docs: {
-					href: "/docs/pipeline/module-graph",
+					href: "/docs/report/module-graph",
 					label: "Module graph docs",
 				},
 			},

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
+import { type PageCopy, pageMetadata } from "@/lib/site";
 
-export const docsMetadata: Record<string, Metadata> = {
+export const DOCS_PAGES: Record<string, PageCopy> = {
 	"/docs": {
 		title: "What is nestjs-doctor?",
 		description:
@@ -15,6 +16,11 @@ export const docsMetadata: Record<string, Metadata> = {
 		title: "The report",
 		description:
 			"Generate the interactive HTML report: score summary, diagnostics with a code viewer, module graph, endpoint traces, schema ER diagram, and the boot trace.",
+	},
+	"/docs/report/module-graph": {
+		title: "Module graph",
+		description:
+			"Visualize your NestJS module dependency graph: cycles in red, blast radius per module, @Global() reach, and cross-package imports in a monorepo.",
 	},
 	"/docs/report/boot-trace": {
 		title: "Boot trace",
@@ -97,7 +103,7 @@ export const docsMetadata: Record<string, Metadata> = {
 			"How nestjs-doctor creates a ts-morph Project instance and loads collected files for TypeScript AST analysis.",
 	},
 	"/docs/pipeline/module-graph": {
-		title: "Module graph",
+		title: "Module graph building",
 		description:
 			"How nestjs-doctor builds a directed dependency graph of NestJS @Module() classes and their relationships.",
 	},
@@ -162,3 +168,10 @@ export const docsMetadata: Record<string, Metadata> = {
 			"Write project-specific nestjs-doctor rules: the rule shape, file and project scopes, the check function's context, and the report's Rule Lab.",
 	},
 };
+
+export const docsMetadata: Record<string, Metadata> = Object.fromEntries(
+	Object.entries(DOCS_PAGES).map(([path, page]) => [
+		path,
+		pageMetadata(path, page),
+	])
+);

--- a/packages/website/src/lib/docs-navigation.ts
+++ b/packages/website/src/lib/docs-navigation.ts
@@ -15,6 +15,7 @@ export const DOCS_NAV: NavSection[] = [
 			{ title: "What is nestjs-doctor?", href: "/docs" },
 			{ title: "Quickstart", href: "/docs/setup" },
 			{ title: "The report", href: "/docs/report" },
+			{ title: "Module graph", href: "/docs/report/module-graph" },
 			{ title: "Boot trace", href: "/docs/report/boot-trace" },
 		],
 	},
@@ -69,7 +70,7 @@ export const DOCS_NAV: NavSection[] = [
 			{ title: "Project detection", href: "/docs/pipeline/project-detection" },
 			{ title: "File collection", href: "/docs/pipeline/file-collection" },
 			{ title: "AST parsing", href: "/docs/pipeline/ast-parsing" },
-			{ title: "Module graph", href: "/docs/pipeline/module-graph" },
+			{ title: "Module graph building", href: "/docs/pipeline/module-graph" },
 			{
 				title: "Provider resolution",
 				href: "/docs/pipeline/provider-resolution",

--- a/packages/website/src/lib/site.ts
+++ b/packages/website/src/lib/site.ts
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+
+export const SITE_URL = "https://www.nestjs.doctor";
+export const SITE_NAME = "NestJS Doctor";
+export const OG_IMAGE_PATH = "/nestjs-doctor-og-banner.png";
+export const OG_IMAGE_ALT = "NestJS Doctor - Diagnose and fix your NestJS code";
+
+export interface PageCopy {
+	description: string;
+	title: string;
+}
+
+/** Page metadata whose social card and og:url match the page's own canonical. */
+export const pageMetadata = (
+	path: string,
+	{ title, description }: PageCopy
+): Metadata => {
+	const socialTitle = `${title} | ${SITE_NAME}`;
+
+	return {
+		title,
+		description,
+		openGraph: {
+			title: socialTitle,
+			description,
+			url: `${SITE_URL}${path}`,
+			siteName: SITE_NAME,
+			type: "website",
+			images: [
+				{
+					url: OG_IMAGE_PATH,
+					width: 1200,
+					height: 630,
+					alt: OG_IMAGE_ALT,
+				},
+			],
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: socialTitle,
+			description,
+			images: [OG_IMAGE_PATH],
+		},
+	};
+};


### PR DESCRIPTION
## Context

The docs site has been live since February. Nothing verifies it is indexed: `site:` counts are unreliable by Google's own account, and there is no Search Console property. So this started as an audit of what a crawler and an LLM actually see, and turned up two separate problems.

The rendering side is fine. Every page is server-rendered with real text, all 34 sitemap URLs return 200, apex 308s to www, and all 16 AI crawlers are allowed and were confirmed fetching the full page.

## Problem

**Every page shipped the landing page's social card.** Next merges metadata shallowly, so a child setting only `title` and `description` inherits the parent's entire `openGraph` block. `out/docs/setup.html` carried `og:url` of `https://www.nestjs.doctor` next to `<link rel="canonical" href="https://www.nestjs.doctor/docs/setup">`. The page contradicted itself in the `<head>`, on 32 docs pages plus `/leaderboard`. `twitter:title` was wrong for the same reason.

**The report draws an interactive module graph and no page said how to read it.** Zero of 34 page titles contained "graph". The single H1 that did sits under Internals and covers `findCircularDeps()` and posix path keys, not the picture. The landing CTA labelled "Module graph docs" pointed at that internals page, which is the clearest evidence the user-facing page was missing.

For scale: `nestjs-spelunker` does 404,832 npm downloads a month for a library that emits a Mermaid edge list.

**Two smaller defects.** `robots.txt` disallowed `/share`, which blocked the crawl that would read that route's own `noindex`, so a shared URL could still be indexed without content. And the npm `homepage` field pointed at the GitHub readme, so the highest-authority page linking to the project skipped the docs site.

## Possible flows

| Surface | Affected | Why |
|---|---|---|
| Docs pages (32) | Yes | Inherited landing `og:title` and `og:url` |
| `/leaderboard` | Yes | Same inheritance |
| `/` | No | Its own metadata is the landing copy |
| `/share`, 404 | No | `noindex`, excluded from indexing |
| Breadcrumb JSON-LD | `/docs/ci/*`, `/docs/report/*` | Parents hardcoded for two prefixes only |
| npm, VS Code registries | Yes | Homepage and keywords |
| Rules, scoring, CLI | No | No engine or CLI code touched |

## Solution

Page metadata now goes through one builder in `src/lib/site.ts` that emits complete `openGraph` and `twitter` objects keyed to the page's own route. That file also holds `SITE_URL`, which was hardcoded in four places.

Breadcrumb parents are derived from the route and included only when they resolve to a real page, which also drops nine lines and fixes `/docs/ci/*` and `/docs/report/*`.

`/docs/report/module-graph` is new. Every claim on it was verified against source first, and several were cut as false: there is no PNG, SVG or DOT export, no layout switcher, no provider-level graph and no diff mode. Clustering is by sub-project only. It also documents that `--report` ignores `--scope`, `--base`, `--staged`, `--min-score` and `--blocking` and always exits `0`, which was written down nowhere.

The internals page becomes "Module graph building" so the two stop competing for the same query. Its URL is unchanged, so no links broke.

The page then went through a voice pass, because the first draft read like a machine wrote it. It used the same "X, not Y" construction five times, opened on a rhetorical hook, and reached for a metaphor that `CLAUDE.md` bans. That pass also caught a factual error: the `@Global()` reach toggle was described as drawing a line to each module that *uses* the global, and `mgDrawGlobalReach` has no usage check at all. It skips the module itself and anything already importing it, then draws to everything else. The page now matches the report's own legend, which reads `Global reach (no import)`. Workspace members are called sub-projects throughout, per the style guide and the UI's "Cross-project import" label.

**A product bug found while verifying, and left alone.** In `mgDrawGlobalReach`, the inner loop walks raw `mgNodes` with no visibility filter, unlike every other draw path in that file which gates on `mgHideExternal`. With reach on and external modules off, the report draws dotted lines terminating at invisible nodes. That is report UI, not docs, so it is not fixed here and the page makes no claim either way.

**Deliberately not done.** `/docs/reference` still 404s: "Reference" is a nav section header, not a route, and a thin index page is what Google marks "crawled – currently not indexed". Search Console and Bing Webmaster Tools verification are human-only steps and are not in this PR. `llms-full.txt` and raw `.md` mirrors are left out; measured over 83 sites, PerplexityBot fetched `llms.txt` 0 times and Google states Search does not use it.

## Before vs after

| Surface | Before | After |
|---|---|---|
| `og:url` on `/docs/setup` | `https://www.nestjs.doctor` | `https://www.nestjs.doctor/docs/setup` |
| Unique `og:title` across indexable pages | 1 of 34 | 34 of 34 |
| Breadcrumb for `/docs/ci/gates` | `Docs → Failing the build` | `Docs → GitHub Actions setup → Failing the build` |
| Page titles containing "graph" | 0 | 1, plus the retitled internals page |
| Sitemap entries | 34 | 35 |
| npm `homepage` | GitHub readme | `https://www.nestjs.doctor` |
| Landing "Module graph docs" CTA | Internals page | User-facing page |
| `nestjs-doctor-vscode` release | Keyword change with no changeset | Covered, so the bump reaches the Marketplace |
| Score, rules, exit codes | Unchanged | Unchanged |

## Example

Head tags on a built docs page, before:

```
<title>Quickstart | NestJS Doctor</title>
<link rel="canonical" href="https://www.nestjs.doctor/docs/setup"/>
<meta property="og:title" content="NestJS Doctor - Diagnose and Fix Your NestJS Code"/>
<meta property="og:url" content="https://www.nestjs.doctor"/>
<meta name="twitter:title" content="NestJS Doctor - Diagnose and Fix Your NestJS Code"/>
```

After:

```
<title>Quickstart | NestJS Doctor</title>
<link rel="canonical" href="https://www.nestjs.doctor/docs/setup"/>
<meta property="og:title" content="Quickstart | NestJS Doctor"/>
<meta property="og:url" content="https://www.nestjs.doctor/docs/setup"/>
<meta name="twitter:title" content="Quickstart | NestJS Doctor"/>
```

Verified across all 34 indexable pages: no duplicate `og:title`, no duplicate `og:url`, and `og:url` equal to `canonical` on every one.
