### PR TITLE
docs: title the Devtools page with the product name

### DIFF
--- a/packages/website/src/app/docs/nest-devtools-alternative/page.mdx
+++ b/packages/website/src/app/docs/nest-devtools-alternative/page.mdx
@@ -4,7 +4,7 @@ export const metadata = docsMetadata["/docs/nest-devtools-alternative"];
 
 <BreadcrumbJsonLd path="/docs/nest-devtools-alternative" />
 
-# nestjs-doctor vs Nest Devtools
+# NestJS Doctor vs Nest Devtools
 
 Both tools draw a NestJS module graph. They get there from opposite ends.
 

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -8,7 +8,7 @@ export const DOCS_PAGES: Record<string, PageCopy> = {
 			"Diagnostic CLI tool that scans NestJS codebases and produces a health score across security, correctness, architecture, performance, and schema.",
 	},
 	"/docs/nest-devtools-alternative": {
-		title: "nestjs-doctor vs Nest Devtools",
+		title: "NestJS Doctor vs Nest Devtools",
 		description:
 			"Both draw a NestJS module graph. Nest Devtools boots your app; nestjs-doctor reads your source, adds 52 rules, an ER diagram and a CI gate, and is MIT licensed.",
 	},

--- a/packages/website/src/lib/docs-navigation.ts
+++ b/packages/website/src/lib/docs-navigation.ts
@@ -14,10 +14,6 @@ export const DOCS_NAV: NavSection[] = [
 		items: [
 			{ title: "What is nestjs-doctor?", href: "/docs" },
 			{ title: "Quickstart", href: "/docs/setup" },
-			{
-				title: "nestjs-doctor vs Nest Devtools",
-				href: "/docs/nest-devtools-alternative",
-			},
 			{ title: "The report", href: "/docs/report" },
 			{ title: "Module graph", href: "/docs/report/module-graph" },
 			{ title: "Boot trace", href: "/docs/report/boot-trace" },
@@ -29,6 +25,15 @@ export const DOCS_NAV: NavSection[] = [
 			{ title: "Coding agents", href: "/docs/coding-agents" },
 			{ title: "VS Code extension", href: "/docs/vscode-extension" },
 			{ title: "Language server", href: "/docs/language-server" },
+		],
+	},
+	{
+		title: "Comparisons",
+		items: [
+			{
+				title: "NestJS Doctor vs Nest Devtools",
+				href: "/docs/nest-devtools-alternative",
+			},
 		],
 	},
 	{


### PR DESCRIPTION
## Context

#281 shipped the Nest Devtools page. Its title led with the package name rather than the product name.

## Problem

The rendered title styled the same product two ways in one string:

```
nestjs-doctor vs Nest Devtools | NestJS Doctor
```

The suffix comes from the site-wide title template, so the mismatch showed on the search result, the browser tab, and the social card.

The page also sat in the Overview nav section, competing with Quickstart, the report and the module graph for a reader who is still deciding whether to use the tool at all.

## Possible flows

| Surface | Affected | Why |
|---|---|---|
| Page `<title>`, OG and Twitter title | Yes | All derive from the `DOCS_PAGES` title |
| Breadcrumb JSON-LD | Yes | Crumb name is the metadata title |
| Docs sidebar | Yes | New section, new label |
| The page URL | No | Slug unchanged, so no links break |
| Sitemap | No | Still 36 entries |
| Page body, tables, claims | No | Not touched |

## Solution

The title is now `NestJS Doctor vs Nest Devtools`, matching the display name used everywhere else on the site.

Three places have to agree, and all three changed together: the H1, the `DOCS_PAGES` title, and the nav label. The metadata title also feeds `BreadcrumbJsonLd`, so a mismatch would have been wrong in the structured data as well as the tab.

Comparisons is now its own nav section, placed after Getting started. One entry today, and the keyword research points at several more worth writing.

## Before vs after

| | Before | After |
|---|---|---|
| `<title>` | `nestjs-doctor vs Nest Devtools \| NestJS Doctor` | `NestJS Doctor vs Nest Devtools \| NestJS Doctor` |
| Breadcrumb | `Docs → nestjs-doctor vs Nest Devtools` | `Docs → NestJS Doctor vs Nest Devtools` |
| Nav location | Overview, sixth item | Comparisons, its own section |
| URL | `/docs/nest-devtools-alternative` | Unchanged |
| Sitemap entries | 36 | 36 |

## Example

Verified in the build:

```
<title>NestJS Doctor vs Nest Devtools | NestJS Doctor</title>
breadcrumb: Docs → NestJS Doctor vs Nest Devtools
```
