### PR TITLE
feat(tui): two-pane score browser, animated progress, worker-thread scans

### DIFF
--- a/.changeset/interactive-worker-scan.md
+++ b/.changeset/interactive-worker-scan.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": minor
+---
+
+Interactive scans run the engine in a worker thread, so the spinner and the progress bar animate continuously instead of freezing while the scan works. The bar eases toward each new count and phase labels wipe in rather than jump, and the parse, module graph, provider, and guard-index passes yield to the event loop in smaller batches. CI and machine-readable runs scan in-process exactly as before, and a worker failure falls back to the in-process scan.
+
+The score screen's sub-project list is now a two-pane browser: the list is ordered worst score first, the view scrolls with the selection, left/right switches between the projects and the action menu, and a right panel shows the selected project's score, counts, and worst rules. Single-project scans render exactly as before.

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -21,8 +21,7 @@ const CONFIG_ERROR_EXIT_CODE = 2;
 const require = createRequire(import.meta.url);
 const { version } = require("../../package.json") as { version: string };
 
-// Sibling of this entry in the built bundle; missing in a source checkout,
-// where the pipeline then always scans in-process.
+// Ships beside this entry in the built bundle.
 setScanWorkerUrl(new URL("./scan-worker.mjs", import.meta.url));
 
 const main = defineCommand({

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -10,6 +10,7 @@ import {
 	type InteractiveArtifacts,
 	MonorepoPipeline,
 	SingleProjectPipeline,
+	setScanWorkerUrl,
 } from "./pipeline.js";
 import { type CliArgs, CliSetup } from "./setup.js";
 import { canPrompt } from "./ui/environment.js";
@@ -19,6 +20,10 @@ const CONFIG_ERROR_EXIT_CODE = 2;
 
 const require = createRequire(import.meta.url);
 const { version } = require("../../package.json") as { version: string };
+
+// Sibling of this entry in the built bundle; missing in a source checkout,
+// where the pipeline then always scans in-process.
+setScanWorkerUrl(new URL("./scan-worker.mjs", import.meta.url));
 
 const main = defineCommand({
 	meta: {
@@ -76,6 +81,7 @@ async function scan(args: CliArgs): Promise<void> {
 			buildReportHtml: artifacts.buildReportHtml,
 			result: artifacts.result,
 			subProjects: artifacts.subProjects?.map(({ name, result }) => ({
+				diagnostics: result.diagnostics,
 				errors: result.summary.errors,
 				fileCount: result.project.fileCount,
 				info: result.summary.info,

--- a/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
@@ -65,6 +65,9 @@ export const App = ({
 	const [toast, setToast] = useState<Toast>(null);
 	const [selectedAction, setSelectedAction] = useState(0);
 	const [selectedHandoff, setSelectedHandoff] = useState(0);
+	const [scoreFocus, setScoreFocus] = useState<"list" | "menu">("menu");
+	const [selectedSub, setSelectedSub] = useState(0);
+	const subCount = context.subProjects?.length ?? 0;
 
 	const shown = useMemo(
 		() => withSurface(context.result, "cli"),
@@ -202,6 +205,18 @@ export const App = ({
 			if (screen !== "score") {
 				return;
 			}
+			if (subCount > 0 && (key.leftArrow || key.rightArrow || key.tab)) {
+				setScoreFocus((previous) => (previous === "menu" ? "list" : "menu"));
+				return;
+			}
+			if (scoreFocus === "list" && subCount > 0) {
+				if (key.upArrow || input === "k") {
+					setSelectedSub((previous) => Math.max(0, previous - 1));
+				} else if (key.downArrow || input === "j") {
+					setSelectedSub((previous) => Math.min(subCount - 1, previous + 1));
+				}
+				return;
+			}
 			if (key.upArrow || input === "k") {
 				setSelectedAction((previous) =>
 					previous === 0 ? items.length - 1 : previous - 1
@@ -308,9 +323,11 @@ export const App = ({
 		<ScoreScreen
 			busy={busy}
 			context={context}
+			focus={scoreFocus}
 			items={items}
 			result={shown}
 			selected={selectedAction}
+			selectedSub={selectedSub}
 			toast={toast}
 		/>
 	);

--- a/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
@@ -205,6 +205,15 @@ export const App = ({
 			if (screen !== "score") {
 				return;
 			}
+			if (input === "q" && !busy) {
+				exit();
+				return;
+			}
+			if (key.return && !busy) {
+				// biome-ignore lint/suspicious/noEmptyBlockStatements: the action reports its own errors as a toast
+				runAction(items[selectedAction].action).catch(() => {});
+				return;
+			}
 			if (subCount > 0 && (key.leftArrow || key.rightArrow || key.tab)) {
 				setScoreFocus((previous) => (previous === "menu" ? "list" : "menu"));
 				return;
@@ -223,11 +232,6 @@ export const App = ({
 				);
 			} else if (key.downArrow || input === "j") {
 				setSelectedAction((previous) => (previous + 1) % items.length);
-			} else if (key.return && !busy) {
-				// biome-ignore lint/suspicious/noEmptyBlockStatements: the action reports its own errors as a toast
-				runAction(items[selectedAction].action).catch(() => {});
-			} else if (input === "q" && !busy) {
-				exit();
 			}
 		},
 		{ isActive: screen === "score" }

--- a/packages/nestjs-doctor/src/cli/interactive/tui/navigate.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/navigate.ts
@@ -87,6 +87,20 @@ export const moveSelection = (
 	return next;
 };
 
+/** Keeps a scroll offset inside [0, total - visible]. */
+export const clampOffset = (
+	offset: number,
+	total: number,
+	visible: number
+): number => Math.max(0, Math.min(offset, Math.max(0, total - visible)));
+
+/** Rows a list may use: terminal height minus everything else on screen, with a floor. */
+export const listCapacity = (
+	rows: number,
+	chromeRows: number,
+	minimum: number
+): number => Math.max(minimum, rows - chromeRows);
+
 /** Keeps the selection inside the visible window. */
 export const scrollWindow = (
 	offset: number,

--- a/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
@@ -2,11 +2,23 @@ import { Box, Text, useStdout } from "ink";
 import { useEffect, useState } from "react";
 import type { DiagnoseResult } from "../../../common/result.js";
 import { formatElapsedTime } from "../../formatters/console-reporter.js";
+import { groupFindings } from "../findings.js";
+import { listCapacity, scrollWindow } from "./navigate.js";
 import { padEnd, truncate } from "./text.js";
-import { getNestBirds, getStarRating, palette, scoreColor } from "./theme.js";
+import {
+	getNestBirds,
+	getStarRating,
+	palette,
+	SEVERITY_MARK,
+	scoreColor,
+	severityColor,
+} from "./theme.js";
 import type { InteractiveContext, MenuAction, Toast } from "./types.js";
 
 const SCORE_BAR_WIDTH = 30;
+/** Nest box, score block, menu borders, footer, and the gaps between them. */
+const CHROME_ROWS = 14;
+const MIN_SUB_ROWS = 3;
 
 const TOAST_STYLE: Record<
 	"error" | "info" | "success",
@@ -107,12 +119,39 @@ const subStatus = (
 	return "  ✓ clean";
 };
 
+const byWorstScore = (
+	a: { name: string; score: number },
+	b: { name: string; score: number }
+): number => a.score - b.score || a.name.localeCompare(b.name);
+
+const shortRule = (rule: string): string =>
+	rule.split("/").slice(1).join("/") || rule;
+
+const keyHints = (
+	busy: boolean,
+	hasSubProjects: boolean,
+	focus: "list" | "menu"
+): string => {
+	if (busy) {
+		return "working…";
+	}
+	if (!hasSubProjects) {
+		return "↑↓ select · enter confirm · q quit";
+	}
+	return focus === "list"
+		? "↑↓ project · ←→ actions · enter confirm · q quit"
+		: "↑↓ select · ←→ projects · enter confirm · q quit";
+};
+
 interface ScoreScreenProps {
 	busy: boolean;
 	context: InteractiveContext;
+	/** Which pane answers to ↑↓: the sub-project list or the action menu. */
+	focus: "list" | "menu";
 	items: MenuItem[];
 	result: DiagnoseResult;
 	selected: number;
+	selectedSub: number;
 	toast: Toast;
 }
 
@@ -143,9 +182,11 @@ const useCountUp = (target: number, durationMs = ANIMATION_MS): number => {
 export const ScoreScreen = ({
 	busy,
 	context,
+	focus,
 	items,
 	result,
 	selected,
+	selectedSub,
 	toast,
 }: ScoreScreenProps): React.JSX.Element => {
 	const { project, score, summary, elapsedMs, diagnostics } = result;
@@ -154,6 +195,42 @@ export const ScoreScreen = ({
 	const shownScore = useCountUp(score.value);
 	const affectedFiles = new Set(diagnostics.map((d) => d.filePath)).size;
 	const labelWidth = Math.max(...items.map((item) => item.label.length));
+
+	const subProjects = [...(context.subProjects ?? [])].sort(byWorstScore);
+	const paneRows = listCapacity(
+		stdout.rows ?? 24,
+		CHROME_ROWS + items.length,
+		MIN_SUB_ROWS
+	);
+	const subProjectsOverflow = subProjects.length > paneRows - 1;
+	const visibleSubRows = Math.max(
+		1,
+		paneRows - 1 - (subProjectsOverflow ? 1 : 0)
+	);
+	const [subOffset, setSubOffset] = useState(0);
+	const selectedSubRow = Math.min(selectedSub, subProjects.length - 1);
+	const safeSubOffset = scrollWindow(
+		Math.min(subOffset, Math.max(0, subProjects.length - visibleSubRows)),
+		selectedSubRow,
+		visibleSubRows
+	);
+
+	useEffect(() => {
+		setSubOffset(safeSubOffset);
+	}, [safeSubOffset]);
+
+	const selectedSubProject = subProjects[selectedSubRow];
+	const selectedRules = selectedSubProject
+		? groupFindings(selectedSubProject.diagnostics)
+		: [];
+	const rulesRoom = Math.max(0, paneRows - 4);
+	const rulesTruncated = selectedRules.length > rulesRoom;
+	const shownRules = selectedRules.slice(
+		0,
+		rulesTruncated ? rulesRoom - 1 : rulesRoom
+	);
+	const leftContent = Math.max(14, Math.min(42, Math.round(columns * 0.34)));
+	const panelWidth = Math.max(12, columns - leftContent - 4);
 
 	const countLabel = (count: number, singular: string): string =>
 		`${count} ${singular}${count === 1 ? "" : "s"}`;
@@ -239,23 +316,157 @@ export const ScoreScreen = ({
 				</Text>
 			</Box>
 
-			{context.subProjects && context.subProjects.length > 0 ? (
-				<Box flexDirection="column">
-					<Text color={palette.muted}>SUB-PROJECTS</Text>
-					{context.subProjects.map((sub) => (
-						<Text key={sub.name}>
-							<Text color={palette.text}>{`  ${padEnd(sub.name, 28)}`}</Text>
-							<Text
-								color={scoreColor(sub.score)}
-							>{`${String(sub.score).padStart(3)}/100`}</Text>
-							<Text color={palette.dim}>{subStatus(sub)}</Text>
+			{subProjects.length > 0 ? (
+				<Box flexDirection="row">
+					<Box flexDirection="column" flexShrink={0} width={leftContent}>
+						<Text
+							bold={focus === "list"}
+							color={focus === "list" ? palette.bright : palette.muted}
+						>
+							{" SUB-PROJECTS"}
 						</Text>
-					))}
+						{subProjects
+							.slice(safeSubOffset, safeSubOffset + visibleSubRows)
+							.map((sub, index) => {
+								const isSelected = safeSubOffset + index === selectedSubRow;
+								return (
+									<Box flexDirection="row" key={sub.name}>
+										<Box
+											backgroundColor={
+												isSelected && focus === "list"
+													? palette.nestRed
+													: undefined
+											}
+											width={1}
+										>
+											<Text> </Text>
+										</Box>
+										<Box
+											backgroundColor={
+												isSelected && focus === "list"
+													? palette.washRed
+													: undefined
+											}
+											flexDirection="row"
+											width={leftContent - 1}
+										>
+											<Text>
+												<Text
+													bold={isSelected}
+													color={isSelected ? palette.bright : palette.text}
+												>
+													{` ${padEnd(
+														truncate(sub.name, leftContent - 12),
+														Math.max(0, leftContent - 12)
+													)}`}
+												</Text>
+												<Text
+													color={
+														isSelected && focus === "list"
+															? palette.bright
+															: scoreColor(sub.score)
+													}
+												>
+													{`${String(sub.score).padStart(3)}/100`}
+												</Text>
+												<Text
+													color={
+														isSelected && focus === "list"
+															? palette.muted
+															: palette.dim
+													}
+												>
+													{` ${subStatus(sub).slice(2, 3)}`}
+												</Text>
+											</Text>
+										</Box>
+									</Box>
+								);
+							})}
+						{subProjectsOverflow ? (
+							<Text color={palette.dim}>
+								{` … ${safeSubOffset + 1}–${Math.min(safeSubOffset + visibleSubRows, subProjects.length)} of ${subProjects.length}`}
+							</Text>
+						) : null}
+					</Box>
+					<Box
+						borderBottom={false}
+						borderColor={palette.border}
+						borderRight={false}
+						borderStyle="single"
+						borderTop={false}
+						flexShrink={0}
+					/>
+					<Box flexDirection="column" paddingLeft={1} width={panelWidth}>
+						{selectedSubProject ? (
+							<>
+								<Text>
+									<Text bold color={palette.bright}>
+										{truncate(selectedSubProject.name, panelWidth - 10)}
+									</Text>
+									<Text color={scoreColor(selectedSubProject.score)}>
+										{`  ${selectedSubProject.score}/100`}
+									</Text>
+								</Text>
+								<ScoreBar score={selectedSubProject.score} />
+								<Text>
+									{selectedSubProject.errors > 0 ? (
+										<Text color={palette.error}>
+											{`✗ ${selectedSubProject.errors}`}
+										</Text>
+									) : null}
+									{selectedSubProject.errors > 0 &&
+									selectedSubProject.warnings > 0 ? (
+										<Text color={palette.dim}>{"  ·  "}</Text>
+									) : null}
+									{selectedSubProject.warnings > 0 ? (
+										<Text color={palette.warning}>
+											{`⚠ ${selectedSubProject.warnings}`}
+										</Text>
+									) : null}
+									{selectedSubProject.info > 0 ? (
+										<Text color={palette.dim}>
+											{`  ·  ${selectedSubProject.info} info`}
+										</Text>
+									) : null}
+									{selectedSubProject.diagnostics.length === 0 ? (
+										<Text color={palette.success}>✓ clean</Text>
+									) : null}
+									<Text color={palette.dim}>
+										{`  ·  ${selectedSubProject.fileCount} files`}
+									</Text>
+								</Text>
+								{selectedRules.length > 0 ? (
+									<Box flexDirection="column" paddingTop={0}>
+										<Text color={palette.muted}>{" TOP RULES"}</Text>
+										{shownRules.map((group) => (
+											<Text key={group.rule}>
+												<Text color={severityColor(group.severity)}>
+													{` ${SEVERITY_MARK[group.severity]} `}
+												</Text>
+												<Text color={palette.text}>
+													{truncate(shortRule(group.rule), panelWidth - 8)}
+												</Text>
+												<Text color={palette.dim}>
+													{` ${group.diagnostics.length}`}
+												</Text>
+											</Text>
+										))}
+										{rulesTruncated ? (
+											<Text color={palette.dim}>
+												{` … +${selectedRules.length - shownRules.length} more rules`}
+											</Text>
+										) : null}
+									</Box>
+								) : null}
+							</>
+						) : null}
+					</Box>
 				</Box>
 			) : null}
 
 			<Box
-				borderColor={palette.border}
+				borderColor={focus === "menu" ? palette.nestRed : palette.border}
 				borderStyle="single"
 				flexDirection="column"
 			>
@@ -310,7 +521,7 @@ export const ScoreScreen = ({
 					</Text>
 				) : null}
 				<Text color={palette.dim}>
-					{busy ? "working…" : "↑↓ select · enter confirm · q quit"}
+					{keyHints(busy, subProjects.length > 0, focus)}
 				</Text>
 			</Box>
 		</Box>

--- a/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import type { DiagnoseResult } from "../../../common/result.js";
 import { formatElapsedTime } from "../../formatters/console-reporter.js";
 import { groupFindings } from "../findings.js";
-import { listCapacity, scrollWindow } from "./navigate.js";
+import { clampOffset, listCapacity, scrollWindow } from "./navigate.js";
 import { padEnd, truncate } from "./text.js";
 import {
 	getNestBirds,
@@ -210,7 +210,7 @@ export const ScoreScreen = ({
 	const [subOffset, setSubOffset] = useState(0);
 	const selectedSubRow = Math.min(selectedSub, subProjects.length - 1);
 	const safeSubOffset = scrollWindow(
-		Math.min(subOffset, Math.max(0, subProjects.length - visibleSubRows)),
+		clampOffset(subOffset, subProjects.length, visibleSubRows),
 		selectedSubRow,
 		visibleSubRows
 	);

--- a/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
@@ -107,16 +107,16 @@ const ScoreBar = ({ score }: { score: number }): React.JSX.Element => {
 	);
 };
 
-const subStatus = (
+const subMark = (
 	sub: NonNullable<InteractiveContext["subProjects"]>[number]
 ): string => {
 	if (sub.errors > 0) {
-		return `  ✗ ${sub.errors} errors`;
+		return "✗";
 	}
 	if (sub.warnings > 0) {
-		return `  ⚠ ${sub.warnings} warnings`;
+		return "⚠";
 	}
-	return "  ✓ clean";
+	return "✓";
 };
 
 const byWorstScore = (
@@ -329,24 +329,17 @@ export const ScoreScreen = ({
 							.slice(safeSubOffset, safeSubOffset + visibleSubRows)
 							.map((sub, index) => {
 								const isSelected = safeSubOffset + index === selectedSubRow;
+								const rowActive = isSelected && focus === "list";
 								return (
 									<Box flexDirection="row" key={sub.name}>
 										<Box
-											backgroundColor={
-												isSelected && focus === "list"
-													? palette.nestRed
-													: undefined
-											}
+											backgroundColor={rowActive ? palette.nestRed : undefined}
 											width={1}
 										>
 											<Text> </Text>
 										</Box>
 										<Box
-											backgroundColor={
-												isSelected && focus === "list"
-													? palette.washRed
-													: undefined
-											}
+											backgroundColor={rowActive ? palette.washRed : undefined}
 											flexDirection="row"
 											width={leftContent - 1}
 										>
@@ -362,21 +355,13 @@ export const ScoreScreen = ({
 												</Text>
 												<Text
 													color={
-														isSelected && focus === "list"
-															? palette.bright
-															: scoreColor(sub.score)
+														rowActive ? palette.bright : scoreColor(sub.score)
 													}
 												>
 													{`${String(sub.score).padStart(3)}/100`}
 												</Text>
-												<Text
-													color={
-														isSelected && focus === "list"
-															? palette.muted
-															: palette.dim
-													}
-												>
-													{` ${subStatus(sub).slice(2, 3)}`}
+												<Text color={rowActive ? palette.muted : palette.dim}>
+													{` ${subMark(sub)}`}
 												</Text>
 											</Text>
 										</Box>

--- a/packages/nestjs-doctor/src/cli/interactive/tui/types.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/types.ts
@@ -1,6 +1,8 @@
+import type { Diagnostic } from "../../../common/diagnostic.js";
 import type { DiagnoseResult } from "../../../common/result.js";
 
 export interface SubProjectView {
+	diagnostics: Diagnostic[];
 	errors: number;
 	fileCount: number;
 	info: number;

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -147,6 +147,7 @@ abstract class ScanPipeline {
 	protected scanConfig!: ScanConfig;
 	/** Live progress line while `run` is in flight; steps update its label. */
 	protected progress: {
+		fail(text: string): void;
 		succeed(text: string): void;
 		update(label: string, done?: number, total?: number): void;
 	} | null = null;
@@ -426,6 +427,28 @@ abstract class ScanPipeline {
 		this.progress = this.options.isMachineReadable
 			? null
 			: createAnimatedProgress("Scanning...");
+		// The spinner puts stdin in raw mode, where Ctrl+C arrives as a 0x03
+		// byte rather than a signal, and the signal path is unreliable once
+		// ora's cleanup hooks are loaded. Watch the byte and the signal.
+		const cancel = (): void => {
+			this.progress?.fail("Scan cancelled");
+			this.progress = null;
+			logger.warn("Scan cancelled.");
+			process.exit(130);
+		};
+		const onInterrupt = (): void => {
+			cancel();
+		};
+		const onByte = (data: Buffer | string): void => {
+			const code = typeof data === "string" ? data.codePointAt(0) : data.at(0);
+			if (code === 0x03) {
+				cancel();
+			}
+		};
+		process.on("SIGINT", onInterrupt);
+		if (process.stdin.isTTY) {
+			process.stdin.on("data", onByte);
+		}
 		try {
 			if (await this.canDelegate()) {
 				try {
@@ -455,6 +478,8 @@ abstract class ScanPipeline {
 				await step();
 			}
 		} finally {
+			process.off("SIGINT", onInterrupt);
+			process.stdin?.off("data", onByte);
 			this.stopProgress();
 		}
 	}

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -431,6 +431,7 @@ abstract class ScanPipeline {
 				try {
 					await this.delegate();
 				} catch (error) {
+					this.stopProgress();
 					logger.warn(
 						`The scan worker failed (${error instanceof Error ? error.message : String(error)}); scanning in process instead.`
 					);

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -88,6 +88,7 @@ export interface ScanWorkerRequest {
 	monorepo?: MonorepoInfo;
 	options: PipelineOptions;
 	targetPath: string;
+	version: string;
 }
 
 /** Worker → main. Progress ticks, then one outcome or one failure. */
@@ -427,9 +428,7 @@ abstract class ScanPipeline {
 		this.progress = this.options.isMachineReadable
 			? null
 			: createAnimatedProgress("Scanning...");
-		// The spinner puts stdin in raw mode, where Ctrl+C arrives as a 0x03
-		// byte rather than a signal, and the signal path is unreliable once
-		// ora's cleanup hooks are loaded. Watch the byte and the signal.
+		// Raw mode turns Ctrl+C into a 0x03 byte; watch for both it and SIGINT.
 		const cancel = (): void => {
 			this.progress?.fail("Scan cancelled");
 			this.progress = null;
@@ -440,8 +439,9 @@ abstract class ScanPipeline {
 			cancel();
 		};
 		const onByte = (data: Buffer | string): void => {
-			const code = typeof data === "string" ? data.codePointAt(0) : data.at(0);
-			if (code === 0x03) {
+			if (
+				typeof data === "string" ? data.includes("\u0003") : data.includes(0x03)
+			) {
 				cancel();
 			}
 		};
@@ -454,7 +454,8 @@ abstract class ScanPipeline {
 				try {
 					await this.delegate();
 				} catch (error) {
-					this.stopProgress();
+					this.progress?.fail("Worker scan failed");
+					this.progress = null;
 					logger.warn(
 						`The scan worker failed (${error instanceof Error ? error.message : String(error)}); scanning in process instead.`
 					);
@@ -641,6 +642,7 @@ export class MonorepoPipeline extends ScanPipeline {
 					onProgress: undefined,
 				},
 				monorepo: this.monorepo,
+				version: getCliVersion(),
 			},
 			(outcome) => {
 				if (outcome.kind !== "monorepo") {
@@ -764,6 +766,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 					skipOutput: true,
 					onProgress: undefined,
 				},
+				version: getCliVersion(),
 			},
 			(outcome) => {
 				if (outcome.kind !== "single") {

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -435,6 +435,9 @@ abstract class ScanPipeline {
 					logger.warn(
 						`The scan worker failed (${error instanceof Error ? error.message : String(error)}); scanning in process instead.`
 					);
+					if (!this.options.isMachineReadable) {
+						this.progress = createAnimatedProgress("Scanning...");
+					}
 					for (const step of this.steps) {
 						await step();
 					}

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -1,4 +1,6 @@
+import { stat } from "node:fs/promises";
 import { performance } from "node:perf_hooks";
+import { Worker } from "node:worker_threads";
 import type { Diagnostic } from "../common/diagnostic.js";
 import type { DiagnoseResult } from "../common/result.js";
 import { computeBaselineDelta } from "../engine/baseline.js";
@@ -55,25 +57,17 @@ import {
 	outputSingleProjectResults,
 } from "./output.js";
 import type { PipelineOptions } from "./setup.js";
+import { createAnimatedProgress } from "./ui/animated-progress.js";
 import { logger } from "./ui/logger.js";
-import { renderProgressBar } from "./ui/progress-bar.js";
-import { spinner } from "./ui/spinner.js";
 
 type PipelineStep = () => void | Promise<void>;
 
-const analysisText = (
-	phase: AnalysisPhase,
-	parsed?: number,
-	total?: number
-): string => {
+const analysisLabel = (phase: AnalysisPhase): string => {
 	if (phase === "collecting") {
 		return "Collecting files";
 	}
 	if (phase === "parsing") {
-		return `Parsing files ${renderProgressBar(parsed ?? 0, total ?? 0)}`;
-	}
-	if (total) {
-		return `Analyzing the project ${renderProgressBar(parsed ?? 0, total)}`;
+		return "Parsing files";
 	}
 	return "Analyzing the project";
 };
@@ -88,6 +82,50 @@ export interface InteractiveArtifacts {
 	subProjects?: { name: string; result: DiagnoseResult }[];
 }
 
+/** Main → scan worker. Everything the engine middle needs. */
+export interface ScanWorkerRequest {
+	kind: "monorepo" | "single";
+	monorepo?: MonorepoInfo;
+	options: PipelineOptions;
+	targetPath: string;
+}
+
+/** Worker → main. Progress ticks, then one outcome or one failure. */
+export type ScanWorkerMessage =
+	| { kind: "progress"; label: string; done?: number; total?: number }
+	| { kind: "outcome"; outcome: ScanOutcome }
+	| { kind: "error"; message: string };
+
+/**
+ * Everything the engine steps produced, in transferable data. Live ts-morph
+ * objects stay in the worker; the report providers arrive pre-converted.
+ */
+export type ScanOutcome =
+	| {
+			kind: "monorepo";
+			customRuleWarnings: string[];
+			moduleGraphs: MonorepoEngineResult["moduleGraphs"];
+			result: MonorepoEngineResult["result"];
+			reportProviders: ReportProvider[];
+			bootstrapRoots: string[];
+			allFiles: string[];
+			subProjectOptOut: boolean;
+			scopeWarnings: string[];
+			resolvedMinimumScore?: number;
+	  }
+	| {
+			kind: "single";
+			customRuleWarnings: string[];
+			files: string[];
+			moduleGraph: EngineResult["moduleGraph"];
+			reportProviders: ReportProvider[];
+			bootstrapRoots: string[];
+			result: DiagnoseResult;
+			schemaGraph: EngineResult["schemaGraph"];
+			scopeWarnings: string[];
+			resolvedMinimumScore?: number;
+	  };
+
 const displayCustomRuleWarnings = (
 	warnings: string[],
 	isMachineReadable: boolean
@@ -100,16 +138,27 @@ const displayCustomRuleWarnings = (
 	}
 };
 
+/**
+ * Points the pipelines at the worker entry. Called by the CLI entry, whose own
+ * directory is where the built worker file lands; code splitting puts this
+ * module in a chunk one level up, so it cannot resolve the path itself.
+ */
+export const setScanWorkerUrl = (url: URL | null): void => {
+	ScanPipeline.setWorkerUrl(url);
+};
+
 /** Abstract base for scan pipelines — shared step queue, config, scoping, warnings */
 abstract class ScanPipeline {
 	protected readonly options: PipelineOptions;
 	protected resolvedMinimumScore: number | undefined;
 	protected scanConfig!: ScanConfig;
-	/** Live spinner handle while `run` is in flight; steps update its text. */
+	/** Live progress line while `run` is in flight; steps update its label. */
 	protected progress: {
 		succeed(text: string): void;
-		update(text: string): void;
+		update(label: string, done?: number, total?: number): void;
 	} | null = null;
+	/** The final step; in worker mode main runs it after the outcome lands. */
+	protected outputStep: PipelineStep | null = null;
 	/** Set when any scanned sub-project declares its own opt-out. */
 	protected subProjectOptOut = false;
 	/** Warnings raised while narrowing the scope; surfaced alongside the report. */
@@ -203,6 +252,9 @@ abstract class ScanPipeline {
 
 	warnCustomRules(): this {
 		this.steps.push(() => {
+			if (this.options.skipOutput) {
+				return;
+			}
 			this.stopProgress();
 			displayCustomRuleWarnings(
 				this.scanConfig.customRuleWarnings,
@@ -221,7 +273,7 @@ abstract class ScanPipeline {
 			return result;
 		}
 
-		this.progress?.update("Comparing against the base revision");
+		this.emitProgress("Comparing against the base revision");
 		const scope: ResolvedScope = resolveScope({
 			base: this.options.base,
 			changedFilesFrom: this.options.changedFilesFrom,
@@ -272,16 +324,130 @@ abstract class ScanPipeline {
 		this.progress = null;
 	}
 
+	/** Phases with a count animate the bar; the rest show the label alone. */
+	protected updateAnalysisProgress(
+		phase: AnalysisPhase,
+		parsed?: number,
+		total?: number,
+		prefix?: string
+	): void {
+		const base = analysisLabel(phase);
+		const label = prefix ? `${prefix} — ${base.toLowerCase()}` : base;
+		if (phase === "parsing") {
+			this.emitProgress(label, parsed ?? 0, total ?? 0);
+		} else if (phase === "analyzing" && total) {
+			this.emitProgress(label, parsed ?? 0, total);
+		} else {
+			this.emitProgress(label);
+		}
+	}
+
+	/** Subclass hook: runs the engine middle, then the main-side tail. */
+	protected delegate(): Promise<void> {
+		return Promise.resolve();
+	}
+
+	/** One funnel for every progress update, wherever the scan runs. */
+	protected emitProgress(label: string, done?: number, total?: number): void {
+		this.progress?.update(label, done, total);
+		this.options.onProgress?.(label, done, total);
+	}
+
+	/**
+	 * Interactive runs execute the engine middle in a worker thread, so the
+	 * spinner never competes with the scan for the event loop. Everything else —
+	 * CI, machine-readable output, tests — scans in-process exactly as before.
+	 * The URL is injected by the CLI entry: code splitting places this class in
+	 * a chunk whose own directory is not where the worker file lands.
+	 */
+	private static workerUrl: URL | null = null;
+
+	static setWorkerUrl(url: URL | null): void {
+		ScanPipeline.workerUrl = url;
+	}
+
+	/** Injected by the CLI entry; null until then. */
+	protected async canDelegate(): Promise<boolean> {
+		if (!this.options.interactive || this.options.isMachineReadable) {
+			return false;
+		}
+		if (this.outputStep === null || ScanPipeline.workerUrl === null) {
+			return false;
+		}
+		try {
+			await stat(ScanPipeline.workerUrl);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	protected runViaWorker(
+		request: ScanWorkerRequest,
+		apply: (outcome: ScanOutcome) => void
+	): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const url = ScanPipeline.workerUrl;
+			if (!url) {
+				reject(new Error("scan worker is not available"));
+				return;
+			}
+			let settled = false;
+			const worker = new Worker(url, { workerData: request });
+			const finish = (error?: Error): void => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				// biome-ignore lint/suspicious/noEmptyBlockStatements: termination is best-effort once the promise is settled
+				worker.terminate().catch(() => {});
+				if (error) {
+					reject(error);
+				} else {
+					resolve();
+				}
+			};
+			worker.on("message", (message: ScanWorkerMessage) => {
+				if (message.kind === "progress") {
+					this.emitProgress(message.label, message.done, message.total);
+				} else if (message.kind === "outcome") {
+					apply(message.outcome);
+					finish();
+				} else {
+					finish(new Error(message.message));
+				}
+			});
+			worker.on("error", (error) => {
+				finish(error instanceof Error ? error : new Error(String(error)));
+			});
+			worker.on("exit", (code) => {
+				if (code !== 0) {
+					finish(new Error(`scan worker exited with code ${code}`));
+				}
+			});
+		});
+	}
+
 	async run(): Promise<void> {
 		this.progress = this.options.isMachineReadable
 			? null
-			: spinner("Scanning...").start();
-
-		for (const step of this.steps) {
-			await step();
+			: createAnimatedProgress("Scanning...");
+		try {
+			if (await this.canDelegate()) {
+				try {
+					await this.delegate();
+					return;
+				} catch {
+					// The worker path is an optimization; the in-process scan is the
+					// source of truth when it is unavailable or fails.
+				}
+			}
+			for (const step of this.steps) {
+				await step();
+			}
+		} finally {
+			this.stopProgress();
 		}
-
-		this.stopProgress();
 	}
 }
 
@@ -346,6 +512,7 @@ export class MonorepoPipeline extends ScanPipeline {
 	}
 
 	private projectLabel = "";
+	private workerWarnings: string[] = [];
 
 	buildContext(): this {
 		this.steps.push(() => {
@@ -385,9 +552,7 @@ export class MonorepoPipeline extends ScanPipeline {
 						);
 					}
 					const rawOutput = await diagnose(context, (checked, total) => {
-						this.progress?.update(
-							`${label} — running rules ${renderProgressBar(checked, total)}`
-						);
+						this.emitProgress(`${label} — running rules`, checked, total);
 					});
 					const scanResult = buildResult(context, rawOutput);
 					return {
@@ -398,12 +563,10 @@ export class MonorepoPipeline extends ScanPipeline {
 				},
 				(name, index, total) => {
 					this.projectLabel = `${name} (${index}/${total})`;
-					this.progress?.update(`${this.projectLabel} — collecting files`);
+					this.emitProgress(`${this.projectLabel} — collecting files`);
 				},
 				(_name, phase, parsed, total) => {
-					this.progress?.update(
-						`${this.projectLabel} — ${analysisText(phase, parsed, total).toLowerCase()}`
-					);
+					this.updateAnalysisProgress(phase, parsed, total, this.projectLabel);
 				}
 			);
 		});
@@ -429,6 +592,64 @@ export class MonorepoPipeline extends ScanPipeline {
 			);
 		});
 		return this;
+	}
+
+	/** Runs the engine middle in a worker; main keeps only the report. */
+	protected delegate(): Promise<void> {
+		return this.runViaWorker(
+			{
+				kind: "monorepo",
+				targetPath: this.targetPath,
+				options: {
+					...this.options,
+					interactive: false,
+					isMachineReadable: true,
+					skipOutput: true,
+					onProgress: undefined,
+				},
+				monorepo: this.monorepo,
+			},
+			(outcome) => {
+				if (outcome.kind !== "monorepo") {
+					throw new Error("unexpected scan outcome");
+				}
+				this.workerWarnings = outcome.customRuleWarnings;
+				this.result = {
+					customRuleWarnings: outcome.customRuleWarnings,
+					moduleGraphs: outcome.moduleGraphs,
+					result: outcome.result,
+				};
+				this.allFiles.push(...outcome.allFiles);
+				this.allProviders.push(...outcome.reportProviders);
+				this.bootstrapRoots.push(...outcome.bootstrapRoots);
+				this.subProjectOptOut = outcome.subProjectOptOut;
+				this.scopeWarnings.push(...outcome.scopeWarnings);
+				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
+			}
+		).then(async () => {
+			this.stopProgress();
+			displayCustomRuleWarnings(
+				this.workerWarnings,
+				this.options.isMachineReadable
+			);
+			await this.outputStep?.();
+		});
+	}
+
+	/** What the worker posts back after the engine steps finish. */
+	get workerOutcome(): ScanOutcome {
+		return {
+			kind: "monorepo",
+			customRuleWarnings: this.result.customRuleWarnings,
+			moduleGraphs: this.result.moduleGraphs,
+			result: this.result.result,
+			reportProviders: this.allProviders,
+			bootstrapRoots: this.bootstrapRoots,
+			allFiles: this.allFiles,
+			subProjectOptOut: this.subProjectOptOut,
+			scopeWarnings: this.scopeWarnings,
+			resolvedMinimumScore: this.resolvedMinimumScore,
+		};
 	}
 
 	applyScope(): this {
@@ -460,7 +681,7 @@ export class MonorepoPipeline extends ScanPipeline {
 	}
 
 	output(): this {
-		this.steps.push(() => {
+		const step: PipelineStep = () => {
 			outputMonorepoResults(
 				this.result,
 				this.resolvedMinimumScore,
@@ -468,7 +689,11 @@ export class MonorepoPipeline extends ScanPipeline {
 				this.options,
 				this.scopeWarnings
 			);
-		});
+		};
+		if (!this.options.skipOutput) {
+			this.steps.push(step);
+		}
+		this.outputStep = step;
 		return this;
 	}
 }
@@ -478,22 +703,19 @@ export class SingleProjectPipeline extends ScanPipeline {
 	private context!: AnalysisContext;
 	private rawOutput!: RawDiagnosticOutput;
 	private result!: EngineResult;
+	private reportProviders: ReportProvider[] = [];
+	private bootstrapRoots: string[] = [];
+	private workerWarnings: string[] = [];
 
 	/** What the post-scan menu needs, without re-scanning. */
 	get interactiveArtifacts(): InteractiveArtifacts {
 		return {
 			buildReportHtml: () => {
-				const { moduleGraph, files, providers } = this.result;
+				const { moduleGraph, files } = this.result;
 				return buildHtmlReport(moduleGraph, this.result.result, {
-					bootstrapRoots: [
-						...collectEntryModules(this.context.astProject, files, moduleGraph),
-					],
+					bootstrapRoots: this.bootstrapRoots,
 					files,
-					providers: [...providers.values()].map((provider) =>
-						toReportProvider(provider, {
-							module: moduleGraph.providerToModule.get(provider.name)?.name,
-						})
-					),
+					providers: this.reportProviders,
 				});
 			},
 			printSummary: () => {
@@ -503,13 +725,71 @@ export class SingleProjectPipeline extends ScanPipeline {
 		};
 	}
 
+	/** Runs the engine middle in a worker; main keeps only the report. */
+	protected delegate(): Promise<void> {
+		return this.runViaWorker(
+			{
+				kind: "single",
+				targetPath: this.targetPath,
+				options: {
+					...this.options,
+					interactive: false,
+					isMachineReadable: true,
+					skipOutput: true,
+					onProgress: undefined,
+				},
+			},
+			(outcome) => {
+				if (outcome.kind !== "single") {
+					throw new Error("unexpected scan outcome");
+				}
+				this.workerWarnings = outcome.customRuleWarnings;
+				this.result = {
+					customRuleWarnings: outcome.customRuleWarnings,
+					files: outcome.files,
+					moduleGraph: outcome.moduleGraph,
+					providers: new Map(),
+					result: outcome.result,
+					schemaGraph: outcome.schemaGraph,
+				};
+				this.reportProviders = outcome.reportProviders;
+				this.bootstrapRoots = outcome.bootstrapRoots;
+				this.scopeWarnings.push(...outcome.scopeWarnings);
+				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
+			}
+		).then(async () => {
+			this.stopProgress();
+			displayCustomRuleWarnings(
+				this.workerWarnings,
+				this.options.isMachineReadable
+			);
+			await this.outputStep?.();
+		});
+	}
+
+	/** What the worker posts back after the engine steps finish. */
+	get workerOutcome(): ScanOutcome {
+		return {
+			kind: "single",
+			customRuleWarnings: this.result.customRuleWarnings,
+			files: this.result.files,
+			moduleGraph: this.result.moduleGraph,
+			reportProviders: this.reportProviders,
+			bootstrapRoots: this.bootstrapRoots,
+			result: this.result.result,
+			schemaGraph: this.result.schemaGraph,
+			scopeWarnings: this.scopeWarnings,
+			resolvedMinimumScore: this.resolvedMinimumScore,
+		};
+	}
+
 	buildContext(): this {
 		this.steps.push(async () => {
 			this.context = await buildAnalysisContext(
 				this.targetPath,
 				this.scanConfig,
 				(phase, parsed, total) => {
-					this.progress?.update(analysisText(phase, parsed, total));
+					this.updateAnalysisProgress(phase, parsed, total);
 				}
 			);
 		});
@@ -519,9 +799,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 	runRules(): this {
 		this.steps.push(async () => {
 			this.rawOutput = await diagnose(this.context, (checked, total) => {
-				this.progress?.update(
-					`Running rules ${renderProgressBar(checked, total)}`
-				);
+				this.emitProgress("Running rules", checked, total);
 			});
 		});
 		return this;
@@ -534,6 +812,26 @@ export class SingleProjectPipeline extends ScanPipeline {
 				this.rawOutput,
 				this.scanConfig.customRuleWarnings
 			);
+			// Entry roots and report providers come from the live graph, before
+			// the detach below strips the ts-morph class declarations.
+			this.bootstrapRoots = [
+				...collectEntryModules(
+					this.context.astProject,
+					this.result.files,
+					this.result.moduleGraph
+				),
+			];
+			this.reportProviders = [...this.result.providers.values()].map(
+				(provider) =>
+					toReportProvider(provider, {
+						module: this.result.moduleGraph.providerToModule.get(provider.name)
+							?.name,
+					})
+			);
+			this.result = {
+				...this.result,
+				moduleGraph: detachModuleGraph(this.result.moduleGraph),
+			};
 			// Before applyScope, which narrows `diagnostics` in place.
 			this.reportScan(
 				this.rawOutput.diagnostics,
@@ -556,7 +854,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 	}
 
 	output(): this {
-		this.steps.push(() => {
+		const step: PipelineStep = () => {
 			outputSingleProjectResults(
 				this.result,
 				this.resolvedMinimumScore,
@@ -564,7 +862,11 @@ export class SingleProjectPipeline extends ScanPipeline {
 				this.options,
 				this.scopeWarnings
 			);
-		});
+		};
+		if (!this.options.skipOutput) {
+			this.steps.push(step);
+		}
+		this.outputStep = step;
 		return this;
 	}
 }

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -96,10 +96,7 @@ export type ScanWorkerMessage =
 	| { kind: "outcome"; outcome: ScanOutcome }
 	| { kind: "error"; message: string };
 
-/**
- * Everything the engine steps produced, in transferable data. Live ts-morph
- * objects stay in the worker; the report providers arrive pre-converted.
- */
+/** Everything the engine steps produced, in transferable data. */
 export type ScanOutcome =
 	| {
 			kind: "monorepo";
@@ -138,11 +135,7 @@ const displayCustomRuleWarnings = (
 	}
 };
 
-/**
- * Points the pipelines at the worker entry. Called by the CLI entry, whose own
- * directory is where the built worker file lands; code splitting puts this
- * module in a chunk one level up, so it cannot resolve the path itself.
- */
+/** Points the pipelines at the worker entry. */
 export const setScanWorkerUrl = (url: URL | null): void => {
 	ScanPipeline.setWorkerUrl(url);
 };
@@ -159,6 +152,8 @@ abstract class ScanPipeline {
 	} | null = null;
 	/** The final step; in worker mode main runs it after the outcome lands. */
 	protected outputStep: PipelineStep | null = null;
+	/** Custom-rule warnings from the worker outcome, shown before the report. */
+	protected workerWarnings: string[] = [];
 	/** Set when any scanned sub-project declares its own opt-out. */
 	protected subProjectOptOut = false;
 	/** Warnings raised while narrowing the scope; surfaced alongside the report. */
@@ -353,13 +348,7 @@ abstract class ScanPipeline {
 		this.options.onProgress?.(label, done, total);
 	}
 
-	/**
-	 * Interactive runs execute the engine middle in a worker thread, so the
-	 * spinner never competes with the scan for the event loop. Everything else —
-	 * CI, machine-readable output, tests — scans in-process exactly as before.
-	 * The URL is injected by the CLI entry: code splitting places this class in
-	 * a chunk whose own directory is not where the worker file lands.
-	 */
+	/** Location of the scan worker entry, injected by the CLI. */
 	private static workerUrl: URL | null = null;
 
 	static setWorkerUrl(url: URL | null): void {
@@ -411,7 +400,12 @@ abstract class ScanPipeline {
 				if (message.kind === "progress") {
 					this.emitProgress(message.label, message.done, message.total);
 				} else if (message.kind === "outcome") {
-					apply(message.outcome);
+					try {
+						apply(message.outcome);
+					} catch (error) {
+						finish(error instanceof Error ? error : new Error(String(error)));
+						return;
+					}
 					finish();
 				} else {
 					finish(new Error(message.message));
@@ -436,11 +430,22 @@ abstract class ScanPipeline {
 			if (await this.canDelegate()) {
 				try {
 					await this.delegate();
+				} catch (error) {
+					logger.warn(
+						`The scan worker failed (${error instanceof Error ? error.message : String(error)}); scanning in process instead.`
+					);
+					for (const step of this.steps) {
+						await step();
+					}
 					return;
-				} catch {
-					// The worker path is an optimization; the in-process scan is the
-					// source of truth when it is unavailable or fails.
 				}
+				this.stopProgress();
+				displayCustomRuleWarnings(
+					this.workerWarnings,
+					this.options.isMachineReadable
+				);
+				await this.outputStep?.();
+				return;
 			}
 			for (const step of this.steps) {
 				await step();
@@ -512,7 +517,6 @@ export class MonorepoPipeline extends ScanPipeline {
 	}
 
 	private projectLabel = "";
-	private workerWarnings: string[] = [];
 
 	buildContext(): this {
 		this.steps.push(() => {
@@ -626,14 +630,7 @@ export class MonorepoPipeline extends ScanPipeline {
 				this.scopeWarnings.push(...outcome.scopeWarnings);
 				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
 			}
-		).then(async () => {
-			this.stopProgress();
-			displayCustomRuleWarnings(
-				this.workerWarnings,
-				this.options.isMachineReadable
-			);
-			await this.outputStep?.();
-		});
+		);
 	}
 
 	/** What the worker posts back after the engine steps finish. */
@@ -681,6 +678,9 @@ export class MonorepoPipeline extends ScanPipeline {
 	}
 
 	output(): this {
+		if (this.options.skipOutput) {
+			return this;
+		}
 		const step: PipelineStep = () => {
 			outputMonorepoResults(
 				this.result,
@@ -690,9 +690,7 @@ export class MonorepoPipeline extends ScanPipeline {
 				this.scopeWarnings
 			);
 		};
-		if (!this.options.skipOutput) {
-			this.steps.push(step);
-		}
+		this.steps.push(step);
 		this.outputStep = step;
 		return this;
 	}
@@ -705,7 +703,6 @@ export class SingleProjectPipeline extends ScanPipeline {
 	private result!: EngineResult;
 	private reportProviders: ReportProvider[] = [];
 	private bootstrapRoots: string[] = [];
-	private workerWarnings: string[] = [];
 
 	/** What the post-scan menu needs, without re-scanning. */
 	get interactiveArtifacts(): InteractiveArtifacts {
@@ -757,14 +754,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 				this.scopeWarnings.push(...outcome.scopeWarnings);
 				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
 			}
-		).then(async () => {
-			this.stopProgress();
-			displayCustomRuleWarnings(
-				this.workerWarnings,
-				this.options.isMachineReadable
-			);
-			await this.outputStep?.();
-		});
+		);
 	}
 
 	/** What the worker posts back after the engine steps finish. */
@@ -812,8 +802,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 				this.rawOutput,
 				this.scanConfig.customRuleWarnings
 			);
-			// Entry roots and report providers come from the live graph, before
-			// the detach below strips the ts-morph class declarations.
+			// Read from the live graph; the detach below strips the rest.
 			this.bootstrapRoots = [
 				...collectEntryModules(
 					this.context.astProject,
@@ -854,6 +843,9 @@ export class SingleProjectPipeline extends ScanPipeline {
 	}
 
 	output(): this {
+		if (this.options.skipOutput) {
+			return this;
+		}
 		const step: PipelineStep = () => {
 			outputSingleProjectResults(
 				this.result,
@@ -863,9 +855,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 				this.scopeWarnings
 			);
 		};
-		if (!this.options.skipOutput) {
-			this.steps.push(step);
-		}
+		this.steps.push(step);
 		this.outputStep = step;
 		return this;
 	}

--- a/packages/nestjs-doctor/src/cli/scan-worker.ts
+++ b/packages/nestjs-doctor/src/cli/scan-worker.ts
@@ -1,0 +1,47 @@
+import { parentPort, workerData } from "node:worker_threads";
+import {
+	MonorepoPipeline,
+	type ScanWorkerMessage,
+	type ScanWorkerRequest,
+	SingleProjectPipeline,
+} from "./pipeline.js";
+import type { PipelineOptions } from "./setup.js";
+
+const request = workerData as ScanWorkerRequest;
+
+const post = (message: ScanWorkerMessage): void => {
+	parentPort?.postMessage(message);
+};
+
+const options: PipelineOptions = {
+	...request.options,
+	interactive: false,
+	isMachineReadable: true,
+	skipOutput: true,
+	onProgress: (label, done, total) => {
+		post({ kind: "progress", label, done, total });
+	},
+};
+
+try {
+	const pipeline =
+		request.kind === "monorepo" && request.monorepo
+			? new MonorepoPipeline(request.targetPath, request.monorepo, options)
+			: new SingleProjectPipeline(request.targetPath, options);
+
+	await pipeline
+		.resolveConfig()
+		.buildContext()
+		.runRules()
+		.buildResult()
+		.applyScope()
+		.warnCustomRules()
+		.run();
+
+	post({ kind: "outcome", outcome: pipeline.workerOutcome });
+} catch (error) {
+	post({
+		kind: "error",
+		message: error instanceof Error ? error.message : String(error),
+	});
+}

--- a/packages/nestjs-doctor/src/cli/scan-worker.ts
+++ b/packages/nestjs-doctor/src/cli/scan-worker.ts
@@ -1,4 +1,5 @@
 import { parentPort, workerData } from "node:worker_threads";
+import { setCliVersion } from "./output.js";
 import {
 	MonorepoPipeline,
 	type ScanWorkerMessage,
@@ -8,6 +9,8 @@ import {
 import type { PipelineOptions } from "./setup.js";
 
 const request = workerData as ScanWorkerRequest;
+
+setCliVersion(request.version);
 
 const post = (message: ScanWorkerMessage): void => {
 	parentPort?.postMessage(message);

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -26,9 +26,13 @@ export interface PipelineOptions {
 	json: boolean;
 	jsonCompact: boolean;
 	minScore: string | undefined;
+	/** Worker-internal: receives the progress line instead of the local spinner. */
+	onProgress?: (label: string, done?: number, total?: number) => void;
 	outputPath: string | undefined;
 	scope: ScopeMode;
 	score: boolean;
+	/** Worker-internal: the worker never prints the report. */
+	skipOutput?: boolean;
 	staged: boolean;
 	telemetry: boolean;
 	verbose: boolean;

--- a/packages/nestjs-doctor/src/cli/ui/animated-progress.ts
+++ b/packages/nestjs-doctor/src/cli/ui/animated-progress.ts
@@ -1,0 +1,104 @@
+import ora from "ora";
+
+const TICK_MS = 33;
+const WIPE_MS = 140;
+const BAR_WIDTH = 20;
+const EASE = 0.4;
+
+interface ProgressFrame {
+	displayed: number;
+	done: number;
+	label: string;
+	total: number;
+}
+
+/**
+ * Moves the displayed fill a step toward the target, so a new count counts up
+ * instead of jumping. A shrinking target snaps, which is what a phase change
+ * wants.
+ */
+export const easedFill = (displayed: number, target: number): number => {
+	if (target <= displayed) {
+		return target;
+	}
+	const next = displayed + (target - displayed) * EASE;
+	return target - next < 1 ? target : next;
+};
+
+/** Reveals the new label left to right over the old one: `Par│ld label`. */
+export const wipeLabel = (
+	previous: string,
+	next: string,
+	progress: number
+): string => {
+	const revealed = Math.min(
+		next.length,
+		Math.floor(progress * (next.length + 1))
+	);
+	return next.slice(0, revealed) + previous.slice(revealed, next.length);
+};
+
+export const renderProgressLine = (frame: ProgressFrame): string => {
+	if (frame.total <= 0) {
+		return frame.label;
+	}
+	const filled = Math.min(
+		BAR_WIDTH,
+		Math.round((frame.displayed / frame.total) * BAR_WIDTH)
+	);
+	const bar = `${"█".repeat(filled)}${"░".repeat(BAR_WIDTH - filled)} ${Math.round(frame.displayed)}/${frame.total}`;
+	return `${frame.label} ${bar}`;
+};
+
+interface AnimatedProgress {
+	fail(text: string): void;
+	succeed(text: string): void;
+	update(label: string, done?: number, total?: number): void;
+}
+
+/** Owns an ora spinner whose bar eases and whose label wipes between phases. */
+export const createAnimatedProgress = (text: string): AnimatedProgress => {
+	const instance = ora({ text }).start();
+	let label = text;
+	let previousLabel = text;
+	let changedAt = Date.now();
+	let done = 0;
+	let total = 0;
+	let displayed = 0;
+
+	const timer = setInterval(() => {
+		displayed = easedFill(displayed, done);
+		const progress = (Date.now() - changedAt) / WIPE_MS;
+		instance.text = renderProgressLine({
+			displayed,
+			done,
+			label: progress < 1 ? wipeLabel(previousLabel, label, progress) : label,
+			total,
+		});
+	}, TICK_MS);
+
+	const stop = (): void => {
+		clearInterval(timer);
+	};
+
+	return {
+		fail(displayText: string): void {
+			stop();
+			instance.fail(displayText);
+		},
+		succeed(displayText: string): void {
+			stop();
+			instance.succeed(displayText);
+		},
+		update(nextLabel: string, nextDone = 0, nextTotal = 0): void {
+			if (nextLabel !== label) {
+				previousLabel = label;
+				label = nextLabel;
+				changedAt = Date.now();
+				displayed = 0;
+			}
+			done = nextDone;
+			total = nextTotal;
+		},
+	};
+};

--- a/packages/nestjs-doctor/src/cli/ui/animated-progress.ts
+++ b/packages/nestjs-doctor/src/cli/ui/animated-progress.ts
@@ -14,8 +14,7 @@ interface ProgressFrame {
 
 /**
  * Moves the displayed fill a step toward the target, so a new count counts up
- * instead of jumping. A shrinking target snaps, which is what a phase change
- * wants.
+ * instead of jumping. A shrinking target snaps.
  */
 export const easedFill = (displayed: number, target: number): number => {
 	if (target <= displayed) {

--- a/packages/nestjs-doctor/src/cli/ui/progress-bar.ts
+++ b/packages/nestjs-doctor/src/cli/ui/progress-bar.ts
@@ -1,8 +1,0 @@
-const BAR_WIDTH = 20;
-
-/** A fixed-width unicode bar with the running count: `████░░░… 132/354`. */
-export const renderProgressBar = (done: number, total: number): string => {
-	const filled =
-		total > 0 ? Math.min(BAR_WIDTH, Math.round((done / total) * BAR_WIDTH)) : 0;
-	return `${"█".repeat(filled)}${"░".repeat(BAR_WIDTH - filled)} ${done}/${total}`;
-};

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -13,12 +13,12 @@ import {
 	updateEndpointGraphForFile,
 } from "./graph/endpoint-graph.js";
 import {
-	buildGuardDecoratorIndex,
+	buildGuardDecoratorIndexAsync,
 	type GuardDecoratorIndex,
 	updateGuardDecoratorIndexForFile,
 } from "./graph/guard-decorators.js";
 import {
-	buildModuleGraph,
+	buildModuleGraphAsync,
 	type ModuleGraph,
 	updateModuleGraphForFile,
 } from "./graph/module-graph.js";
@@ -28,7 +28,7 @@ import {
 } from "./graph/tsconfig-paths.js";
 import type { ProviderInfo } from "./graph/type-resolver.js";
 import {
-	resolveProviders,
+	resolveProvidersAsync,
 	updateProvidersForFile,
 } from "./graph/type-resolver.js";
 import { detectProject, type MonorepoInfo } from "./project-detector.js";
@@ -88,9 +88,13 @@ export async function buildAnalysisContext(
 	);
 	onProgress?.("analyzing");
 	await yieldToEventLoop();
-	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
+	const moduleGraph = await buildModuleGraphAsync(
+		astProject,
+		files,
+		pathAliases
+	);
 	await yieldToEventLoop();
-	const providers = resolveProviders(astProject, files);
+	const providers = await resolveProvidersAsync(astProject, files);
 	await yieldToEventLoop();
 	const endpointGraph = await buildEndpointGraphWithProgress(
 		astProject,
@@ -108,7 +112,7 @@ export async function buildAnalysisContext(
 		endpointGraph,
 		fileRules,
 		files,
-		guardDecorators: buildGuardDecoratorIndex(astProject, files),
+		guardDecorators: await buildGuardDecoratorIndexAsync(astProject, files),
 		moduleGraph,
 		pathAliases,
 		project,
@@ -203,9 +207,13 @@ async function buildSubProjectContext(
 	);
 	onProgress?.("analyzing");
 	await yieldToEventLoop();
-	const moduleGraph = buildModuleGraph(astProject, files, pathAliases);
+	const moduleGraph = await buildModuleGraphAsync(
+		astProject,
+		files,
+		pathAliases
+	);
 	await yieldToEventLoop();
-	const providers = resolveProviders(astProject, files);
+	const providers = await resolveProvidersAsync(astProject, files);
 	await yieldToEventLoop();
 	const endpointGraph = await buildEndpointGraphWithProgress(
 		astProject,
@@ -232,7 +240,7 @@ async function buildSubProjectContext(
 		endpointGraph,
 		fileRules,
 		files,
-		guardDecorators: buildGuardDecoratorIndex(astProject, files),
+		guardDecorators: await buildGuardDecoratorIndexAsync(astProject, files),
 		moduleGraph,
 		pathAliases,
 		project,

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -1,5 +1,6 @@
 import type { Node, Project, SourceFile } from "ts-morph";
 import { SyntaxKind } from "ts-morph";
+import { YIELD_INTERVAL, yieldToEventLoop } from "../yield.js";
 
 /** Decorator names that compose `UseGuards`, keyed by the file declaring them. */
 export type GuardDecoratorIndex = Map<string, Set<string>>;
@@ -112,6 +113,24 @@ export function buildGuardDecoratorIndex(
 		const sourceFile = project.getSourceFile(filePath);
 		if (sourceFile) {
 			index.set(filePath, namesInFile(sourceFile));
+		}
+	}
+	return index;
+}
+
+/** Batched so a spinner on the same event loop keeps repainting mid-pass. */
+export async function buildGuardDecoratorIndexAsync(
+	project: Project,
+	files: string[]
+): Promise<GuardDecoratorIndex> {
+	const index: GuardDecoratorIndex = new Map();
+	for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+		const sourceFile = project.getSourceFile(files[fileIndex]);
+		if (sourceFile) {
+			index.set(files[fileIndex], namesInFile(sourceFile));
+		}
+		if ((fileIndex + 1) % YIELD_INTERVAL === 0) {
+			await yieldToEventLoop();
 		}
 	}
 	return index;

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -118,7 +118,7 @@ export function buildGuardDecoratorIndex(
 	return index;
 }
 
-/** Batched so a spinner on the same event loop keeps repainting mid-pass. */
+/** Batched variant of buildGuardDecoratorIndex; yields between files. */
 export async function buildGuardDecoratorIndexAsync(
 	project: Project,
 	files: string[]

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -304,7 +304,7 @@ export function buildModuleGraph(
 	return finishModuleGraph(collectModuleNodes(project, files, pathAliases));
 }
 
-/** Batched so a spinner on the same event loop keeps repainting mid-pass. */
+/** Batched variant of buildModuleGraph; yields between files. */
 export async function buildModuleGraphAsync(
 	project: Project,
 	files: string[],

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -7,6 +7,7 @@ import type {
 	SourceFile,
 } from "ts-morph";
 import { SyntaxKind } from "ts-morph";
+import { YIELD_INTERVAL, yieldToEventLoop } from "../yield.js";
 import { invalidateEntryModules } from "./entry-points.js";
 import type { PathAliasMap } from "./tsconfig-paths.js";
 import { resolvePathAlias } from "./tsconfig-paths.js";
@@ -248,15 +249,12 @@ function addModuleNode(
 	modules.set(node.name, node);
 }
 
-export function buildModuleGraph(
+function collectModuleNodes(
 	project: Project,
 	files: string[],
 	pathAliases: PathAliasMap = new Map()
-): ModuleGraph {
+): Map<string, ModuleNode> {
 	const modules = new Map<string, ModuleNode>();
-	const edges = new Map<string, Set<string>>();
-
-	// First pass: collect all @Module() classes
 	for (const filePath of files) {
 		const sourceFile = project.getSourceFile(filePath);
 		if (!sourceFile) {
@@ -271,8 +269,12 @@ export function buildModuleGraph(
 			addModuleNode(modules, node);
 		}
 	}
+	return modules;
+}
 
-	// Second pass: build edges from import relationships
+function finishModuleGraph(modules: Map<string, ModuleNode>): ModuleGraph {
+	// Build edges from import relationships
+	const edges = new Map<string, Set<string>>();
 	for (const [name, node] of modules) {
 		const importSet = new Set<string>();
 		for (const imp of node.imports) {
@@ -292,6 +294,39 @@ export function buildModuleGraph(
 	}
 
 	return { modules, edges, providerToModule };
+}
+
+export function buildModuleGraph(
+	project: Project,
+	files: string[],
+	pathAliases: PathAliasMap = new Map()
+): ModuleGraph {
+	return finishModuleGraph(collectModuleNodes(project, files, pathAliases));
+}
+
+/** Batched so a spinner on the same event loop keeps repainting mid-pass. */
+export async function buildModuleGraphAsync(
+	project: Project,
+	files: string[],
+	pathAliases: PathAliasMap = new Map()
+): Promise<ModuleGraph> {
+	const modules = new Map<string, ModuleNode>();
+	for (let index = 0; index < files.length; index++) {
+		const sourceFile = project.getSourceFile(files[index]);
+		if (sourceFile) {
+			for (const node of extractModulesFromFile(
+				sourceFile,
+				files[index],
+				pathAliases
+			)) {
+				addModuleNode(modules, node);
+			}
+		}
+		if ((index + 1) % YIELD_INTERVAL === 0) {
+			await yieldToEventLoop();
+		}
+	}
+	return finishModuleGraph(modules);
 }
 
 const MAX_RESOLVE_DEPTH = 5;

--- a/packages/nestjs-doctor/src/engine/graph/type-resolver.ts
+++ b/packages/nestjs-doctor/src/engine/graph/type-resolver.ts
@@ -105,7 +105,7 @@ export function resolveProviders(
 	return providers;
 }
 
-/** Batched so a spinner on the same event loop keeps repainting mid-pass. */
+/** Batched variant of resolveProviders; yields between files. */
 export async function resolveProvidersAsync(
 	project: Project,
 	files: string[]

--- a/packages/nestjs-doctor/src/engine/graph/type-resolver.ts
+++ b/packages/nestjs-doctor/src/engine/graph/type-resolver.ts
@@ -1,4 +1,5 @@
 import type { ClassDeclaration, Decorator, Project } from "ts-morph";
+import { YIELD_INTERVAL, yieldToEventLoop } from "../yield.js";
 
 const REQUEST_SCOPE_REGEX = /Scope\s*\.\s*REQUEST/;
 const TRANSIENT_SCOPE_REGEX = /Scope\s*\.\s*TRANSIENT/;
@@ -101,6 +102,26 @@ export function resolveProviders(
 		}
 	}
 
+	return providers;
+}
+
+/** Batched so a spinner on the same event loop keeps repainting mid-pass. */
+export async function resolveProvidersAsync(
+	project: Project,
+	files: string[]
+): Promise<Map<string, ProviderInfo>> {
+	const providers = new Map<string, ProviderInfo>();
+	for (let index = 0; index < files.length; index++) {
+		const sourceFile = project.getSourceFile(files[index]);
+		if (sourceFile) {
+			for (const info of extractProvidersFromFile(sourceFile, files[index])) {
+				providers.set(info.name, info);
+			}
+		}
+		if ((index + 1) % YIELD_INTERVAL === 0) {
+			await yieldToEventLoop();
+		}
+	}
 	return providers;
 }
 

--- a/packages/nestjs-doctor/src/engine/yield.ts
+++ b/packages/nestjs-doctor/src/engine/yield.ts
@@ -1,5 +1,4 @@
 // Yields to the event loop between work batches so a spinner can repaint.
-// Ten units of work keeps a blocked stretch well under one spinner frame.
 export const YIELD_INTERVAL = 10;
 
 export const yieldToEventLoop = (): Promise<void> =>

--- a/packages/nestjs-doctor/src/engine/yield.ts
+++ b/packages/nestjs-doctor/src/engine/yield.ts
@@ -1,5 +1,6 @@
 // Yields to the event loop between work batches so a spinner can repaint.
-export const YIELD_INTERVAL = 25;
+// Ten units of work keeps a blocked stretch well under one spinner frame.
+export const YIELD_INTERVAL = 10;
 
 export const yieldToEventLoop = (): Promise<void> =>
 	new Promise((resolve) => setImmediate(resolve));

--- a/packages/nestjs-doctor/tests/unit/animated-progress.test.ts
+++ b/packages/nestjs-doctor/tests/unit/animated-progress.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+	easedFill,
+	renderProgressLine,
+	wipeLabel,
+} from "../../src/cli/ui/animated-progress.js";
+
+describe("easedFill", () => {
+	it("approaches the target without overshooting", () => {
+		let value = 0;
+		for (let tick = 0; tick < 40 && value !== 354; tick++) {
+			value = easedFill(value, 354);
+			expect(value).toBeLessThanOrEqual(354);
+		}
+		expect(value).toBe(354);
+	});
+
+	it("snaps down immediately when the target shrinks", () => {
+		expect(easedFill(300, 40)).toBe(40);
+	});
+});
+
+describe("wipeLabel", () => {
+	it("shows only the old label at the start", () => {
+		expect(wipeLabel("Parsing files", "Running rules", 0)).toBe(
+			"Parsing files"
+		);
+	});
+
+	it("shows only the new label at the end", () => {
+		expect(wipeLabel("Parsing files", "Running rules", 1)).toBe(
+			"Running rules"
+		);
+	});
+
+	it("blends the head of the new label with the tail of the old", () => {
+		const mixed = wipeLabel("Parsing files", "Running rules", 0.5);
+		expect(mixed.startsWith("Running")).toBe(true);
+		expect(mixed).not.toBe("Running rules");
+	});
+});
+
+describe("renderProgressLine", () => {
+	it("renders the label alone when there is no count", () => {
+		expect(
+			renderProgressLine({
+				displayed: 0,
+				done: 0,
+				label: "Collecting files",
+				total: 0,
+			})
+		).toBe("Collecting files");
+	});
+
+	it("renders the eased fill with the displayed count", () => {
+		const line = renderProgressLine({
+			displayed: 100,
+			done: 354,
+			label: "Parsing files",
+			total: 354,
+		});
+		expect(line).toContain("Parsing files");
+		expect(line).toContain("100/354");
+		expect(line).toContain("█");
+		expect(line).toContain("░");
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/module-graph.test.ts
+++ b/packages/nestjs-doctor/tests/unit/module-graph.test.ts
@@ -2,6 +2,7 @@ import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
 import {
 	buildModuleGraph,
+	buildModuleGraphAsync,
 	findCircularDeps,
 	findProviderModule,
 	mergeModuleGraphs,
@@ -19,6 +20,28 @@ function createProject(files: Record<string, string>) {
 }
 
 describe("module-graph", () => {
+	it("builds the same graph batched as it does in one pass", async () => {
+		const { project, paths } = createProject({
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { UsersModule } from './users.module';
+        @Module({ imports: [UsersModule] })
+        export class AppModule {}
+      `,
+			"users.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class UsersModule {}
+      `,
+		});
+		const sync = buildModuleGraph(project, paths);
+		const batched = await buildModuleGraphAsync(project, paths);
+		expect(batched.modules.size).toBe(sync.modules.size);
+		expect([...batched.modules.keys()]).toEqual([...sync.modules.keys()]);
+		expect(batched.edges.get("AppModule")).toEqual(sync.edges.get("AppModule"));
+		expect(batched.providerToModule).toEqual(sync.providerToModule);
+	});
+
 	it("records the tokens of object-literal providers", () => {
 		const { project, paths } = createProject({
 			"app.module.ts": `

--- a/packages/nestjs-doctor/tests/unit/tui-navigate.test.ts
+++ b/packages/nestjs-doctor/tests/unit/tui-navigate.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import { groupFindings } from "../../src/cli/interactive/findings.js";
 import {
 	buildListRows,
+	clampOffset,
 	flattenFindings,
+	listCapacity,
 	moveSelection,
 	scrollWindow,
 } from "../../src/cli/interactive/tui/navigate.js";
@@ -62,6 +64,28 @@ describe("scrollWindow", () => {
 
 	it("keeps the offset while the selection stays visible", () => {
 		expect(scrollWindow(2, 3, 4)).toBe(2);
+	});
+});
+
+describe("listCapacity", () => {
+	it("gives the list what the terminal has left after the fixed chrome", () => {
+		expect(listCapacity(40, 21, 3)).toBe(19);
+	});
+
+	it("keeps a floor so a tiny terminal still shows some rows", () => {
+		expect(listCapacity(12, 21, 3)).toBe(3);
+	});
+});
+
+describe("clampOffset", () => {
+	it("keeps the window inside the list", () => {
+		expect(clampOffset(-4, 20, 8)).toBe(0);
+		expect(clampOffset(99, 20, 8)).toBe(12);
+		expect(clampOffset(3, 20, 8)).toBe(3);
+	});
+
+	it("collapses to the top when everything fits", () => {
+		expect(clampOffset(5, 8, 8)).toBe(0);
 	});
 });
 

--- a/packages/nestjs-doctor/tsdown.config.ts
+++ b/packages/nestjs-doctor/tsdown.config.ts
@@ -10,7 +10,10 @@ export default defineConfig([
 		minify: true,
 	},
 	{
-		entry: { "cli/index": "src/cli/index.ts" },
+		entry: {
+			"cli/index": "src/cli/index.ts",
+			"cli/scan-worker": "src/cli/scan-worker.ts",
+		},
 		format: ["esm"],
 		banner: { js: "#!/usr/bin/env node" },
 		clean: false,


### PR DESCRIPTION
## Context

An interactive scan ends on a full-screen score panel; in a monorepo it lists every sub-project with its score. The scan itself shows a spinner and a progress bar through the parse, graph, and rule phases. Both were built assuming the scan and the drawing share the terminal politely — they share a thread.

## Problem

On a 27-project workspace the score panel showed ~15 sub-projects and the rest were unreachable: the list overflowed the terminal and did not scroll, and the only scroll keys it offered (pgup/pgdn) do not exist on most laptops.

During the scan, the spinner and the bar froze for seconds at a time. A CPU profile of a real scan (2592 files) shows why: ~16% of samples in GC and the rest in ts-morph parse/bind and file IO, all on the main thread the spinner animates on. Yielding between batches lets the dots stutter back to life; it can never keep them smooth.

## Possible flows

| Flow | Before | After |
| --- | --- | --- |
| Interactive scan in a terminal | Engine on the main thread; spinner freezes for seconds | Engine in a worker thread; spinner and bar animate continuously |
| CI, `--format json`, tests, any machine-readable run | In-process scan | Unchanged — in-process scan |
| Worker unavailable or fails | n/a | Falls back to the in-process scan |
| Monorepo score screen | Alphabetical list, overflows, no scrolling | Two-pane browser: worst score first, `↑↓` scrolls with the selection, `←→`/tab switches to the action menu, right panel with the selected project's score, counts, and worst rules |
| Single-project score screen | Score box + menu | Unchanged |
| Progress line | Jumps between values | Bar eases to each new count; labels wipe in |

## Solution

- `scan-worker.ts` runs the engine steps (context, rules, result, scope) in a worker thread and posts progress plus one outcome of plain data — detached module graphs and pre-converted report providers; live ts-morph objects never cross. The CLI entry injects the worker URL (code splitting places the pipeline class in a chunk that cannot resolve the path itself).
- `animated-progress.ts` owns the spinner: a 33 ms tick renders an eased bar and a 140 ms label wipe. The pipeline passes structured `(label, done, total)` instead of pre-formatted strings.
- The parse, module graph, provider, and guard-index passes gained batched async variants that yield every 10 files; the sync originals are untouched, so the LSP incremental path and ~150 existing test call sites stay as they were.
- The score screen sorts sub-projects worst score first and scrolls the list with the selection, reusing the review screen's viewport helpers.

Deliberately not done: ORM schema extraction is still one synchronous pass — it is the next candidate if a stall remains. The 52 pre-existing `no-sync-io` warnings in this repo were left alone; the one the scan flagged in new code (`statSync` in the delegation check) was fixed.

## Before vs after

| | Before | After |
| --- | --- | --- |
| Spinner during scan | Frozen for seconds at a time | Continuous |
| Sub-projects visible | First ~15, rest unreachable | All, scrolled worst-first |
| Scroll keys | pgup/pgdn | `↑↓`, `←→`, tab |
| CI scan path | in-process | in-process (unchanged) |
| Score, diagnostics, exit codes | — | unchanged (worker returns the same result) |

## Example

```
$ npx nestjs-doctor ~/monorepo
⠹ Parsing files ████████░░░░ 812/2592   ← bar fills, dots never stop
…
 SUB-PROJECTS          │ journeys-api  27/100
 ▌journeys-api   27/100 │ █░░░░░░░░░░░░░░░░░░░
  communications 45/100 │ ✗ 0 · ⚠ 42 · 118 files
 … 1–8 of 27            │ TOP RULES
                        │ ⚠ rule-name 42
↑↓ project · ←→ actions · enter confirm · q quit
```
