### PR TITLE
docs: scan cancellation, two-pane score screen, and where the scan runs

### DIFF
--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -51,7 +51,8 @@ The `--blocking` default depends on the output mode: `error` for the console
 report and `--format github`, `none` for `--score` and for the json, sarif,
 gitlab, and markdown formats.
 
-Exit codes: 0 = pass, 1 = a gate failed (min-score or blocking), 2 = bad input.
+Exit codes: 0 = pass, 1 = a gate failed (min-score or blocking), 2 = bad input,
+130 = cancelled with Ctrl+C.
 `--report` writes HTML, so combining it with `--format`, `--json` or `--score`
 exits 2 rather than writing anything.
 

--- a/packages/website/src/app/docs/pipeline/output/page.mdx
+++ b/packages/website/src/app/docs/pipeline/output/page.mdx
@@ -103,6 +103,9 @@ them. The error, warning and info columns count only what the combined result
 took, so they add up to the totals above. Each score is recalculated from that
 same kept set.
 
+In an interactive terminal this breakdown renders as the score screen's two-pane
+browser instead of a table. See [The menu](/docs/reference/cli#the-menu).
+
 ### HTML report (`--report`)
 
 Generates a single HTML file with an interactive report:
@@ -145,6 +148,7 @@ graph. See [Boot trace](/docs/report/boot-trace).
 | `0` | Passed |
 | `1` | A gate failed |
 | `2` | Invalid input (bad path, invalid flags) |
+| `130` | The scan was cancelled with Ctrl+C |
 
 Two gates produce `1`: the `--min-score` threshold, and the severity gate set by `--blocking`. The severity gate defaults per output mode, so the same findings exit `1` under the console report and `0` under `--format json`. See [Exit codes](/docs/reference/cli#exit-codes) for the defaults.
 

--- a/packages/website/src/app/docs/pipeline/page.mdx
+++ b/packages/website/src/app/docs/pipeline/page.mdx
@@ -17,7 +17,7 @@ How nestjs-doctor works from CLI invocation to final output.
 
 | Directory | Responsibility |
 |-----------|---------------|
-| `src/cli/` | CLI flags, entry point, output formatters |
+| `src/cli/` | CLI flags, entry point, output formatters, and the scan worker entry |
 | `src/engine/` | Config loading, project detection, file collection, AST parsing, module graph, provider resolution, rule execution, diagnostic filtering, scoring |
 | `src/engine/rules/definitions/` | All 52 rules organized by category (`security/`, `correctness/`, `architecture/`, `performance/`, `schema/`) |
 | `src/report/` | HTML report generation (interactive dashboard, module graph, schema ER diagram) |
@@ -50,3 +50,7 @@ Stages that do not depend on each other run concurrently:
 
 - **Single-project mode:** config loading and custom rule resolution run first. Project detection and file collection then run together via `Promise.all`. The remaining stages run in order, from AST parsing through scoring.
 - **Monorepo mode:** file collection for every sub-project runs in parallel via `Promise.all`. The sub-projects themselves are then built one at a time. Each context is dropped before the next one is built, so peak memory stays close to a single project.
+
+### Where the scan runs
+
+An interactive terminal run executes the engine middle in a worker thread, so the spinner and progress bar keep painting while rules run. CI, every machine-readable format, and `--score` scans run in process. If the worker cannot start or fails mid-scan, the scan reruns in process and a warning goes to stderr.

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -29,6 +29,8 @@ The directory defaults to the current one.
 | `--list-rules` | Print every built-in rule and exit |
 | `-h`, `--help` | Print usage and exit |
 
+Ctrl+C cancels a running scan immediately and exits `130`.
+
 ## Scope
 
 Scoping changes what is reported, never what is analyzed. Cross-file rules
@@ -80,11 +82,18 @@ either stream.
 ## The menu
 
 A console scan in a terminal ends on a score screen: the nest, the score with
-its bar, the severity counts, the per-project breakdown in a monorepo, and a
-short action menu — review the findings, open the HTML report, hand off to a
-coding agent, scaffold the GitHub Actions workflow when it is missing, or copy
-the findings as markdown. Everything comes from the scan that just ran, so
-nothing is scanned twice.
+its bar, the severity counts, and a short action menu. Review the findings,
+open the HTML report, hand off to a coding agent, scaffold the GitHub Actions
+workflow when it is missing, or copy the findings as markdown. Everything comes
+from the scan that just ran, so nothing is scanned twice.
+
+In a monorepo the breakdown is a two-pane browser. Sub-projects list worst score
+first. The left pane is the scrollable project list, and the right pane is the
+action menu.
+
+A side panel shows the selected project's score, error, warning and info counts,
+file count, and the rules it trips most. `↑↓` moves in the focused pane, `←→` or
+`tab` switches panes, `enter` confirms the menu action, `q` quits.
 
 An interactive run hands its presentation to that screen and prints nothing
 else. Pass `--verbose` to print the full findings list above it instead.
@@ -140,13 +149,14 @@ agrees.
 
 ## Exit codes
 
-Every run ends in one of three codes:
+Every run ends in one of four codes:
 
 | Code | Meaning |
 |------|---------|
 | `0` | Passed |
 | `1` | A gate failed |
 | `2` | Bad input: the path does not exist, a flag is invalid, or two flags conflict |
+| `130` | You cancelled the scan with Ctrl+C |
 
 The score gate is checked before the severity gate, so a run below `--min-score`
 exits `1` whether or not any diagnostic was blocking.

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -49,6 +49,7 @@ it loads nestjs-doctor from your workspace.
 | `0` | Passed |
 | `1` | A gate failed: errors were found, or the score is below `--min-score` |
 | `2` | Bad input: the path does not exist, or a flag is invalid |
+| `130` | The scan was cancelled with Ctrl+C |
 
 The console report exits `1` on any error-severity finding. The machine-readable
 formats exit `0` unless you set a gate. See


### PR DESCRIPTION
## Context

PR #285 changed the interactive scan: worker-thread execution, instant Ctrl+C cancellation (exit 130), and a two-pane score screen for monorepos. The docs drifted in five places.

## Problem

The CLI reference said every run ends in one of three codes. Three exit-code tables lacked the new `130`. The menu page described the monorepo breakdown as a flat table. The pipeline internals page did not say where the scan runs. Nothing documented Ctrl+C.

## Possible flows

| Surface | Before | After |
| --- | --- | --- |
| `docs/reference/cli` exit codes + Scanning + The menu | three codes, flat breakdown, no cancel | four codes, cancel documented, two-pane browser described |
| `llms.txt` exit codes | three codes | four codes |
| `docs/pipeline` (internals) | no execution location | "Where the scan runs" section |
| `docs/pipeline/output` | table only, three codes | browser note, link to The menu, `130` row |
| `docs/setup` | three codes | `130` row |
| README, SKILL.md, CI pages, rules pages | no relevant claims | unchanged (verified) |

## Solution

Applied the nd-docs drift report verbatim, adjusted to house style (25-word sentences, 3-sentence paragraphs, no em dashes). The cancel fact lives once, in the CLI reference; other pages link or repeat the table row.

## Before vs after

| | Before | After |
| --- | --- | --- |
| Exit codes documented | 0, 1, 2 | 0, 1, 2, 130 |
| Monorepo breakdown described as | flat per-project table | two-pane browser, worst first, side panel |
| Where the scan executes | undocumented | internals section, three sentences |
| CI pages, README, SKILL.md | — | unchanged |

## Example

`tmux send-keys C-c` mid-scan now prints `✖ Scan cancelled` and exits `130`, which is the behavior `/docs/reference/cli#exit-codes` now documents.
