### PR TITLE
fix(telemetry): mint ci identity only for known providers

### DIFF
--- a/.changeset/ci-telemetry-identity.md
+++ b/.changeset/ci-telemetry-identity.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Fixes CI classification in telemetry. A shared `ci.<provider>` identity is now minted only when a known provider variable matches; a bare `CI` env var keeps the personal install id and records `ci_provider: "unknown"` instead of merging the run into an anonymous machine pool. The provider table expands from 6 to 34 systems (TeamCity, Azure Pipelines, Bitbucket, CodeBuild, Drone, Render, and others), so automated runners that set none of the previous variables are no longer counted as individual users.

--- a/.changeset/ci-telemetry-identity.md
+++ b/.changeset/ci-telemetry-identity.md
@@ -1,5 +1,6 @@
 ---
 "nestjs-doctor": patch
+"nestjs-doctor-lsp": patch
 ---
 
-Fixes CI classification in telemetry. A shared `ci.<provider>` identity is now minted only when a known provider variable matches; a bare `CI` env var keeps the personal install id and records `ci_provider: "unknown"` instead of merging the run into an anonymous machine pool. The provider table expands from 6 to 34 systems (TeamCity, Azure Pipelines, Bitbucket, CodeBuild, Drone, Render, and others), so automated runners that set none of the previous variables are no longer counted as individual users.
+Fixes CI classification in telemetry for both the CLI and the language server. A shared `ci.<provider>` identity is now minted only when a known provider variable matches; a bare `CI` env var keeps the personal install id (the CLI records `ci_provider: "unknown"`) instead of merging the run into an anonymous machine pool. The provider table expands from 6 to 34 systems (TeamCity, Azure Pipelines, Bitbucket Pipelines, CodeBuild, Drone, Render, and others), so automated runners that set none of the previous variables are no longer counted as individual users.

--- a/packages/nestjs-doctor-lsp/src/telemetry.ts
+++ b/packages/nestjs-doctor-lsp/src/telemetry.ts
@@ -40,6 +40,8 @@ function configDir(env: NodeJS.ProcessEnv): string {
 	);
 }
 
+/** The CI systems worth naming: env var first, slug second. Each slug is a
+ * `ci.<provider>` identity. */
 const CI_PROVIDERS: [string, string][] = [
 	["GITHUB_ACTIONS", "github"],
 	["GITLAB_CI", "gitlab"],
@@ -47,14 +49,39 @@ const CI_PROVIDERS: [string, string][] = [
 	["TRAVIS", "travis"],
 	["BUILDKITE", "buildkite"],
 	["JENKINS_URL", "jenkins"],
+	["TEAMCITY_VERSION", "teamcity"],
+	["APPVEYOR", "appveyor"],
+	["TF_BUILD", "azure"],
+	["BITBUCKET_COMMIT", "bitbucket"],
+	["BITRISE_IO", "bitrise"],
+	["BUDDY_WORKSPACE_ID", "buddy"],
+	["CIRRUS_CI", "cirrus"],
+	["CODEBUILD_BUILD_ARN", "codebuild"],
+	["CF_BUILD_ID", "codefresh"],
+	["CM_BUILD_ID", "codemagic"],
+	["DRONE", "drone"],
+	["EARTHLY_CI", "earthly"],
+	["EAS_BUILD", "eas"],
+	["GITEA_ACTIONS", "gitea"],
+	["GO_PIPELINE_LABEL", "gocd"],
+	["BUILDER_OUTPUT", "google-cloud-build"],
+	["HARNESS_BUILD_ID", "harness"],
+	["NETLIFY", "netlify"],
+	["PROW_JOB_ID", "prow"],
+	["RENDER", "render"],
+	["SCREWDRIVER", "screwdriver"],
+	["SEMAPHORE", "semaphore"],
+	["SHIPPABLE", "shippable"],
+	["VERCEL", "vercel"],
+	["APPCENTER_BUILD_ID", "appcenter"],
+	["VELA", "vela"],
+	["CI_XCODE_PROJECT", "xcode-cloud"],
+	["XCS", "xcode-server"],
 ];
 
 function ciIdentity(env: NodeJS.ProcessEnv): string | undefined {
 	const provider = CI_PROVIDERS.find(([name]) => isSet(env[name]));
-	if (provider) {
-		return `ci.${provider[1]}`;
-	}
-	return isSet(env.CI) ? "ci.unknown" : undefined;
+	return provider ? `ci.${provider[1]}` : undefined;
 }
 
 function readStored(file: string): StoredConfig | undefined {
@@ -68,7 +95,7 @@ function readStored(file: string): StoredConfig | undefined {
 
 export interface LspIdentity {
 	anonymousId: string;
-	/** Absent in CI. */
+	/** Absent under a known CI provider. */
 	projectId?: string;
 }
 

--- a/packages/nestjs-doctor-lsp/tests/telemetry.test.ts
+++ b/packages/nestjs-doctor-lsp/tests/telemetry.test.ts
@@ -6,6 +6,8 @@ import { lspTelemetryEnabled, resolveIdentity } from "../src/telemetry.js";
 
 const dirs: string[] = [];
 
+const CI_PREFIX = /^ci\./;
+
 const workspace = (config?: Record<string, unknown>): string => {
 	const dir = mkdtempSync(join(tmpdir(), "nd-lsp-"));
 	dirs.push(dir);
@@ -111,5 +113,16 @@ describe("lsp identity", () => {
 		expect(
 			resolveIdentity("/repo/a", { ...home(), GITHUB_ACTIONS: "1" }).anonymousId
 		).toBe("ci.github");
+	});
+
+	it("treats a bare CI variable as a machine, not a named provider", () => {
+		const env = { ...home(), CI: "1" };
+
+		const first = resolveIdentity("/repo/a", env);
+		const again = resolveIdentity("/repo/a", env);
+
+		expect(first.anonymousId).not.toMatch(CI_PREFIX);
+		expect(again.anonymousId).toBe(first.anonymousId);
+		expect(again.projectId).toBe(first.projectId);
 	});
 });

--- a/packages/nestjs-doctor/src/telemetry/environment.ts
+++ b/packages/nestjs-doctor/src/telemetry/environment.ts
@@ -9,7 +9,11 @@ export function generatedIn(
 	return isSet(env.CI) || isSet(env.GITHUB_ACTIONS) ? "ci" : "cli";
 }
 
-/** The CI systems worth naming. Read through `detectCiProvider`. */
+/**
+ * The CI systems worth naming: env var first, slug second. The slug is the
+ * `ci.<provider>` identity and the `ci_provider` payload value, so published
+ * slugs never change. Single-variable checks only, mirroring ci-info.
+ */
 const CI_PROVIDERS: readonly (readonly [string, string])[] = [
 	["GITHUB_ACTIONS", "github"],
 	["GITLAB_CI", "gitlab"],
@@ -17,17 +21,47 @@ const CI_PROVIDERS: readonly (readonly [string, string])[] = [
 	["TRAVIS", "travis"],
 	["BUILDKITE", "buildkite"],
 	["JENKINS_URL", "jenkins"],
+	["TEAMCITY_VERSION", "teamcity"],
+	["APPVEYOR", "appveyor"],
+	["TF_BUILD", "azure"],
+	["BITBUCKET_COMMIT", "bitbucket"],
+	["BITRISE_IO", "bitrise"],
+	["BUDDY_WORKSPACE_ID", "buddy"],
+	["CIRRUS_CI", "cirrus"],
+	["CODEBUILD_BUILD_ARN", "codebuild"],
+	["CF_BUILD_ID", "codefresh"],
+	["CM_BUILD_ID", "codemagic"],
+	["DRONE", "drone"],
+	["EARTHLY_CI", "earthly"],
+	["EAS_BUILD", "eas"],
+	["GITEA_ACTIONS", "gitea"],
+	["GO_PIPELINE_LABEL", "gocd"],
+	["BUILDER_OUTPUT", "google-cloud-build"],
+	["HARNESS_BUILD_ID", "harness"],
+	["NETLIFY", "netlify"],
+	["PROW_JOB_ID", "prow"],
+	["RENDER", "render"],
+	["SCREWDRIVER", "screwdriver"],
+	["SEMAPHORE", "semaphore"],
+	["SHIPPABLE", "shippable"],
+	["VERCEL", "vercel"],
+	["APPCENTER_BUILD_ID", "appcenter"],
+	["VELA", "vela"],
+	["CI_XCODE_PROJECT", "xcode-cloud"],
+	["XCS", "xcode-server"],
 ];
 
-/** Which CI this is, or `unknown` on a runner that only sets `CI`. */
-export function detectCiProvider(
+/** A named CI provider, or null when none of its env vars are set. */
+export function detectKnownCiProvider(
 	env: NodeJS.ProcessEnv = process.env
 ): string | null {
 	const provider = CI_PROVIDERS.find(([name]) => isSet(env[name]));
-	if (provider) {
-		return provider[1];
-	}
-	return isSet(env.CI) ? "unknown" : null;
+	return provider ? provider[1] : null;
+}
+
+/** Which CI this is, or `unknown` on a runner that only sets `CI`. */
+function detectCiProvider(env: NodeJS.ProcessEnv = process.env): string | null {
+	return detectKnownCiProvider(env) ?? (isSet(env.CI) ? "unknown" : null);
 }
 
 /**

--- a/packages/nestjs-doctor/src/telemetry/environment.ts
+++ b/packages/nestjs-doctor/src/telemetry/environment.ts
@@ -9,11 +9,8 @@ export function generatedIn(
 	return isSet(env.CI) || isSet(env.GITHUB_ACTIONS) ? "ci" : "cli";
 }
 
-/**
- * The CI systems worth naming: env var first, slug second. The slug is the
- * `ci.<provider>` identity and the `ci_provider` payload value, so published
- * slugs never change. Single-variable checks only, mirroring ci-info.
- */
+/** The CI systems worth naming: env var first, slug second. Each slug is a
+ * `ci.<provider>` identity and the `ci_provider` payload value. */
 const CI_PROVIDERS: readonly (readonly [string, string])[] = [
 	["GITHUB_ACTIONS", "github"],
 	["GITLAB_CI", "gitlab"],

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { dirname, join } from "node:path";
-import { detectCiProvider } from "./environment.js";
+import { detectKnownCiProvider } from "./environment.js";
 
 interface TelemetryIdentity {
 	/** Stable per-install id, or a shared one per provider in CI. */
@@ -42,7 +42,7 @@ export function configDir(env: NodeJS.ProcessEnv = process.env): string {
  * One id per CI provider, shared by every runner.
  */
 function ciIdentity(env: NodeJS.ProcessEnv): string | undefined {
-	const provider = detectCiProvider(env);
+	const provider = detectKnownCiProvider(env);
 	return provider ? `ci.${provider}` : undefined;
 }
 

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -7,7 +7,7 @@ import { detectKnownCiProvider } from "./environment.js";
 interface TelemetryIdentity {
 	/** Stable per-install id, or a shared one per provider in CI. */
 	anonymousId: string;
-	/** Per-project, salted with a value that never leaves the machine. Absent in CI. */
+	/** Per-project, salted with a value that never leaves the machine. Absent under a known CI provider. */
 	projectId?: string;
 }
 

--- a/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
+++ b/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
@@ -6,6 +6,7 @@ import { configDir, resolveIdentity } from "../../src/telemetry/install-id.js";
 import { scanTelemetryEnabled } from "../../src/telemetry/send.js";
 
 const SHA256_HEX = /^[a-f0-9]{64}$/;
+const CI_PREFIX = /^ci\./;
 
 const homes: string[] = [];
 
@@ -72,9 +73,23 @@ describe("install identity", () => {
 
 		expect(runner().anonymousId).toBe("ci.github");
 		expect(runner().anonymousId).toBe("ci.github");
-		expect(resolveIdentity("/repo/a", isolated({ CI: "1" })).anonymousId).toBe(
-			"ci.unknown"
-		);
+		expect(
+			resolveIdentity(
+				"/repo/a",
+				isolated({ JENKINS_URL: "https://ci.example.com" })
+			).anonymousId
+		).toBe("ci.jenkins");
+	});
+
+	it("treats a bare CI variable as a machine, not a named provider", () => {
+		const env = isolated({ CI: "1" });
+
+		const identity = resolveIdentity("/repo/a", env);
+		const again = resolveIdentity("/repo/a", env);
+
+		expect(identity.anonymousId).not.toMatch(CI_PREFIX);
+		expect(again.anonymousId).toBe(identity.anonymousId);
+		expect(again.projectId).toBe(identity.projectId);
 	});
 
 	it("sends no project id from CI", () => {


### PR DESCRIPTION
## Context

`nestjs-doctor` reports anonymous scan telemetry to PostHog. Identity is decided in `resolveIdentity` (`src/telemetry/install-id.ts`): when the environment looks like CI, every runner shares one `ci.<provider>` id and withholds its per-project salted id; otherwise each install gets a personal UUID. "Looks like CI" meant env-var sniffing over a six-entry table, with bare `CI` mapping to the shared person `ci.unknown`.

## Problem

Both directions of the sniff were wrong, visible in today's production data:

- **False positive (human → CI pool).** A developer's local run with `CI=1` exported — an agent harness, a `.envrc`, muscle memory — was merged into the anonymous `ci.unknown` person. Confirmed on our own machines: one Mac sent scans under both its personal UUID and `ci.unknown` on the same day.
- **False negative (automation → user).** A Linux box in France ran 50 scans nonstop from 06:25 to 20:10 and was recorded as an ordinary user: `generated_in: "cli"`, `ci_provider: null`, personal UUID **with** a populated `project_id` — leaking exactly the salted id the CI path exists to withhold. PostHog's own classifier flagged the traffic as bot/automation; our labels did not. Similar unflagged machines appear at 36, 10, and 7 scans/day.

The score is unaffected; this pollutes telemetry only.

## Possible flows

| Path into detection | Before | Affected |
|---|---|---|
| Known provider var set (e.g. `GITHUB_ACTIONS`) | Shared `ci.<provider>` identity | No change |
| Only bare `CI` set | Shared `ci.unknown` identity, no project id | Yes — now keeps personal id |
| Automation setting none of the 6 vars | Personal UUID + project id | Yes — 28 more providers covered |
| Plain local machine | Personal UUID + project id | No change |

## Solution

- Split detection: new `detectKnownCiProvider` returns a provider slug only for a known variable; `detectCiProvider` keeps the old contract (bare `CI` → `"unknown"`) for payload properties like `ci_provider`, so the signal survives without dragging identity with it.
- `ciIdentity` now uses the known-only variant.
- Provider table grew from 6 to 34 systems, mirroring ci-info's single-variable checks (TeamCity, Azure Pipelines, Bitbucket Pipelines, CodeBuild, Drone, Render, Vercel, Xcode Cloud, …). Existing slugs (`github`, `gitlab`, …) are untouched so history stays comparable.
- Not done: runners that set no detectable variable remain invisible client-side; analysis should lean on PostHog's `$virt_is_bot` / traffic-type properties instead of chasing parity in the CLI.

## Before vs after

| Run | Before | After |
|---|---|---|
| GitHub Actions runner | `ci.github` | `ci.github` (unchanged) |
| Local shell with `CI=1` exported | Merged into `ci.unknown`, project id dropped | Personal install id kept, `ci_provider: "unknown"` |
| Jenkins agent | `ci.unknown` | `ci.jenkins` |
| Headless automation with no CI vars | Counted as a user, leaked `project_id` | Recognized as CI where a var matches; otherwise unchanged |
| Ordinary laptop | Personal UUID + project id | Unchanged |

## Example

```
$ CI=1 npx nestjs-doctor .

# before
distinct_id = "ci.unknown", project_id = absent

# after
distinct_id = "<install uuid>", ci_provider = "unknown", generated_in = "ci"
```

Changeset: patch on `nestjs-doctor`.
