### PR TITLE
feat(website): /report playground rendering report-ui

### DIFF
--- a/packages/report-ui/package.json
+++ b/packages/report-ui/package.json
@@ -7,7 +7,8 @@
     ".": "./src/index.tsx",
     "./app": "./src/app.tsx",
     "./model": "./src/model.ts",
-    "./styles.css": "./src/styles/report.css"
+    "./styles.css": "./src/styles/report.css",
+    "./demo/fixture": "./demo/fixture.ts"
   },
   "scripts": {
     "build": "vite build && node scripts/emit-embed.mjs",

--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
 	output: "export",
 	images: { unoptimized: true },
 	pageExtensions: ["tsx", "ts", "mdx"],
+	transpilePackages: ["report-ui"],
 };
 
 const withMDX = createMDX({

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -16,6 +16,8 @@
     "@xyflow/react": "12.10.1",
     "lucide-react": "^1.27.0",
     "next": "16.3.2",
+    "react-doctor": "^0.9.12",
+    "report-ui": "workspace:*",
     "posthog-js": "^1.418.10",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/packages/website/src/app/report/page.tsx
+++ b/packages/website/src/app/report/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { App } from "report-ui/app";
+import { fixtureModel } from "report-ui/demo/fixture";
+
+import "report-ui/styles.css";
+import "@/app/globals.css";
+
+export default function ReportPlayground() {
+	return (
+		<div className="mx-auto min-h-screen max-w-6xl">
+			<p className="p-4 text-neutral-500 text-xs">
+				dev playground — the same components the CLI embeds in its HTML report,
+				fed with fixture data
+			</p>
+			<App model={fixtureModel()} />
+		</div>
+	);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       react:
         specifier: 19.2.3
         version: 19.2.3
+      react-doctor:
+        specifier: ^0.9.12
+        version: 0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.9.0(jiti@2.7.0))
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
@@ -180,6 +183,9 @@ importers:
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
+      report-ui:
+        specifier: workspace:*
+        version: link:../report-ui
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -196,9 +202,6 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
-      react-doctor:
-        specifier: ^0.9.12
-        version: 0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.9.0(jiti@2.7.0))
       rehype-pretty-code:
         specifier: ^0.14.5
         version: 0.14.5(shiki@4.4.3)


### PR DESCRIPTION
## Context

Fifth level of the stacked React-report series (#295 → #296 → #297 → #298 → this). First deliverable of Stage 8: the dev playground that lets report components be iterated with hot reload instead of CLI round-trips.

## Possible flows

| Flow | Affected |
|---|---|
| nestjs.doctor/report | New page: App mounted with fixture data |
| Static export | Verified: out/report.html contains the mounted shell |
| Docs/landing | Untouched |

## Solution

- website depends on `report-ui: workspace:*` + `transpilePackages: ["report-ui"]` (raw TSX, live HMR; compiled-dist documented as fallback).
- `src/app/report/page.tsx`: client page mounting `<App model={fixtureModel()} />` — identical component tree to the CLI's embedded bundle.
- report-ui exports `./demo/fixture` for the sample data.

## Before vs after

| Scenario | Before | After |
|---|---|---|
| Report UI development | edit → pnpm build → CLI scan → open file | edit → browser HMR at /report |
| CI website build | still absent (pre-existing gap) | unchanged here; workflow job lands with hosted-viewer stage |

## Example

```
$ pnpm --filter website build && grep -c "nd-report" out/report.html
1
```