### PR TITLE
refactor: collect scan facts through one shared function

### DIFF
--- a/.changeset/shared-scan-facts.md
+++ b/.changeset/shared-scan-facts.md
@@ -1,0 +1,8 @@
+---
+"nestjs-doctor": patch
+---
+
+Internal refactor, no behavior change: the report facts each scan yields
+(bootstrap entry roots and mapped providers) are now collected by one
+shared function instead of four hand-copied loops across the CLI and
+report pipelines.

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -5,7 +5,6 @@ import type { ReportArtifact, ReportProvider } from "../common/artifact.js";
 import type { Diagnostic } from "../common/diagnostic.js";
 import type { DiagnoseResult } from "../common/result.js";
 import { computeBaselineDelta } from "../engine/baseline.js";
-import { collectEntryModules } from "../engine/graph/entry-points.js";
 import {
 	detachModuleGraph,
 	mergeModuleGraphs,
@@ -34,7 +33,7 @@ import {
 	type ResolvedScope,
 	resolveScope,
 } from "../engine/scope.js";
-import { buildReportArtifact, toReportProvider } from "../report/artifact.js";
+import { buildReportArtifact, collectScanFacts } from "../report/artifact.js";
 import { buildHtmlReport } from "../report/html-report.js";
 import { getEcosystem, resetEcosystem } from "../telemetry/ecosystem.js";
 import { actionContext, generatedIn } from "../telemetry/environment.js";
@@ -574,24 +573,9 @@ export class MonorepoPipeline extends ScanPipeline {
 					}
 					const label = this.projectLabel || name;
 					this.allFiles.push(...context.files);
-					for (const root of collectEntryModules(
-						context.astProject,
-						context.files,
-						context.moduleGraph
-					)) {
-						this.bootstrapRoots.push(`${name}/${root}`);
-					}
-					for (const provider of context.providers.values()) {
-						const owner = context.moduleGraph.providerToModule.get(
-							provider.name
-						);
-						this.allProviders.push(
-							toReportProvider(provider, {
-								project: name,
-								module: owner ? `${name}/${owner.name}` : undefined,
-							})
-						);
-					}
+					const facts = collectScanFacts({ ...context, projectName: name });
+					this.bootstrapRoots.push(...facts.bootstrapRoots);
+					this.allProviders.push(...facts.providers);
 					const rawOutput = await diagnose(context, (checked, total) => {
 						this.emitProgress(`${label} — running rules`, checked, total);
 					});
@@ -855,20 +839,14 @@ export class SingleProjectPipeline extends ScanPipeline {
 				this.scanConfig.customRuleWarnings
 			);
 			// Read from the live graph; the detach below strips the rest.
-			this.bootstrapRoots = [
-				...collectEntryModules(
-					this.context.astProject,
-					this.result.files,
-					this.result.moduleGraph
-				),
-			];
-			this.reportProviders = [...this.result.providers.values()].map(
-				(provider) =>
-					toReportProvider(provider, {
-						module: this.result.moduleGraph.providerToModule.get(provider.name)
-							?.name,
-					})
-			);
+			const facts = collectScanFacts({
+				astProject: this.context.astProject,
+				files: this.result.files,
+				moduleGraph: this.result.moduleGraph,
+				providers: this.result.providers,
+			});
+			this.bootstrapRoots = facts.bootstrapRoots;
+			this.reportProviders = facts.providers;
 			this.result = {
 				...this.result,
 				moduleGraph: detachModuleGraph(this.result.moduleGraph),

--- a/packages/nestjs-doctor/src/report/artifact.ts
+++ b/packages/nestjs-doctor/src/report/artifact.ts
@@ -53,7 +53,8 @@ export function collectScanFacts(input: ScanFactsInput): {
 	bootstrapRoots: string[];
 	providers: ReportProvider[];
 } {
-	const prefix = input.projectName ? `${input.projectName}/` : "";
+	const projectName = input.projectName || undefined;
+	const prefix = projectName ? `${projectName}/` : "";
 	return {
 		bootstrapRoots: [
 			...collectEntryModules(input.astProject, input.files, input.moduleGraph),
@@ -62,7 +63,7 @@ export function collectScanFacts(input: ScanFactsInput): {
 			const owner = input.moduleGraph.providerToModule.get(provider.name);
 			return toReportProvider(provider, {
 				module: owner ? `${prefix}${owner.name}` : undefined,
-				project: input.projectName,
+				project: projectName,
 			});
 		}),
 	};

--- a/packages/nestjs-doctor/src/report/artifact.ts
+++ b/packages/nestjs-doctor/src/report/artifact.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import type { Project } from "ts-morph";
 import {
 	REPORT_ARTIFACT_VERSION,
 	type ReportArtifact,
@@ -8,6 +9,7 @@ import {
 import { forSurface } from "../common/diagnostic.js";
 import type { DiagnoseResult } from "../common/result.js";
 import type { SerializedSchemaGraph } from "../common/schema.js";
+import { collectEntryModules } from "../engine/graph/entry-points.js";
 import type { ModuleGraph } from "../engine/graph/module-graph.js";
 import type { ProviderInfo } from "../engine/graph/type-resolver.js";
 import { getRuleExamples } from "./data/examples.js";
@@ -20,7 +22,7 @@ const EMPTY_SCHEMA: SerializedSchemaGraph = {
 	orm: "",
 };
 
-export function toReportProvider(
+function toReportProvider(
 	provider: ProviderInfo,
 	owner?: { module?: string; project?: string }
 ): ReportProvider {
@@ -32,6 +34,37 @@ export function toReportProvider(
 		scope: provider.scope,
 		module: owner?.module,
 		project: owner?.project,
+	};
+}
+
+interface ScanFactsInput {
+	astProject: Project;
+	files: string[];
+	moduleGraph: ModuleGraph;
+	projectName?: string;
+	providers: Map<string, ProviderInfo>;
+}
+
+/**
+ * The facts a scan yields for a report: bootstrap entry roots and mapped
+ * providers, prefixed with the project name in monorepo mode.
+ */
+export function collectScanFacts(input: ScanFactsInput): {
+	bootstrapRoots: string[];
+	providers: ReportProvider[];
+} {
+	const prefix = input.projectName ? `${input.projectName}/` : "";
+	return {
+		bootstrapRoots: [
+			...collectEntryModules(input.astProject, input.files, input.moduleGraph),
+		].map((root) => `${prefix}${root}`),
+		providers: [...input.providers.values()].map((provider) => {
+			const owner = input.moduleGraph.providerToModule.get(provider.name);
+			return toReportProvider(provider, {
+				module: owner ? `${prefix}${owner.name}` : undefined,
+				project: input.projectName,
+			});
+		}),
 	};
 }
 

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -1,6 +1,5 @@
 import { performance } from "node:perf_hooks";
 import type { ReportProvider, SourceInclusion } from "../common/artifact.js";
-import { collectEntryModules } from "../engine/graph/entry-points.js";
 import {
 	detachModuleGraph,
 	type ModuleGraph,
@@ -23,7 +22,7 @@ import {
 } from "../engine/scanner.js";
 import { scanTelemetryEnabled } from "../telemetry/send.js";
 import { spinner } from "../ui/spinner.js";
-import { buildReportArtifact, toReportProvider } from "./artifact.js";
+import { buildReportArtifact, collectScanFacts } from "./artifact.js";
 import { buildHtmlReport } from "./html-report.js";
 import type { BootstrapTimings } from "./timings.js";
 
@@ -141,19 +140,19 @@ export class SingleProjectReportPipeline extends ReportPipeline {
 	generateHtml(): this {
 		this.steps.push(() => {
 			const { moduleGraph, result, files, providers } = this._scanResult;
+			const facts = collectScanFacts({
+				astProject: this.context.astProject,
+				files,
+				moduleGraph,
+				providers,
+			});
 			this._html = buildHtmlReport(
 				buildReportArtifact({
 					moduleGraph,
 					result,
 					files,
-					bootstrapRoots: [
-						...collectEntryModules(this.context.astProject, files, moduleGraph),
-					],
-					providers: [...providers.values()].map((provider) =>
-						toReportProvider(provider, {
-							module: moduleGraph.providerToModule.get(provider.name)?.name,
-						})
-					),
+					bootstrapRoots: facts.bootstrapRoots,
+					providers: facts.providers,
 					sources: this.sources,
 					timings: this.timings,
 					version: this.version,
@@ -212,24 +211,9 @@ export class MonorepoReportPipeline extends ReportPipeline {
 				this.monorepo,
 				async (name, context: AnalysisContext) => {
 					this.allFiles.push(...context.files);
-					for (const root of collectEntryModules(
-						context.astProject,
-						context.files,
-						context.moduleGraph
-					)) {
-						this.bootstrapRoots.push(`${name}/${root}`);
-					}
-					for (const provider of context.providers.values()) {
-						const owner = context.moduleGraph.providerToModule.get(
-							provider.name
-						);
-						this.allProviders.push(
-							toReportProvider(provider, {
-								project: name,
-								module: owner ? `${name}/${owner.name}` : undefined,
-							})
-						);
-					}
+					const facts = collectScanFacts({ ...context, projectName: name });
+					this.bootstrapRoots.push(...facts.bootstrapRoots);
+					this.allProviders.push(...facts.providers);
 					const scanResult = buildResult(context, await diagnose(context));
 					return {
 						...scanResult,

--- a/packages/nestjs-doctor/tests/unit/scan-facts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-facts.test.ts
@@ -1,0 +1,162 @@
+import { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import type {
+	ModuleGraph,
+	ModuleNode,
+} from "../../src/engine/graph/module-graph.js";
+import type { ProviderInfo } from "../../src/engine/graph/type-resolver.js";
+import { collectScanFacts } from "../../src/report/artifact.js";
+
+const moduleNode = (name: string, filePath: string): ModuleNode => ({
+	exports: [],
+	filePath,
+	forwardRefImports: new Set(),
+	imports: [],
+	isGlobal: false,
+	name,
+	providers: [],
+	providerTokens: [],
+});
+
+interface Fixture {
+	astProject: Project;
+	graph: ModuleGraph;
+	providers: Map<string, ProviderInfo>;
+}
+
+function fixture(): Fixture {
+	const astProject = new Project({ useInMemoryFileSystem: true });
+	const servicePath = "/repo/apps/api/src/users.service.ts";
+	const serviceFile = astProject.createSourceFile(
+		servicePath,
+		"export class UsersService {}\n"
+	);
+	const unownedPath = "/repo/apps/api/src/unowned.service.ts";
+	const unownedFile = astProject.createSourceFile(
+		unownedPath,
+		"export class UnownedService {}\n"
+	);
+
+	const usersModule = moduleNode(
+		"UsersModule",
+		"/repo/apps/api/src/users.module.ts"
+	);
+	const graph: ModuleGraph = {
+		edges: new Map(),
+		modules: new Map([
+			[
+				"AppModule",
+				moduleNode("AppModule", "/repo/apps/api/src/app.module.ts"),
+			],
+			["UsersModule", usersModule],
+		]),
+		providerToModule: new Map([["UsersService", usersModule]]),
+	};
+
+	const providers = new Map<string, ProviderInfo>([
+		[
+			"UsersService",
+			{
+				classDeclaration: serviceFile.getClassOrThrow("UsersService"),
+				dependencies: ["PrismaService"],
+				filePath: servicePath,
+				name: "UsersService",
+				publicMethodCount: 2,
+			},
+		],
+		[
+			"UnownedService",
+			{
+				classDeclaration: unownedFile.getClassOrThrow("UnownedService"),
+				dependencies: [],
+				filePath: unownedPath,
+				name: "UnownedService",
+				publicMethodCount: 0,
+				scope: "request",
+			},
+		],
+	]);
+
+	return { astProject, graph, providers };
+}
+
+describe("collectScanFacts", () => {
+	it("prefixes roots and owner modules with the project name in monorepo mode", () => {
+		const { astProject, graph, providers } = fixture();
+
+		const facts = collectScanFacts({
+			astProject,
+			files: [],
+			moduleGraph: graph,
+			projectName: "api",
+			providers,
+		});
+
+		expect(facts.bootstrapRoots).toEqual(["api/AppModule"]);
+		expect(facts.providers).toHaveLength(2);
+		expect(facts.providers[0]).toEqual({
+			dependencies: ["PrismaService"],
+			filePath: "/repo/apps/api/src/users.service.ts",
+			module: "api/UsersModule",
+			name: "UsersService",
+			project: "api",
+			publicMethodCount: 2,
+		});
+	});
+
+	it("leaves unmapped owners as undefined while keeping the project label", () => {
+		const { astProject, graph, providers } = fixture();
+
+		const facts = collectScanFacts({
+			astProject,
+			files: [],
+			moduleGraph: graph,
+			projectName: "api",
+			providers,
+		});
+
+		expect(facts.providers[1].module).toBeUndefined();
+		expect(facts.providers[1].project).toBe("api");
+		expect(facts.providers[1].scope).toBe("request");
+	});
+
+	it("keeps provider Map insertion order", () => {
+		const { astProject, graph, providers } = fixture();
+
+		const facts = collectScanFacts({
+			astProject,
+			files: [],
+			moduleGraph: graph,
+			projectName: "api",
+			providers,
+		});
+
+		expect(facts.providers.map((p) => p.name)).toEqual([
+			"UsersService",
+			"UnownedService",
+		]);
+	});
+
+	it("returns unprefixed roots and no project field in single-project mode", () => {
+		const { astProject, graph, providers } = fixture();
+
+		const facts = collectScanFacts({
+			astProject,
+			files: [],
+			moduleGraph: graph,
+			providers,
+		});
+
+		expect(facts.bootstrapRoots).toEqual(["AppModule"]);
+		expect(facts.providers[0]).toEqual({
+			dependencies: ["PrismaService"],
+			filePath: "/repo/apps/api/src/users.service.ts",
+			module: "UsersModule",
+			name: "UsersService",
+			project: undefined,
+			publicMethodCount: 2,
+		});
+		expect(facts.providers[1].module).toBeUndefined();
+		expect(facts.providers[1].project).toBeUndefined();
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/scan-facts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-facts.test.ts
@@ -159,4 +159,20 @@ describe("collectScanFacts", () => {
 		expect(facts.providers[1].module).toBeUndefined();
 		expect(facts.providers[1].project).toBeUndefined();
 	});
+
+	it("treats an empty project name as single-project mode", () => {
+		const { astProject, graph, providers } = fixture();
+
+		const facts = collectScanFacts({
+			astProject,
+			files: [],
+			moduleGraph: graph,
+			projectName: "",
+			providers,
+		});
+
+		expect(facts.bootstrapRoots).toEqual(["AppModule"]);
+		expect(facts.providers[0].module).toBe("UsersModule");
+		expect(facts.providers[0].project).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## What

One shared function now collects what a scan yields for a report: bootstrap entry roots and mapped providers. The four hand-copied loops across the CLI and report pipelines call it instead.

```ts
collectScanFacts({ projectName?, astProject, files, moduleGraph, providers })
// -> { bootstrapRoots, providers }
```

It lives beside `buildReportArtifact`, and `toReportProvider` became module-internal since nothing outside imports it anymore.

## Why

Whenever one of those loops drifted from its twins, the console report and `--report` would quietly disagree about what a scan found. Four copies of the same mapping was four chances for that. Now there is one definition, covered by its own tests.

## Notes

| Thing | Changed? |
|---|---|
| Behavior | No, byte-equal prefixes, owner resolution, and ordering |
| Public API surface | No (`toReportProvider` was never exported) |
| Line count | Net −5 |

TDD: the collector's tests went red on a stub before implementation. A patch changeset is included.
