### PR TITLE
refactor: split scan options from presentation options at the worker boundary

### DIFF
--- a/.changeset/worker-options-split.md
+++ b/.changeset/worker-options-split.md
@@ -1,0 +1,8 @@
+---
+"nestjs-doctor": patch
+---
+
+Internal refactor, no behavior change: the scan worker now receives only
+the options the engine steps read (ScanOptions) instead of the full CLI
+options object, and the defensive re-sanitization on both sides of the
+worker boundary is gone.

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -54,7 +54,11 @@ import {
 	outputMonorepoResults,
 	outputSingleProjectResults,
 } from "./output.js";
-import type { PipelineOptions } from "./setup.js";
+import {
+	type PipelineOptions,
+	type ScanOptions,
+	toScanOptions,
+} from "./setup.js";
 import { createAnimatedProgress } from "./ui/animated-progress.js";
 
 type PipelineStep = () => void | Promise<void>;
@@ -83,7 +87,7 @@ export interface InteractiveArtifacts {
 export interface ScanWorkerRequest {
 	kind: "monorepo" | "single";
 	monorepo?: MonorepoInfo;
-	options: PipelineOptions;
+	options: ScanOptions;
 	targetPath: string;
 	version: string;
 }
@@ -625,13 +629,7 @@ export class MonorepoPipeline extends ScanPipeline {
 			{
 				kind: "monorepo",
 				targetPath: this.targetPath,
-				options: {
-					...this.options,
-					interactive: false,
-					isMachineReadable: true,
-					skipOutput: true,
-					onProgress: undefined,
-				},
+				options: toScanOptions(this.options),
 				monorepo: this.monorepo,
 				version: getCliVersion(),
 			},
@@ -763,13 +761,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 			{
 				kind: "single",
 				targetPath: this.targetPath,
-				options: {
-					...this.options,
-					interactive: false,
-					isMachineReadable: true,
-					skipOutput: true,
-					onProgress: undefined,
-				},
+				options: toScanOptions(this.options),
 				version: getCliVersion(),
 			},
 			(outcome) => {

--- a/packages/nestjs-doctor/src/cli/scan-worker.ts
+++ b/packages/nestjs-doctor/src/cli/scan-worker.ts
@@ -18,12 +18,19 @@ const post = (message: ScanWorkerMessage): void => {
 
 const options: PipelineOptions = {
 	...request.options,
+	format: "console",
 	interactive: false,
 	isMachineReadable: true,
-	skipOutput: true,
+	jsonCompact: false,
 	onProgress: (label, done, total) => {
 		post({ kind: "progress", label, done, total });
 	},
+	outputPath: undefined,
+	score: false,
+	skipOutput: true,
+	sources: "none",
+	timings: undefined,
+	verbose: false,
 };
 
 try {

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -16,33 +16,48 @@ import {
 import { validateMinScoreArg } from "./min-score.js";
 import { validateTargetPathArg } from "./target-path.js";
 
-export interface PipelineOptions {
+/** Fields the engine steps read, wherever the scan runs — safe to post to a worker. */
+export interface ScanOptions {
 	base: string | undefined;
 	blocking: BlockingLevel;
 	changedFilesFrom: string | undefined;
 	configPath: string | undefined;
+	minScore: string | undefined;
+	scope: ScopeMode;
+	staged: boolean;
+	telemetry: boolean;
+}
+
+export interface PipelineOptions extends ScanOptions {
 	format: OutputFormat;
 	/** True when the run ends in the menu; set after setup from `canPrompt`. */
 	interactive: boolean;
 	isMachineReadable: boolean;
-	json: boolean;
 	jsonCompact: boolean;
-	minScore: string | undefined;
 	/** Worker-internal: receives the progress line instead of the local spinner. */
 	onProgress?: (label: string, done?: number, total?: number) => void;
 	outputPath: string | undefined;
-	scope: ScopeMode;
 	score: boolean;
 	/** Worker-internal: the worker never prints the report. */
 	skipOutput?: boolean;
 	/** How much source text the report artifact embeds. */
 	sources: SourceInclusion;
-	staged: boolean;
-	telemetry: boolean;
 	/** Parsed bootstrap dump, for the artifact's module-graph overlay. */
 	timings?: BootstrapTimings;
 	verbose: boolean;
 }
+
+/** Picks only the engine fields; an explicit literal so new options stay opt-in. */
+export const toScanOptions = (options: PipelineOptions): ScanOptions => ({
+	base: options.base,
+	blocking: options.blocking,
+	changedFilesFrom: options.changedFilesFrom,
+	configPath: options.configPath,
+	minScore: options.minScore,
+	scope: options.scope,
+	staged: options.staged,
+	telemetry: options.telemetry,
+});
 
 interface SetupContext {
 	options: PipelineOptions;
@@ -301,7 +316,6 @@ export class CliSetup {
 				format,
 				interactive: false,
 				isMachineReadable,
-				json: format === "json",
 				jsonCompact: this.args["json-compact"] ?? false,
 				minScore: this.args["min-score"],
 				outputPath: this.args.output,

--- a/packages/nestjs-doctor/tests/unit/output-report-json.test.ts
+++ b/packages/nestjs-doctor/tests/unit/output-report-json.test.ts
@@ -30,7 +30,6 @@ const options = (format: PipelineOptions["format"]): PipelineOptions => ({
 	format,
 	interactive: false,
 	isMachineReadable: true,
-	json: false,
 	jsonCompact: false,
 	minScore: undefined,
 	outputPath: undefined,

--- a/packages/nestjs-doctor/tests/unit/scan-options.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-options.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { type PipelineOptions, toScanOptions } from "../../src/cli/setup.js";
+import type { BootstrapTimings } from "../../src/common/timings.js";
+
+const timings: BootstrapTimings = {
+	byModule: new Map([
+		[
+			"AppModule",
+			[{ id: "app", initTime: 3, name: "AppModule", type: "module" }],
+		],
+	]),
+	hooksByClass: new Map([["AppModule", [{ hook: "onModuleInit", ms: 5 }]]]),
+	phases: { initMs: 9 },
+	startupMs: 12,
+	trace: {
+		AppModule: { deps: [], initTime: 3, name: "AppModule", type: "module" },
+	},
+};
+
+const options = (over: Partial<PipelineOptions> = {}): PipelineOptions => ({
+	base: "main",
+	blocking: "error",
+	changedFilesFrom: "origin/main",
+	configPath: "nestjs-doctor.config.ts",
+	format: "report-json",
+	interactive: true,
+	isMachineReadable: false,
+	jsonCompact: true,
+	minScore: "80",
+	onProgress: (label) => label.length > 0,
+	outputPath: "out/report.json",
+	scope: "changed",
+	score: true,
+	skipOutput: false,
+	sources: "touched",
+	staged: true,
+	telemetry: false,
+	timings,
+	verbose: true,
+	...over,
+});
+
+describe("toScanOptions", () => {
+	const scan = toScanOptions(options());
+
+	it("carries every engine field through with the source value", () => {
+		expect(scan).toStrictEqual({
+			base: "main",
+			blocking: "error",
+			changedFilesFrom: "origin/main",
+			configPath: "nestjs-doctor.config.ts",
+			minScore: "80",
+			scope: "changed",
+			staged: true,
+			telemetry: false,
+		});
+	});
+
+	it("is JSON-safe: no functions and a lossless round-trip", () => {
+		for (const value of Object.values(scan)) {
+			expect(typeof value).not.toBe("function");
+		}
+		expect(JSON.parse(JSON.stringify(scan))).toStrictEqual(scan);
+	});
+
+	it("drops presentation fields", () => {
+		for (const key of [
+			"format",
+			"interactive",
+			"isMachineReadable",
+			"jsonCompact",
+			"onProgress",
+			"outputPath",
+			"score",
+			"skipOutput",
+			"sources",
+			"timings",
+			"verbose",
+		]) {
+			expect(scan).not.toHaveProperty(key);
+		}
+	});
+});


### PR DESCRIPTION
## What

The scan worker now receives `ScanOptions`, an explicit serializable subset of eight fields, instead of the full CLI options object. `ScanWorkerRequest.options` is typed as that subset, and both delegate methods build it with one `toScanOptions()` call.

Before this, both delegate sites stripped fields before posting (`interactive: false, isMachineReadable: true, skipOutput: true, onProgress: undefined`) and the worker stripped three of them again before constructing its pipeline. That second strip is deleted, along with the write-only `json` field on PipelineOptions.

## Why

`PipelineOptions` mixed main-thread presentation concerns with what the engine steps read, so every function-valued or main-only option was a worker-crash hazard held back only by manual stripping in two places. The type now draws that line: putting a callback into the worker request is a compile error.

## Notes

| Thing | Changed? |
|---|---|
| Worker behavior | No — same steps, same telemetry payload (including the blocking level it reads) |
| CLI flags or output | No; the `--json` flag still works, only the unused internal field is gone |
| Public API surface | No |

TDD: the new tests JSON-round-trip `toScanOptions` output to prove no functions leak across the boundary. A patch changeset is included.
