### PR TITLE
refactor: extract the scan pipeline's collaborators

### DIFF
--- a/.changeset/pipeline-collaborators.md
+++ b/.changeset/pipeline-collaborators.md
@@ -1,0 +1,9 @@
+---
+"nestjs-doctor": patch
+---
+
+Internal refactor, no behavior change: the scan pipeline's cancellation
+watching, worker-thread delegation, and telemetry reporting moved from
+methods on the pipeline base class into their own modules
+(src/cli/cancellation-watcher.ts, src/cli/worker-delegate.ts,
+src/cli/scan-telemetry-reporter.ts), each covered by its own tests.

--- a/packages/nestjs-doctor/src/cli/cancellation-watcher.ts
+++ b/packages/nestjs-doctor/src/cli/cancellation-watcher.ts
@@ -1,0 +1,38 @@
+interface CancellationWatcherDeps {
+	/** Fired when the interrupt arrives as SIGINT or as a raw-mode 0x03 byte. */
+	onInterrupt: () => void;
+	/** Injectable for tests; defaults to the real process. */
+	signals?: Pick<NodeJS.Process, "on" | "off">;
+	/** Injectable for tests; defaults to process.stdin. */
+	stdin?: {
+		isTTY?: boolean;
+		off(event: string, listener: (data: Buffer | string) => void): unknown;
+		on(event: string, listener: (data: Buffer | string) => void): unknown;
+	};
+}
+
+/** Watches for Ctrl+C as SIGINT and, on a TTY stdin, as a raw-mode 0x03 byte. */
+export const watchCancellation = (
+	deps: CancellationWatcherDeps
+): (() => void) => {
+	const signals = deps.signals ?? process;
+	const stdin = deps.stdin ?? process.stdin;
+	const onInterrupt = (): void => {
+		deps.onInterrupt();
+	};
+	const onByte = (data: Buffer | string): void => {
+		if (
+			typeof data === "string" ? data.includes("\u0003") : data.includes(0x03)
+		) {
+			deps.onInterrupt();
+		}
+	};
+	signals.on("SIGINT", onInterrupt);
+	if (stdin.isTTY) {
+		stdin.on("data", onByte);
+	}
+	return () => {
+		signals.off("SIGINT", onInterrupt);
+		stdin.off("data", onByte);
+	};
+};

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -1,6 +1,4 @@
-import { stat } from "node:fs/promises";
 import { performance } from "node:perf_hooks";
-import { Worker } from "node:worker_threads";
 import type { ReportArtifact, ReportProvider } from "../common/artifact.js";
 import type { Diagnostic } from "../common/diagnostic.js";
 import type { DiagnoseResult } from "../common/result.js";
@@ -12,7 +10,6 @@ import {
 import { pruneCrossProjectOrphans } from "../engine/orphan-prune.js";
 import type { MonorepoInfo } from "../engine/project-detector.js";
 import { withScopedDiagnostics } from "../engine/result-builder.js";
-import { allRules } from "../engine/rules/index.js";
 import {
 	type AnalysisContext,
 	type AnalysisPhase,
@@ -35,14 +32,7 @@ import {
 } from "../engine/scope.js";
 import { buildReportArtifact, collectScanFacts } from "../report/artifact.js";
 import { buildHtmlReport } from "../report/html-report.js";
-import { getEcosystem, resetEcosystem } from "../telemetry/ecosystem.js";
-import { actionContext, generatedIn } from "../telemetry/environment.js";
-import { resolveIdentity } from "../telemetry/install-id.js";
-import {
-	buildScanPayload,
-	readConfigFacts,
-} from "../telemetry/scan-telemetry.js";
-import { scanTelemetryEnabled, sendScanTelemetry } from "../telemetry/send.js";
+import { resetEcosystem } from "../telemetry/ecosystem.js";
 import { logger } from "../ui/logger.js";
 import {
 	printConsoleReport,
@@ -54,11 +44,22 @@ import {
 	outputMonorepoResults,
 	outputSingleProjectResults,
 } from "./output.js";
+import type { ScanOutcome, ScanWorkerRequest } from "./worker-delegate.js";
 import {
-	type PipelineOptions,
-	type ScanOptions,
-	toScanOptions,
-} from "./setup.js";
+	canDelegateToWorker,
+	runInWorker,
+	setWorkerUrl as storeWorkerUrl,
+} from "./worker-delegate.js";
+
+// ScanOutcome lives in worker-delegate.ts; nothing imported it from here.
+export type {
+	ScanWorkerMessage,
+	ScanWorkerRequest,
+} from "./worker-delegate.js";
+
+import { watchCancellation } from "./cancellation-watcher.js";
+import { reportScanTelemetry } from "./scan-telemetry-reporter.js";
+import { type PipelineOptions, toScanOptions } from "./setup.js";
 import { createAnimatedProgress } from "./ui/animated-progress.js";
 
 type PipelineStep = () => void | Promise<void>;
@@ -82,48 +83,6 @@ export interface InteractiveArtifacts {
 	/** Per-project results in a monorepo, for the score screen's breakdown. */
 	subProjects?: { name: string; result: DiagnoseResult }[];
 }
-
-/** Main → scan worker. Everything the engine middle needs. */
-export interface ScanWorkerRequest {
-	kind: "monorepo" | "single";
-	monorepo?: MonorepoInfo;
-	options: ScanOptions;
-	targetPath: string;
-	version: string;
-}
-
-/** Worker → main. Progress ticks, then one outcome or one failure. */
-export type ScanWorkerMessage =
-	| { kind: "progress"; label: string; done?: number; total?: number }
-	| { kind: "outcome"; outcome: ScanOutcome }
-	| { kind: "error"; message: string };
-
-/** Everything the engine steps produced, in transferable data. */
-export type ScanOutcome =
-	| {
-			kind: "monorepo";
-			customRuleWarnings: string[];
-			moduleGraphs: MonorepoEngineResult["moduleGraphs"];
-			result: MonorepoEngineResult["result"];
-			reportProviders: ReportProvider[];
-			bootstrapRoots: string[];
-			allFiles: string[];
-			subProjectOptOut: boolean;
-			scopeWarnings: string[];
-			resolvedMinimumScore?: number;
-	  }
-	| {
-			kind: "single";
-			customRuleWarnings: string[];
-			files: string[];
-			moduleGraph: EngineResult["moduleGraph"];
-			reportProviders: ReportProvider[];
-			bootstrapRoots: string[];
-			result: DiagnoseResult;
-			schemaGraph: EngineResult["schemaGraph"];
-			scopeWarnings: string[];
-			resolvedMinimumScore?: number;
-	  };
 
 const displayCustomRuleWarnings = (
 	warnings: string[],
@@ -179,52 +138,18 @@ abstract class ScanPipeline {
 		fileCount: number,
 		monorepo: boolean
 	): void {
-		if (
-			this.subProjectOptOut ||
-			!scanTelemetryEnabled(this.options.telemetry, this.scanConfig?.config)
-		) {
-			return;
-		}
-		try {
-			const identity = resolveIdentity(this.targetPath);
-			const enabled = new Set(
-				[
-					...this.scanConfig.fileRules,
-					...this.scanConfig.projectRules,
-					...this.scanConfig.schemaRules,
-				].map((rule) => rule.meta.id)
-			);
-			sendScanTelemetry(
-				buildScanPayload({
-					action: actionContext(),
-					blocking: this.options.blocking,
-					config: readConfigFacts(this.scanConfig.config),
-					customRulesLoaded: this.scanConfig.combinedRules.filter((rule) =>
-						rule.meta.id.startsWith("custom/")
-					).length,
-					diagnostics,
-					disabledRuleIds: allRules
-						.map((rule) => rule.meta.id)
-						.filter((id) => !enabled.has(id)),
-					ecosystem: getEcosystem(),
-					elapsedMs: result.elapsedMs,
-					fileCount,
-					framework: result.project.framework,
-					monorepo,
-					nestVersion: result.project.nestVersion,
-					orm: result.project.orm,
-					projectId: identity.projectId,
-					ruleErrors: result.ruleErrors,
-					scopeRequested: this.options.scope,
-					score: result.score,
-					source: generatedIn(),
-					version: getCliVersion(),
-				}),
-				identity.anonymousId
-			);
-		} catch {
-			// Reporting never breaks a scan.
-		}
+		reportScanTelemetry({
+			blocking: this.options.blocking,
+			diagnostics,
+			fileCount,
+			monorepo,
+			optionsTelemetry: this.options.telemetry,
+			result,
+			scanConfig: this.scanConfig,
+			scopeRequested: this.options.scope,
+			subProjectOptOut: this.subProjectOptOut,
+			targetPath: this.targetPath,
+		});
 	}
 
 	abstract applyScope(): this;
@@ -352,76 +277,27 @@ abstract class ScanPipeline {
 	}
 
 	/** Location of the scan worker entry, injected by the CLI. */
-	private static workerUrl: URL | null = null;
-
 	static setWorkerUrl(url: URL | null): void {
-		ScanPipeline.workerUrl = url;
+		storeWorkerUrl(url);
 	}
 
 	/** Injected by the CLI entry; null until then. */
-	protected async canDelegate(): Promise<boolean> {
-		if (!this.options.interactive || this.options.isMachineReadable) {
-			return false;
-		}
-		if (this.outputStep === null || ScanPipeline.workerUrl === null) {
-			return false;
-		}
-		try {
-			await stat(ScanPipeline.workerUrl);
-			return true;
-		} catch {
-			return false;
-		}
+	protected canDelegate(): Promise<boolean> {
+		return canDelegateToWorker({
+			hasOutputStep: this.outputStep !== null,
+			interactive: this.options.interactive,
+			isMachineReadable: this.options.isMachineReadable,
+		});
 	}
 
 	protected runViaWorker(
 		request: ScanWorkerRequest,
 		apply: (outcome: ScanOutcome) => void
 	): Promise<void> {
-		return new Promise((resolve, reject) => {
-			const url = ScanPipeline.workerUrl;
-			if (!url) {
-				reject(new Error("scan worker is not available"));
-				return;
-			}
-			let settled = false;
-			const worker = new Worker(url, { workerData: request });
-			const finish = (error?: Error): void => {
-				if (settled) {
-					return;
-				}
-				settled = true;
-				// biome-ignore lint/suspicious/noEmptyBlockStatements: termination is best-effort once the promise is settled
-				worker.terminate().catch(() => {});
-				if (error) {
-					reject(error);
-				} else {
-					resolve();
-				}
-			};
-			worker.on("message", (message: ScanWorkerMessage) => {
-				if (message.kind === "progress") {
-					this.emitProgress(message.label, message.done, message.total);
-				} else if (message.kind === "outcome") {
-					try {
-						apply(message.outcome);
-					} catch (error) {
-						finish(error instanceof Error ? error : new Error(String(error)));
-						return;
-					}
-					finish();
-				} else {
-					finish(new Error(message.message));
-				}
-			});
-			worker.on("error", (error) => {
-				finish(error instanceof Error ? error : new Error(String(error)));
-			});
-			worker.on("exit", (code) => {
-				if (code !== 0) {
-					finish(new Error(`scan worker exited with code ${code}`));
-				}
-			});
+		return runInWorker(request, apply, {
+			emitProgress: (label, done, total) => {
+				this.emitProgress(label, done, total);
+			},
 		});
 	}
 
@@ -436,20 +312,7 @@ abstract class ScanPipeline {
 			logger.warn("Scan cancelled.");
 			process.exit(130);
 		};
-		const onInterrupt = (): void => {
-			cancel();
-		};
-		const onByte = (data: Buffer | string): void => {
-			if (
-				typeof data === "string" ? data.includes("\u0003") : data.includes(0x03)
-			) {
-				cancel();
-			}
-		};
-		process.on("SIGINT", onInterrupt);
-		if (process.stdin.isTTY) {
-			process.stdin.on("data", onByte);
-		}
+		const stopWatching = watchCancellation({ onInterrupt: cancel });
 		try {
 			if (await this.canDelegate()) {
 				try {
@@ -480,8 +343,7 @@ abstract class ScanPipeline {
 				await step();
 			}
 		} finally {
-			process.off("SIGINT", onInterrupt);
-			process.stdin?.off("data", onByte);
+			stopWatching();
 			this.stopProgress();
 		}
 	}

--- a/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
@@ -1,0 +1,91 @@
+import type { Diagnostic } from "../common/diagnostic.js";
+import type { DiagnoseResult } from "../common/result.js";
+import type { ScopeMode } from "../common/scope.js";
+import { allRules } from "../engine/rules/index.js";
+import type { ScanConfig } from "../engine/scanner.js";
+import { getEcosystem } from "../telemetry/ecosystem.js";
+import { actionContext, generatedIn } from "../telemetry/environment.js";
+import { resolveIdentity } from "../telemetry/install-id.js";
+import {
+	buildScanPayload,
+	readConfigFacts,
+} from "../telemetry/scan-telemetry.js";
+import { scanTelemetryEnabled, sendScanTelemetry } from "../telemetry/send.js";
+import type { BlockingLevel } from "./blocking.js";
+import { getCliVersion } from "./output.js";
+
+export interface ScanTelemetryInput {
+	blocking: BlockingLevel;
+	diagnostics: Diagnostic[];
+	fileCount: number;
+	/** Injectable for tests; defaults to the compiled-in gating. */
+	isEnabled?: typeof scanTelemetryEnabled;
+	monorepo: boolean;
+	optionsTelemetry: boolean;
+	/** Injectable for tests; defaults to the real install-id resolver. */
+	resolveIdentityFn?: typeof resolveIdentity;
+	result: DiagnoseResult;
+	scanConfig: ScanConfig | undefined;
+	scopeRequested: ScopeMode;
+	/** Injectable for tests; defaults to the detached-child sender. */
+	send?: typeof sendScanTelemetry;
+	subProjectOptOut: boolean;
+	targetPath: string;
+}
+
+/**
+ * Reports the scan anonymously. A failure here leaves the scan untouched,
+ * and the network call runs in a detached child.
+ */
+export const reportScanTelemetry = (input: ScanTelemetryInput): void => {
+	const isEnabled = input.isEnabled ?? scanTelemetryEnabled;
+	if (
+		input.subProjectOptOut ||
+		!isEnabled(input.optionsTelemetry, input.scanConfig?.config)
+	) {
+		return;
+	}
+	try {
+		const identity = (input.resolveIdentityFn ?? resolveIdentity)(
+			input.targetPath
+		);
+		const scanConfig = input.scanConfig as ScanConfig;
+		const enabled = new Set(
+			[
+				...scanConfig.fileRules,
+				...scanConfig.projectRules,
+				...scanConfig.schemaRules,
+			].map((rule) => rule.meta.id)
+		);
+		(input.send ?? sendScanTelemetry)(
+			buildScanPayload({
+				action: actionContext(),
+				blocking: input.blocking,
+				config: readConfigFacts(scanConfig.config),
+				customRulesLoaded: scanConfig.combinedRules.filter((rule) =>
+					rule.meta.id.startsWith("custom/")
+				).length,
+				diagnostics: input.diagnostics,
+				disabledRuleIds: allRules
+					.map((rule) => rule.meta.id)
+					.filter((id) => !enabled.has(id)),
+				ecosystem: getEcosystem(),
+				elapsedMs: input.result.elapsedMs,
+				fileCount: input.fileCount,
+				framework: input.result.project.framework,
+				monorepo: input.monorepo,
+				nestVersion: input.result.project.nestVersion,
+				orm: input.result.project.orm,
+				projectId: identity.projectId,
+				ruleErrors: input.result.ruleErrors,
+				scopeRequested: input.scopeRequested,
+				score: input.result.score,
+				source: generatedIn(),
+				version: getCliVersion(),
+			}),
+			identity.anonymousId
+		);
+	} catch {
+		// Reporting never breaks a scan.
+	}
+};

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -47,7 +47,7 @@ export interface PipelineOptions extends ScanOptions {
 	verbose: boolean;
 }
 
-/** Picks only the engine fields; an explicit literal so new options stay opt-in. */
+/** Picks only the engine fields. */
 export const toScanOptions = (options: PipelineOptions): ScanOptions => ({
 	base: options.base,
 	blocking: options.blocking,

--- a/packages/nestjs-doctor/src/cli/worker-delegate.ts
+++ b/packages/nestjs-doctor/src/cli/worker-delegate.ts
@@ -1,0 +1,150 @@
+import { stat } from "node:fs/promises";
+import { Worker } from "node:worker_threads";
+import type { ReportProvider } from "../common/artifact.js";
+import type { DiagnoseResult } from "../common/result.js";
+import type { MonorepoInfo } from "../engine/project-detector.js";
+import type { EngineResult, MonorepoEngineResult } from "../engine/scanner.js";
+import type { ScanOptions } from "./setup.js";
+
+/** Main → scan worker. Everything the engine middle needs. */
+export interface ScanWorkerRequest {
+	kind: "monorepo" | "single";
+	monorepo?: MonorepoInfo;
+	options: ScanOptions;
+	targetPath: string;
+	version: string;
+}
+
+/** Worker → main. Progress ticks, then one outcome or one failure. */
+export type ScanWorkerMessage =
+	| { kind: "progress"; label: string; done?: number; total?: number }
+	| { kind: "outcome"; outcome: ScanOutcome }
+	| { kind: "error"; message: string };
+
+/** Everything the engine steps produced, in transferable data. */
+export type ScanOutcome =
+	| {
+			kind: "monorepo";
+			customRuleWarnings: string[];
+			moduleGraphs: MonorepoEngineResult["moduleGraphs"];
+			result: MonorepoEngineResult["result"];
+			reportProviders: ReportProvider[];
+			bootstrapRoots: string[];
+			allFiles: string[];
+			subProjectOptOut: boolean;
+			scopeWarnings: string[];
+			resolvedMinimumScore?: number;
+	  }
+	| {
+			kind: "single";
+			customRuleWarnings: string[];
+			files: string[];
+			moduleGraph: EngineResult["moduleGraph"];
+			reportProviders: ReportProvider[];
+			bootstrapRoots: string[];
+			result: DiagnoseResult;
+			schemaGraph: EngineResult["schemaGraph"];
+			scopeWarnings: string[];
+			resolvedMinimumScore?: number;
+	  };
+
+/** The parts of a worker thread the delegate wiring touches. */
+export interface WorkerLike {
+	on(event: "error", listener: (error: Error) => void): unknown;
+	on(event: "exit", listener: (code: number) => void): unknown;
+	on(event: "message", listener: (message: ScanWorkerMessage) => void): unknown;
+	terminate(): Promise<number>;
+}
+
+/** Location of the scan worker entry, injected by the CLI. */
+let workerUrl: URL | null = null;
+
+export const setWorkerUrl = (url: URL | null): void => {
+	workerUrl = url;
+};
+
+export interface CanDelegateInput {
+	hasOutputStep: boolean;
+	interactive: boolean;
+	isMachineReadable: boolean;
+	/** Injectable for tests; defaults to fs stat on the worker entry. */
+	statFile?: typeof stat;
+}
+
+export const canDelegateToWorker = async (
+	input: CanDelegateInput
+): Promise<boolean> => {
+	if (!input.interactive || input.isMachineReadable) {
+		return false;
+	}
+	if (!input.hasOutputStep || workerUrl === null) {
+		return false;
+	}
+	try {
+		await (input.statFile ?? stat)(workerUrl);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+interface RunInWorkerDeps {
+	/** Injectable for tests; defaults to a real worker thread. */
+	createWorker?: (url: URL, request: ScanWorkerRequest) => WorkerLike;
+	emitProgress(label: string, done?: number, total?: number): void;
+}
+
+export const runInWorker = (
+	request: ScanWorkerRequest,
+	apply: (outcome: ScanOutcome) => void,
+	deps: RunInWorkerDeps
+): Promise<void> =>
+	new Promise((resolve, reject) => {
+		const url = workerUrl;
+		if (!url) {
+			reject(new Error("scan worker is not available"));
+			return;
+		}
+		let settled = false;
+		const createWorker =
+			deps.createWorker ??
+			((entryUrl: URL, entryRequest: ScanWorkerRequest) =>
+				new Worker(entryUrl, { workerData: entryRequest }) as WorkerLike);
+		const thread = createWorker(url, request);
+		const finish = (error?: Error): void => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			// biome-ignore lint/suspicious/noEmptyBlockStatements: termination is best-effort once the promise is settled
+			thread.terminate().catch(() => {});
+			if (error) {
+				reject(error);
+			} else {
+				resolve();
+			}
+		};
+		thread.on("message", (message: ScanWorkerMessage) => {
+			if (message.kind === "progress") {
+				deps.emitProgress(message.label, message.done, message.total);
+			} else if (message.kind === "outcome") {
+				try {
+					apply(message.outcome);
+				} catch (error) {
+					finish(error instanceof Error ? error : new Error(String(error)));
+					return;
+				}
+				finish();
+			} else {
+				finish(new Error(message.message));
+			}
+		});
+		thread.on("error", (error) => {
+			finish(error instanceof Error ? error : new Error(String(error)));
+		});
+		thread.on("exit", (code) => {
+			if (code !== 0) {
+				finish(new Error(`scan worker exited with code ${code}`));
+			}
+		});
+	});

--- a/packages/nestjs-doctor/tests/unit/cancellation-watcher.test.ts
+++ b/packages/nestjs-doctor/tests/unit/cancellation-watcher.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import { watchCancellation } from "../../src/cli/cancellation-watcher.js";
+
+type SignalHub = ReturnType<typeof signalHub>;
+type StdinHub = ReturnType<typeof stdinHub>;
+
+const signalHub = () => {
+	const listeners = new Map<string, Array<() => void>>();
+	return {
+		count: (event: string) => listeners.get(event)?.length ?? 0,
+		emit: (event: string) => {
+			for (const listener of [...(listeners.get(event) ?? [])]) {
+				listener();
+			}
+		},
+		off: (event: string, listener: () => void) => {
+			listeners.set(
+				event,
+				(listeners.get(event) ?? []).filter((kept) => kept !== listener)
+			);
+		},
+		on: (event: string, listener: () => void) => {
+			listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+		},
+	};
+};
+
+const stdinHub = (isTTY = true) => {
+	const listeners = new Map<string, Array<(data: Buffer | string) => void>>();
+	return {
+		isTTY,
+		count: (event: string) => listeners.get(event)?.length ?? 0,
+		emit: (data: Buffer | string) => {
+			for (const listener of [...(listeners.get("data") ?? [])]) {
+				listener(data);
+			}
+		},
+		off: (event: string, listener: (data: Buffer | string) => void) => {
+			listeners.set(
+				event,
+				(listeners.get(event) ?? []).filter((kept) => kept !== listener)
+			);
+		},
+		on: (event: string, listener: (data: Buffer | string) => void) => {
+			listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+		},
+	};
+};
+
+const startWatching = (
+	onInterrupt = vi.fn(),
+	signals: SignalHub = signalHub(),
+	stdin: StdinHub = stdinHub()
+) => ({
+	onInterrupt,
+	signals,
+	dispose: watchCancellation({ onInterrupt, signals, stdin }),
+	stdin,
+});
+
+describe("cancellation watcher", () => {
+	it("fires the interrupt callback when SIGINT arrives", () => {
+		const watch = startWatching();
+
+		watch.signals.emit("SIGINT");
+
+		expect(watch.onInterrupt).toHaveBeenCalledTimes(1);
+	});
+
+	it("registers exactly one SIGINT handler", () => {
+		const watch = startWatching();
+
+		expect(watch.signals.count("SIGINT")).toBe(1);
+	});
+
+	it("keeps firing until disposed", () => {
+		const watch = startWatching();
+
+		watch.signals.emit("SIGINT");
+		watch.signals.emit("SIGINT");
+
+		expect(watch.onInterrupt).toHaveBeenCalledTimes(2);
+	});
+
+	it("fires on a raw-mode 0x03 byte", () => {
+		const watch = startWatching();
+
+		watch.stdin.emit(Buffer.from([0x03]));
+
+		expect(watch.onInterrupt).toHaveBeenCalledTimes(1);
+	});
+
+	it("fires when a chunk contains 0x03 among other bytes", () => {
+		const watch = startWatching();
+
+		watch.stdin.emit(Buffer.from([0x41, 0x03, 0x42]));
+
+		expect(watch.onInterrupt).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores bytes that are not ETX", () => {
+		const watch = startWatching();
+
+		watch.stdin.emit(Buffer.from("abc"));
+		watch.stdin.emit("hello");
+
+		expect(watch.onInterrupt).not.toHaveBeenCalled();
+	});
+
+	it("fires on a string containing the ETX character", () => {
+		const watch = startWatching();
+
+		watch.stdin.emit("x\u0003");
+
+		expect(watch.onInterrupt).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not watch stdin when it is not a TTY", () => {
+		const watch = startWatching(vi.fn(), signalHub(), stdinHub(false));
+
+		expect(watch.stdin.count("data")).toBe(0);
+
+		watch.stdin.emit(Buffer.from([0x03]));
+
+		expect(watch.onInterrupt).not.toHaveBeenCalled();
+	});
+
+	it("still registers the SIGINT handler without a TTY", () => {
+		const watch = startWatching(vi.fn(), signalHub(), stdinHub(false));
+
+		expect(watch.signals.count("SIGINT")).toBe(1);
+
+		watch.signals.emit("SIGINT");
+
+		expect(watch.onInterrupt).toHaveBeenCalledTimes(1);
+	});
+
+	it("decides whether to watch bytes at registration time", () => {
+		const stdin = stdinHub(true);
+		const watch = startWatching(vi.fn(), signalHub(), stdin);
+
+		stdin.isTTY = false;
+
+		expect(stdin.count("data")).toBe(1);
+
+		stdin.emit(Buffer.from([0x03]));
+
+		expect(watch.onInterrupt).toHaveBeenCalledTimes(1);
+	});
+
+	it("the disposer removes the SIGINT handler", () => {
+		const watch = startWatching();
+
+		watch.dispose();
+		watch.signals.emit("SIGINT");
+
+		expect(watch.onInterrupt).not.toHaveBeenCalled();
+		expect(watch.signals.count("SIGINT")).toBe(0);
+	});
+
+	it("the disposer removes the byte watcher", () => {
+		const watch = startWatching();
+
+		watch.dispose();
+		watch.stdin.emit(Buffer.from([0x03]));
+
+		expect(watch.onInterrupt).not.toHaveBeenCalled();
+		expect(watch.stdin.count("data")).toBe(0);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import { getCliVersion } from "../../src/cli/output.js";
+import {
+	reportScanTelemetry,
+	type ScanTelemetryInput,
+} from "../../src/cli/scan-telemetry-reporter.js";
+import type { Rule } from "../../src/engine/rules/types.js";
+import type { ScanConfig } from "../../src/engine/scanner.js";
+import { emptyResult } from "./report-artifact-fixture.js";
+
+const ruleWithId = (id: string): Rule => ({ meta: { id } }) as unknown as Rule;
+
+const scanConfigFixture = (): ScanConfig =>
+	({
+		combinedRules: [
+			ruleWithId("performance/no-unused-providers"),
+			ruleWithId("custom/acme-internal"),
+		],
+		config: { minScore: 70 },
+		customRuleWarnings: [],
+		fileRules: [ruleWithId("performance/no-unused-providers")],
+		projectRules: [],
+		schemaRules: [],
+	}) as unknown as ScanConfig;
+
+const buildInput = (
+	overrides: Partial<ScanTelemetryInput> = {}
+): ScanTelemetryInput => ({
+	blocking: "error",
+	diagnostics: [],
+	fileCount: 4,
+	isEnabled: () => true,
+	monorepo: false,
+	optionsTelemetry: true,
+	resolveIdentityFn: vi.fn(() => ({
+		anonymousId: "anon-123",
+		projectId: "proj-hash",
+	})),
+	result: { ...emptyResult(), elapsedMs: 12.7 },
+	scanConfig: scanConfigFixture(),
+	scopeRequested: "full",
+	send: vi.fn(),
+	subProjectOptOut: false,
+	targetPath: "/repo/app",
+	...overrides,
+});
+
+describe("scan telemetry reporter", () => {
+	it("resolves the identity and sends the payload to the anonymous id", () => {
+		const input = buildInput();
+
+		reportScanTelemetry(input);
+
+		expect(input.resolveIdentityFn).toHaveBeenCalledWith("/repo/app");
+		expect(input.send).toHaveBeenCalledTimes(1);
+		expect(input.send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				blocking: "error",
+				config_min_score: 70,
+				custom_rules_loaded: 1,
+				duration_ms: 13,
+				file_count: 4,
+				framework: "express",
+				monorepo: false,
+				nest_version: "11.0.0",
+				orm: "prisma",
+				project_id: "proj-hash",
+				rules_disabled: expect.arrayContaining([
+					"security/no-hardcoded-secrets",
+				]),
+				score: 90,
+				scope_requested: "full",
+				version: getCliVersion(),
+			}),
+			"anon-123"
+		);
+		expect(input.send.mock.calls[0]?.[0].rules_disabled).not.toContain(
+			"performance/no-unused-providers"
+		);
+	});
+
+	it("keeps custom rule names out of the disabled list", () => {
+		const input = buildInput();
+
+		reportScanTelemetry(input);
+
+		expect(
+			JSON.stringify(input.send.mock.calls[0]?.[0].rules_disabled)
+		).not.toContain("custom/");
+	});
+
+	it("sends nothing when a sub-project opted out", () => {
+		const isEnabled = vi.fn(() => true);
+		const resolveIdentityFn = vi.fn();
+		const input = buildInput({
+			isEnabled,
+			resolveIdentityFn,
+			subProjectOptOut: true,
+		});
+
+		reportScanTelemetry(input);
+
+		expect(input.send).not.toHaveBeenCalled();
+		expect(resolveIdentityFn).not.toHaveBeenCalled();
+		expect(isEnabled).not.toHaveBeenCalled();
+	});
+
+	it("sends nothing when telemetry is disabled", () => {
+		const isEnabled = vi.fn(() => false);
+		const resolveIdentityFn = vi.fn();
+		const input = buildInput({ isEnabled, resolveIdentityFn });
+
+		reportScanTelemetry(input);
+
+		expect(input.send).not.toHaveBeenCalled();
+		expect(resolveIdentityFn).not.toHaveBeenCalled();
+	});
+
+	it("swallows a throw from sending", () => {
+		const input = buildInput({
+			send: vi.fn(() => {
+				throw new Error("network down");
+			}),
+		});
+
+		expect(() => reportScanTelemetry(input)).not.toThrow();
+	});
+
+	it("swallows a throw from resolving the identity", () => {
+		const input = buildInput({
+			resolveIdentityFn: vi.fn(() => {
+				throw new Error("fs gone");
+			}),
+		});
+
+		expect(() => reportScanTelemetry(input)).not.toThrow();
+		expect(input.send).not.toHaveBeenCalled();
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/worker-delegate.test.ts
+++ b/packages/nestjs-doctor/tests/unit/worker-delegate.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type CanDelegateInput,
+	canDelegateToWorker,
+	runInWorker,
+	type ScanOutcome,
+	type ScanWorkerRequest,
+	setWorkerUrl,
+	type WorkerLike,
+} from "../../src/cli/worker-delegate.js";
+
+const workerUrl = new URL("file:///fake/scan-worker.mjs");
+
+class FakeWorker {
+	readonly handlers = new Map<string, Array<(...args: never[]) => void>>();
+	terminateCalls = 0;
+
+	on(event: string, listener: (...args: never[]) => void): void {
+		this.handlers.set(event, [...(this.handlers.get(event) ?? []), listener]);
+	}
+
+	emit(event: string, ...args: never[]): void {
+		for (const listener of [...(this.handlers.get(event) ?? [])]) {
+			listener(...args);
+		}
+	}
+
+	terminate(): Promise<number> {
+		this.terminateCalls += 1;
+		return Promise.resolve(1);
+	}
+
+	asWorkerLike(): WorkerLike {
+		return this as unknown as WorkerLike;
+	}
+}
+
+const requestFixture = (): ScanWorkerRequest =>
+	({
+		kind: "single",
+		options: {
+			base: undefined,
+			blocking: "error",
+			changedFilesFrom: undefined,
+			configPath: undefined,
+			minScore: undefined,
+			scope: "full",
+			staged: false,
+			telemetry: true,
+		},
+		targetPath: "/repo/app",
+		version: "0.0.0",
+	}) as unknown as ScanWorkerRequest;
+
+const outcomeFixture = (): ScanOutcome =>
+	({ kind: "single", customRuleWarnings: [] }) as unknown as ScanOutcome;
+
+const delegateInput = (
+	overrides: Partial<CanDelegateInput> = {}
+): CanDelegateInput => ({
+	hasOutputStep: true,
+	interactive: true,
+	isMachineReadable: false,
+	statFile: vi.fn(async () => ({}) as Awaited<ReturnType<typeof stat>>),
+	...overrides,
+});
+
+describe("worker delegate — canDelegateToWorker", () => {
+	beforeEach(() => {
+		setWorkerUrl(null);
+	});
+
+	it("cannot delegate without a worker url, even when interactive", async () => {
+		const input = delegateInput();
+
+		await expect(canDelegateToWorker(input)).resolves.toBe(false);
+		expect(input.statFile).not.toHaveBeenCalled();
+	});
+
+	it("cannot delegate when not interactive", async () => {
+		setWorkerUrl(workerUrl);
+		const input = delegateInput({ interactive: false });
+
+		await expect(canDelegateToWorker(input)).resolves.toBe(false);
+		expect(input.statFile).not.toHaveBeenCalled();
+	});
+
+	it("cannot delegate when machine readable", async () => {
+		setWorkerUrl(workerUrl);
+		const input = delegateInput({ isMachineReadable: true });
+
+		await expect(canDelegateToWorker(input)).resolves.toBe(false);
+		expect(input.statFile).not.toHaveBeenCalled();
+	});
+
+	it("cannot delegate without an output step", async () => {
+		setWorkerUrl(workerUrl);
+		const input = delegateInput({ hasOutputStep: false });
+
+		await expect(canDelegateToWorker(input)).resolves.toBe(false);
+		expect(input.statFile).not.toHaveBeenCalled();
+	});
+
+	it("a stat failure means no delegation", async () => {
+		setWorkerUrl(workerUrl);
+		const input = delegateInput({
+			statFile: vi.fn(() => Promise.reject(new Error("ENOENT"))),
+		});
+
+		await expect(canDelegateToWorker(input)).resolves.toBe(false);
+	});
+
+	it("an existing worker entry delegates", async () => {
+		setWorkerUrl(workerUrl);
+
+		await expect(canDelegateToWorker(delegateInput())).resolves.toBe(true);
+	});
+});
+
+describe("worker delegate — runInWorker", () => {
+	beforeEach(() => {
+		setWorkerUrl(null);
+	});
+
+	it("rejects when the worker was never configured", async () => {
+		const createWorker = vi.fn();
+
+		await expect(
+			runInWorker(requestFixture(), vi.fn(), {
+				createWorker,
+				emitProgress: vi.fn(),
+			})
+		).rejects.toThrow("scan worker is not available");
+		expect(createWorker).not.toHaveBeenCalled();
+	});
+
+	it("posts the request and resolves on the outcome message", async () => {
+		setWorkerUrl(workerUrl);
+		const worker = new FakeWorker();
+		const createWorker = vi.fn(() => worker.asWorkerLike());
+		const apply = vi.fn();
+		const promise = runInWorker(requestFixture(), apply, {
+			createWorker,
+			emitProgress: vi.fn(),
+		});
+
+		const outcome = outcomeFixture();
+		worker.emit("message", { kind: "outcome", outcome } as never);
+		worker.emit("exit", 0 as never);
+
+		await expect(promise).resolves.toBeUndefined();
+		expect(createWorker).toHaveBeenCalledWith(workerUrl, requestFixture());
+		expect(apply).toHaveBeenCalledWith(outcome);
+		expect(worker.terminateCalls).toBe(1);
+	});
+
+	it("forwards progress messages through emitProgress", async () => {
+		setWorkerUrl(workerUrl);
+		const worker = new FakeWorker();
+		const emitProgress = vi.fn();
+		const promise = runInWorker(requestFixture(), vi.fn(), {
+			createWorker: () => worker.asWorkerLike(),
+			emitProgress,
+		});
+
+		worker.emit("message", {
+			kind: "progress",
+			label: "Parsing files",
+			done: 3,
+			total: 9,
+		} as never);
+		worker.emit("message", {
+			kind: "progress",
+			label: "Analyzing the project",
+		} as never);
+		worker.emit("message", {
+			kind: "outcome",
+			outcome: outcomeFixture(),
+		} as never);
+
+		await expect(promise).resolves.toBeUndefined();
+		expect(emitProgress).toHaveBeenNthCalledWith(1, "Parsing files", 3, 9);
+		expect(emitProgress).toHaveBeenNthCalledWith(
+			2,
+			"Analyzing the project",
+			undefined,
+			undefined
+		);
+	});
+
+	it("rejects on an error message", async () => {
+		setWorkerUrl(workerUrl);
+		const worker = new FakeWorker();
+		const promise = runInWorker(requestFixture(), vi.fn(), {
+			createWorker: () => worker.asWorkerLike(),
+			emitProgress: vi.fn(),
+		});
+
+		worker.emit("message", { kind: "error", message: "boom" } as never);
+
+		await expect(promise).rejects.toThrow("boom");
+		expect(worker.terminateCalls).toBe(1);
+	});
+
+	it("rejects on a nonzero exit", async () => {
+		setWorkerUrl(workerUrl);
+		const worker = new FakeWorker();
+		const promise = runInWorker(requestFixture(), vi.fn(), {
+			createWorker: () => worker.asWorkerLike(),
+			emitProgress: vi.fn(),
+		});
+
+		worker.emit("exit", 1 as never);
+
+		await expect(promise).rejects.toThrow("scan worker exited with code 1");
+		expect(worker.terminateCalls).toBe(1);
+	});
+
+	it("maps a throw from apply to a rejection and still terminates", async () => {
+		setWorkerUrl(workerUrl);
+		const worker = new FakeWorker();
+		const promise = runInWorker(
+			requestFixture(),
+			vi.fn(() => {
+				throw new Error("apply blew up");
+			}),
+			{ createWorker: () => worker.asWorkerLike(), emitProgress: vi.fn() }
+		);
+
+		worker.emit("message", {
+			kind: "outcome",
+			outcome: outcomeFixture(),
+		} as never);
+
+		await expect(promise).rejects.toThrow("apply blew up");
+		expect(worker.terminateCalls).toBe(1);
+	});
+
+	it("a late error after the outcome leaves the promise resolved", async () => {
+		setWorkerUrl(workerUrl);
+		const worker = new FakeWorker();
+		const apply = vi.fn();
+		const promise = runInWorker(requestFixture(), apply, {
+			createWorker: () => worker.asWorkerLike(),
+			emitProgress: vi.fn(),
+		});
+
+		worker.emit("message", {
+			kind: "outcome",
+			outcome: outcomeFixture(),
+		} as never);
+		worker.emit("message", { kind: "error", message: "late boom" } as never);
+
+		await expect(promise).resolves.toBeUndefined();
+		expect(apply).toHaveBeenCalledTimes(1);
+		expect(worker.terminateCalls).toBe(1);
+	});
+});


### PR DESCRIPTION
## What

Three collaborators extracted out of the scan pipeline base class:

- `src/cli/cancellation-watcher.ts` — detects SIGINT and the raw-mode Ctrl+C byte; the pipeline keeps deciding what cancellation does.
- `src/cli/worker-delegate.ts` — the can-delegate checks, worker-thread wiring, and the worker protocol types.
- `src/cli/scan-telemetry-reporter.ts` — builds and sends the anonymous scan report.

The base class goes from 885 to 747 lines and keeps thin delegating shims, its step queue, and every existing export. 31 characterization tests cover the extracted behavior, written red before each move.

## Why

Cancellation, delegation, and telemetry were methods welded into one class, which made them testable only through spinners, process signals, and real worker threads. Cancellation handling shipped broken once already when reshaped carelessly (the handler must be registered relative to ora loading); pinned tests make that class of mistake fail loudly now.

## Notes

| Thing | Changed? |
|---|---|
| Behavior | No, line-for-line moves with injected dependencies |
| Public exports | No (`ScanOutcome` moved to worker-delegate with the rest of the protocol) |
| Step queue design | Untouched |

A patch changeset is included.
