### PR TITLE
fix(rules): stop no-manual-instantiation reporting provider factories

### DIFF
--- a/.changeset/no-manual-instantiation-factories.md
+++ b/.changeset/no-manual-instantiation-factories.md
@@ -1,16 +1,7 @@
 ---
-"@nestjs-doctor/cli": patch
+"nestjs-doctor": patch
 ---
 
-Stop `architecture/no-manual-instantiation` reporting provider factories (#293)
-
-A `new X()` inside a custom provider's `useFactory` or `useValue` is NestJS
-taking ownership of the instance, not a bypass of dependency injection — it is
-the documented way to construct a service whose constructor arguments are only
-known at runtime. The rule now skips construction inside a `useFactory`
-(arrow or method shorthand) or `useValue` initializer of an object literal that
-carries a `provide` key, and inside options objects handed directly to
-`forRoot`/`forFeature`/`register` calls. It also no longer requires a name
-suffix (`Service`, `Guard`, …) when project decorator facts already identify
-the class as `@Injectable`, so unsuffixed registered classes constructed by
-hand are now caught.
+Stop `architecture/no-manual-instantiation` reporting instances created by
+custom provider factories, values, dynamic module options, and module-scope
+composition helpers.

--- a/.changeset/no-manual-instantiation-factories.md
+++ b/.changeset/no-manual-instantiation-factories.md
@@ -1,0 +1,16 @@
+---
+"@nestjs-doctor/cli": patch
+---
+
+Stop `architecture/no-manual-instantiation` reporting provider factories (#293)
+
+A `new X()` inside a custom provider's `useFactory` or `useValue` is NestJS
+taking ownership of the instance, not a bypass of dependency injection — it is
+the documented way to construct a service whose constructor arguments are only
+known at runtime. The rule now skips construction inside a `useFactory`
+(arrow or method shorthand) or `useValue` initializer of an object literal that
+carries a `provide` key, and inside options objects handed directly to
+`forRoot`/`forFeature`/`register` calls. It also no longer requires a name
+suffix (`Service`, `Guard`, …) when project decorator facts already identify
+the class as `@Injectable`, so unsuffixed registered classes constructed by
+hand are now caught.

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
@@ -3,9 +3,79 @@ import type { Rule } from "../../types.js";
 
 const DI_ONLY_SUFFIXES = ["Service", "Repository", "Gateway", "Resolver"];
 const CONTEXT_AWARE_SUFFIXES = ["Guard", "Interceptor", "Pipe", "Filter"];
+const DYNAMIC_MODULE_CALL = /\.(?:forRoot|forFeature|register)(?:Async)?$/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
+}
+
+// Start positions of `new` expressions that build what NestJS will own:
+// factory/useValue bodies of provider literals, and options handed to a
+// dynamic-module registration call.
+function getProviderConstructionStarts(
+	sourceFile: import("ts-morph").SourceFile
+): Set<number> {
+	const starts = new Set<number>();
+
+	for (const obj of sourceFile.getDescendantsOfKind(
+		SyntaxKind.ObjectLiteralExpression
+	)) {
+		if (!obj.getProperty("provide")) {
+			continue;
+		}
+		for (const key of ["useFactory", "useValue"]) {
+			const prop = obj.getProperty(key);
+			if (!prop) {
+				continue;
+			}
+			const initializer = prop
+				.asKind(SyntaxKind.PropertyAssignment)
+				?.getInitializer();
+			if (initializer) {
+				const direct = initializer.asKind(SyntaxKind.NewExpression);
+				if (direct) {
+					starts.add(direct.getStart());
+				}
+				for (const expr of initializer.getDescendantsOfKind(
+					SyntaxKind.NewExpression
+				)) {
+					starts.add(expr.getStart());
+				}
+			}
+			// useFactory(config) { ... }
+			const method = prop.asKind(SyntaxKind.MethodDeclaration);
+			if (method) {
+				for (const expr of method.getDescendantsOfKind(
+					SyntaxKind.NewExpression
+				)) {
+					starts.add(expr.getStart());
+				}
+			}
+		}
+	}
+
+	for (const call of sourceFile.getDescendantsOfKind(
+		SyntaxKind.CallExpression
+	)) {
+		if (!DYNAMIC_MODULE_CALL.test(call.getExpression().getText())) {
+			continue;
+		}
+		for (const arg of call.getArguments()) {
+			const literal =
+				arg.asKind(SyntaxKind.ObjectLiteralExpression) ??
+				arg.asKind(SyntaxKind.ArrayLiteralExpression);
+			if (!literal) {
+				continue;
+			}
+			for (const expr of literal.getDescendantsOfKind(
+				SyntaxKind.NewExpression
+			)) {
+				starts.add(expr.getStart());
+			}
+		}
+	}
+
+	return starts;
 }
 
 function getExcludedClasses(ruleConfig: unknown): Set<string> {
@@ -50,6 +120,9 @@ export const noManualInstantiation: Rule = {
 		const excludedClasses = getExcludedClasses(
 			context.config?.rules?.[this.meta.id]
 		);
+		const providerConstructionStarts = getProviderConstructionStarts(
+			context.sourceFile
+		);
 		const newExpressions = context.sourceFile.getDescendantsOfKind(
 			SyntaxKind.NewExpression
 		);
@@ -65,15 +138,18 @@ export const noManualInstantiation: Rule = {
 				continue;
 			}
 
+			if (providerConstructionStarts.has(expr.getStart())) {
+				continue;
+			}
+
+			const knownInjectable =
+				!!context.diProviders &&
+				(context.diProviders.has(exprText) ||
+					context.diProviders.has(simpleExprText));
+
 			// A name suffix is not a provider. Only a class NestJS instantiates can
 			// be injected instead; a plain class, or one from node_modules, cannot.
-			if (
-				context.diProviders &&
-				!(
-					context.diProviders.has(exprText) ||
-					context.diProviders.has(simpleExprText)
-				)
-			) {
+			if (context.diProviders && !knownInjectable) {
 				continue;
 			}
 
@@ -82,7 +158,9 @@ export const noManualInstantiation: Rule = {
 				exprText.endsWith(s)
 			);
 
-			if (!(isDiOnly || isContextAware)) {
+			// With decorator facts the suffix guess is unnecessary; it only
+			// widens the net when they are unavailable.
+			if (!(knownInjectable || isDiOnly || isContextAware)) {
 				continue;
 			}
 
@@ -99,7 +177,7 @@ export const noManualInstantiation: Rule = {
 				}
 			}
 
-			if (isContextAware) {
+			if (!knownInjectable && isContextAware) {
 				// Only flag if inside a method body or constructor body
 				const inMethod = expr.getFirstAncestorByKind(
 					SyntaxKind.MethodDeclaration

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-manual-instantiation.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind } from "ts-morph";
+import { type Node, type SourceFile, SyntaxKind } from "ts-morph";
 import type { Rule } from "../../types.js";
 
 const DI_ONLY_SUFFIXES = ["Service", "Repository", "Gateway", "Resolver"];
@@ -9,12 +9,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
 
-// Start positions of `new` expressions that build what NestJS will own:
-// factory/useValue bodies of provider literals, and options handed to a
-// dynamic-module registration call.
-function getProviderConstructionStarts(
-	sourceFile: import("ts-morph").SourceFile
-): Set<number> {
+function addNewExpressionStarts(node: Node, starts: Set<number>): void {
+	const directExpression = node.asKind(SyntaxKind.NewExpression);
+	if (directExpression) {
+		starts.add(directExpression.getStart());
+	}
+
+	for (const expression of node.getDescendantsOfKind(
+		SyntaxKind.NewExpression
+	)) {
+		starts.add(expression.getStart());
+	}
+}
+
+function getProviderConstructionStarts(sourceFile: SourceFile): Set<number> {
 	const starts = new Set<number>();
 
 	for (const obj of sourceFile.getDescendantsOfKind(
@@ -25,31 +33,11 @@ function getProviderConstructionStarts(
 		}
 		for (const key of ["useFactory", "useValue"]) {
 			const prop = obj.getProperty(key);
-			if (!prop) {
-				continue;
-			}
-			const initializer = prop
-				.asKind(SyntaxKind.PropertyAssignment)
-				?.getInitializer();
-			if (initializer) {
-				const direct = initializer.asKind(SyntaxKind.NewExpression);
-				if (direct) {
-					starts.add(direct.getStart());
-				}
-				for (const expr of initializer.getDescendantsOfKind(
-					SyntaxKind.NewExpression
-				)) {
-					starts.add(expr.getStart());
-				}
-			}
-			// useFactory(config) { ... }
-			const method = prop.asKind(SyntaxKind.MethodDeclaration);
-			if (method) {
-				for (const expr of method.getDescendantsOfKind(
-					SyntaxKind.NewExpression
-				)) {
-					starts.add(expr.getStart());
-				}
+			const construction =
+				prop?.asKind(SyntaxKind.PropertyAssignment)?.getInitializer() ??
+				prop?.asKind(SyntaxKind.MethodDeclaration);
+			if (construction) {
+				addNewExpressionStarts(construction, starts);
 			}
 		}
 	}
@@ -67,15 +55,32 @@ function getProviderConstructionStarts(
 			if (!literal) {
 				continue;
 			}
-			for (const expr of literal.getDescendantsOfKind(
-				SyntaxKind.NewExpression
-			)) {
-				starts.add(expr.getStart());
-			}
+			addNewExpressionStarts(literal, starts);
 		}
 	}
 
 	return starts;
+}
+
+function isRuntimeClassConstruction(node: Node): boolean {
+	const member = node.getFirstAncestor((ancestor) =>
+		[
+			SyntaxKind.MethodDeclaration,
+			SyntaxKind.Constructor,
+			SyntaxKind.PropertyDeclaration,
+			SyntaxKind.GetAccessor,
+			SyntaxKind.SetAccessor,
+		].includes(ancestor.getKind())
+	);
+	if (!member) {
+		return false;
+	}
+	return !(
+		member.asKind(SyntaxKind.MethodDeclaration)?.isStatic() ||
+		member.asKind(SyntaxKind.PropertyDeclaration)?.isStatic() ||
+		member.asKind(SyntaxKind.GetAccessor)?.isStatic() ||
+		member.asKind(SyntaxKind.SetAccessor)?.isStatic()
+	);
 }
 
 function getExcludedClasses(ruleConfig: unknown): Set<string> {
@@ -142,14 +147,19 @@ export const noManualInstantiation: Rule = {
 				continue;
 			}
 
-			const knownInjectable =
-				!!context.diProviders &&
-				(context.diProviders.has(exprText) ||
-					context.diProviders.has(simpleExprText));
+			if (!isRuntimeClassConstruction(expr)) {
+				continue;
+			}
 
 			// A name suffix is not a provider. Only a class NestJS instantiates can
 			// be injected instead; a plain class, or one from node_modules, cannot.
-			if (context.diProviders && !knownInjectable) {
+			if (
+				context.diProviders &&
+				!(
+					context.diProviders.has(exprText) ||
+					context.diProviders.has(simpleExprText)
+				)
+			) {
 				continue;
 			}
 
@@ -158,9 +168,7 @@ export const noManualInstantiation: Rule = {
 				exprText.endsWith(s)
 			);
 
-			// With decorator facts the suffix guess is unnecessary; it only
-			// widens the net when they are unavailable.
-			if (!(knownInjectable || isDiOnly || isContextAware)) {
+			if (!(isDiOnly || isContextAware)) {
 				continue;
 			}
 
@@ -177,7 +185,7 @@ export const noManualInstantiation: Rule = {
 				}
 			}
 
-			if (!knownInjectable && isContextAware) {
+			if (isContextAware) {
 				// Only flag if inside a method body or constructor body
 				const inMethod = expr.getFirstAncestorByKind(
 					SyntaxKind.MethodDeclaration

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "factory-providers-app",
+	"version": "1.0.0",
+	"dependencies": {
+		"@nestjs/common": "^11.0.0",
+		"@nestjs/core": "^11.0.0"
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/app.module.ts
@@ -9,14 +9,11 @@ import {
 	paymentGatewayProvider,
 } from "./payments/payments.providers";
 import { AuditService } from "./legacy/audit.service";
-import { buildGuestUser } from "./legacy/legacy.helpers";
-import { legacyDescriptor } from "./legacy/legacy.providers";
+import { LegacyHelperService } from "./legacy/legacy.helpers";
+import { LegacyDescriptorService } from "./legacy/legacy.providers";
 import { searchProvider, SearchIndexService } from "./search/search.providers";
 import { storageProvider, LocalStorageService } from "./storage/storage.providers";
 import { UserService } from "./users/user.service";
-
-void buildGuestUser;
-void legacyDescriptor;
 
 @Module({
 	imports: [JwtModule.register("dev-secret"), JwtModule.registerAsync()],
@@ -34,6 +31,8 @@ void legacyDescriptor;
 		TokenSignerService,
 		KeyStoreService,
 		AuditService,
+		LegacyHelperService,
+		LegacyDescriptorService,
 	],
 })
 export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/app.module.ts
@@ -1,0 +1,39 @@
+import { Module } from "@nestjs/common";
+import { JwtModule } from "./auth/jwt.module";
+import { KeyStoreService, TokenSignerService } from "./auth/auth.services";
+import { AppConfigService } from "./config/app-config.service";
+import { mailProviders } from "./mail/mail-dispatcher.service";
+import { PaymentGateway } from "./payments/payment-gateway.service";
+import {
+	legacyGatewayProvider,
+	paymentGatewayProvider,
+} from "./payments/payments.providers";
+import { AuditService } from "./legacy/audit.service";
+import { buildGuestUser } from "./legacy/legacy.helpers";
+import { legacyDescriptor } from "./legacy/legacy.providers";
+import { searchProvider, SearchIndexService } from "./search/search.providers";
+import { storageProvider, LocalStorageService } from "./storage/storage.providers";
+import { UserService } from "./users/user.service";
+
+void buildGuestUser;
+void legacyDescriptor;
+
+@Module({
+	imports: [JwtModule.register("dev-secret"), JwtModule.registerAsync()],
+	providers: [
+		AppConfigService,
+		UserService,
+		...mailProviders,
+		searchProvider,
+		SearchIndexService,
+		storageProvider,
+		LocalStorageService,
+		paymentGatewayProvider,
+		legacyGatewayProvider,
+		PaymentGateway,
+		TokenSignerService,
+		KeyStoreService,
+		AuditService,
+	],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/auth/auth.services.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/auth/auth.services.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class TokenSignerService {
+	constructor(private readonly secret: string) {}
+
+	sign(payload: object): string {
+		return `${JSON.stringify(payload).length}.${this.secret.length}`;
+	}
+}
+
+@Injectable()
+export class KeyStoreService {
+	constructor(private readonly url: string) {}
+
+	load(kid: string): string {
+		return `${this.url}/${kid}`;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/auth/jwt.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/auth/jwt.module.ts
@@ -1,0 +1,39 @@
+import { DynamicModule, Module, Provider } from "@nestjs/common";
+import { AppConfigService } from "../config/app-config.service";
+import { KeyStoreService, TokenSignerService } from "./auth.services";
+
+const JWT_SIGNER = "JWT_SIGNER";
+const JWT_KEY_STORE = "JWT_KEY_STORE";
+
+// Dynamic module in the @nestjs/jwt shape: a sync register() path stamping
+// resolved options into useValue providers, and an async registerAsync()
+// path whose factories the container invokes.
+@Module({})
+export class JwtModule {
+	static register(secret: string): DynamicModule {
+		const providers: Provider[] = [
+			{ provide: JWT_SIGNER, useValue: new TokenSignerService(secret) },
+			{
+				provide: JWT_KEY_STORE,
+				useValue: new KeyStoreService("redis://localhost:6379"),
+			},
+		];
+		return { module: JwtModule, providers, exports: providers };
+	}
+
+	static registerAsync(): DynamicModule {
+		return {
+			module: JwtModule,
+			imports: [],
+			providers: [
+				{
+					provide: JWT_SIGNER,
+					inject: [AppConfigService],
+					useFactory: (config: AppConfigService) =>
+						new TokenSignerService(config.stripeKey),
+				},
+			],
+			exports: [JWT_SIGNER],
+		};
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/auth/jwt.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/auth/jwt.module.ts
@@ -5,9 +5,6 @@ import { KeyStoreService, TokenSignerService } from "./auth.services";
 const JWT_SIGNER = "JWT_SIGNER";
 const JWT_KEY_STORE = "JWT_KEY_STORE";
 
-// Dynamic module in the @nestjs/jwt shape: a sync register() path stamping
-// resolved options into useValue providers, and an async registerAsync()
-// path whose factories the container invokes.
 @Module({})
 export class JwtModule {
 	static register(secret: string): DynamicModule {

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/config/app-config.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/config/app-config.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from "@nestjs/common";
+
+export interface SmtpOptions {
+	host: string;
+	port: number;
+}
+
+@Injectable()
+export class AppConfigService {
+	readonly smtpOptions: SmtpOptions = {
+		host: process.env.SMTP_HOST ?? "localhost",
+		port: Number(process.env.SMTP_PORT ?? 587),
+	};
+
+	readonly defaultFrom = '"Acme" <no-reply@acme.dev>';
+	readonly redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379";
+	readonly stripeKey = process.env.STRIPE_SECRET_KEY ?? "";
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/audit.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/audit.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { UserService } from "../users/user.service";
 
-// BAD: runtime construction inside a service method shadows the
-// container-managed instance.
 @Injectable()
 export class AuditService {
 	snapshot(): string {

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/audit.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/audit.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from "@nestjs/common";
+import { UserService } from "../users/user.service";
+
+// BAD: runtime construction inside a service method shadows the
+// container-managed instance.
+@Injectable()
+export class AuditService {
+	snapshot(): string {
+		const users = new UserService();
+		return users.findAll().join(",");
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/legacy.helpers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/legacy.helpers.ts
@@ -1,6 +1,9 @@
+import { Injectable } from "@nestjs/common";
 import { UserService } from "../users/user.service";
 
-// BAD: plain helper constructing a registered injectable by hand.
-export function buildGuestUser(): UserService {
-	return new UserService();
+@Injectable()
+export class LegacyHelperService {
+	buildGuestUser(): UserService {
+		return new UserService();
+	}
 }

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/legacy.helpers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/legacy.helpers.ts
@@ -1,0 +1,6 @@
+import { UserService } from "../users/user.service";
+
+// BAD: plain helper constructing a registered injectable by hand.
+export function buildGuestUser(): UserService {
+	return new UserService();
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/legacy.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/legacy.providers.ts
@@ -1,0 +1,12 @@
+import { AppConfigService } from "../config/app-config.service";
+import { UserService } from "../users/user.service";
+
+// BAD: resembles a provider but carries no `provide` key, so nothing ever
+// hands it to Nest — the construction is an ordinary bypass.
+export const legacyDescriptor = {
+	inject: [AppConfigService],
+	useFactory: (config: AppConfigService) => {
+		void config;
+		return new UserService();
+	},
+};

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/legacy.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/legacy/legacy.providers.ts
@@ -1,12 +1,16 @@
+import { Injectable } from "@nestjs/common";
 import { AppConfigService } from "../config/app-config.service";
 import { UserService } from "../users/user.service";
 
-// BAD: resembles a provider but carries no `provide` key, so nothing ever
-// hands it to Nest — the construction is an ordinary bypass.
-export const legacyDescriptor = {
-	inject: [AppConfigService],
-	useFactory: (config: AppConfigService) => {
-		void config;
-		return new UserService();
-	},
-};
+@Injectable()
+export class LegacyDescriptorService {
+	build() {
+		return {
+			inject: [AppConfigService],
+			useFactory: (config: AppConfigService) => {
+				void config;
+				return new UserService();
+			},
+		};
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/create-mailer.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/create-mailer.ts
@@ -1,0 +1,6 @@
+import { AppConfigService } from "../config/app-config.service";
+import { MailerService } from "./mailer.service";
+
+export function createMailer(config: AppConfigService): MailerService {
+	return new MailerService(config.smtpOptions, { from: config.defaultFrom });
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/mail-dispatcher.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/mail-dispatcher.service.ts
@@ -1,0 +1,16 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { MAILER_TOKEN, mailerProvider } from "./mailer.providers";
+import { MailerService } from "./mailer.service";
+
+@Injectable()
+export class MailDispatcherService {
+	constructor(
+		@Inject(MAILER_TOKEN) private readonly mailer: MailerService,
+	) {}
+
+	dispatch(to: string): string {
+		return this.mailer.send(to, "hello");
+	}
+}
+
+export const mailProviders = [mailerProvider, MailDispatcherService];

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/mailer.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/mailer.providers.ts
@@ -1,14 +1,11 @@
 import { type Provider } from "@nestjs/common";
 import { AppConfigService } from "../config/app-config.service";
-import { MailerService } from "./mailer.service";
+import { createMailer } from "./create-mailer";
 
 export const MAILER_TOKEN = "MAILER_TOKEN";
 
-// Factory providers are the documented way to build a service whose
-// constructor arguments are only known at runtime.
 export const mailerProvider: Provider = {
 	provide: MAILER_TOKEN,
 	inject: [AppConfigService],
-	useFactory: (config: AppConfigService) =>
-		new MailerService(config.smtpOptions, { from: config.defaultFrom }),
+	useFactory: createMailer,
 };

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/mailer.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/mailer.providers.ts
@@ -1,0 +1,14 @@
+import { type Provider } from "@nestjs/common";
+import { AppConfigService } from "../config/app-config.service";
+import { MailerService } from "./mailer.service";
+
+export const MAILER_TOKEN = "MAILER_TOKEN";
+
+// Factory providers are the documented way to build a service whose
+// constructor arguments are only known at runtime.
+export const mailerProvider: Provider = {
+	provide: MAILER_TOKEN,
+	inject: [AppConfigService],
+	useFactory: (config: AppConfigService) =>
+		new MailerService(config.smtpOptions, { from: config.defaultFrom }),
+};

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/mailer.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/mail/mailer.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from "@nestjs/common";
+import type { SmtpOptions } from "../config/app-config.service";
+
+@Injectable()
+export class MailerService {
+	constructor(
+		private readonly transport: SmtpOptions,
+		private readonly defaults: { from: string },
+	) {}
+
+	send(to: string, body: string): string {
+		return `${this.defaults.from} -> ${to}: ${body} via ${this.transport.host}`;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/payments/payment-gateway.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/payments/payment-gateway.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class PaymentGateway {
+	constructor(private readonly apiKey: string) {}
+
+	charge(amount: number): string {
+		return `charged ${amount} with ${this.apiKey.slice(0, 4)}`;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/payments/payments.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/payments/payments.providers.ts
@@ -11,9 +11,9 @@ export const paymentGatewayProvider: Provider = {
 	}),
 };
 
-// Registration-time construction: the container takes ownership of this
-// exact instance, same as a decorator argument.
+const legacyGateway = new PaymentGateway(process.env.LEGACY_KEY ?? "");
+
 export const legacyGatewayProvider: Provider = {
 	provide: "LEGACY_GATEWAY",
-	useValue: new PaymentGateway(process.env.LEGACY_KEY ?? ""),
+	useValue: legacyGateway,
 };

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/payments/payments.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/payments/payments.providers.ts
@@ -1,0 +1,19 @@
+import { type Provider } from "@nestjs/common";
+import { AppConfigService } from "../config/app-config.service";
+import { PaymentGateway } from "./payment-gateway.service";
+
+export const paymentGatewayProvider: Provider = {
+	provide: "PAYMENT_GATEWAY",
+	inject: [AppConfigService],
+	useFactory: (config: AppConfigService) => ({
+		gateway: new PaymentGateway(config.stripeKey),
+		retryLimit: 3,
+	}),
+};
+
+// Registration-time construction: the container takes ownership of this
+// exact instance, same as a decorator argument.
+export const legacyGatewayProvider: Provider = {
+	provide: "LEGACY_GATEWAY",
+	useValue: new PaymentGateway(process.env.LEGACY_KEY ?? ""),
+};

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/search/search-index.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/search/search-index.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class SearchIndexService {
+	constructor(private readonly nodeUrl: string) {}
+
+	ping(): string {
+		return `up at ${this.nodeUrl}`;
+	}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/search/search.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/search/search.providers.ts
@@ -6,7 +6,6 @@ export interface VaultCredentials {
 	node: string;
 }
 
-// Async factory: credentials fetched before construction.
 export const searchProvider: Provider = {
 	provide: "SEARCH_INDEX",
 	inject: [AppConfigService],

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/search/search.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/search/search.providers.ts
@@ -1,0 +1,26 @@
+import { type Provider } from "@nestjs/common";
+import { AppConfigService } from "../config/app-config.service";
+import { SearchIndexService } from "./search-index.service";
+
+export interface VaultCredentials {
+	node: string;
+}
+
+// Async factory: credentials fetched before construction.
+export const searchProvider: Provider = {
+	provide: "SEARCH_INDEX",
+	inject: [AppConfigService],
+	useFactory: async (config: AppConfigService): Promise<SearchIndexService> => {
+		let creds: VaultCredentials;
+		try {
+			creds = await fetchCredentials(config);
+		} catch {
+			creds = { node: config.redisUrl };
+		}
+		return new SearchIndexService(creds.node);
+	},
+};
+
+async function fetchCredentials(config: AppConfigService): Promise<VaultCredentials> {
+	return { node: `https://${config.smtpOptions.host}:9200` };
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/storage/storage.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/storage/storage.providers.ts
@@ -2,7 +2,6 @@ import { type Provider } from "@nestjs/common";
 import { AppConfigService } from "../config/app-config.service";
 import { LocalStorageService, S3StorageService } from "./storage.services";
 
-// Method-shorthand factory with driver selection.
 export const storageProvider: Provider = {
 	provide: "OBJECT_STORAGE",
 	inject: [AppConfigService],

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/storage/storage.providers.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/storage/storage.providers.ts
@@ -1,0 +1,15 @@
+import { type Provider } from "@nestjs/common";
+import { AppConfigService } from "../config/app-config.service";
+import { LocalStorageService, S3StorageService } from "./storage.services";
+
+// Method-shorthand factory with driver selection.
+export const storageProvider: Provider = {
+	provide: "OBJECT_STORAGE",
+	inject: [AppConfigService],
+	useFactory(config: AppConfigService) {
+		if (config.smtpOptions.host === "s3.internal") {
+			return new S3StorageService("acme-uploads");
+		}
+		return new LocalStorageService();
+	},
+};

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/storage/storage.services.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/storage/storage.services.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class S3StorageService {
+	constructor(private readonly bucket: string) {}
+
+	put(key: string): string {
+		return `s3://${this.bucket}/${key}`;
+	}
+}
+
+@Injectable()
+export class LocalStorageService {
+	constructor(private readonly rootDir = "/tmp/uploads") {}
+}

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/users/user.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/users/user.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class UserService {
+	findAll(): string[] {
+		return ["ada", "grace"];
+	}
+}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -1198,23 +1198,23 @@ describe("scanner integration", () => {
 
 	describe("factory-providers-app fixture (#293)", () => {
 		const targetPath = resolve(FIXTURES, "factory-providers-app/src");
-		let result: Awaited<ReturnType<typeof buildResult>>["result"];
+		let diags: Awaited<ReturnType<typeof buildResult>>["result"]["diagnostics"];
 
 		beforeAll(async () => {
 			const scanConfig = await resolveScanConfig(targetPath);
 			const context = await buildAnalysisContext(targetPath, scanConfig);
 			const rawOutput = await diagnose(context);
-			({ result } = buildResult(
+			const { result } = buildResult(
 				context,
 				rawOutput,
 				scanConfig.customRuleWarnings
-			));
+			);
+			diags = result.diagnostics.filter(
+				(d) => d.rule === "architecture/no-manual-instantiation"
+			);
 		});
 
 		it("does not report manual instantiation inside provider factories", () => {
-			const diags = result.diagnostics.filter(
-				(d) => d.rule === "architecture/no-manual-instantiation"
-			);
 			const factoryDiags = diags.filter(
 				(d) =>
 					d.filePath.includes("mailer.providers") ||
@@ -1227,9 +1227,6 @@ describe("scanner integration", () => {
 		});
 
 		it("still reports the genuine bypasses in the legacy files", () => {
-			const diags = result.diagnostics.filter(
-				(d) => d.rule === "architecture/no-manual-instantiation"
-			);
 			expect(diags).toHaveLength(3);
 			expect(diags.filter((d) => d.filePath.includes("legacy"))).toHaveLength(
 				3

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -1196,6 +1196,47 @@ describe("scanner integration", () => {
 		expect(result.diagnostics).toHaveLength(0);
 	});
 
+	describe("factory-providers-app fixture (#293)", () => {
+		const targetPath = resolve(FIXTURES, "factory-providers-app/src");
+		let result: Awaited<ReturnType<typeof buildResult>>["result"];
+
+		beforeAll(async () => {
+			const scanConfig = await resolveScanConfig(targetPath);
+			const context = await buildAnalysisContext(targetPath, scanConfig);
+			const rawOutput = await diagnose(context);
+			({ result } = buildResult(
+				context,
+				rawOutput,
+				scanConfig.customRuleWarnings
+			));
+		});
+
+		it("does not report manual instantiation inside provider factories", () => {
+			const diags = result.diagnostics.filter(
+				(d) => d.rule === "architecture/no-manual-instantiation"
+			);
+			const factoryDiags = diags.filter(
+				(d) =>
+					d.filePath.includes("mailer.providers") ||
+					d.filePath.includes("search.providers") ||
+					d.filePath.includes("storage.providers") ||
+					d.filePath.includes("payments.providers") ||
+					d.filePath.includes("jwt.module")
+			);
+			expect(factoryDiags).toHaveLength(0);
+		});
+
+		it("still reports the genuine bypasses in the legacy files", () => {
+			const diags = result.diagnostics.filter(
+				(d) => d.rule === "architecture/no-manual-instantiation"
+			);
+			expect(diags).toHaveLength(3);
+			expect(diags.filter((d) => d.filePath.includes("legacy"))).toHaveLength(
+				3
+			);
+		});
+	});
+
 	describe("drizzle-app fixture", () => {
 		const targetPath = resolve(FIXTURES, "drizzle-app");
 		let context: Awaited<ReturnType<typeof buildAnalysisContext>>;

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -1079,6 +1079,277 @@ describe("no-manual-instantiation", () => {
 	});
 });
 
+describe("no-manual-instantiation: provider factories (#293)", () => {
+	const DI = new Set(["MailerService", "ConfigService"]);
+
+	it("does not flag a factory body in a standalone const provider", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      export const mailerProvider = {
+        provide: 'MAILER_TOKEN',
+        inject: [ConfigService],
+        useFactory: (config) =>
+          new MailerService({ host: config.smtpHost }, { from: config.from }),
+      };
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag an async factory with control flow around the construction", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      export const storageProvider = {
+        provide: 'STORAGE',
+        inject: [ConfigService],
+        useFactory: async (config) => {
+          if (config.driver === 's3') {
+            try {
+              return new MailerService(config.s3, {});
+            } catch {
+              // fall through
+            }
+          }
+          return new MailerService(config.local, {});
+        },
+      };
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag constructions inside the object a factory returns", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      export const paymentsProvider = {
+        provide: 'PAYMENTS_BUNDLE',
+        inject: [ConfigService],
+        useFactory: (config) => ({
+          charges: new MailerService(config.stripe, {}),
+          cache: new ConfigService(config.redis),
+        }),
+      };
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag a method-shorthand factory", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      export const fxProvider = {
+        provide: 'FX_RATES',
+        inject: [ConfigService],
+        useFactory(config) {
+          return new MailerService(config.url, {});
+        },
+      };
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag a useValue construction outside any decorator", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      export const paymentProvider = {
+        provide: 'PAYMENT_GATEWAY',
+        useValue: new MailerService(process.env.KEY ?? '', {}),
+      };
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag options handed directly to a forRoot call outside a decorator", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      export const dynamicModule = MailModule.forRoot({
+        transport: new MailerService({ host: 'smtp' }, {}),
+        templateAdapter: new ConfigService({}),
+      });
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("does not flag providers declared as a plain exported array", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      export const queueProviders = [
+        {
+          provide: 'MAIL_QUEUE',
+          inject: [ConfigService],
+          useFactory: (config) => new MailerService(config.url, {}),
+        },
+      ];
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags a bypass inside a service method", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      class ReportComposer {
+        snapshot() {
+          return new MailerService({}, {});
+        }
+      }
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("still flags a literal that has useFactory but no provide key", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      const legacyDescriptor = {
+        inject: [ConfigService],
+        useFactory: (config) => new MailerService(config, {}),
+      };
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("still flags options assembled in a plain helper function", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      function buildMailOptions() {
+        return { transport: new MailerService({}, {}) };
+      }
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("still flags a hoisted instance captured by a passthrough factory", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      const impl = new MailerService({}, {});
+      export const CACHE_PROVIDER = {
+        provide: 'CACHE',
+        useFactory: () => impl,
+      };
+    `,
+			"test.ts",
+			{},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(1);
+	});
+
+	it("flags an unsuffixed registered injectable constructed in app code", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      class AuthService {
+        constructor(users) {
+          this.strategy = new LocalStrategy(users);
+        }
+      }
+    `,
+			"test.ts",
+			{},
+			undefined,
+			new Set(["LocalStrategy"])
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("LocalStrategy");
+	});
+
+	it("keeps suffix matching as the fallback when DI facts are unavailable", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      class AuthService {
+        constructor(users) {
+          this.strategy = new LocalStrategy(users);
+        }
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still respects excludedClasses for provider factories", () => {
+		const diags = runRule(
+			noManualInstantiation,
+			`
+      class ReportComposer {
+        snapshot() {
+          return new MailerService({}, {});
+        }
+      }
+    `,
+			"test.ts",
+			{
+				rules: {
+					"architecture/no-manual-instantiation": {
+						excludeClasses: ["MailerService"],
+					},
+				},
+			},
+			undefined,
+			DI
+		);
+		expect(diags).toHaveLength(0);
+	});
+});
+
 describe("prefer-constructor-injection", () => {
 	it("flags @Inject() property injection", () => {
 		const diags = runRule(

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -777,7 +777,11 @@ describe("no-manual-instantiation", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      const svc = new UserService();
+      class OrdersController {
+        run() {
+          return new UserService();
+        }
+      }
     `
 		);
 		expect(diags).toHaveLength(1);
@@ -788,7 +792,11 @@ describe("no-manual-instantiation", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      const repo = new UsersRepository();
+      class UsersService {
+        load() {
+          return new UsersRepository();
+        }
+      }
     `
 		);
 		expect(diags).toHaveLength(1);
@@ -905,12 +913,16 @@ describe("no-manual-instantiation", () => {
 		expect(diags[0].message).toContain("AuthGuard");
 	});
 
-	it("still flags Service/Repository regardless of context", () => {
+	it("flags Service/Repository inside class members", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      export const svc = new UserService();
-      const repo = new UsersRepository();
+      class OrdersController {
+        private readonly svc = new UserService();
+        run() {
+          return new UsersRepository();
+        }
+      }
     `
 		);
 		expect(diags).toHaveLength(2);
@@ -920,7 +932,11 @@ describe("no-manual-instantiation", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      const logger = new LoggerService();
+      class AppService {
+        run() {
+          return new LoggerService();
+        }
+      }
     `,
 			"test.ts",
 			{
@@ -938,7 +954,11 @@ describe("no-manual-instantiation", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      const logger = new LoggerService();
+      class AppService {
+        run() {
+          return new LoggerService();
+        }
+      }
     `,
 			"test.ts",
 			{
@@ -956,7 +976,11 @@ describe("no-manual-instantiation", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      const logger = new Foo.LoggerService();
+      class AppService {
+        run() {
+          return new Foo.LoggerService();
+        }
+      }
     `,
 			"test.ts",
 			{
@@ -974,9 +998,14 @@ describe("no-manual-instantiation", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      const logger = new LoggerService();
-      const cache = new CacheService();
-      const user = new UserService();
+      class AppService {
+        run() {
+          const logger = new LoggerService();
+          const cache = new CacheService();
+          const user = new UserService();
+          return [logger, cache, user];
+        }
+      }
     `,
 			"test.ts",
 			{
@@ -995,7 +1024,11 @@ describe("no-manual-instantiation", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      const logger = new Foo.LoggerService();
+      class AppService {
+        run() {
+          return new Foo.LoggerService();
+        }
+      }
     `,
 			"test.ts",
 			{
@@ -1013,7 +1046,11 @@ describe("no-manual-instantiation", () => {
 		const diags = runRule(
 			noManualInstantiation,
 			`
-      const svc = new UserService();
+      class AppService {
+        run() {
+          return new UserService();
+        }
+      }
     `,
 			"test.ts",
 			{
@@ -1080,254 +1117,236 @@ describe("no-manual-instantiation", () => {
 });
 
 describe("no-manual-instantiation: provider factories (#293)", () => {
-	const DI = new Set(["MailerService", "ConfigService"]);
-
-	it("does not flag a factory body in a standalone const provider", () => {
-		const diags = runRule(
+	const DI = new Set([
+		"MailerService",
+		"ConfigService",
+		"CustomValidationPipe",
+	]);
+	const runProviderRule = (
+		code: string,
+		diProviders: ReadonlySet<string> = DI,
+		config: NestjsDoctorConfig = {}
+	) =>
+		runRule(
 			noManualInstantiation,
-			`
-      export const mailerProvider = {
-        provide: 'MAILER_TOKEN',
-        inject: [ConfigService],
-        useFactory: (config) =>
-          new MailerService({ host: config.smtpHost }, { from: config.from }),
-      };
-    `,
+			code,
 			"test.ts",
-			{},
+			config,
 			undefined,
-			DI
+			diProviders
 		);
-		expect(diags).toHaveLength(0);
-	});
 
-	it("does not flag an async factory with control flow around the construction", () => {
-		const diags = runRule(
-			noManualInstantiation,
+	it.each([
+		[
+			"a factory body in a standalone const provider",
 			`
-      export const storageProvider = {
-        provide: 'STORAGE',
-        inject: [ConfigService],
-        useFactory: async (config) => {
-          if (config.driver === 's3') {
-            try {
-              return new MailerService(config.s3, {});
-            } catch {
-              // fall through
-            }
-          }
-          return new MailerService(config.local, {});
-        },
-      };
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag constructions inside the object a factory returns", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
-      export const paymentsProvider = {
-        provide: 'PAYMENTS_BUNDLE',
-        inject: [ConfigService],
-        useFactory: (config) => ({
-          charges: new MailerService(config.stripe, {}),
-          cache: new ConfigService(config.redis),
-        }),
-      };
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag a method-shorthand factory", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
-      export const fxProvider = {
-        provide: 'FX_RATES',
-        inject: [ConfigService],
-        useFactory(config) {
-          return new MailerService(config.url, {});
-        },
-      };
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag a useValue construction outside any decorator", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
-      export const paymentProvider = {
-        provide: 'PAYMENT_GATEWAY',
-        useValue: new MailerService(process.env.KEY ?? '', {}),
-      };
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag options handed directly to a forRoot call outside a decorator", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
-      export const dynamicModule = MailModule.forRoot({
-        transport: new MailerService({ host: 'smtp' }, {}),
-        templateAdapter: new ConfigService({}),
-      });
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("does not flag providers declared as a plain exported array", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
-      export const queueProviders = [
-        {
-          provide: 'MAIL_QUEUE',
+        export const mailerProvider = {
+          provide: 'MAILER_TOKEN',
           inject: [ConfigService],
-          useFactory: (config) => new MailerService(config.url, {}),
-        },
-      ];
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(0);
-	});
-
-	it("still flags a bypass inside a service method", () => {
-		const diags = runRule(
-			noManualInstantiation,
+          useFactory: (config) =>
+            new MailerService({ host: config.smtpHost }, { from: config.from }),
+        };
+      `,
+		],
+		[
+			"an async factory with control flow around the construction",
 			`
-      class ReportComposer {
-        snapshot() {
-          return new MailerService({}, {});
+        export const storageProvider = {
+          provide: 'STORAGE',
+          inject: [ConfigService],
+          useFactory: async (config) => {
+            if (config.driver === 's3') {
+              try {
+                return new MailerService(config.s3, {});
+              } catch {
+                // fall through
+              }
+            }
+            return new MailerService(config.local, {});
+          },
+        };
+      `,
+		],
+		[
+			"constructions inside the object a factory returns",
+			`
+        export const paymentsProvider = {
+          provide: 'PAYMENTS_BUNDLE',
+          inject: [ConfigService],
+          useFactory: (config) => ({
+            charges: new MailerService(config.stripe, {}),
+            cache: new ConfigService(config.redis),
+          }),
+        };
+      `,
+		],
+		[
+			"a method-shorthand factory",
+			`
+        export const fxProvider = {
+          provide: 'FX_RATES',
+          inject: [ConfigService],
+          useFactory(config) {
+            return new MailerService(config.url, {});
+          },
+        };
+      `,
+		],
+		[
+			"a useValue construction outside any decorator",
+			`
+        export const paymentProvider = {
+          provide: 'PAYMENT_GATEWAY',
+          useValue: new MailerService(process.env.KEY ?? '', {}),
+        };
+      `,
+		],
+		[
+			"options handed directly to a forRoot call outside a decorator",
+			`
+        export const dynamicModule = MailModule.forRoot({
+          transport: new MailerService({ host: 'smtp' }, {}),
+          templateAdapter: new ConfigService({}),
+        });
+      `,
+		],
+		[
+			"providers declared as a plain exported array",
+			`
+        export const queueProviders = [
+          {
+            provide: 'MAIL_QUEUE',
+            inject: [ConfigService],
+            useFactory: (config) => new MailerService(config.url, {}),
+          },
+        ];
+      `,
+		],
+		[
+			"a named factory referenced by a provider",
+			`
+        function createMailer(config) {
+          return new MailerService(config.url, {});
         }
-      }
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(1);
+        export const mailerProvider = {
+          provide: 'MAILER',
+          inject: [ConfigService],
+          useFactory: createMailer,
+        };
+      `,
+		],
+		[
+			"an identifier-backed useValue provider",
+			`
+        const mailer = new MailerService({}, {});
+        export const mailerProvider = {
+          provide: 'MAILER',
+          useValue: mailer,
+        };
+      `,
+		],
+		[
+			"options assembled in a module-scope helper",
+			`
+        function buildMailOptions() {
+          return { transport: new MailerService({}, {}) };
+        }
+      `,
+		],
+		[
+			"a hoisted instance captured by a passthrough factory",
+			`
+        const impl = new MailerService({}, {});
+        export const CACHE_PROVIDER = {
+          provide: 'CACHE',
+          useFactory: () => impl,
+        };
+      `,
+		],
+		[
+			"a context-aware injectable constructed during bootstrap",
+			`
+        function bootstrap(app) {
+          app.useGlobalPipes(new CustomValidationPipe());
+        }
+      `,
+		],
+		[
+			"a static class factory referenced by a provider",
+			`
+        class MailerFactory {
+          static create(config) {
+            return new MailerService(config.url, {});
+          }
+        }
+        export const mailerProvider = {
+          provide: 'MAILER',
+          inject: [ConfigService],
+          useFactory: MailerFactory.create,
+        };
+      `,
+		],
+		[
+			"a static class value referenced by a provider",
+			`
+        class MailerFactory {
+          static readonly instance = new MailerService({}, {});
+        }
+        export const mailerProvider = {
+          provide: 'MAILER',
+          useValue: MailerFactory.instance,
+        };
+      `,
+		],
+	])("does not flag %s", (_name, code) => {
+		expect(runProviderRule(code)).toHaveLength(0);
 	});
 
-	it("still flags a literal that has useFactory but no provide key", () => {
-		const diags = runRule(
-			noManualInstantiation,
+	it.each([
+		[
+			"a bypass inside a service method",
 			`
-      const legacyDescriptor = {
-        inject: [ConfigService],
-        useFactory: (config) => new MailerService(config, {}),
-      };
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(1);
+        class ReportComposer {
+          snapshot() {
+            return new MailerService({}, {});
+          }
+        }
+      `,
+		],
+		[
+			"a literal that has useFactory but no provide key",
+			`
+        class LegacyService {
+          build() {
+            return {
+              inject: [ConfigService],
+              useFactory: (config) => new MailerService(config, {}),
+            };
+          }
+        }
+      `,
+		],
+	])("still flags %s", (_name, code) => {
+		expect(runProviderRule(code)).toHaveLength(1);
 	});
 
-	it("still flags options assembled in a plain helper function", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
-      function buildMailOptions() {
-        return { transport: new MailerService({}, {}) };
-      }
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(1);
-	});
-
-	it("still flags a hoisted instance captured by a passthrough factory", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
-      const impl = new MailerService({}, {});
-      export const CACHE_PROVIDER = {
-        provide: 'CACHE',
-        useFactory: () => impl,
-      };
-    `,
-			"test.ts",
-			{},
-			undefined,
-			DI
-		);
-		expect(diags).toHaveLength(1);
-	});
-
-	it("flags an unsuffixed registered injectable constructed in app code", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
+	it("does not guess that an unsuffixed class is a provider", () => {
+		expect(
+			runProviderRule(
+				`
       class AuthService {
         constructor(users) {
           this.strategy = new LocalStrategy(users);
         }
       }
     `,
-			"test.ts",
-			{},
-			undefined,
-			new Set(["LocalStrategy"])
-		);
-		expect(diags).toHaveLength(1);
-		expect(diags[0].message).toContain("LocalStrategy");
-	});
-
-	it("keeps suffix matching as the fallback when DI facts are unavailable", () => {
-		const diags = runRule(
-			noManualInstantiation,
-			`
-      class AuthService {
-        constructor(users) {
-          this.strategy = new LocalStrategy(users);
-        }
-      }
-    `
-		);
-		expect(diags).toHaveLength(0);
+				new Set(["LocalStrategy"])
+			)
+		).toHaveLength(0);
 	});
 
 	it("still respects excludedClasses for provider factories", () => {
-		const diags = runRule(
-			noManualInstantiation,
+		const diags = runProviderRule(
 			`
       class ReportComposer {
         snapshot() {
@@ -1335,16 +1354,14 @@ describe("no-manual-instantiation: provider factories (#293)", () => {
         }
       }
     `,
-			"test.ts",
+			DI,
 			{
 				rules: {
 					"architecture/no-manual-instantiation": {
 						excludeClasses: ["MailerService"],
 					},
 				},
-			},
-			undefined,
-			DI
+			}
 		);
 		expect(diags).toHaveLength(0);
 	});


### PR DESCRIPTION
## Context

A custom provider whose instance needs runtime-derived constructor arguments is written as `{ provide: TOKEN, inject: [...], useFactory: (cfg) => new X(...) }`. This is the documented NestJS factory-provider pattern. It also appears in nestjs/nest's own integration tests, novuhq/novu, runtipi, railsstudent/nest-stripe-integration, and hodfords-solutions/nestjs-mailer.

The rule reads syntax, not runtime ownership. Construction at module scope or in static class helpers can be composition-root wiring referenced by `useFactory` or `useValue` from another file.

## Problem

`architecture/no-manual-instantiation` reported `new X()` inside a standalone provider's `useFactory` or `useValue`, severity `error`, failing `--blocking=error` on valid NestJS wiring (#293).

```
✗ Manual instantiation of 'MailerService' detected. Use dependency injection instead.
```

Inline-only exemption is not enough. These valid variants also exist:

```ts
const instance = new MailerService(options);
const provider = { provide: MAILER, useValue: instance };

class MailerFactory {
  static create(config: ConfigService) {
    return new MailerService(config.options);
  }
}
const factoryProvider = { provide: MAILER, useFactory: MailerFactory.create };
```

## Possible flows

| Construction site | Before | After |
|---|---|---|
| Inline `useFactory` body, including async and method shorthand | error | not reported |
| Inline `useValue: new X()` | error | not reported |
| Module-scope function/value referenced by a provider | error | not reported |
| Static class factory/value referenced by a provider | error | not reported |
| Direct options passed to `forRoot`/`forFeature`/`register(+Async)` | error outside decorators | not reported |
| Bootstrap construction such as `useGlobalPipes(new CustomPipe())` | possible error | not reported |
| Instance class method, constructor, or field bypass | error | still error |
| Provider-like literal without `provide` inside instance code | error | still error |
| Parameter decorator `@Inject(new ConfigService())` | error | still error |

## Solution

The rule now marks construction owned by a `provide`-bearing `useFactory`/`useValue` literal or direct dynamic-module options as safe. It also narrows reporting to instance class members. Module-scope and static construction stay silent because they may be provider wiring and the rule cannot prove otherwise without cross-file dataflow.

Suffix matching and the existing context-aware limits remain unchanged. The change deliberately favors false negatives over false positives: when ownership is ambiguous, the rule does not report.

The module-graph half is separate: factory-built classes remain invisible to `no-unused-providers` and `injectable-must-be-provided`; #306 tracks that shared-collector work.

TDD coverage includes 18 focused unit cases and a multi-file fixture with mail, async search, storage selection, payments, JWT dynamic modules, cross-file named factories, identifier-backed values, static helpers, bootstrap setup, and genuine bypasses.

## Before vs after

| Scenario | 0.9.0 | this branch |
|---|---|---|
| Issue #293 repro | 1 error | clean |
| Fixture composition/factory files | 9 errors | clean |
| Fixture instance-code bypasses | 3 errors | same 3 errors |
| Full nestjs-doctor suite | 1511 pass | 1529 pass |

## Example

```
$ npx nestjs-doctor tests/fixtures/factory-providers-app/src
```

0.9.0 reports factory files such as `mail/mailer.providers.ts`, `search/search.providers.ts`, and `auth/jwt.module.ts`. This branch reports only:

```
legacy/audit.service.ts:9
legacy/legacy.helpers.ts:7
legacy/legacy.providers.ts:11
```

All are `new UserService()` inside instance class code.

Closes #293