### PR TITLE
fix(rules): recognize factory-created providers

### DIFF
--- a/.changeset/factory-provider-class-facts.md
+++ b/.changeset/factory-provider-class-facts.md
@@ -1,0 +1,6 @@
+---
+"nestjs-doctor": patch
+---
+
+Stop `injectable-must-be-provided` and `no-unused-providers` reporting local
+classes constructed by custom `useFactory` and `useValue` providers.

--- a/.changeset/factory-provider-class-facts.md
+++ b/.changeset/factory-provider-class-facts.md
@@ -3,4 +3,5 @@
 ---
 
 Stop `injectable-must-be-provided` and `no-unused-providers` reporting local
-classes constructed by custom `useFactory` and `useValue` providers.
+classes constructed by custom `useFactory` and `useValue` providers. Both rules
+now derive custom-provider facts from production files only.

--- a/packages/nestjs-doctor/src/engine/graph/custom-providers.ts
+++ b/packages/nestjs-doctor/src/engine/graph/custom-providers.ts
@@ -1,26 +1,107 @@
-import { type Project, SyntaxKind } from "ts-morph";
+import {
+	type ClassDeclaration,
+	type Node,
+	type Project,
+	type SourceFile,
+	SyntaxKind,
+} from "ts-morph";
 
 const IMPLEMENTATION_KEYS = ["useClass", "useExisting"];
 
-/**
- * Classes named as the implementation of an object-literal provider, as
- * `{ provide: TOKEN, useClass: Impl }`. Nest instantiates them, so they are in
- * use even though nothing injects them by type.
- */
-export function collectProviderImplementations(
+function declarationsOf(node: Node): Node[] {
+	const identifier =
+		node.asKind(SyntaxKind.Identifier) ??
+		node.asKind(SyntaxKind.PropertyAccessExpression)?.getNameNode();
+	if (!identifier) {
+		return [];
+	}
+	const definitions = identifier.getDefinitionNodes();
+	if (definitions.length > 0) {
+		return definitions;
+	}
+	const symbol = identifier.getSymbol();
+	return (symbol?.getAliasedSymbol() ?? symbol)?.getDeclarations() ?? [];
+}
+
+function classOf(
+	node: Node,
+	scannedFiles: ReadonlySet<SourceFile>
+): ClassDeclaration | undefined {
+	for (const declaration of declarationsOf(node)) {
+		const cls = declaration.asKind(SyntaxKind.ClassDeclaration);
+		if (cls && scannedFiles.has(cls.getSourceFile())) {
+			return cls;
+		}
+	}
+	return undefined;
+}
+
+function collectFromProviderValue(
+	node: Node,
+	scannedFiles: ReadonlySet<SourceFile>,
+	classes: Set<ClassDeclaration>,
+	visited: Set<Node>
+): void {
+	if (visited.has(node)) {
+		return;
+	}
+	visited.add(node);
+
+	const expressions = node.getDescendantsOfKind(SyntaxKind.NewExpression);
+	const directExpression = node.asKind(SyntaxKind.NewExpression);
+	if (directExpression) {
+		expressions.unshift(directExpression);
+	}
+	for (const expression of expressions) {
+		const cls = classOf(expression.getExpression(), scannedFiles);
+		if (cls) {
+			classes.add(cls);
+		}
+	}
+
+	const references = [
+		node,
+		...node.getDescendantsOfKind(SyntaxKind.Identifier),
+	];
+	for (const reference of references) {
+		for (const declaration of declarationsOf(reference)) {
+			if (!scannedFiles.has(declaration.getSourceFile())) {
+				continue;
+			}
+			const value =
+				declaration.asKind(SyntaxKind.VariableDeclaration)?.getInitializer() ??
+				declaration.asKind(SyntaxKind.PropertyDeclaration)?.getInitializer() ??
+				declaration.asKind(SyntaxKind.PropertyAssignment)?.getInitializer() ??
+				declaration.asKind(SyntaxKind.FunctionDeclaration) ??
+				declaration.asKind(SyntaxKind.MethodDeclaration) ??
+				declaration.asKind(SyntaxKind.GetAccessor) ??
+				declaration.asKind(SyntaxKind.ExportAssignment)?.getExpression();
+			if (value) {
+				collectFromProviderValue(value, scannedFiles, classes, visited);
+			}
+		}
+	}
+}
+
+export function collectCustomProviderClasses(
 	project: Project,
 	files: string[]
-): Set<string> {
-	const implementations = new Set<string>();
-
+): {
+	implementationNames: Set<string>;
+	constructedClasses: Set<ClassDeclaration>;
+} {
+	const scannedFiles = new Set<SourceFile>();
 	for (const filePath of files) {
 		const sourceFile = project.getSourceFile(filePath);
-		if (!sourceFile) {
-			continue;
+		if (sourceFile) {
+			scannedFiles.add(sourceFile);
 		}
+	}
+	const implementationNames = new Set<string>();
+	const constructedClasses = new Set<ClassDeclaration>();
+	const visited = new Set<Node>();
 
-		// Any object literal carrying `provide` is a provider definition, wherever
-		// it sits — modules commonly group them into consts and spread them in.
+	for (const sourceFile of scannedFiles) {
 		for (const obj of sourceFile.getDescendantsOfKind(
 			SyntaxKind.ObjectLiteralExpression
 		)) {
@@ -33,13 +114,30 @@ export function collectProviderImplementations(
 					?.asKind(SyntaxKind.PropertyAssignment)
 					?.getInitializer();
 				if (initializer) {
-					implementations.add(initializer.getText());
+					implementationNames.add(initializer.getText());
+				}
+			}
+			for (const key of ["useFactory", "useValue"]) {
+				const property = obj.getProperty(key);
+				const value =
+					property?.asKind(SyntaxKind.PropertyAssignment)?.getInitializer() ??
+					property?.asKind(SyntaxKind.MethodDeclaration) ??
+					property
+						?.asKind(SyntaxKind.ShorthandPropertyAssignment)
+						?.getNameNode();
+				if (value) {
+					collectFromProviderValue(
+						value,
+						scannedFiles,
+						constructedClasses,
+						visited
+					);
 				}
 			}
 		}
 	}
 
-	return implementations;
+	return { implementationNames, constructedClasses };
 }
 
 /** Names appearing in an `extends` clause — a base class is used by its subclasses. */

--- a/packages/nestjs-doctor/src/engine/graph/custom-providers.ts
+++ b/packages/nestjs-doctor/src/engine/graph/custom-providers.ts
@@ -8,6 +8,15 @@ import {
 
 const IMPLEMENTATION_KEYS = ["useClass", "useExisting"];
 
+export function isTestFile(filePath: string): boolean {
+	return (
+		filePath.includes(".spec.") ||
+		filePath.includes(".test.") ||
+		filePath.includes("__test__") ||
+		filePath.includes("__tests__")
+	);
+}
+
 function declarationsOf(node: Node): Node[] {
 	const identifier =
 		node.asKind(SyntaxKind.Identifier) ??

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
@@ -1,6 +1,7 @@
 import {
 	collectCustomProviderClasses,
 	collectExtendedClasses,
+	isTestFile,
 } from "../../../graph/custom-providers.js";
 import { INFRA_SUFFIXES } from "../../constants.js";
 import type { ProjectRule } from "../../types.js";
@@ -18,12 +19,6 @@ export const injectableMustBeProvided: ProjectRule = {
 	},
 
 	check(context) {
-		const isTestFile = (filePath: string): boolean =>
-			filePath.includes(".spec.") ||
-			filePath.includes(".test.") ||
-			filePath.includes("__test__") ||
-			filePath.includes("__tests__");
-
 		// Collect all provider names registered in module metadata
 		const registeredProviders = new Set<string>();
 		for (const mod of context.moduleGraph.modules.values()) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/injectable-must-be-provided.ts
@@ -1,6 +1,6 @@
 import {
+	collectCustomProviderClasses,
 	collectExtendedClasses,
-	collectProviderImplementations,
 } from "../../../graph/custom-providers.js";
 import { INFRA_SUFFIXES } from "../../constants.js";
 import type { ProjectRule } from "../../types.js";
@@ -35,19 +35,20 @@ export const injectableMustBeProvided: ProjectRule = {
 			}
 		}
 
-		for (const implementation of collectProviderImplementations(
+		const productionFiles = context.files.filter(
+			(filePath) => !isTestFile(filePath)
+		);
+		const customProviderClasses = collectCustomProviderClasses(
 			context.project,
-			context.files
-		)) {
-			registeredProviders.add(implementation);
+			productionFiles
+		);
+		for (const name of customProviderClasses.implementationNames) {
+			registeredProviders.add(name);
 		}
 
 		// A base class is registered through its subclasses, not on its own. Test
 		// files are left out so a stub cannot exempt a production class.
-		const extended = collectExtendedClasses(
-			context.project,
-			context.files.filter((filePath) => !isTestFile(filePath))
-		);
+		const extended = collectExtendedClasses(context.project, productionFiles);
 
 		// Scan all files for @Injectable() classes
 		for (const filePath of context.files) {
@@ -77,7 +78,10 @@ export const injectableMustBeProvided: ProjectRule = {
 				}
 
 				// Skip if registered in any module
-				if (registeredProviders.has(className)) {
+				if (
+					registeredProviders.has(className) ||
+					customProviderClasses.constructedClasses.has(cls)
+				) {
 					continue;
 				}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
@@ -1,7 +1,7 @@
 import type { ClassDeclaration } from "ts-morph";
 import {
+	collectCustomProviderClasses,
 	collectExtendedClasses,
-	collectProviderImplementations,
 } from "../../../graph/custom-providers.js";
 import { isController } from "../../../nest-class-inspector.js";
 import { INFRA_SUFFIXES } from "../../constants.js";
@@ -131,9 +131,8 @@ export const noUnusedProviders: ProjectRule = {
 			}
 		}
 
-		// Nest instantiates a useClass/useExisting target, and a base class runs
-		// through every subclass, without either being injected by type.
-		const implementations = collectProviderImplementations(
+		// Custom-provider targets and base classes are in use without being injected.
+		const customProviderClasses = collectCustomProviderClasses(
 			context.project,
 			context.files
 		);
@@ -142,7 +141,13 @@ export const noUnusedProviders: ProjectRule = {
 		for (const provider of context.providers.values()) {
 			const name = provider.name;
 
-			if (implementations.has(name) || extended.has(name)) {
+			if (
+				customProviderClasses.implementationNames.has(name) ||
+				customProviderClasses.constructedClasses.has(
+					provider.classDeclaration
+				) ||
+				extended.has(name)
+			) {
 				continue;
 			}
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/performance/no-unused-providers.ts
@@ -2,6 +2,7 @@ import type { ClassDeclaration } from "ts-morph";
 import {
 	collectCustomProviderClasses,
 	collectExtendedClasses,
+	isTestFile,
 } from "../../../graph/custom-providers.js";
 import { isController } from "../../../nest-class-inspector.js";
 import { INFRA_SUFFIXES } from "../../constants.js";
@@ -132,11 +133,15 @@ export const noUnusedProviders: ProjectRule = {
 		}
 
 		// Custom-provider targets and base classes are in use without being injected.
+		// Test files are left out so a spec cannot exempt a production provider.
+		const productionFiles = context.files.filter(
+			(filePath) => !isTestFile(filePath)
+		);
 		const customProviderClasses = collectCustomProviderClasses(
 			context.project,
-			context.files
+			productionFiles
 		);
-		const extended = collectExtendedClasses(context.project, context.files);
+		const extended = collectExtendedClasses(context.project, productionFiles);
 
 		for (const provider of context.providers.values()) {
 			const name = provider.name;

--- a/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/factory-providers-app/src/app.module.ts
@@ -1,9 +1,7 @@
 import { Module } from "@nestjs/common";
 import { JwtModule } from "./auth/jwt.module";
-import { KeyStoreService, TokenSignerService } from "./auth/auth.services";
 import { AppConfigService } from "./config/app-config.service";
 import { mailProviders } from "./mail/mail-dispatcher.service";
-import { PaymentGateway } from "./payments/payment-gateway.service";
 import {
 	legacyGatewayProvider,
 	paymentGatewayProvider,
@@ -11,8 +9,8 @@ import {
 import { AuditService } from "./legacy/audit.service";
 import { LegacyHelperService } from "./legacy/legacy.helpers";
 import { LegacyDescriptorService } from "./legacy/legacy.providers";
-import { searchProvider, SearchIndexService } from "./search/search.providers";
-import { storageProvider, LocalStorageService } from "./storage/storage.providers";
+import { searchProvider } from "./search/search.providers";
+import { storageProvider } from "./storage/storage.providers";
 import { UserService } from "./users/user.service";
 
 @Module({
@@ -22,14 +20,9 @@ import { UserService } from "./users/user.service";
 		UserService,
 		...mailProviders,
 		searchProvider,
-		SearchIndexService,
 		storageProvider,
-		LocalStorageService,
 		paymentGatewayProvider,
 		legacyGatewayProvider,
-		PaymentGateway,
-		TokenSignerService,
-		KeyStoreService,
 		AuditService,
 		LegacyHelperService,
 		LegacyDescriptorService,

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -1209,28 +1209,49 @@ describe("scanner integration", () => {
 				rawOutput,
 				scanConfig.customRuleWarnings
 			);
-			diags = result.diagnostics.filter(
-				(d) => d.rule === "architecture/no-manual-instantiation"
-			);
+			diags = result.diagnostics;
 		});
 
 		it("does not report manual instantiation inside provider factories", () => {
 			const factoryDiags = diags.filter(
 				(d) =>
-					d.filePath.includes("mailer.providers") ||
-					d.filePath.includes("search.providers") ||
-					d.filePath.includes("storage.providers") ||
-					d.filePath.includes("payments.providers") ||
-					d.filePath.includes("jwt.module")
+					d.rule === "architecture/no-manual-instantiation" &&
+					(d.filePath.includes("mailer.providers") ||
+						d.filePath.includes("search.providers") ||
+						d.filePath.includes("storage.providers") ||
+						d.filePath.includes("payments.providers") ||
+						d.filePath.includes("jwt.module"))
 			);
 			expect(factoryDiags).toHaveLength(0);
 		});
 
 		it("still reports the genuine bypasses in the legacy files", () => {
-			expect(diags).toHaveLength(3);
-			expect(diags.filter((d) => d.filePath.includes("legacy"))).toHaveLength(
-				3
+			const manualDiags = diags.filter(
+				(d) => d.rule === "architecture/no-manual-instantiation"
 			);
+			expect(manualDiags).toHaveLength(3);
+			expect(
+				manualDiags.filter((d) => d.filePath.includes("legacy"))
+			).toHaveLength(3);
+		});
+
+		it("counts factory-constructed classes as provided and used (#306)", () => {
+			const factoryClasses = [
+				"MailerService",
+				"SearchIndexService",
+				"S3StorageService",
+				"LocalStorageService",
+				"PaymentGateway",
+				"TokenSignerService",
+				"KeyStoreService",
+			];
+			const projectRuleDiags = diags.filter(
+				(d) =>
+					(d.rule === "correctness/injectable-must-be-provided" ||
+						d.rule === "performance/no-unused-providers") &&
+					factoryClasses.some((name) => d.message.includes(`'${name}'`))
+			);
+			expect(projectRuleDiags).toHaveLength(0);
 		});
 	});
 

--- a/packages/nestjs-doctor/tests/unit/custom-providers.test.ts
+++ b/packages/nestjs-doctor/tests/unit/custom-providers.test.ts
@@ -109,6 +109,28 @@ describe("collectCustomProviderClasses", () => {
 		);
 	});
 
+	it("terminates on circular factory indirection and still collects", () => {
+		const { constructedClasses } = collect({
+			"a.ts": `
+        import { getCycleB } from './b';
+        export class PingService {}
+        export function cycleA() { return new PingService(getCycleB()); }
+      `,
+			"b.ts": `
+        import { cycleA } from './a';
+        export function getCycleB() { return cycleA(); }
+      `,
+			"providers.ts": `
+        import { getCycleB } from './b';
+        export const provider = { provide: 'CYCLE', useFactory: getCycleB };
+      `,
+		});
+
+		expect(
+			new Set([...constructedClasses].map((cls) => cls.getName()))
+		).toEqual(new Set(["PingService"]));
+	});
+
 	it("requires provide, ignores unresolved classes, and keeps declaration identity", () => {
 		const { constructedClasses, project } = collect({
 			"a.ts": "export class DuplicateService {}",

--- a/packages/nestjs-doctor/tests/unit/custom-providers.test.ts
+++ b/packages/nestjs-doctor/tests/unit/custom-providers.test.ts
@@ -1,0 +1,134 @@
+import { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import { collectCustomProviderClasses } from "../../src/engine/graph/custom-providers.js";
+
+function collect(files: Record<string, string>) {
+	const project = new Project({ useInMemoryFileSystem: true });
+	for (const [path, code] of Object.entries(files)) {
+		project.createSourceFile(path, code);
+	}
+	return {
+		project,
+		...collectCustomProviderClasses(project, Object.keys(files)),
+	};
+}
+
+describe("collectCustomProviderClasses", () => {
+	it("collects local classes constructed under inline factory and value providers", () => {
+		const { constructedClasses } = collect({
+			"providers.ts": `
+        class RootService {}
+        class HelperService {}
+        class AlternativeService {}
+        class BundleService {}
+        class ValueService {}
+
+        const providers = [
+          {
+            provide: 'ROOT',
+            useFactory: async () => new RootService(new HelperService()),
+          },
+          {
+            provide: 'ALTERNATIVE',
+            useFactory() {
+              if (process.env.ALT) return new AlternativeService();
+              return { service: new BundleService() };
+            },
+          },
+          { provide: 'VALUE', useValue: new ValueService() },
+        ];
+      `,
+		});
+
+		expect(
+			new Set([...constructedClasses].map((cls) => cls.getName()))
+		).toEqual(
+			new Set([
+				"RootService",
+				"HelperService",
+				"AlternativeService",
+				"BundleService",
+				"ValueService",
+			])
+		);
+	});
+
+	it("resolves named factories, static factories, values, and passthrough factories", () => {
+		const { constructedClasses } = collect({
+			"factory.ts": `
+        export class MailerService {}
+        export function createMailer() { return new MailerService(); }
+      `,
+			"default-factory.ts": `
+        export class DefaultService {}
+        export default () => new DefaultService();
+      `,
+			"providers.ts": `
+        import { createMailer } from './factory';
+        import createDefault from './default-factory';
+
+        class StaticService {}
+        class ValueService {}
+        class CapturedService {}
+        class ShorthandFactoryService {}
+        class ShorthandValueService {}
+
+        class ProviderFactory {
+          static create() { return new StaticService(); }
+        }
+
+        const value = new ValueService();
+        const captured = new CapturedService();
+        const useFactory = () => new ShorthandFactoryService();
+        const useValue = new ShorthandValueService();
+
+        const providers = [
+          { provide: 'MAILER', useFactory: createMailer },
+          { provide: 'DEFAULT', useFactory: createDefault },
+          { provide: 'STATIC', useFactory: ProviderFactory.create },
+          { provide: 'VALUE', useValue: value },
+          { provide: 'CAPTURED', useFactory: () => captured },
+          { provide: 'SHORTHAND_FACTORY', useFactory },
+          { provide: 'SHORTHAND_VALUE', useValue },
+        ];
+      `,
+		});
+
+		expect(
+			new Set([...constructedClasses].map((cls) => cls.getName()))
+		).toEqual(
+			new Set([
+				"MailerService",
+				"DefaultService",
+				"StaticService",
+				"ValueService",
+				"CapturedService",
+				"ShorthandFactoryService",
+				"ShorthandValueService",
+			])
+		);
+	});
+
+	it("requires provide, ignores unresolved classes, and keeps declaration identity", () => {
+		const { constructedClasses, project } = collect({
+			"a.ts": "export class DuplicateService {}",
+			"b.ts": "export class DuplicateService {}",
+			"providers.ts": `
+        import { DuplicateService } from './a';
+        class OrphanService {}
+
+        const invalid = { useFactory: () => new OrphanService() };
+        const external = { provide: 'STRIPE', useFactory: () => new Stripe() };
+        const valid = { provide: 'DUPLICATE', useValue: new DuplicateService() };
+      `,
+		});
+
+		expect(constructedClasses).toEqual(
+			new Set([
+				project
+					.getSourceFileOrThrow("a.ts")
+					.getClassOrThrow("DuplicateService"),
+			])
+		);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -484,6 +484,32 @@ describe("factory provider consumers", () => {
 			)
 		).toHaveLength(0);
 	});
+
+	it("no-unused-providers ignores factories declared in test files", () => {
+		const diags = runProjectRule(noUnusedProviders, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { MailerService } from './mailer.service';
+        @Module({ providers: [MailerService] })
+        export class AppModule {}
+      `,
+			"mailer.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable() export class MailerService {}
+      `,
+			"mailer.service.spec.ts": `
+        import { MailerService } from './mailer.service';
+        const provider = {
+          provide: 'MAILER',
+          useFactory: () => new MailerService(),
+        };
+      `,
+		});
+
+		expect(
+			diags.filter((d) => d.message.includes("MailerService"))
+		).toHaveLength(1);
+	});
 });
 
 describe("no-orphan-modules", () => {

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -450,6 +450,42 @@ describe("no-unused-providers", () => {
 	});
 });
 
+describe("factory provider consumers", () => {
+	it.each([
+		["no-unused-providers", noUnusedProviders],
+		["injectable-must-be-provided", injectableMustBeProvided],
+	])("%s counts constructed classes as provided and used", (_name, rule) => {
+		const diags = runProjectRule(rule, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { mailerProvider } from './mailer.provider';
+        @Module({ providers: [mailerProvider] })
+        export class AppModule {}
+      `,
+			"mailer.provider.ts": `
+        import { MailerService, TransportService } from './mailer.service';
+        export const mailerProvider = {
+          provide: 'MAILER',
+          useFactory: async () => new MailerService(new TransportService()),
+        };
+      `,
+			"mailer.service.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable() export class MailerService {}
+        @Injectable() export class TransportService {}
+      `,
+		});
+
+		expect(
+			diags.filter(
+				(d) =>
+					d.message.includes("MailerService") ||
+					d.message.includes("TransportService")
+			)
+		).toHaveLength(0);
+	});
+});
+
 describe("no-orphan-modules", () => {
 	it("does not flag a module bootstrapped by NestFactory", () => {
 		const diags = runProjectRule(noOrphanModules, {
@@ -737,6 +773,31 @@ describe("injectable-must-be-provided", () => {
 			"orphan.spec.ts": `
         import { OrphanThing } from './orphan';
         class Stub extends OrphanThing {}
+      `,
+		});
+		expect(diags.filter((d) => d.message.includes("OrphanThing"))).toHaveLength(
+			1
+		);
+	});
+
+	it("does not let a factory in a test file exempt a production class", () => {
+		const diags = runProjectRule(injectableMustBeProvided, {
+			"app.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class AppModule {}
+      `,
+			"orphan.ts": `
+        import { Injectable } from '@nestjs/common';
+        @Injectable()
+        export class OrphanThing {}
+      `,
+			"orphan.spec.ts": `
+        import { OrphanThing } from './orphan';
+        const provider = {
+          provide: 'TEST_ORPHAN',
+          useFactory: () => new OrphanThing(),
+        };
       `,
 		});
 		expect(diags.filter((d) => d.message.includes("OrphanThing"))).toHaveLength(


### PR DESCRIPTION
## Context

PR #305 stopped `architecture/no-manual-instantiation` from reporting classes created inside Nest custom providers. Issue #306 covers the remaining two rules that still disagreed with that result.

## Problem

`correctness/injectable-must-be-provided` and `performance/no-unused-providers` only understood provider registrations visible through the module graph. A local injectable created under a custom provider `useFactory` or `useValue` was therefore reported as both unregistered and unused.

## Possible flows

| Flow | Before | This PR |
|---|---|---|
| Inline or async `useFactory` | False positives | Recognized |
| Named, static, default, or passthrough factory | False positives | Recognized |
| Identifier-backed or hoisted `useValue` | False positives | Recognized |
| Object without `provide` | No exemption | Unchanged |
| External class construction | No exemption | Unchanged |
| Factory code in test files | Could affect production facts | Excluded |

## Solution

Extend the shared custom-provider collector to return exact local class declarations constructed by provider factories and values. Both project rules consume that declaration set while the module graph remains unchanged, because the custom token, not the class token, is injectable.

The collector follows local identifier and function indirection, requires a `provide` property, and keeps declaration identity when class names collide.

## Before vs after

| Case | Before | After |
|---|---|---|
| `new MailerService()` under `useFactory` | Unregistered and unused diagnostics | Neither diagnostic |
| `new CacheService()` under `useValue` | Unregistered and unused diagnostics | Neither diagnostic |
| Same construction without `provide` | Diagnostics remain | Unchanged |
| Existing `useClass` handling | Recognized | Unchanged |

## Example

```bash
pnpm --filter nestjs-doctor exec vitest run tests/integration/cli.test.ts -t "treats classes constructed by custom providers as provided and used"
```

Before:

```text
FAIL expected 13 custom-provider diagnostics to deeply equal []
```

After:

```text
PASS treats classes constructed by custom providers as provided and used
```

Closes #306.