### PR TITLE
fix(schema): honor primary: true on MikroORM relation decorators

### DIFF
--- a/.changeset/mikroorm-relation-primary-keys.md
+++ b/.changeset/mikroorm-relation-primary-keys.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+Stop `schema/require-primary-key` reporting MikroORM entities whose primary
+key is declared through relations, via `primary: true` on `@ManyToOne` or
+`@OneToOne` (composite pivot tables, shared 1:1 keys).

--- a/packages/nestjs-doctor/src/engine/schema/mikro-orm-extractor.ts
+++ b/packages/nestjs-doctor/src/engine/schema/mikro-orm-extractor.ts
@@ -286,6 +286,24 @@ function extractColumnsFromClass(
 				if (relation) {
 					relations.push(relation);
 				}
+
+				// `primary: true` on @ManyToOne/@OneToOne makes the FK column part
+				// of the primary key — composites of relations need no surrogate id.
+				if (decName === "ManyToOne" || decName === "OneToOne") {
+					const objArg = getDecoratorObjectArg(dec);
+					if (objArg?.primary === "true") {
+						columns.push({
+							name: objArg.fieldName
+								? objArg.fieldName.replace(/['"]/g, "")
+								: propName,
+							type: "unknown",
+							isPrimary: true,
+							isNullable: false,
+							isGenerated: false,
+							isUnique: false,
+						});
+					}
+				}
 				break;
 			}
 		}

--- a/packages/nestjs-doctor/tests/fixtures/mikro-orm-app/src/entities/relation-pk.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/mikro-orm-app/src/entities/relation-pk.entity.ts
@@ -58,9 +58,9 @@ export class UserProfile {
 	updatedAt!: Date;
 }
 
-// GOOD: options-first factory form from the docs; target typed as a bare
-// entity class, so the relation target does not resolve and must not be
-// required for the column to count as primary.
+// GOOD: options-first factory form from the docs. The bare `Rel<User>`
+// property type alone would miss both target regexes, but the explicit
+// `entity: () => User` resolves, so this also yields a relation.
 @Entity({ tableName: "order_items" })
 export class OrderItem {
 	@ManyToOne({ entity: () => User, primary: true, deleteRule: "cascade" })

--- a/packages/nestjs-doctor/tests/fixtures/mikro-orm-app/src/entities/relation-pk.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/mikro-orm-app/src/entities/relation-pk.entity.ts
@@ -1,0 +1,114 @@
+import {
+	Entity,
+	ManyToOne,
+	OneToOne,
+	PrimaryKey,
+	Property,
+	Rel,
+	Ref,
+} from "@mikro-orm/core";
+import { User } from "../users/user.entity";
+import { Order } from "../orders/order.entity";
+
+// GOOD: composite primary key declared through relations (issue #294).
+// Both halves are @ManyToOne with primary: true, no surrogate id.
+@Entity({ tableName: "user_bases" })
+export class UserBases {
+	@ManyToOne(() => User, {
+		ref: true,
+		fieldName: "user_id",
+		deleteRule: "cascade",
+		primary: true,
+	})
+	user!: Ref<User>;
+
+	@ManyToOne(() => Order, {
+		ref: true,
+		fieldName: "base_id",
+		deleteRule: "cascade",
+		primary: true,
+	})
+	base!: Ref<Order>;
+
+	@Property({ type: "Date", defaultRaw: "now()" })
+	createdAt!: Date;
+
+	@Property({ type: "Date", onUpdate: () => new Date() })
+	updatedAt!: Date;
+}
+
+// GOOD: single-column 1:1 shared primary key.
+@Entity({ tableName: "user_profiles" })
+export class UserProfile {
+	@OneToOne(() => User, {
+		ref: true,
+		fieldName: "user_id",
+		deleteRule: "cascade",
+		primary: true,
+	})
+	user!: Ref<User>;
+
+	@Property({ nullable: true })
+	avatarUrl?: string;
+
+	@Property({ type: "Date", defaultRaw: "now()" })
+	createdAt!: Date;
+
+	@Property({ type: "Date", onUpdate: () => new Date() })
+	updatedAt!: Date;
+}
+
+// GOOD: options-first factory form from the docs; target typed as a bare
+// entity class, so the relation target does not resolve and must not be
+// required for the column to count as primary.
+@Entity({ tableName: "order_items" })
+export class OrderItem {
+	@ManyToOne({ entity: () => User, primary: true, deleteRule: "cascade" })
+	order!: Rel<User>;
+
+	@Property({ default: 1 })
+	amount!: number;
+
+	@Property({ type: "Date", defaultRaw: "now()" })
+	createdAt!: Date;
+
+	@Property({ type: "Date", onUpdate: () => new Date() })
+	updatedAt!: Date;
+}
+
+// GOOD: mixed composite — one relation half plus one scalar half.
+@Entity({ tableName: "event_details" })
+export class EventDetail {
+	@ManyToOne(() => User, { fieldName: "weekday_id", deleteRule: "cascade", primary: true })
+	weekday!: Rel<User>;
+
+	@PrimaryKey()
+	slot!: string;
+
+	@Property()
+	what!: string;
+
+	@Property({ type: "Date", defaultRaw: "now()" })
+	createdAt!: Date;
+
+	@Property({ type: "Date", onUpdate: () => new Date() })
+	updatedAt!: Date;
+}
+
+// CONTROL: a plain relation without primary: true contributes no column.
+// Everything else is exemplary, so this entity fires exactly one diagnostic:
+// schema/require-primary-key.
+@Entity({ tableName: "keyless_things" })
+export class KeylessThing {
+	@ManyToOne(() => User, { deleteRule: "cascade" })
+	user!: Rel<User>;
+
+	@Property()
+	label!: string;
+
+	@Property({ type: "Date", defaultRaw: "now()" })
+	createdAt!: Date;
+
+	@Property({ type: "Date", onUpdate: () => new Date() })
+	updatedAt!: Date;
+}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -1341,30 +1341,36 @@ describe("scanner integration", () => {
 		it("detects MikroORM and extracts schema", () => {
 			expect(result.project.orm).toBe("mikro-orm");
 			expect(result.schema).toBeDefined();
-			expect(result.schema!.entities).toHaveLength(4);
-			expect(result.schema!.relations).toHaveLength(3);
+			expect(result.schema!.entities).toHaveLength(9);
+			expect(result.schema!.relations).toHaveLength(9);
 			expect(result.schema!.orm).toBe("mikro-orm");
 
 			const entityNames = result.schema!.entities.map((e) => e.name).sort();
 			expect(entityNames).toEqual([
 				"AuditLog",
+				"EventDetail",
+				"KeylessThing",
 				"Notification",
 				"Order",
+				"OrderItem",
 				"User",
+				"UserBases",
+				"UserProfile",
 			]);
 		});
 
-		it("fires exactly 4 schema diagnostics", () => {
+		it("fires exactly 5 schema diagnostics", () => {
 			const schemaDiags = result.diagnostics.filter(
 				(d) => d.category === "schema"
 			);
-			expect(schemaDiags).toHaveLength(4);
+			expect(schemaDiags).toHaveLength(5);
 
 			const pkDiags = schemaDiags.filter(
 				(d) => d.rule === "schema/require-primary-key"
 			);
-			expect(pkDiags).toHaveLength(1);
-			expect(pkDiags[0].entity).toBe("AuditLog");
+			expect(pkDiags).toHaveLength(2);
+			const pkEntities = pkDiags.map((d) => d.entity).sort();
+			expect(pkEntities).toEqual(["AuditLog", "KeylessThing"]);
 
 			const tsDiags = schemaDiags.filter(
 				(d) => d.rule === "schema/require-timestamps"

--- a/packages/nestjs-doctor/tests/unit/schema/mikro-orm-extractor.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/mikro-orm-extractor.test.ts
@@ -582,4 +582,187 @@ export class User extends BaseEntity {
 		const graph = extractSchema(project, paths, null, "/test");
 		expect(graph.entities.size).toBe(0);
 	});
+
+	describe("relation primary keys (issue #294)", () => {
+		it("should synthesize primary columns for @ManyToOne({ primary: true }) composite keys", () => {
+			const { project, paths } = createProject({
+				"user.entity.ts": `
+import { Entity, PrimaryKey } from "@mikro-orm/core";
+
+@Entity()
+export class User {
+  @PrimaryKey()
+  id!: number;
+}`,
+				"user-bases.entity.ts": `
+import { Entity, ManyToOne, Ref } from "@mikro-orm/core";
+import { User } from "./user.entity";
+
+@Entity()
+export class UserBases {
+  @ManyToOne(() => User, { ref: true, fieldName: "user_id", primary: true })
+  user!: Ref<User>;
+
+  @ManyToOne(() => User, { ref: true, fieldName: "base_id", primary: true })
+  base!: Ref<User>;
+}`,
+			});
+
+			const graph = extractSchema(project, paths, "mikro-orm", "/test");
+			const userBases = graph.entities.get("UserBases");
+
+			expect(userBases?.relations).toHaveLength(2);
+
+			const primaryCols = userBases?.columns.filter((c) => c.isPrimary);
+			expect(primaryCols?.map((c) => c.name).sort()).toEqual([
+				"base_id",
+				"user_id",
+			]);
+
+			const userIdCol = userBases?.columns.find((c) => c.name === "user_id");
+			expect(userIdCol?.type).toBe("unknown");
+			expect(userIdCol?.isNullable).toBe(false);
+
+			const baseIdCol = userBases?.columns.find((c) => c.name === "base_id");
+			expect(baseIdCol?.isPrimary).toBe(true);
+		});
+
+		it("should synthesize a primary column for @OneToOne({ primary: true }) shared keys", () => {
+			const { project, paths } = createProject({
+				"user.entity.ts": `
+import { Entity, PrimaryKey } from "@mikro-orm/core";
+
+@Entity()
+export class User {
+  @PrimaryKey()
+  id!: number;
+}`,
+				"user-profile.entity.ts": `
+import { Entity, OneToOne, Property, Ref } from "@mikro-orm/core";
+import { User } from "./user.entity";
+
+@Entity()
+export class UserProfile {
+  @OneToOne(() => User, { ref: true, fieldName: "user_id", primary: true })
+  user!: Ref<User>;
+
+  @Property({ nullable: true })
+  avatarUrl?: string;
+}`,
+			});
+
+			const graph = extractSchema(project, paths, "mikro-orm", "/test");
+			const profile = graph.entities.get("UserProfile");
+
+			expect(profile?.relations).toHaveLength(1);
+			expect(profile?.relations[0]?.type).toBe("one-to-one");
+
+			const userIdCol = profile?.columns.find((c) => c.name === "user_id");
+			expect(userIdCol?.isPrimary).toBe(true);
+			expect(userIdCol?.type).toBe("unknown");
+
+			const avatarCol = profile?.columns.find((c) => c.name === "avatarUrl");
+			expect(avatarCol?.isPrimary).toBe(false);
+		});
+
+		it("should synthesize a primary column when the relation target cannot be resolved", () => {
+			// Options-first factory form with a bare Rel<T>: the target stays
+			// unresolved so no relation entry is produced, but the column must
+			// still exist and fall back to the property name.
+			const { project, paths } = createProject({
+				"order-item.entity.ts": `
+import { Entity, ManyToOne, Property, Rel } from "@mikro-orm/core";
+
+@Entity()
+export class OrderItem {
+  @ManyToOne({ primary: true })
+  order!: Rel<User>;
+
+  @Property({ default: 1 })
+  amount!: number;
+}`,
+			});
+
+			const graph = extractSchema(project, paths, "mikro-orm", "/test");
+			const orderItem = graph.entities.get("OrderItem");
+
+			const orderCol = orderItem?.columns.find((c) => c.name === "order");
+			expect(orderCol?.isPrimary).toBe(true);
+			expect(orderCol?.type).toBe("unknown");
+
+			const amountCol = orderItem?.columns.find((c) => c.name === "amount");
+			expect(amountCol?.isPrimary).toBe(false);
+		});
+
+		it("should treat mixed composite keys (relation + scalar PrimaryKey) as all-primary", () => {
+			const { project, paths } = createProject({
+				"user.entity.ts": `
+import { Entity, PrimaryKey } from "@mikro-orm/core";
+
+@Entity()
+export class User {
+  @PrimaryKey()
+  id!: number;
+}`,
+				"event-detail.entity.ts": `
+import { Entity, ManyToOne, PrimaryKey, Property, Rel } from "@mikro-orm/core";
+import { User } from "./user.entity";
+
+@Entity()
+export class EventDetail {
+  @ManyToOne(() => User, { fieldName: "weekday_id", primary: true })
+  weekday!: Rel<User>;
+
+  @PrimaryKey()
+  slot!: string;
+
+  @Property()
+  what!: string;
+}`,
+			});
+
+			const graph = extractSchema(project, paths, "mikro-orm", "/test");
+			const detail = graph.entities.get("EventDetail");
+
+			expect(detail?.relations).toHaveLength(1);
+
+			const weekdayCol = detail?.columns.find((c) => c.name === "weekday_id");
+			expect(weekdayCol?.isPrimary).toBe(true);
+			expect(weekdayCol?.type).toBe("unknown");
+
+			const slotCol = detail?.columns.find((c) => c.name === "slot");
+			expect(slotCol?.isPrimary).toBe(true);
+		});
+
+		it("should not treat plain relations as primary key columns", () => {
+			const { project, paths } = createProject({
+				"user.entity.ts": `
+import { Entity, PrimaryKey } from "@mikro-orm/core";
+
+@Entity()
+export class User {
+  @PrimaryKey()
+  id!: number;
+}`,
+				"keyless-thing.entity.ts": `
+import { Entity, ManyToOne, Property, Rel } from "@mikro-orm/core";
+import { User } from "./user.entity";
+
+@Entity()
+export class KeylessThing {
+  @ManyToOne(() => User)
+  user!: Rel<User>;
+
+  @Property()
+  label!: string;
+}`,
+			});
+
+			const graph = extractSchema(project, paths, "mikro-orm", "/test");
+			const thing = graph.entities.get("KeylessThing");
+
+			expect(thing?.relations).toHaveLength(1);
+			expect(thing?.columns.some((c) => c.isPrimary)).toBe(false);
+		});
+	});
 });

--- a/packages/nestjs-doctor/tests/unit/schema/schema-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/schema-rules.test.ts
@@ -1,3 +1,4 @@
+import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
 import type { SchemaDiagnostic } from "../../../src/common/diagnostic.js";
 import type {
@@ -10,6 +11,7 @@ import { requireCascadeRule } from "../../../src/engine/rules/definitions/schema
 import { requirePrimaryKey } from "../../../src/engine/rules/definitions/schema/require-primary-key.js";
 import { requireTimestamps } from "../../../src/engine/rules/definitions/schema/require-timestamps.js";
 import type { SchemaRule } from "../../../src/engine/rules/types.js";
+import { extractSchema } from "../../../src/engine/schema/extract.js";
 
 const TIMESTAMP_MESSAGE_REGEX = /timestamp/;
 
@@ -109,6 +111,98 @@ describe("schema/require-primary-key", () => {
 		const diagnostics = runSchemaRule(requirePrimaryKey, graph);
 
 		expect(diagnostics).toHaveLength(1);
+	});
+});
+
+// ── require-primary-key vs MikroORM relation primary keys (issue #294) ──
+
+function createProject(files: Record<string, string>) {
+	const project = new Project({ useInMemoryFileSystem: true });
+	const paths: string[] = [];
+	for (const [name, code] of Object.entries(files)) {
+		project.createSourceFile(name, code);
+		paths.push(name);
+	}
+	return { project, paths };
+}
+
+const RELATION_PK_FILES = {
+	"user.entity.ts": `
+import { Entity, ManyToOne, OneToOne, PrimaryKey, Property, Ref, Rel } from "@mikro-orm/core";
+
+@Entity()
+export class User {
+  @PrimaryKey()
+  id!: number;
+}
+
+@Entity({ tableName: "user_bases" })
+export class UserBases {
+  @ManyToOne(() => User, { ref: true, fieldName: "user_id", primary: true })
+  user!: Ref<User>;
+
+  @ManyToOne(() => User, { ref: true, fieldName: "base_id", primary: true })
+  base!: Ref<User>;
+}
+
+@Entity({ tableName: "user_profiles" })
+export class UserProfile {
+  @OneToOne(() => User, { ref: true, fieldName: "user_id", primary: true })
+  user!: Ref<User>;
+}
+
+@Entity({ tableName: "order_items" })
+export class OrderItem {
+  @ManyToOne({ primary: true })
+  order!: Rel<User>;
+
+  @Property({ default: 1 })
+  amount!: number;
+}
+
+@Entity({ tableName: "event_details" })
+export class EventDetail {
+  @ManyToOne(() => User, { fieldName: "weekday_id", primary: true })
+  weekday!: Rel<User>;
+
+  @PrimaryKey()
+  slot!: string;
+}
+
+@Entity({ tableName: "keyless_things" })
+export class KeylessThing {
+  @ManyToOne(() => User)
+  user!: Rel<User>;
+
+  @Property()
+  label!: string;
+}`,
+};
+
+describe("require-primary-key with MikroORM relation primary keys (issue #294)", () => {
+	it("should not report entities whose primary keys come from relations", () => {
+		const { project, paths } = createProject(RELATION_PK_FILES);
+		const graph = extractSchema(project, paths, "mikro-orm", "/test");
+		const diagnostics = runSchemaRule(requirePrimaryKey, graph);
+
+		const relationKeyed = [
+			"UserBases",
+			"UserProfile",
+			"OrderItem",
+			"EventDetail",
+		];
+		expect(diagnostics.filter((d) => relationKeyed.includes(d.entity))).toEqual(
+			[]
+		);
+	});
+
+	it("should still report KeylessThing as missing a primary key", () => {
+		const { project, paths } = createProject(RELATION_PK_FILES);
+		const graph = extractSchema(project, paths, "mikro-orm", "/test");
+		const diagnostics = runSchemaRule(requirePrimaryKey, graph);
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].entity).toBe("KeylessThing");
 	});
 });
 


### PR DESCRIPTION
## Context

MikroORM lets a relation be part of the primary key: `primary: true` on `@ManyToOne`/`@OneToOne`. Documented mapping for pivot tables and shared 1:1 keys ([composite keys](https://mikro-orm.io/docs/composite-keys)). The rule `schema/require-primary-key` is correct; the gap is in the MikroORM entity extractor.

## Problem

The extractor set `isPrimary` only from `@PrimaryKey`/`@SerializedPrimaryKey`. Relation-decorated properties never contributed a column, so entities keyed entirely by relations — every many-to-many join with metadata, every 1:1 shared key — were reported as having no primary key. Evidence from issue #294 (verified before this PR):

```
✗ Entity 'UserBases' has no primary key column.
    Add a primary key column (e.g. @id in Prisma, @PrimaryColumn/@PrimaryGeneratedColumn in TypeORM).
```

Two sharp edges: the suggested fix is harmful here (a surrogate PK changes the schema and drops composite uniqueness), and severity is `error`, so each false positive costs 3.0 × 1.1 schema weight against a real project's score.

## Possible flows

| Flow | Before | This PR |
|---|---|---|
| `@ManyToOne(() => X, { primary: true })` + `fieldName` | No column, false positive | `isPrimary` column named by `fieldName` |
| `@ManyToOne({ primary: true })` options-first, bare type | Same | Column named by property name |
| `@OneToOne(..., { primary: true })` shared key | Same | Same as ManyToOne |
| Mixed composite (relation + scalar PK) | Scalar counted only | Both counted |
| Plain relation without `primary` | No column | Unchanged — no column |
| Relation extraction itself | Worked | Unchanged; columns and relations now both emitted |

## Solution

In `extractColumnsFromClass`, when a `ManyToOne`/`OneToOne` decorator's options carry `primary === "true"`, also push a synthesized column (`fieldName` stripped of quotes, else the property name; type `"unknown"`). Synthesis is independent of target resolution, so docs-style options-first forms whose targets match no existing regex still count. Relations continue to be extracted as before. Options position doesn't matter because `getDecoratorObjectArg` already scans all args.

Deliberately not done: guessing implicit column names for naming strategies (unknowable statically — no consumer needs it today; `require-primary-key` reads `isPrimary` only). `ManyToMany`/`OneToMany` ignore `primary` per upstream docs.

## Before vs after

| Case | Before | After |
|---|---|---|
| Entity keyed only by relations | `error` diagnostic | Clean |
| Genuinely keyless entity | Reported | Still reported (fixture control) |
| Timestamps/cascade diagnostics on those entities | n/a | Unchanged |

## Example

```bash
pnpm --filter nestjs-doctor exec vitest run tests/unit/schema/mikro-orm-extractor.test.ts tests/unit/schema/schema-rules.test.ts
```

Before:

```text
expected [] to deeply equal [ 'base_id', 'user_id' ]
Tests 6 failed | 38 passed
```

After:

```text
Test Files  2 passed (2)
     Tests  44 passed (44)
```

Fixture coverage (`tests/fixtures/mikro-orm-app/src/entities/relation-pk.entity.ts`) was built from the upstream docs plus three real-world threads (mikro-orm discussions #3531 / #4499, issue #5774) and covers options-first forms, mixed composites, and an exemplary keyless control that still fires exactly once.

Closes #294.