### PR TITLE
chore: ship these changes as 0.9.1

### DIFF
--- a/.changeset/interactive-worker-scan.md
+++ b/.changeset/interactive-worker-scan.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Interactive scans run the engine in a worker thread, so the spinner and the progress bar animate continuously instead of freezing while the scan works. The bar eases toward each new count and phase labels wipe in rather than jump, and the parse, module graph, provider, and guard-index passes yield to the event loop in smaller batches. CI and machine-readable runs scan in-process exactly as before, and a worker failure falls back to the in-process scan.

--- a/.changeset/report-artifact-json.md
+++ b/.changeset/report-artifact-json.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Report artifact: `--format report-json` writes the document the HTML report


### PR DESCRIPTION
Flips the two minor changesets (`interactive-worker-scan`, `report-artifact-json`) to patch so the Version Packages PR proposes `nestjs-doctor@0.9.1` instead of 0.10.0. No code change.