### PR TITLE
feat(report): shareable report slices from the menu, the CLI, and the page

### DIFF
--- a/.changeset/shareable-reports.md
+++ b/.changeset/shareable-reports.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": minor
+---
+
+Shareable reports. Pick which sections to share — the health score, findings per category, endpoints — and whether to include code snippets, from the post-scan menu or the report's new share button; both write a `nestjs-doctor-shared.json`. Also available non-interactively via `--share-sections score,findings:security` and `--share-code`.

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -89,6 +89,17 @@ export const flags = {
 		description:
 			"How much source text the report embeds: all (default), touched (only files with findings), none",
 	},
+	"share-sections": {
+		type: "string",
+		description:
+			"Write a shareable nestjs-doctor-shared.json beside the project, limited to these comma-separated sections: score, endpoints, findings:<category> (e.g. findings:security)",
+	},
+	"share-code": {
+		type: "boolean",
+		description:
+			"With --share-sections, include a few lines of code around each shared finding",
+		default: false,
+	},
 	init: {
 		type: "boolean",
 		description:

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -62,6 +62,7 @@ async function scan(args: CliArgs): Promise<void> {
 		.handleReport()
 		.validateMinScore()
 		.validateBlocking()
+		.validateShareSections()
 		.run();
 
 	if (!ctx) {

--- a/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
@@ -20,11 +20,12 @@ import { copyToClipboard } from "../clipboard.js";
 import { groupFindings } from "../findings.js";
 import { ReviewScreen } from "./review-screen.js";
 import { buildMenuItems, ScoreScreen } from "./score-screen.js";
+import { ShareScreen } from "./share-screen.js";
 import { padEnd } from "./text.js";
 import { palette } from "./theme.js";
 import type { InteractiveContext, MenuAction, Toast } from "./types.js";
 
-type Screen = "handoff" | "review" | "score";
+type Screen = "handoff" | "review" | "score" | "share";
 
 interface HandoffItem {
 	agent?: LaunchableAgent;
@@ -120,6 +121,11 @@ export const App = ({
 				setToast(null);
 				setSelectedHandoff(0);
 				setScreen("handoff");
+				return;
+			}
+			if (action === "share") {
+				setToast(null);
+				setScreen("share");
 				return;
 			}
 
@@ -277,6 +283,18 @@ export const App = ({
 				onQuit={exit}
 				onToast={setToast}
 				targetPath={context.targetPath}
+			/>
+		);
+	}
+
+	if (screen === "share") {
+		return (
+			<ShareScreen
+				onBack={() => setScreen("score")}
+				onToast={setToast}
+				result={shown}
+				targetPath={context.targetPath}
+				version={context.version}
 			/>
 		);
 	}

--- a/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
@@ -80,6 +80,11 @@ export const buildMenuItems = (
 		hint: "The pull request summary, for pasting anywhere",
 		label: "Copy findings as markdown",
 	},
+	{
+		action: "share" as const,
+		hint: "Pick the sections and save a .json others can open",
+		label: "Share the report",
+	},
 	{ action: "quit", label: "Quit" },
 ];
 

--- a/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
@@ -1,0 +1,171 @@
+import { Box, Text, useInput } from "ink";
+import { useMemo, useState } from "react";
+import type { DiagnoseResult } from "../../../common/result.js";
+import {
+	buildSharedReport,
+	enumerateShareSections,
+	type ShareSection,
+	writeSharedReportFile,
+} from "../../../report/share.js";
+import { truncate } from "./text.js";
+import { palette } from "./theme.js";
+import type { Toast } from "./types.js";
+
+interface ShareScreenProps {
+	onBack: () => void;
+	onToast: (toast: Toast) => void;
+	result: DiagnoseResult;
+	targetPath: string;
+	version: string;
+}
+
+interface ShareRow {
+	checked: boolean;
+	kind: "code" | "section";
+	label: string;
+	section?: ShareSection;
+}
+
+export const ShareScreen = ({
+	onBack,
+	onToast,
+	result,
+	targetPath,
+	version,
+}: ShareScreenProps): React.JSX.Element => {
+	const sections = useMemo(() => enumerateShareSections(result), [result]);
+	const [rows, setRows] = useState<ShareRow[]>(() => [
+		...sections.map((section) => ({
+			checked: true,
+			kind: "section" as const,
+			label: `${section.label} (${section.count})`,
+			section,
+		})),
+		{ checked: false, kind: "code", label: "Include code snippets" },
+	]);
+	const [selected, setSelected] = useState(0);
+	const [busy, setBusy] = useState(false);
+
+	const toggle = (index: number): void => {
+		setRows((previous) =>
+			previous.map((row, at) =>
+				at === index ? { ...row, checked: !row.checked } : row
+			)
+		);
+	};
+
+	const save = async (): Promise<void> => {
+		if (busy) {
+			return;
+		}
+		const picked = rows.flatMap((row) =>
+			row.checked && row.section ? [row.section.id] : []
+		);
+		if (picked.length === 0) {
+			onToast({ kind: "error", text: "Pick at least one section." });
+			return;
+		}
+		setBusy(true);
+		try {
+			const includeCode =
+				rows.find((row) => row.kind === "code")?.checked ?? false;
+			const shared = buildSharedReport(
+				result,
+				{ includeCode, sections: picked },
+				version
+			);
+			if (!shared) {
+				onToast({
+					kind: "error",
+					text: "Nothing was shareable in those sections.",
+				});
+				return;
+			}
+			const outPath = await writeSharedReportFile(targetPath, shared);
+			onToast({
+				kind: "success",
+				text: `Shared report written to ${outPath}`,
+			});
+			onBack();
+		} catch (error) {
+			onToast({
+				kind: "error",
+				text: error instanceof Error ? error.message : String(error),
+			});
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	useInput(
+		(input, key) => {
+			if (key.upArrow || input === "k") {
+				setSelected((previous) =>
+					previous === 0 ? rows.length - 1 : previous - 1
+				);
+			} else if (key.downArrow || input === "j") {
+				setSelected((previous) => (previous + 1) % rows.length);
+			} else if (input === " ") {
+				toggle(selected);
+			} else if (input === "c") {
+				const index = rows.findIndex((row) => row.kind === "code");
+				if (index >= 0) {
+					toggle(index);
+					setSelected(index);
+				}
+			} else if (key.escape) {
+				onBack();
+			} else if (key.return) {
+				// biome-ignore lint/suspicious/noEmptyBlockStatements: save reports its own errors as a toast
+				save().catch(() => {});
+			}
+		},
+		{ isActive: true }
+	);
+
+	return (
+		<Box
+			borderColor={palette.border}
+			borderStyle="single"
+			flexDirection="column"
+		>
+			<Text bold color={palette.bright}>
+				{" SHARE THE REPORT"}
+			</Text>
+			{rows.map((row, index) => {
+				const isSelected = index === selected;
+				return (
+					<Box flexDirection="row" key={row.label}>
+						<Box
+							backgroundColor={isSelected ? palette.nestRed : undefined}
+							width={1}
+						>
+							<Text> </Text>
+						</Box>
+						<Box
+							backgroundColor={isSelected ? palette.washRed : undefined}
+							flexDirection="row"
+							gap={2}
+							paddingLeft={1}
+						>
+							<Text color={isSelected ? palette.bright : palette.text}>
+								{`[${row.checked ? "x" : " "}] ${truncate(row.label, 64)}`}
+							</Text>
+							{row.kind === "code" ? (
+								<Text color={isSelected ? palette.muted : palette.dim}>
+									{"a few lines around each finding"}
+								</Text>
+							) : null}
+						</Box>
+					</Box>
+				);
+			})}
+			<Text color={palette.dim}>
+				{`${targetPath}/nestjs-doctor-shared.json`}
+			</Text>
+			<Text color={palette.dim}>
+				{"↑↓ select · space toggle · c code · enter save · esc back"}
+			</Text>
+		</Box>
+	);
+};

--- a/packages/nestjs-doctor/src/cli/interactive/tui/types.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/types.ts
@@ -22,7 +22,8 @@ export type MenuAction =
 	| "markdown"
 	| "quit"
 	| "report"
-	| "review";
+	| "review"
+	| "share";
 
 /** Everything the post-scan UI needs, handed over by the pipeline. */
 export interface InteractiveContext {

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -4,6 +4,7 @@ import type { ReportArtifact } from "../common/artifact.js";
 import { MAX_DEPENDENCY_NODES } from "../common/endpoint.js";
 import type { DiagnoseResult, MonorepoResult } from "../common/result.js";
 import type { EngineResult, MonorepoEngineResult } from "../engine/scanner.js";
+import { buildSharedReport, writeSharedReportFile } from "../report/share.js";
 import { highlighter } from "../ui/highlighter.js";
 import { logger } from "../ui/logger.js";
 import { shouldBlock } from "./blocking.js";
@@ -70,14 +71,14 @@ function enforceGates(
 	}
 }
 
-function emit(
+async function emit(
 	result: DiagnoseResult,
 	targetPath: string,
 	options: PipelineOptions,
 	scopeWarnings: string[],
 	monorepo?: MonorepoResult,
 	artifact?: () => ReportArtifact
-): void {
+): Promise<void> {
 	// Always surfaced, on stderr, whatever the format: a silently degraded scope
 	// makes a report look cleaner than the code actually is.
 	for (const warning of scopeWarnings) {
@@ -153,30 +154,56 @@ function emit(
 			printConsoleReport(result, options.verbose, false);
 		}
 	}
+
+	if (options.shareSections) {
+		const shared = buildSharedReport(
+			result,
+			{
+				includeCode: options.shareCode,
+				sections: options.shareSections,
+			},
+			cliVersion
+		);
+		if (!shared) {
+			logger.warn(
+				"No shareable content matched --share-sections; nothing was written."
+			);
+			return;
+		}
+		const outPath = await writeSharedReportFile(targetPath, shared);
+		logger.info(`Shared report written to ${highlighter.info(outPath)}`);
+	}
 }
 
-export const outputMonorepoResults = (
+export const outputMonorepoResults = async (
 	monorepoScanResult: MonorepoEngineResult,
 	resolvedMinimumScore: number | undefined,
 	targetPath: string,
 	options: PipelineOptions,
 	scopeWarnings: string[] = [],
 	artifact?: () => ReportArtifact
-): void => {
+): Promise<void> => {
 	const { result } = monorepoScanResult;
-	emit(result.combined, targetPath, options, scopeWarnings, result, artifact);
+	await emit(
+		result.combined,
+		targetPath,
+		options,
+		scopeWarnings,
+		result,
+		artifact
+	);
 	enforceGates(result.combined, resolvedMinimumScore, options);
 };
 
-export const outputSingleProjectResults = (
+export const outputSingleProjectResults = async (
 	singleProjectScanResult: EngineResult,
 	resolvedMinimumScore: number | undefined,
 	targetPath: string,
 	options: PipelineOptions,
 	scopeWarnings: string[] = [],
 	artifact?: () => ReportArtifact
-): void => {
+): Promise<void> => {
 	const { result } = singleProjectScanResult;
-	emit(result, targetPath, options, scopeWarnings, undefined, artifact);
+	await emit(result, targetPath, options, scopeWarnings, undefined, artifact);
 	enforceGates(result, resolvedMinimumScore, options);
 };

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -564,7 +564,7 @@ export class MonorepoPipeline extends ScanPipeline {
 			return this;
 		}
 		const step: PipelineStep = () => {
-			outputMonorepoResults(
+			return outputMonorepoResults(
 				this.result,
 				this.resolvedMinimumScore,
 				this.targetPath,
@@ -731,7 +731,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 			return this;
 		}
 		const step: PipelineStep = () => {
-			outputSingleProjectResults(
+			return outputSingleProjectResults(
 				this.result,
 				this.resolvedMinimumScore,
 				this.targetPath,

--- a/packages/nestjs-doctor/src/cli/scan-worker.ts
+++ b/packages/nestjs-doctor/src/cli/scan-worker.ts
@@ -27,6 +27,8 @@ const options: PipelineOptions = {
 	},
 	outputPath: undefined,
 	score: false,
+	shareCode: false,
+	shareSections: undefined,
 	skipOutput: true,
 	sources: "none",
 	timings: undefined,

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 import type { SourceInclusion } from "../common/artifact.js";
 import { isScopeMode, type ScopeMode } from "../common/scope.js";
 import type { BootstrapTimings } from "../common/timings.js";
+import { parseShareSections, type ShareSectionId } from "../report/share.js";
 import { logger } from "../ui/logger.js";
 import {
 	type BlockingLevel,
@@ -38,6 +39,10 @@ export interface PipelineOptions extends ScanOptions {
 	onProgress?: (label: string, done?: number, total?: number) => void;
 	outputPath: string | undefined;
 	score: boolean;
+	/** With `shareSections`, keep a few lines of code around each shared finding. */
+	shareCode: boolean;
+	/** Sections to write into a shareable JSON beside the project. */
+	shareSections: ShareSectionId[] | undefined;
 	/** Worker-internal: the worker never prints the report. */
 	skipOutput?: boolean;
 	/** How much source text the report artifact embeds. */
@@ -82,6 +87,8 @@ export interface CliArgs {
 	report: boolean;
 	scope: string | undefined;
 	score: boolean;
+	"share-code": boolean;
+	"share-sections": string | undefined;
 	sources: string | undefined;
 	staged: boolean;
 	telemetry: boolean;
@@ -280,6 +287,27 @@ export class CliSetup {
 		return this;
 	}
 
+	validateShareSections(): this {
+		this.steps.push(() => {
+			if (this.args["share-sections"] !== undefined) {
+				const { error } = parseShareSections(this.args["share-sections"]);
+				if (error) {
+					failWith(error);
+				}
+			}
+			return true;
+		});
+		return this;
+	}
+
+	private parseResolvedShareSections(): ShareSectionId[] | undefined {
+		if (!this.args["share-sections"]) {
+			return undefined;
+		}
+		const parsed = parseShareSections(this.args["share-sections"]);
+		return "sections" in parsed ? parsed.sections : undefined;
+	}
+
 	async run(): Promise<SetupContext | null> {
 		for (const step of this.steps) {
 			const shouldContinue = await step();
@@ -321,6 +349,8 @@ export class CliSetup {
 				outputPath: this.args.output,
 				scope: resolveScopeMode(this.args),
 				score,
+				shareCode: this.args["share-code"] ?? false,
+				shareSections: this.parseResolvedShareSections(),
 				sources: resolveSources(this.args),
 				staged: this.args.staged ?? false,
 				telemetry: this.args.telemetry ?? true,

--- a/packages/nestjs-doctor/src/engine/result-builder.ts
+++ b/packages/nestjs-doctor/src/engine/result-builder.ts
@@ -72,7 +72,7 @@ export function withSurface(
 	return { ...result, diagnostics, summary: buildSummary(diagnostics) };
 }
 
-function buildSummary(diagnostics: Diagnostic[]): DiagnoseSummary {
+export function buildSummary(diagnostics: Diagnostic[]): DiagnoseSummary {
 	const summary: DiagnoseSummary = {
 		total: 0,
 		errors: 0,

--- a/packages/nestjs-doctor/src/report/share.ts
+++ b/packages/nestjs-doctor/src/report/share.ts
@@ -1,0 +1,200 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+	type Category,
+	type CodeDiagnostic,
+	isCodeDiagnostic,
+	isSchemaDiagnostic,
+	type SchemaDiagnostic,
+} from "../common/diagnostic.js";
+import type {
+	DiagnoseResult,
+	DiagnoseSummary,
+	Score,
+} from "../common/result.js";
+import { buildSummary } from "../engine/result-builder.js";
+
+export const SHARED_REPORT_VERSION = 1;
+
+const FINDINGS_PREFIX = "findings:";
+export const SCORE_SECTION = "score";
+export const ENDPOINTS_SECTION = "endpoints";
+const FINDINGS_CATEGORIES: Category[] = [
+	"security",
+	"performance",
+	"correctness",
+	"architecture",
+	"schema",
+];
+
+export type ShareSectionId =
+	| "score"
+	| "endpoints"
+	| `${typeof FINDINGS_PREFIX}${Category}`;
+
+/** Parses a `--share-sections` value; the string is what failed validation. */
+export function parseShareSections(
+	csv: string
+): { sections: ShareSectionId[]; error?: undefined } | { error: string } {
+	const valid = new Set<string>([SCORE_SECTION, ENDPOINTS_SECTION]);
+	for (const category of FINDINGS_CATEGORIES) {
+		valid.add(`${FINDINGS_PREFIX}${category}`);
+	}
+	const sections: ShareSectionId[] = [];
+	for (const raw of csv.split(",")) {
+		const id = raw.trim();
+		if (id.length === 0) {
+			continue;
+		}
+		if (!valid.has(id)) {
+			return {
+				error: `Invalid --share-sections value: "${id}". Must be one of ${[...valid].join(", ")}.`,
+			};
+		}
+		sections.push(id as ShareSectionId);
+	}
+	if (sections.length === 0) {
+		return { error: "Invalid --share-sections value: no sections given." };
+	}
+	return { sections };
+}
+
+export interface ShareSection {
+	count: number;
+	id: ShareSectionId;
+	label: string;
+}
+
+/**
+ * The sections a result can offer, derived from its content so both the
+ * terminal picker and report's share dialog show only what exists.
+ */
+export function enumerateShareSections(result: DiagnoseResult): ShareSection[] {
+	const sections: ShareSection[] = [
+		{
+			id: SCORE_SECTION,
+			count: result.score.value,
+			label: "Health score and project info",
+		},
+	];
+	for (const category of FINDINGS_CATEGORIES) {
+		const count = result.diagnostics.filter(
+			(diagnostic) => diagnostic.category === category
+		).length;
+		if (count > 0) {
+			sections.push({
+				id: `${FINDINGS_PREFIX}${category}` as ShareSectionId,
+				count,
+				label: `Findings · ${category}`,
+			});
+		}
+	}
+	const endpointCount = result.endpoints?.endpoints.length ?? 0;
+	if (endpointCount > 0) {
+		sections.push({
+			id: ENDPOINTS_SECTION,
+			count: endpointCount,
+			label: "HTTP endpoints",
+		});
+	}
+	return sections;
+}
+
+interface SharedEndpoint {
+	controllerClass: string;
+	handlerMethod: string;
+	httpMethod: string;
+	routePath: string;
+}
+
+interface SharedReport {
+	endpoints?: SharedEndpoint[];
+	findings: CodeDiagnostic[];
+	generatedAt: string;
+	generator: { name: "nestjs-doctor"; version: string };
+	includeCode: boolean;
+	project: DiagnoseResult["project"];
+	schemaIssues: SchemaDiagnostic[];
+	score: Score;
+	sections: ShareSectionId[];
+	summary: DiagnoseSummary;
+	version: number;
+}
+
+/**
+ * A shareable slice of a result. The score is carried over untouched: it
+ * measures the whole project whatever the shared subset is.
+ */
+export function buildSharedReport(
+	result: DiagnoseResult,
+	options: { includeCode: boolean; sections: ShareSectionId[] },
+	version: string
+): SharedReport | null {
+	const categories = new Set<Category>();
+	for (const section of options.sections) {
+		if (section.startsWith(FINDINGS_PREFIX)) {
+			categories.add(section.slice(FINDINGS_PREFIX.length) as Category);
+		}
+	}
+	const picked = result.diagnostics.filter((diagnostic) =>
+		categories.has(diagnostic.category)
+	);
+
+	const findings: CodeDiagnostic[] = picked.flatMap((diagnostic) => {
+		if (!isCodeDiagnostic(diagnostic)) {
+			return [];
+		}
+		if (options.includeCode && diagnostic.sourceLines) {
+			return [{ ...diagnostic }];
+		}
+		const { sourceLines, ...rest } = diagnostic;
+		return [rest as CodeDiagnostic];
+	});
+	const schemaIssues = picked.flatMap((diagnostic) =>
+		isSchemaDiagnostic(diagnostic) ? [diagnostic] : []
+	);
+	const endpoints = options.sections.includes(ENDPOINTS_SECTION)
+		? (result.endpoints?.endpoints ?? []).map((endpoint) => ({
+				controllerClass: endpoint.controllerClass,
+				handlerMethod: endpoint.handlerMethod,
+				httpMethod: endpoint.httpMethod,
+				routePath: endpoint.routePath,
+			}))
+		: undefined;
+	const summary = buildSummary(picked);
+	if (
+		!summary.total &&
+		(endpoints?.length ?? 0) === 0 &&
+		!options.sections.includes(SCORE_SECTION)
+	) {
+		return null;
+	}
+
+	return {
+		findings,
+		generatedAt: new Date().toISOString(),
+		generator: { name: "nestjs-doctor", version },
+		includeCode: options.includeCode && findings.length > 0,
+		project: result.project,
+		schemaIssues,
+		score: result.score,
+		sections: options.sections,
+		summary,
+		version: SHARED_REPORT_VERSION,
+		...(endpoints ? { endpoints } : {}),
+	};
+}
+
+/** Writes the shared payload beside the scanned project unless named. */
+export async function writeSharedReportFile(
+	targetPath: string,
+	shared: SharedReport,
+	outputPath?: string
+): Promise<string> {
+	const outPath = outputPath
+		? outputPath
+		: join(targetPath, "nestjs-doctor-shared.json");
+	await mkdir(dirname(outPath), { recursive: true });
+	await writeFile(outPath, `${JSON.stringify(shared, null, 2)}\n`, "utf-8");
+	return outPath;
+}

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -9,6 +9,7 @@ export function getReportHtml(): string {
   <div class="meta" id="header-meta"></div>
   <div class="spacer"></div>
   <div class="nav-actions">
+    <button class="nav-btn" id="nav-share" type="button">share</button>
     <a class="nav-btn" href="https://nestjs.doctor/docs" target="_blank" rel="noopener">docs</a>
     <a class="nav-btn" href="https://github.com/RoloBits/nestjs-doctor" target="_blank" rel="noopener">github</a>
   </div>

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6463,5 +6463,132 @@ function renderEndpoints() {
   epCanvas.style.display = "none";
 }
 
-switchTab("summary");`;
+switchTab("summary");
+
+// ── Share dialog ──
+(function() {
+  var btn = document.getElementById("nav-share");
+  if (!btn) return;
+  var SHARE_CATS = ["security", "performance", "correctness", "architecture", "schema"];
+  var SHARE_VERSION = 1;
+
+  function shareSections() {
+    var secs = [{id: "score", label: "Health score", count: project.score}];
+    for (var i = 0; i < SHARE_CATS.length; i++) {
+      var cat = SHARE_CATS[i], n = 0;
+      for (var j = 0; j < diagnostics.length; j++) {
+        if (diagnostics[j].category === cat) n++;
+      }
+      if (n > 0) secs.push({id: "findings:" + cat, label: "Findings \\u00b7 " + cat, count: n});
+    }
+    if (endpoints.endpoints.length > 0) {
+      secs.push({id: "endpoints", label: "HTTP endpoints", count: endpoints.endpoints.length});
+    }
+    return secs;
+  }
+
+  function buildSharedJson(includeCode, picked) {
+    var cats = {};
+    for (var i = 0; i < picked.length; i++) {
+      if (picked[i].indexOf("findings:") === 0) cats[picked[i].slice(9)] = true;
+    }
+    var pickedDiags = [];
+    for (var j = 0; j < diagnostics.length; j++) {
+      if (cats[diagnostics[j].category]) pickedDiags.push(diagnostics[j]);
+    }
+    var findings = [];
+    var schemaIssues = [];
+    var counts = {total: 0, errors: 0, warnings: 0, info: 0, byCategory: {security: 0, performance: 0, correctness: 0, architecture: 0, schema: 0}};
+    for (var k = 0; k < pickedDiags.length; k++) {
+      var d = pickedDiags[k];
+      counts.total++;
+      if (d.severity === "error") counts.errors++;
+      else if (d.severity === "warning") counts.warnings++;
+      else counts.info++;
+      counts.byCategory[d.category]++;
+      if (typeof d.line === "number") {
+        if (!includeCode) {
+          var copy = {};
+          for (var key in d) if (key !== "sourceLines") copy[key] = d[key];
+          findings.push(copy);
+        } else {
+          findings.push(d);
+        }
+      } else {
+        schemaIssues.push(d);
+      }
+    }
+    var sharedEndpoints;
+    if (picked.indexOf("endpoints") >= 0) {
+      sharedEndpoints = [];
+      for (var e = 0; e < endpoints.endpoints.length; e++) {
+        var ep = endpoints.endpoints[e];
+        sharedEndpoints.push({controllerClass: ep.controllerClass, handlerMethod: ep.handlerMethod, httpMethod: ep.httpMethod, routePath: ep.routePath});
+      }
+    }
+    return {
+      version: SHARE_VERSION,
+      generator: REPORT.generator,
+      generatedAt: new Date().toISOString(),
+      project: REPORT.project,
+      score: REPORT.score,
+      summary: counts,
+      sections: picked,
+      includeCode: includeCode && findings.length > 0,
+      findings: findings,
+      schemaIssues: schemaIssues,
+      endpoints: sharedEndpoints
+    };
+  }
+
+  btn.addEventListener("click", function() {
+    var old = document.getElementById("share-overlay");
+    if (old) { document.body.removeChild(old); return; }
+
+    var overlay = document.createElement("div");
+    overlay.id = "share-overlay";
+    overlay.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:9999;display:flex;align-items:center;justify-content:center";
+
+    var sections = shareSections();
+    var html = '<div id="share-panel" style="background:#141420;border:1px solid #2a2a3a;border-radius:10px;padding:20px 24px;width:340px;max-width:90vw;color:#e8e8f0;font-family:var(--font);box-shadow:0 12px 40px rgba(0,0,0,0.5)">';
+    html += '<div style="font-weight:700;font-size:14px;margin-bottom:12px">Share the report</div>';
+    for (var i = 0; i < sections.length; i++) {
+      var s = sections[i];
+      html += '<label style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:13px;cursor:pointer"><input type="checkbox" class="share-section" value="' + s.id + '" checked> ' + s.label + ' (' + s.count + ')</label>';
+    }
+    html += '<label style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:13px;cursor:pointer;margin-top:4px"><input type="checkbox" id="share-code"> Include code snippets <span style="color:#8888a0">a few lines around each finding</span></label>';
+    html += '<div style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end">';
+    html += '<button id="share-download" style="padding:6px 14px;border-radius:6px;border:1px solid #ea2845;background:#ea2845;color:#fff;font-family:var(--font);font-size:13px;cursor:pointer">Download .json</button>';
+    html += '</div></div>';
+    overlay.innerHTML = html;
+
+    function close() { if (overlay.parentNode) document.body.removeChild(overlay); }
+    overlay.addEventListener("click", function(e) { if (e.target === overlay) close(); });
+    document.addEventListener("keydown", function esc(e) {
+      if (e.key === "Escape") { close(); document.removeEventListener("keydown", esc); }
+    });
+
+    overlay.querySelector("#share-download").addEventListener("click", function() {
+      var picked = [];
+      var boxes = overlay.querySelectorAll(".share-section");
+      for (var i = 0; i < boxes.length; i++) {
+        if (boxes[i].checked) picked.push(boxes[i].value);
+      }
+      if (picked.length === 0) return;
+      var includeCode = overlay.querySelector("#share-code").checked;
+      var data = buildSharedJson(includeCode, picked);
+      var blob = new Blob([JSON.stringify(data, null, 2)], {type: "application/json"});
+      var a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = project.name + "-nestjs-doctor.shared.json";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(a.href);
+      close();
+    });
+
+    document.body.appendChild(overlay);
+  });
+})();`;
 }

--- a/packages/nestjs-doctor/tests/unit/report-share.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-share.test.ts
@@ -1,0 +1,272 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type {
+	CodeDiagnostic,
+	Diagnostic,
+} from "../../src/common/diagnostic.js";
+import type { DiagnoseResult } from "../../src/common/result.js";
+import {
+	buildSharedReport,
+	ENDPOINTS_SECTION,
+	enumerateShareSections,
+	parseShareSections,
+	SCORE_SECTION,
+	SHARED_REPORT_VERSION,
+	writeSharedReportFile,
+} from "../../src/report/share.js";
+
+const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
+	category: "security",
+	column: 1,
+	filePath: "/repo/src/a.service.ts",
+	help: "Do better.",
+	line: 3,
+	message: "Hardcoded secret.",
+	rule: "security/hardcoded-secret",
+	severity: "error",
+	sourceLines: [
+		{ line: 2, text: "const a = 1;" },
+		{ line: 3, text: "b();" },
+	],
+	...overrides,
+});
+
+const schemaIssue = (category: "schema"): Diagnostic => ({
+	category,
+	entity: "User",
+	filePath: "/repo/prisma/schema.prisma",
+	help: "Add an index.",
+	message: "Foreign key is unindexed.",
+	rule: "schema/missing-index",
+	severity: "warning",
+});
+
+function resultWith(diagnostics: Diagnostic[]): DiagnoseResult {
+	const byCategory = {
+		security: 0,
+		performance: 0,
+		correctness: 0,
+		architecture: 0,
+		schema: 0,
+	};
+	for (const diagnostic of diagnostics) {
+		byCategory[diagnostic.category]++;
+	}
+	return {
+		diagnostics,
+		elapsedMs: 10,
+		project: {
+			name: "app",
+			nestVersion: "11.0.0",
+			orm: null,
+			framework: null,
+			fileCount: 4,
+			moduleCount: 1,
+		},
+		ruleErrors: [],
+		score: { value: 55, label: "Needs work" },
+		summary: {
+			total: diagnostics.length,
+			errors: byCategory.security,
+			warnings: diagnostics.length - byCategory.security,
+			info: 0,
+			byCategory,
+		},
+	};
+}
+
+describe("enumerateShareSections", () => {
+	it("always offers the score and only categories that have findings", () => {
+		const sections = enumerateShareSections(
+			resultWith([code({}), schemaIssue("schema")])
+		);
+
+		expect(sections.map((section) => section.id)).toEqual([
+			SCORE_SECTION,
+			"findings:security",
+			"findings:schema",
+		]);
+		expect(sections.map((section) => section.count)).toEqual([55, 1, 1]);
+	});
+
+	it("offers endpoints only when the result has them", () => {
+		const bare = enumerateShareSections(resultWith([]));
+		expect(bare).toHaveLength(1);
+
+		const withEndpoints = resultWith([]);
+		withEndpoints.endpoints = {
+			endpoints: [
+				{
+					controllerClass: "CatsController",
+					dependencies: [],
+					endLine: 9,
+					filePath: "/repo/src/cats.controller.ts",
+					handlerMethod: "findMany",
+					httpMethod: "GET",
+					line: 7,
+					returnType: null,
+					routePath: "/cats",
+					swagger: null,
+				},
+			],
+		};
+		expect(enumerateShareSections(withEndpoints)).toEqual([
+			{
+				id: SCORE_SECTION,
+				count: 55,
+				label: "Health score and project info",
+			},
+			{
+				id: ENDPOINTS_SECTION,
+				count: 1,
+				label: "HTTP endpoints",
+			},
+		]);
+	});
+});
+
+describe("buildSharedReport", () => {
+	it("narrows to the picked categories and keeps the whole-project score", () => {
+		const shared = buildSharedReport(
+			resultWith([
+				code({ category: "performance", rule: "perf/x" }),
+				code({}),
+				schemaIssue("schema"),
+			]),
+			{ includeCode: false, sections: [SCORE_SECTION, "findings:security"] },
+			"1.2.3"
+		);
+
+		expect(shared?.score).toEqual({ value: 55, label: "Needs work" });
+		expect(shared?.findings).toHaveLength(1);
+		expect(shared?.findings[0].rule).toBe("security/hardcoded-secret");
+		expect(shared?.schemaIssues).toEqual([]);
+		expect(shared?.version).toBe(SHARED_REPORT_VERSION);
+		expect(shared?.generator).toEqual({
+			name: "nestjs-doctor",
+			version: "1.2.3",
+		});
+		expect(shared?.summary.total).toBe(1);
+	});
+
+	it("strips snippets unless includeCode is set", () => {
+		const result = resultWith([code({})]);
+
+		const withoutCode = buildSharedReport(
+			result,
+			{
+				includeCode: false,
+				sections: ["findings:security"],
+			},
+			"1.2.3"
+		);
+		expect(JSON.stringify(withoutCode)).not.toContain("sourceLines");
+		expect(withoutCode?.includeCode).toBe(false);
+
+		const withCode = buildSharedReport(
+			result,
+			{
+				includeCode: true,
+				sections: ["findings:security"],
+			},
+			"1.2.3"
+		);
+		expect(withCode?.findings[0].sourceLines).toHaveLength(2);
+		expect(withCode?.includeCode).toBe(true);
+	});
+
+	it("slims shared endpoints to their route facts", () => {
+		const result = resultWith([]);
+		result.endpoints = {
+			endpoints: [
+				{
+					controllerClass: "CatsController",
+					dependencies: [],
+					endLine: 9,
+					filePath: "/repo/src/cats.controller.ts",
+					handlerMethod: "findMany",
+					httpMethod: "GET",
+					line: 7,
+					returnType: null,
+					routePath: "/cats",
+					swagger: null,
+				},
+			],
+		};
+
+		const shared = buildSharedReport(
+			result,
+			{ includeCode: false, sections: [ENDPOINTS_SECTION] },
+			"1.2.3"
+		);
+
+		expect(shared?.endpoints).toEqual([
+			{
+				controllerClass: "CatsController",
+				handlerMethod: "findMany",
+				httpMethod: "GET",
+				routePath: "/cats",
+			},
+		]);
+		const serialized = JSON.stringify(shared);
+		expect(serialized).not.toContain("dependencies");
+		expect(serialized).not.toContain("/repo/src/cats.controller.ts");
+	});
+
+	it("returns null when nothing was selected or nothing matched", () => {
+		expect(
+			buildSharedReport(
+				resultWith([]),
+				{ includeCode: false, sections: [] },
+				"1.2.3"
+			)
+		).toBeNull();
+		expect(
+			buildSharedReport(
+				resultWith([]),
+				{ includeCode: true, sections: [ENDPOINTS_SECTION] },
+				"1.2.3"
+			)
+		).toBeNull();
+	});
+});
+
+const INVALID_MESSAGE = /Invalid --share-sections/;
+const CATEGORY_HINT = /findings:security/;
+const EMPTY_LIST_MESSAGE = /no sections/;
+
+describe("parseShareSections", () => {
+	it("parses a csv and tolerates spaces", () => {
+		expect(parseShareSections(" score, findings:security,endpoints")).toEqual({
+			sections: [SCORE_SECTION, "findings:security", ENDPOINTS_SECTION],
+		});
+	});
+
+	it("rejects unknown sections and empty lists", () => {
+		expect(parseShareSections("nope").error).toMatch(INVALID_MESSAGE);
+		expect(parseShareSections("findings:nope").error).toMatch(CATEGORY_HINT);
+		expect(parseShareSections(" , ").error).toMatch(EMPTY_LIST_MESSAGE);
+	});
+});
+
+describe("writeSharedReportFile", () => {
+	it("writes beside the scanned project when no path is named", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "nd-share-"));
+		const outPath = await writeSharedReportFile(
+			dir,
+			buildSharedReport(
+				resultWith([code({})]),
+				{ includeCode: false, sections: [SCORE_SECTION] },
+				"1.2.3"
+			) as NonNullable<ReturnType<typeof buildSharedReport>>
+		);
+
+		expect(outPath).toBe(join(dir, "nestjs-doctor-shared.json"));
+		const parsed = JSON.parse(readFileSync(outPath, "utf-8")) as {
+			score: unknown;
+		};
+		expect(parsed.score).toEqual({ value: 55, label: "Needs work" });
+	});
+});


### PR DESCRIPTION
## Context

The scan produces a health score, findings, and a full HTML report, but none of it travels well: the console output is terminal-bound, and the HTML report embeds everything — including all source text by default — so pasting or forwarding it shares far more than intended. A second effort (a loader that lets users share and browse each other's reports) needs a small, structured payload to consume.

## Problem

There is no way to export a *subset* of a scan. The machine-readable outputs are all-or-nothing (`--format json`, `report-json`), and the artifact shape carries the module graph, providers, and source text — the wrong weight and the wrong privacy posture for sharing.

## Possible flows

| Flow into report data | Affected |
|---|---|
| TUI post-scan menu → actions | Yes — new "Share the report" action + picker screen |
| Non-interactive CLI run (CI, pipes) | Yes — new `--share-sections` / `--share-code` flags on the main path |
| HTML report opened in a browser | Yes — share button in the nav + overlay, downloads JSON client-side |
| `--format json/sarif/gitlab/markdown/report-json` | No — untouched; share is additive at the end of `emit()` |
| Worker scan path | Yes, trivially — new required `PipelineOptions` fields set to inert defaults |

## Solution

One builder both surfaces reuse: `enumerateShareSections(result)` derives the section list from result content (score always; `findings:<category>` where count > 0; endpoints when present), so the TUI checkboxes and the browser overlay can never drift apart. `buildSharedReport()` slices picked categories into `findings`/`schemaIssues`, slims endpoint nodes to route facts (no dependency traces, no file paths), strips snippet windows unless code inclusion was asked for, and always carries the whole-project score.

Both surfaces produce `{version: 1, ...}` JSON written as `nestjs-doctor-shared.json`. Deliberately not done: markdown rendering in the browser (duplicate of the CLI formatter for no consumer yet), clipboard copy of the payload (the file is what the loader will consume), any upload service.

Snippet windows were already embedded per-diagnostic at rule time (`rule-runner.ts` attaches `sourceLines`), so include-code costs nothing extra — it's a filter, not an extraction. `buildSummary` moved from private to exported rather than duplicating the counter.

## Before vs after

| Path | Before | After |
|---|---|---|
| Post-scan menu | Copy-all markdown only | Sectioned `.shared.json` via picker |
| CI run | Full-report formats only | `--share-sections score,findings:security --share-code` |
| HTML report | Static page, exports nothing | Share button → same JSON via Blob download |
| Scan exit codes | — | Unchanged; bad flag values exit 2 like other validation |

## Example

```
$ nestjs-doctor . --share-sections "score,findings:security,endpoints"
Shared report written to ./nestjs-doctor-shared.json
```

```json
{
  "version": 1,
  "sections": ["score", "findings:security", "endpoints"],
  "includeCode": false,
  "score": { "value": 66, "label": "Fair" },
  "summary": { "total": 3, "errors": 1 },
  "findings": [ { "rule": "security/no-hardcoded-secrets", "...": "..." } ],
  "endpoints": [ { "httpMethod": "GET", "routePath": "/cats" } ]
}
```
