### PR TITLE
feat(report): shareable report slices from the menu, the CLI, and the page

### DIFF
--- a/.changeset/shareable-reports.md
+++ b/.changeset/shareable-reports.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": minor
 ---
 
-Shareable reports. Pick which sections to share — the health score, findings per category, endpoints — and whether to include code snippets, from the post-scan menu or the report's new share button; both write a `nestjs-doctor-shared.json`. Also available non-interactively via `--share-sections score,findings:security` and `--share-code`.
+Shareable reports. Pick which sections to share — the health score, findings per category, the relational schema, the module graph, endpoints — and whether to include code snippets, from the post-scan menu or the report's new share button; both write a `nestjs-doctor-shared.json`. Also available non-interactively via `--share-sections score,findings:security` and `--share-code`.

--- a/.changeset/shareable-reports.md
+++ b/.changeset/shareable-reports.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": minor
+---
+
+Shareable reports. Pick which sections to share — the health score, findings per category, endpoints — and whether to include code snippets, from the post-scan menu or the report's new share button; both write a `nestjs-doctor-shared.json`. Also available non-interactively via `--share-sections score,findings:security` and `--share-code`.

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -56,6 +56,11 @@ graph. Traced HTTP endpoints, the schema ER diagram, and a
 rule playground get their own tabs.
 [Module graph docs →](https://nestjs.doctor/docs/report/module-graph)
 
+The report's share button, and `--share-sections` on the CLI, write a JSON slice
+of a scan: pick the score, a findings category, the endpoints, the schema, or the
+module graph.
+[Sharing docs →](https://nestjs.doctor/docs/report/share)
+
 ![Module Graph](https://nestjs.doctor/module-graph.png)
 
 Add a few lines to `main.ts`, boot once, and `--timings` overlays the real

--- a/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
@@ -120,6 +120,8 @@ Construction times need a real boot, which a scan never performs. Use the
 | `--output <path>` | Where to write it, instead of the project root |
 | `--timings <path>` | Overlay real boot times on the report |
 | `--sources <mode>` | Report source text: all (default), touched, none |
+| `--share-sections <csv>` | Write a shareable JSON slice: score, endpoints, schema, modules, findings:<category> |
+| `--share-code` | With `--share-sections`, include code around each shared finding |
 | `--min-score <n>` | Fail below a score |
 | `--blocking <level>` | Fail on `error`, `warning`, or never with `none` |
 | `--config <path>` | Use a specific config file |

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -92,7 +92,7 @@ export const flags = {
 	"share-sections": {
 		type: "string",
 		description:
-			"Write a shareable nestjs-doctor-shared.json beside the project, limited to these comma-separated sections: score, endpoints, findings:<category> (e.g. findings:security)",
+			"Write a shareable nestjs-doctor-shared.json beside the project, limited to these comma-separated sections: score, endpoints, schema, modules, findings:<category> (e.g. findings:security)",
 	},
 	"share-code": {
 		type: "boolean",

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -89,6 +89,17 @@ export const flags = {
 		description:
 			"How much source text the report embeds: all (default), touched (only files with findings), none",
 	},
+	"share-sections": {
+		type: "string",
+		description:
+			"Write a shareable nestjs-doctor-shared.json beside the project, limited to these comma-separated sections: score, endpoints, findings:<category> (e.g. findings:security)",
+	},
+	"share-code": {
+		type: "boolean",
+		description:
+			"With --share-sections, include a few lines of code around each shared finding",
+		default: false,
+	},
 	init: {
 		type: "boolean",
 		description:

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -79,6 +79,7 @@ async function scan(args: CliArgs): Promise<void> {
 		const { runInteractiveApp } = await import("./interactive/tui/run.js");
 		await runInteractiveApp({
 			buildReportHtml: artifacts.buildReportHtml,
+			moduleGraph: artifacts.moduleGraph,
 			result: artifacts.result,
 			subProjects: artifacts.subProjects?.map(({ name, result }) => ({
 				diagnostics: result.diagnostics,

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -62,6 +62,7 @@ async function scan(args: CliArgs): Promise<void> {
 		.handleReport()
 		.validateMinScore()
 		.validateBlocking()
+		.validateShareSections()
 		.run();
 
 	if (!ctx) {

--- a/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
@@ -20,11 +20,12 @@ import { copyToClipboard } from "../clipboard.js";
 import { groupFindings } from "../findings.js";
 import { ReviewScreen } from "./review-screen.js";
 import { buildMenuItems, ScoreScreen } from "./score-screen.js";
+import { ShareScreen } from "./share-screen.js";
 import { padEnd } from "./text.js";
 import { palette } from "./theme.js";
 import type { InteractiveContext, MenuAction, Toast } from "./types.js";
 
-type Screen = "handoff" | "review" | "score";
+type Screen = "handoff" | "review" | "score" | "share";
 
 interface HandoffItem {
 	agent?: LaunchableAgent;
@@ -120,6 +121,11 @@ export const App = ({
 				setToast(null);
 				setSelectedHandoff(0);
 				setScreen("handoff");
+				return;
+			}
+			if (action === "share") {
+				setToast(null);
+				setScreen("share");
 				return;
 			}
 
@@ -277,6 +283,18 @@ export const App = ({
 				onQuit={exit}
 				onToast={setToast}
 				targetPath={context.targetPath}
+			/>
+		);
+	}
+
+	if (screen === "share") {
+		return (
+			<ShareScreen
+				onBack={() => setScreen("score")}
+				onToast={setToast}
+				result={shown}
+				targetPath={context.targetPath}
+				version={context.version}
 			/>
 		);
 	}

--- a/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/app.tsx
@@ -290,6 +290,7 @@ export const App = ({
 	if (screen === "share") {
 		return (
 			<ShareScreen
+				moduleGraph={context.moduleGraph}
 				onBack={() => setScreen("score")}
 				onToast={setToast}
 				result={shown}

--- a/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
@@ -80,6 +80,11 @@ export const buildMenuItems = (
 		hint: "The pull request summary, for pasting anywhere",
 		label: "Copy findings as markdown",
 	},
+	{
+		action: "share" as const,
+		hint: "Pick the sections and save a .json others can open",
+		label: "Share the report",
+	},
 	{ action: "quit", label: "Quit" },
 ];
 

--- a/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
@@ -1,0 +1,171 @@
+import { Box, Text, useInput } from "ink";
+import { useMemo, useState } from "react";
+import type { DiagnoseResult } from "../../../common/result.js";
+import {
+	buildSharedReport,
+	enumerateShareSections,
+	type ShareSection,
+	writeSharedReportFile,
+} from "../../../report/share.js";
+import { truncate } from "./text.js";
+import { palette } from "./theme.js";
+import type { Toast } from "./types.js";
+
+interface ShareScreenProps {
+	onBack: () => void;
+	onToast: (toast: Toast) => void;
+	result: DiagnoseResult;
+	targetPath: string;
+	version: string;
+}
+
+interface ShareRow {
+	checked: boolean;
+	kind: "code" | "section";
+	label: string;
+	section?: ShareSection;
+}
+
+export const ShareScreen = ({
+	onBack,
+	onToast,
+	result,
+	targetPath,
+	version,
+}: ShareScreenProps): React.JSX.Element => {
+	const sections = useMemo(() => enumerateShareSections(result), [result]);
+	const [rows, setRows] = useState<ShareRow[]>(() => [
+		...sections.map((section) => ({
+			checked: true,
+			kind: "section" as const,
+			label: `${section.label} (${section.count})`,
+			section,
+		})),
+		{ checked: false, kind: "code", label: "Include code snippets" },
+	]);
+	const [selected, setSelected] = useState(0);
+	const [busy, setBusy] = useState(false);
+
+	const toggle = (index: number): void => {
+		setRows((previous) =>
+			previous.map((row, at) =>
+				at === index ? { ...row, checked: !row.checked } : row
+			)
+		);
+	};
+
+	const save = async (): Promise<void> => {
+		if (busy) {
+			return;
+		}
+		const picked = rows.flatMap((row) =>
+			row.checked && row.section ? [row.section.id] : []
+		);
+		if (picked.length === 0) {
+			onToast({ kind: "error", text: "Pick at least one section." });
+			return;
+		}
+		setBusy(true);
+		try {
+			const includeCode =
+				rows.find((row) => row.kind === "code")?.checked ?? false;
+			const shared = buildSharedReport(
+				result,
+				{ includeCode, sections: picked },
+				version
+			);
+			if (!shared) {
+				onToast({
+					kind: "error",
+					text: "Nothing was shareable in those sections.",
+				});
+				return;
+			}
+			const outPath = await writeSharedReportFile(targetPath, shared);
+			onToast({
+				kind: "success",
+				text: `Shared report written to ${outPath}`,
+			});
+			onBack();
+		} catch (error) {
+			onToast({
+				kind: "error",
+				text: error instanceof Error ? error.message : String(error),
+			});
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	useInput(
+		(input, key) => {
+			if (key.upArrow || input === "k") {
+				setSelected((previous) =>
+					previous === 0 ? rows.length - 1 : previous - 1
+				);
+			} else if (key.downArrow || input === "j") {
+				setSelected((previous) => (previous + 1) % rows.length);
+			} else if (input === " ") {
+				toggle(selected);
+			} else if (input === "c") {
+				const index = rows.findIndex((row) => row.kind === "code");
+				if (index >= 0) {
+					toggle(index);
+					setSelected(index);
+				}
+			} else if (key.escape) {
+				onBack();
+			} else if (key.return) {
+				// biome-ignore lint/suspicious/noEmptyBlockStatements: save reports its own errors as a toast
+				save().catch(() => {});
+			}
+		},
+		{ isActive: true }
+	);
+
+	return (
+		<Box
+			borderColor={palette.border}
+			borderStyle="single"
+			flexDirection="column"
+		>
+			<Text bold color={palette.bright}>
+				{" SHARE THE REPORT"}
+			</Text>
+			{rows.map((row, index) => {
+				const isSelected = index === selected;
+				return (
+					<Box flexDirection="row" key={row.label}>
+						<Box
+							backgroundColor={isSelected ? palette.nestRed : undefined}
+							width={1}
+						>
+							<Text> </Text>
+						</Box>
+						<Box
+							backgroundColor={isSelected ? palette.washRed : undefined}
+							flexDirection="row"
+							gap={2}
+							paddingLeft={1}
+						>
+							<Text color={isSelected ? palette.bright : palette.text}>
+								{`[${row.checked ? "x" : " "}] ${truncate(row.label, 64)}`}
+							</Text>
+							{row.kind === "code" ? (
+								<Text color={isSelected ? palette.muted : palette.dim}>
+									{"a few lines around each finding"}
+								</Text>
+							) : null}
+						</Box>
+					</Box>
+				);
+			})}
+			<Text color={palette.dim}>
+				{`${targetPath}/nestjs-doctor-shared.json`}
+			</Text>
+			<Text color={palette.dim}>
+				{"↑↓ select · space toggle · c code · enter save · esc back"}
+			</Text>
+		</Box>
+	);
+};

--- a/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
@@ -37,10 +37,7 @@ export const ShareScreen = ({
 	targetPath,
 	version,
 }: ShareScreenProps): React.JSX.Element => {
-	const sections = useMemo(
-		() => enumerateShareSections(result, moduleGraph()),
-		[moduleGraph, result]
-	);
+	const sections = useMemo(() => enumerateShareSections(result), [result]);
 	const [rows, setRows] = useState<ShareRow[]>(() => [
 		...sections.map((section) => ({
 			checked: true,

--- a/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useInput } from "ink";
 import { useMemo, useState } from "react";
+import type { ReportArtifact } from "../../../common/artifact.js";
 import type { DiagnoseResult } from "../../../common/result.js";
 import {
 	buildSharedReport,
@@ -12,6 +13,7 @@ import { palette } from "./theme.js";
 import type { Toast } from "./types.js";
 
 interface ShareScreenProps {
+	moduleGraph: () => ReportArtifact["graph"];
 	onBack: () => void;
 	onToast: (toast: Toast) => void;
 	result: DiagnoseResult;
@@ -27,6 +29,7 @@ interface ShareRow {
 }
 
 export const ShareScreen = ({
+	moduleGraph,
 	onBack,
 	onToast,
 	result,
@@ -73,7 +76,8 @@ export const ShareScreen = ({
 				result,
 				{ includeCode, sections: picked },
 				version,
-				targetPath
+				targetPath,
+				picked.includes("modules") ? moduleGraph() : undefined
 			);
 			if (!shared) {
 				onToast({

--- a/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
@@ -2,10 +2,11 @@ import { Box, Text, useInput } from "ink";
 import { useMemo, useState } from "react";
 import type { ReportArtifact } from "../../../common/artifact.js";
 import type { DiagnoseResult } from "../../../common/result.js";
+import type { ShareSection } from "../../../common/share.js";
 import {
 	buildSharedReport,
 	enumerateShareSections,
-	type ShareSection,
+	type ShareSectionId,
 	writeSharedReportFile,
 } from "../../../report/share.js";
 import { truncate } from "./text.js";
@@ -36,7 +37,10 @@ export const ShareScreen = ({
 	targetPath,
 	version,
 }: ShareScreenProps): React.JSX.Element => {
-	const sections = useMemo(() => enumerateShareSections(result), [result]);
+	const sections = useMemo(
+		() => enumerateShareSections(result, moduleGraph()),
+		[moduleGraph, result]
+	);
 	const [rows, setRows] = useState<ShareRow[]>(() => [
 		...sections.map((section) => ({
 			checked: true,
@@ -62,7 +66,7 @@ export const ShareScreen = ({
 			return;
 		}
 		const picked = rows.flatMap((row) =>
-			row.checked && row.section ? [row.section.id] : []
+			row.checked && row.section ? [row.section.id as ShareSectionId] : []
 		);
 		if (picked.length === 0) {
 			onToast({ kind: "error", text: "Pick at least one section." });

--- a/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/share-screen.tsx
@@ -72,7 +72,8 @@ export const ShareScreen = ({
 			const shared = buildSharedReport(
 				result,
 				{ includeCode, sections: picked },
-				version
+				version,
+				targetPath
 			);
 			if (!shared) {
 				onToast({

--- a/packages/nestjs-doctor/src/cli/interactive/tui/types.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/types.ts
@@ -22,7 +22,8 @@ export type MenuAction =
 	| "markdown"
 	| "quit"
 	| "report"
-	| "review";
+	| "review"
+	| "share";
 
 /** Everything the post-scan UI needs, handed over by the pipeline. */
 export interface InteractiveContext {

--- a/packages/nestjs-doctor/src/cli/interactive/tui/types.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/types.ts
@@ -1,3 +1,4 @@
+import type { ReportArtifact } from "../../../common/artifact.js";
 import type { Diagnostic } from "../../../common/diagnostic.js";
 import type { DiagnoseResult } from "../../../common/result.js";
 
@@ -28,6 +29,8 @@ export type MenuAction =
 /** Everything the post-scan UI needs, handed over by the pipeline. */
 export interface InteractiveContext {
 	buildReportHtml: () => string;
+	/** The serialized module graph, for sharing the modules section. */
+	moduleGraph: () => ReportArtifact["graph"];
 	result: DiagnoseResult;
 	subProjects?: SubProjectView[];
 	targetPath: string;

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -105,6 +105,15 @@ async function emit(
 		);
 	}
 
+	if (
+		options.shareSections &&
+		(options.score || options.format === "report-json")
+	) {
+		logger.warn(
+			`--share-sections is ignored with ${options.score ? "--score" : "--format report-json"}; nothing was shared.`
+		);
+	}
+
 	if (options.score) {
 		writeRendered(String(result.score.value), options.outputPath);
 		return;
@@ -162,7 +171,8 @@ async function emit(
 				includeCode: options.shareCode,
 				sections: options.shareSections,
 			},
-			cliVersion
+			cliVersion,
+			targetPath
 		);
 		if (!shared) {
 			logger.warn(
@@ -170,8 +180,12 @@ async function emit(
 			);
 			return;
 		}
-		const outPath = await writeSharedReportFile(targetPath, shared);
-		logger.info(`Shared report written to ${highlighter.info(outPath)}`);
+		const outPath = await writeSharedReportFile(
+			targetPath,
+			shared,
+			options.outputPath
+		);
+		console.error(`Shared report written to ${highlighter.info(outPath)}`);
 	}
 }
 

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -4,6 +4,7 @@ import type { ReportArtifact } from "../common/artifact.js";
 import { MAX_DEPENDENCY_NODES } from "../common/endpoint.js";
 import type { DiagnoseResult, MonorepoResult } from "../common/result.js";
 import type { EngineResult, MonorepoEngineResult } from "../engine/scanner.js";
+import { buildSharedReport, writeSharedReportFile } from "../report/share.js";
 import { highlighter } from "../ui/highlighter.js";
 import { logger } from "../ui/logger.js";
 import { shouldBlock } from "./blocking.js";
@@ -70,14 +71,14 @@ function enforceGates(
 	}
 }
 
-function emit(
+async function emit(
 	result: DiagnoseResult,
 	targetPath: string,
 	options: PipelineOptions,
 	scopeWarnings: string[],
 	monorepo?: MonorepoResult,
 	artifact?: () => ReportArtifact
-): void {
+): Promise<void> {
 	// Always surfaced, on stderr, whatever the format: a silently degraded scope
 	// makes a report look cleaner than the code actually is.
 	for (const warning of scopeWarnings) {
@@ -153,30 +154,56 @@ function emit(
 			printConsoleReport(result, options.verbose, false);
 		}
 	}
+
+	if (options.shareSections) {
+		const shared = buildSharedReport(
+			result,
+			{
+				includeCode: options.shareCode,
+				sections: options.shareSections,
+			},
+			cliVersion
+		);
+		if (!shared) {
+			logger.warn(
+				"No shareable content matched --share-sections; nothing was written."
+			);
+			return;
+		}
+		const outPath = await writeSharedReportFile(targetPath, shared);
+		logger.info(`Shared report written to ${highlighter.info(outPath)}`);
+	}
 }
 
-export const outputMonorepoResults = (
+export const outputMonorepoResults = async (
 	monorepoScanResult: MonorepoEngineResult,
 	resolvedMinimumScore: number | undefined,
 	targetPath: string,
 	options: PipelineOptions,
 	scopeWarnings: string[] = [],
 	artifact?: () => ReportArtifact
-): void => {
+): Promise<void> => {
 	const { result } = monorepoScanResult;
-	emit(result.combined, targetPath, options, scopeWarnings, result, artifact);
+	await emit(
+		result.combined,
+		targetPath,
+		options,
+		scopeWarnings,
+		result,
+		artifact
+	);
 	enforceGates(result.combined, resolvedMinimumScore, options);
 };
 
-export const outputSingleProjectResults = (
+export const outputSingleProjectResults = async (
 	singleProjectScanResult: EngineResult,
 	resolvedMinimumScore: number | undefined,
 	targetPath: string,
 	options: PipelineOptions,
 	scopeWarnings: string[] = [],
 	artifact?: () => ReportArtifact
-): void => {
+): Promise<void> => {
 	const { result } = singleProjectScanResult;
-	emit(result, targetPath, options, scopeWarnings, undefined, artifact);
+	await emit(result, targetPath, options, scopeWarnings, undefined, artifact);
 	enforceGates(result, resolvedMinimumScore, options);
 };

--- a/packages/nestjs-doctor/src/cli/output.ts
+++ b/packages/nestjs-doctor/src/cli/output.ts
@@ -172,7 +172,8 @@ async function emit(
 				sections: options.shareSections,
 			},
 			cliVersion,
-			targetPath
+			targetPath,
+			options.shareSections.includes("modules") ? artifact?.().graph : undefined
 		);
 		if (!shared) {
 			logger.warn(

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -77,6 +77,8 @@ const analysisLabel = (phase: AnalysisPhase): string => {
 /** Handed to the post-scan menu so its actions reuse the finished scan. */
 export interface InteractiveArtifacts {
 	buildReportHtml: () => string;
+	/** The serialized module graph, for sharing the modules section. */
+	moduleGraph: () => ReportArtifact["graph"];
 	/** Prints the persistent score box after the TUI leaves the alt screen. */
 	printSummary: () => void;
 	result: DiagnoseResult;
@@ -398,6 +400,7 @@ export class MonorepoPipeline extends ScanPipeline {
 	get interactiveArtifacts(): InteractiveArtifacts {
 		return {
 			buildReportHtml: () => buildHtmlReport(this.reportArtifact),
+			moduleGraph: () => this.reportArtifact.graph,
 			printSummary: () => {
 				printMonorepoReport(this.result.result, this.options.verbose, true);
 			},
@@ -610,6 +613,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 	get interactiveArtifacts(): InteractiveArtifacts {
 		return {
 			buildReportHtml: () => buildHtmlReport(this.reportArtifact),
+			moduleGraph: () => this.reportArtifact.graph,
 			printSummary: () => {
 				printConsoleReport(this.result.result, this.options.verbose, true);
 			},

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -381,6 +381,7 @@ export class MonorepoPipeline extends ScanPipeline {
 		if (!this.cachedArtifact) {
 			const { moduleGraphs, result } = this.result;
 			this.cachedArtifact = buildReportArtifact({
+				targetPath: this.targetPath,
 				moduleGraph: mergeModuleGraphs(moduleGraphs),
 				result: result.combined,
 				projects: [...moduleGraphs.keys()],
@@ -596,6 +597,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 		if (!this.cachedArtifact) {
 			const { moduleGraph, files, result } = this.result;
 			this.cachedArtifact = buildReportArtifact({
+				targetPath: this.targetPath,
 				moduleGraph,
 				result,
 				files,

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -564,7 +564,7 @@ export class MonorepoPipeline extends ScanPipeline {
 			return this;
 		}
 		const step: PipelineStep = () => {
-			outputMonorepoResults(
+			return outputMonorepoResults(
 				this.result,
 				this.resolvedMinimumScore,
 				this.targetPath,
@@ -731,7 +731,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 			return this;
 		}
 		const step: PipelineStep = () => {
-			outputSingleProjectResults(
+			return outputSingleProjectResults(
 				this.result,
 				this.resolvedMinimumScore,
 				this.targetPath,

--- a/packages/nestjs-doctor/src/cli/scan-worker.ts
+++ b/packages/nestjs-doctor/src/cli/scan-worker.ts
@@ -27,6 +27,8 @@ const options: PipelineOptions = {
 	},
 	outputPath: undefined,
 	score: false,
+	shareCode: false,
+	shareSections: undefined,
 	skipOutput: true,
 	sources: "none",
 	timings: undefined,

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -291,6 +291,11 @@ export class CliSetup {
 	validateShareSections(): this {
 		this.steps.push(() => {
 			if (this.args["share-sections"] !== undefined) {
+				if (this.args.output) {
+					failWith(
+						"--share-sections writes nestjs-doctor-shared.json beside the project, so it cannot be combined with --output. Run them as separate commands."
+					);
+				}
 				const { error } = parseShareSections(this.args["share-sections"]);
 				if (error) {
 					failWith(error);

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -105,8 +105,9 @@ export function reportConflict(args: {
 	format?: string;
 	json?: boolean;
 	score?: boolean;
+	"share-sections"?: string;
 }): string | null {
-	const named = (["format", "json", "score"] as const).filter(
+	const named = (["format", "json", "score", "share-sections"] as const).filter(
 		(flag) => args[flag]
 	);
 	if (named.length === 0) {

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 import type { SourceInclusion } from "../common/artifact.js";
 import { isScopeMode, type ScopeMode } from "../common/scope.js";
 import type { BootstrapTimings } from "../common/timings.js";
+import { parseShareSections, type ShareSectionId } from "../report/share.js";
 import { logger } from "../ui/logger.js";
 import {
 	type BlockingLevel,
@@ -38,6 +39,10 @@ export interface PipelineOptions extends ScanOptions {
 	onProgress?: (label: string, done?: number, total?: number) => void;
 	outputPath: string | undefined;
 	score: boolean;
+	/** With `shareSections`, keep a few lines of code around each shared finding. */
+	shareCode: boolean;
+	/** Sections to write into a shareable JSON beside the project. */
+	shareSections: ShareSectionId[] | undefined;
 	/** Worker-internal: the worker never prints the report. */
 	skipOutput?: boolean;
 	/** How much source text the report artifact embeds. */
@@ -82,6 +87,8 @@ export interface CliArgs {
 	report: boolean;
 	scope: string | undefined;
 	score: boolean;
+	"share-code": boolean;
+	"share-sections": string | undefined;
 	sources: string | undefined;
 	staged: boolean;
 	telemetry: boolean;
@@ -280,6 +287,27 @@ export class CliSetup {
 		return this;
 	}
 
+	validateShareSections(): this {
+		this.steps.push(() => {
+			if (this.args["share-sections"] !== undefined) {
+				const { error } = parseShareSections(this.args["share-sections"]);
+				if (error) {
+					failWith(error);
+				}
+			}
+			return true;
+		});
+		return this;
+	}
+
+	private parseResolvedShareSections(): ShareSectionId[] | undefined {
+		if (!this.args["share-sections"]) {
+			return undefined;
+		}
+		const parsed = parseShareSections(this.args["share-sections"]);
+		return "sections" in parsed ? parsed.sections : undefined;
+	}
+
 	async run(): Promise<SetupContext | null> {
 		for (const step of this.steps) {
 			const shouldContinue = await step();
@@ -321,6 +349,8 @@ export class CliSetup {
 				outputPath: this.args.output,
 				scope: resolveScopeMode(this.args),
 				score,
+				shareCode: this.args["share-code"] ?? false,
+				shareSections: this.parseResolvedShareSections(),
 				sources: resolveSources(this.args),
 				staged: this.args.staged ?? false,
 				telemetry: this.args.telemetry ?? true,

--- a/packages/nestjs-doctor/src/common/artifact.ts
+++ b/packages/nestjs-doctor/src/common/artifact.ts
@@ -8,6 +8,7 @@ import type {
 } from "./result.js";
 import type { SerializedSchemaGraph } from "./schema.js";
 import type { ScopeInfo } from "./scope.js";
+import type { ShareManifest } from "./share.js";
 import type {
 	BootPhases,
 	ClassTiming,
@@ -90,6 +91,8 @@ export interface ReportArtifact {
 	/** What `diagnostics` covers. Absent when nothing was narrowed. */
 	scope?: ScopeInfo;
 	score: Score;
+	/** Precomputed share slices, so the page merges instead of rebuilding. */
+	share: ShareManifest;
 	/** Full source text keyed by absolute posix path. */
 	sources: Record<string, string>;
 	summary: DiagnoseSummary;

--- a/packages/nestjs-doctor/src/common/artifact.ts
+++ b/packages/nestjs-doctor/src/common/artifact.ts
@@ -18,7 +18,8 @@ import type {
 
 /**
  * Version of the report artifact shape. Bump when a field changes meaning;
- * consumers narrow on this literal after checking it.
+ * additive fields do not bump. Consumers narrow on this literal after
+ * checking it.
  */
 export const REPORT_ARTIFACT_VERSION = 1;
 

--- a/packages/nestjs-doctor/src/common/share.ts
+++ b/packages/nestjs-doctor/src/common/share.ts
@@ -6,6 +6,7 @@ import type {
 } from "./diagnostic.js";
 import type { DiagnoseSummary, ProjectInfo, Score } from "./result.js";
 import type { SchemaRelation, SerializedSchemaEntity } from "./schema.js";
+import type { ScopeInfo } from "./scope.js";
 
 /** A section the share flow can offer, with the count shown beside it. */
 export interface ShareSection {
@@ -62,6 +63,8 @@ export interface ShareManifest {
 	/** Offered to the share when the score section is picked. */
 	project: ProjectInfo;
 	schema?: SharedSchema;
+	/** What the scan's diagnostics covered, when anything was narrowed. */
+	scope?: ScopeInfo;
 	score: Score;
 	sections: ShareSection[];
 	version: number;
@@ -79,7 +82,10 @@ export interface SharedReport {
 	project?: ProjectInfo;
 	schema?: SharedSchema;
 	schemaIssues: SchemaDiagnostic[];
-	score: Score;
+	/** Present when the scan ran narrowed, so a thin share reads as such. */
+	scope?: ScopeInfo;
+	/** Present only when the score section is shared. */
+	score?: Score;
 	sections: string[];
 	summary: DiagnoseSummary;
 	version: number;

--- a/packages/nestjs-doctor/src/common/share.ts
+++ b/packages/nestjs-doctor/src/common/share.ts
@@ -1,0 +1,86 @@
+import type { SerializedModuleNode } from "./artifact.js";
+import type {
+	Category,
+	CodeDiagnostic,
+	SchemaDiagnostic,
+} from "./diagnostic.js";
+import type { DiagnoseSummary, ProjectInfo, Score } from "./result.js";
+import type { SchemaRelation, SerializedSchemaEntity } from "./schema.js";
+
+/** A section the share flow can offer, with the count shown beside it. */
+export interface ShareSection {
+	count: number;
+	id: string;
+	label: string;
+}
+
+export interface SharedEndpoint {
+	controllerClass: string;
+	handlerMethod: string;
+	httpMethod: string;
+	routePath: string;
+}
+
+/** One findings category's slice: its diagnostics and its counts alone. */
+export interface ShareCategorySlice {
+	findings: CodeDiagnostic[];
+	schemaIssues: SchemaDiagnostic[];
+	summary: DiagnoseSummary;
+}
+
+/** The module graph as a share exports it: no timings, relative paths. */
+export interface SharedModules {
+	bootstrapRoots?: string[];
+	circularDeps: string[][];
+	edges: Array<{ from: string; to: string }>;
+	modules: Array<
+		Omit<SerializedModuleNode, "filePath" | "hookTimings" | "initTimings"> & {
+			filePath: string;
+		}
+	>;
+	projects: string[];
+}
+
+export interface SharedSchema {
+	entities: Array<
+		Omit<SerializedSchemaEntity, "filePath"> & { filePath: string }
+	>;
+	orm: string;
+	relations: SchemaRelation[];
+}
+
+/**
+ * Everything the report page needs to assemble a shared payload without
+ * deciding anything about its shape: the sections, each section's slice,
+ * and the payload constants.
+ */
+export interface ShareManifest {
+	endpoints?: SharedEndpoint[];
+	filename: string;
+	findingsByCategory: Partial<Record<Category, ShareCategorySlice>>;
+	modules?: SharedModules;
+	/** Offered to the share when the score section is picked. */
+	project: ProjectInfo;
+	schema?: SharedSchema;
+	score: Score;
+	sections: ShareSection[];
+	version: number;
+}
+
+/** The assembled shareable document, whichever surface produced it. */
+export interface SharedReport {
+	endpoints?: SharedEndpoint[];
+	findings: CodeDiagnostic[];
+	generatedAt: string;
+	generator: { name: "nestjs-doctor"; version: string };
+	includeCode: boolean;
+	modules?: SharedModules;
+	/** Present only when the score section is shared. */
+	project?: ProjectInfo;
+	schema?: SharedSchema;
+	schemaIssues: SchemaDiagnostic[];
+	score: Score;
+	sections: string[];
+	summary: DiagnoseSummary;
+	version: number;
+}

--- a/packages/nestjs-doctor/src/engine/result-builder.ts
+++ b/packages/nestjs-doctor/src/engine/result-builder.ts
@@ -72,7 +72,7 @@ export function withSurface(
 	return { ...result, diagnostics, summary: buildSummary(diagnostics) };
 }
 
-function buildSummary(diagnostics: Diagnostic[]): DiagnoseSummary {
+export function buildSummary(diagnostics: Diagnostic[]): DiagnoseSummary {
 	const summary: DiagnoseSummary = {
 		total: 0,
 		errors: 0,

--- a/packages/nestjs-doctor/src/report/artifact.ts
+++ b/packages/nestjs-doctor/src/report/artifact.ts
@@ -14,6 +14,7 @@ import type { ModuleGraph } from "../engine/graph/module-graph.js";
 import type { ProviderInfo } from "../engine/graph/type-resolver.js";
 import { getRuleExamples } from "./data/examples.js";
 import { serializeModuleGraph } from "./formatters/module-serializer.js";
+import { buildShareManifest } from "./share.js";
 import type { BootstrapTimings } from "./timings.js";
 
 const EMPTY_SCHEMA: SerializedSchemaGraph = {
@@ -90,6 +91,8 @@ interface ReportArtifactInput {
 	providers?: ReportProvider[];
 	result: DiagnoseResult;
 	sources?: SourceInclusion;
+	/** Where the scan ran; share slices relativize their paths against it. */
+	targetPath?: string;
 	timings?: BootstrapTimings;
 	version: string;
 }
@@ -99,6 +102,17 @@ export function buildReportArtifact(
 	input: ReportArtifactInput
 ): ReportArtifact {
 	const shown = forSurface(input.result.diagnostics, "cli");
+	const graph = serializeModuleGraph(
+		input.moduleGraph,
+		input.result,
+		input.projects,
+		input.bootstrapRoots,
+		input.timings
+	);
+	const share = buildShareManifest(input.result, {
+		graph,
+		targetPath: input.targetPath,
+	});
 
 	let paths: string[];
 	switch (input.sources ?? "all") {
@@ -126,17 +140,12 @@ export function buildReportArtifact(
 		diagnostics: shown,
 		ruleErrors: input.result.ruleErrors,
 		elapsedMs: input.result.elapsedMs,
-		graph: serializeModuleGraph(
-			input.moduleGraph,
-			input.result,
-			input.projects,
-			input.bootstrapRoots,
-			input.timings
-		),
+		graph,
 		providers: input.providers ?? [],
 		endpoints: input.result.endpoints ?? { endpoints: [] },
 		schema: input.result.schema ?? EMPTY_SCHEMA,
 		examples: getRuleExamples(),
+		share,
 		sources: readSources(paths),
 	};
 }

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -148,6 +148,7 @@ export class SingleProjectReportPipeline extends ReportPipeline {
 			});
 			this._html = buildHtmlReport(
 				buildReportArtifact({
+					targetPath: this.targetPath,
 					moduleGraph,
 					result,
 					files,
@@ -250,6 +251,7 @@ export class MonorepoReportPipeline extends ReportPipeline {
 
 			this._html = buildHtmlReport(
 				buildReportArtifact({
+					targetPath: this.targetPath,
 					moduleGraph: merged,
 					result: result.combined,
 					projects,

--- a/packages/nestjs-doctor/src/report/share.ts
+++ b/packages/nestjs-doctor/src/report/share.ts
@@ -82,12 +82,10 @@ export function parseShareSections(
 
 /**
  * The sections a result can offer, derived from its content so every
- * surface's picker shows only what exists.
+ * surface's picker shows only what exists. Reads nothing but the result,
+ * so callers never build the report artifact just to list sections.
  */
-export function enumerateShareSections(
-	result: DiagnoseResult,
-	graph?: SerializedModuleGraph
-): ShareSection[] {
+export function enumerateShareSections(result: DiagnoseResult): ShareSection[] {
 	const sections: ShareSection[] = [
 		{
 			id: SCORE_SECTION,
@@ -124,7 +122,7 @@ export function enumerateShareSections(
 			label: "Relational schema",
 		});
 	}
-	const moduleCount = graph?.modules.length ?? 0;
+	const moduleCount = result.project.moduleCount;
 	if (moduleCount > 0) {
 		sections.push({
 			id: MODULES_SECTION,
@@ -241,7 +239,7 @@ export function buildShareManifest(
 			findingsByCategory[category] = slice;
 		}
 	}
-	const sections = enumerateShareSections(result, options.graph);
+	const sections = enumerateShareSections(result);
 	const endpoints = sliceEndpoints(result);
 	const schema = sliceSchema(result, relativePath);
 	const modules = options.graph
@@ -253,6 +251,7 @@ export function buildShareManifest(
 		project: result.project,
 		sections,
 		score: result.score,
+		...(result.scope ? { scope: result.scope } : {}),
 		version: SHARED_REPORT_VERSION,
 		...(endpoints.length > 0 ? { endpoints } : {}),
 		...(schema ? { schema } : {}),
@@ -319,11 +318,13 @@ export function mergeShareSlices(
 		generator: options.generator,
 		includeCode: options.includeCode && findings.length > 0,
 		schemaIssues,
-		score: manifest.score,
 		sections: options.sections,
 		summary,
 		version: manifest.version,
-		...(has(SCORE_SECTION) ? { project: manifest.project } : {}),
+		...(has(SCORE_SECTION)
+			? { project: manifest.project, score: manifest.score }
+			: {}),
+		...(manifest.scope ? { scope: manifest.scope } : {}),
 		...(has(ENDPOINTS_SECTION) && manifest.endpoints
 			? { endpoints: manifest.endpoints }
 			: {}),
@@ -338,8 +339,7 @@ export function mergeShareSlices(
 
 /**
  * A shareable slice of a result, built by the same manifest the report page
- * assembles from. The score is carried over untouched: it measures the whole
- * project whatever the shared subset is.
+ * assembles from.
  */
 export function buildSharedReport(
 	result: DiagnoseResult,

--- a/packages/nestjs-doctor/src/report/share.ts
+++ b/packages/nestjs-doctor/src/report/share.ts
@@ -1,0 +1,200 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+	type Category,
+	type CodeDiagnostic,
+	isCodeDiagnostic,
+	isSchemaDiagnostic,
+	type SchemaDiagnostic,
+} from "../common/diagnostic.js";
+import type {
+	DiagnoseResult,
+	DiagnoseSummary,
+	Score,
+} from "../common/result.js";
+import { buildSummary } from "../engine/result-builder.js";
+
+export const SHARED_REPORT_VERSION = 1;
+
+const FINDINGS_PREFIX = "findings:";
+export const SCORE_SECTION = "score";
+export const ENDPOINTS_SECTION = "endpoints";
+const FINDINGS_CATEGORIES: Category[] = [
+	"security",
+	"performance",
+	"correctness",
+	"architecture",
+	"schema",
+];
+
+export type ShareSectionId =
+	| "score"
+	| "endpoints"
+	| `${typeof FINDINGS_PREFIX}${Category}`;
+
+/** Parses a `--share-sections` value; the string is what failed validation. */
+export function parseShareSections(
+	csv: string
+): { sections: ShareSectionId[]; error?: undefined } | { error: string } {
+	const valid = new Set<string>([SCORE_SECTION, ENDPOINTS_SECTION]);
+	for (const category of FINDINGS_CATEGORIES) {
+		valid.add(`${FINDINGS_PREFIX}${category}`);
+	}
+	const sections: ShareSectionId[] = [];
+	for (const raw of csv.split(",")) {
+		const id = raw.trim();
+		if (id.length === 0) {
+			continue;
+		}
+		if (!valid.has(id)) {
+			return {
+				error: `Invalid --share-sections value: "${id}". Must be one of ${[...valid].join(", ")}.`,
+			};
+		}
+		sections.push(id as ShareSectionId);
+	}
+	if (sections.length === 0) {
+		return { error: "Invalid --share-sections value: no sections given." };
+	}
+	return { sections };
+}
+
+export interface ShareSection {
+	count: number;
+	id: ShareSectionId;
+	label: string;
+}
+
+/**
+ * The sections a result can offer, derived from its content so both the
+ * terminal picker and report's share dialog show only what exists.
+ */
+export function enumerateShareSections(result: DiagnoseResult): ShareSection[] {
+	const sections: ShareSection[] = [
+		{
+			id: SCORE_SECTION,
+			count: result.score.value,
+			label: "Health score and project info",
+		},
+	];
+	for (const category of FINDINGS_CATEGORIES) {
+		const count = result.diagnostics.filter(
+			(diagnostic) => diagnostic.category === category
+		).length;
+		if (count > 0) {
+			sections.push({
+				id: `${FINDINGS_PREFIX}${category}` as ShareSectionId,
+				count,
+				label: `Findings · ${category}`,
+			});
+		}
+	}
+	const endpointCount = result.endpoints?.endpoints.length ?? 0;
+	if (endpointCount > 0) {
+		sections.push({
+			id: ENDPOINTS_SECTION,
+			count: endpointCount,
+			label: "HTTP endpoints",
+		});
+	}
+	return sections;
+}
+
+interface SharedEndpoint {
+	controllerClass: string;
+	handlerMethod: string;
+	httpMethod: string;
+	routePath: string;
+}
+
+interface SharedReport {
+	endpoints?: SharedEndpoint[];
+	findings: CodeDiagnostic[];
+	generatedAt: string;
+	generator: { name: "nestjs-doctor"; version: string };
+	includeCode: boolean;
+	project: DiagnoseResult["project"];
+	schemaIssues: SchemaDiagnostic[];
+	score: Score;
+	sections: ShareSectionId[];
+	summary: DiagnoseSummary;
+	version: number;
+}
+
+/**
+ * A shareable slice of a result. The score is carried over untouched: it
+ * measures the whole project whatever the shared subset is.
+ */
+export function buildSharedReport(
+	result: DiagnoseResult,
+	options: { includeCode: boolean; sections: ShareSectionId[] },
+	version: string
+): SharedReport | null {
+	const categories = new Set<Category>();
+	for (const section of options.sections) {
+		if (section.startsWith(FINDINGS_PREFIX)) {
+			categories.add(section.slice(FINDINGS_PREFIX.length) as Category);
+		}
+	}
+	const picked = result.diagnostics.filter((diagnostic) =>
+		categories.has(diagnostic.category)
+	);
+
+	const findings: CodeDiagnostic[] = picked.flatMap((diagnostic) => {
+		if (!isCodeDiagnostic(diagnostic)) {
+			return [];
+		}
+		if (options.includeCode && diagnostic.sourceLines) {
+			return [{ ...diagnostic }];
+		}
+		const { sourceLines, ...rest } = diagnostic;
+		return [rest as CodeDiagnostic];
+	});
+	const schemaIssues = picked.flatMap((diagnostic) =>
+		isSchemaDiagnostic(diagnostic) ? [diagnostic] : []
+	);
+	const endpoints = options.sections.includes(ENDPOINTS_SECTION)
+		? (result.endpoints?.endpoints ?? []).map((endpoint) => ({
+				controllerClass: endpoint.controllerClass,
+				handlerMethod: endpoint.handlerMethod,
+				httpMethod: endpoint.httpMethod,
+				routePath: endpoint.routePath,
+			}))
+		: undefined;
+	const summary = buildSummary(picked);
+	if (
+		!summary.total &&
+		(endpoints?.length ?? 0) === 0 &&
+		!options.sections.includes(SCORE_SECTION)
+	) {
+		return null;
+	}
+
+	return {
+		findings,
+		generatedAt: new Date().toISOString(),
+		generator: { name: "nestjs-doctor", version },
+		includeCode: options.includeCode && findings.length > 0,
+		project: result.project,
+		schemaIssues,
+		score: result.score,
+		sections: options.sections,
+		summary,
+		version: SHARED_REPORT_VERSION,
+		...(endpoints ? { endpoints } : {}),
+	};
+}
+
+/** Writes the shared payload beside the scanned project unless named. */
+export async function writeSharedReportFile(
+	targetPath: string,
+	shared: SharedReport,
+	outputPath?: string
+): Promise<string> {
+	const outPath = outputPath
+		? outputPath
+		: join(targetPath, "nestjs-doctor-shared.json");
+	await mkdir(dirname(outPath), { recursive: true });
+	await writeFile(outPath, `${JSON.stringify(shared, null, 2)}\n`, "utf-8");
+	return outPath;
+}

--- a/packages/nestjs-doctor/src/report/share.ts
+++ b/packages/nestjs-doctor/src/report/share.ts
@@ -1,27 +1,32 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { SerializedModuleGraph } from "../common/artifact.js";
+import type {
+	Category,
+	CodeDiagnostic,
+	SchemaDiagnostic,
+} from "../common/diagnostic.js";
 import {
-	type Category,
-	type CodeDiagnostic,
 	forSurface,
 	isCodeDiagnostic,
 	isSchemaDiagnostic,
-	type SchemaDiagnostic,
 } from "../common/diagnostic.js";
+import type { DiagnoseResult } from "../common/result.js";
+import type { SerializedSchemaEntity } from "../common/schema.js";
 import type {
-	DiagnoseResult,
-	DiagnoseSummary,
-	Score,
-} from "../common/result.js";
-import type {
-	SchemaRelation,
-	SerializedSchemaEntity,
-} from "../common/schema.js";
+	ShareCategorySlice,
+	SharedEndpoint,
+	SharedModules,
+	SharedReport,
+	SharedSchema,
+	ShareManifest,
+	ShareSection,
+} from "../common/share.js";
 import { toRelativePath } from "../engine/fingerprint.js";
 import { buildSummary } from "../engine/result-builder.js";
 
 export const SHARED_REPORT_VERSION = 1;
+const SHARED_FILENAME = "nestjs-doctor-shared.json";
 
 const FINDINGS_PREFIX = "findings:";
 export const SCORE_SECTION = "score";
@@ -75,17 +80,14 @@ export function parseShareSections(
 	return { sections };
 }
 
-export interface ShareSection {
-	count: number;
-	id: ShareSectionId;
-	label: string;
-}
-
 /**
- * The sections a result can offer, derived from its content so both the
- * terminal picker and report's share dialog show only what exists.
+ * The sections a result can offer, derived from its content so every
+ * surface's picker shows only what exists.
  */
-export function enumerateShareSections(result: DiagnoseResult): ShareSection[] {
+export function enumerateShareSections(
+	result: DiagnoseResult,
+	graph?: SerializedModuleGraph
+): ShareSection[] {
 	const sections: ShareSection[] = [
 		{
 			id: SCORE_SECTION,
@@ -93,8 +95,9 @@ export function enumerateShareSections(result: DiagnoseResult): ShareSection[] {
 			label: "Health score and project info",
 		},
 	];
+	const cliDiagnostics = forSurface(result.diagnostics, "cli");
 	for (const category of FINDINGS_CATEGORIES) {
-		const count = result.diagnostics.filter(
+		const count = cliDiagnostics.filter(
 			(diagnostic) => diagnostic.category === category
 		).length;
 		if (count > 0) {
@@ -121,85 +124,26 @@ export function enumerateShareSections(result: DiagnoseResult): ShareSection[] {
 			label: "Relational schema",
 		});
 	}
-	if (result.project.moduleCount > 0) {
+	const moduleCount = graph?.modules.length ?? 0;
+	if (moduleCount > 0) {
 		sections.push({
 			id: MODULES_SECTION,
-			count: result.project.moduleCount,
+			count: moduleCount,
 			label: "Module graph",
 		});
 	}
 	return sections;
 }
 
-interface SharedEndpoint {
-	controllerClass: string;
-	handlerMethod: string;
-	httpMethod: string;
-	routePath: string;
-}
-
-/** The module graph as a share exports it: no timings, relative paths. */
-interface SharedModuleGraph {
-	bootstrapRoots?: string[];
-	circularDeps: string[][];
-	edges: SerializedModuleGraph["edges"];
-	modules: Array<
-		Omit<
-			SerializedModuleGraph["modules"][number],
-			"hookTimings" | "initTimings" | "filePath"
-		> & { filePath: string }
-	>;
-	projects: string[];
-}
-
-interface SharedReport {
-	endpoints?: SharedEndpoint[];
-	findings: CodeDiagnostic[];
-	generatedAt: string;
-	generator: { name: "nestjs-doctor"; version: string };
-	includeCode: boolean;
-	modules?: SharedModuleGraph;
-	/** Present only when the score section is shared. */
-	project?: DiagnoseResult["project"];
-	schema?: {
-		entities: Array<
-			Omit<SerializedSchemaEntity, "filePath"> & { filePath: string }
-		>;
-		orm: string;
-		relations: SchemaRelation[];
-	};
-	schemaIssues: SchemaDiagnostic[];
-	score: Score;
-	sections: ShareSectionId[];
-	summary: DiagnoseSummary;
-	version: number;
-}
-
-/**
- * A shareable slice of a result. The score is carried over untouched: it
- * measures the whole project whatever the shared subset is. Only the cli
- * surface's diagnostics are eligible, and finding paths are stored relative
- * to the scanned directory.
- */
-export function buildSharedReport(
+/** One category's shareable diagnostics, paths relative to the scan root. */
+function sliceCategory(
 	result: DiagnoseResult,
-	options: { includeCode: boolean; sections: ShareSectionId[] },
-	version: string,
-	targetPath?: string,
-	graph?: SerializedModuleGraph
-): SharedReport | null {
-	const categories = new Set<Category>();
-	for (const section of options.sections) {
-		if (section.startsWith(FINDINGS_PREFIX)) {
-			categories.add(section.slice(FINDINGS_PREFIX.length) as Category);
-		}
-	}
-	const picked = forSurface(result.diagnostics, "cli").filter((diagnostic) =>
-		categories.has(diagnostic.category)
+	category: Category,
+	relativePath: (filePath: string) => string
+): ShareCategorySlice {
+	const picked = forSurface(result.diagnostics, "cli").filter(
+		(diagnostic) => diagnostic.category === category
 	);
-	const relativePath = (filePath: string): string =>
-		targetPath ? toRelativePath(targetPath, filePath) : filePath;
-
 	const findings: CodeDiagnostic[] = picked.flatMap((diagnostic) => {
 		if (!isCodeDiagnostic(diagnostic)) {
 			return [];
@@ -209,7 +153,7 @@ export function buildSharedReport(
 			{
 				...rest,
 				filePath: relativePath(rest.filePath),
-				...(options.includeCode && diagnostic.sourceLines
+				...(diagnostic.sourceLines
 					? {
 							sourceLines: diagnostic.sourceLines.map((entry) => ({
 								...entry,
@@ -219,70 +163,196 @@ export function buildSharedReport(
 			},
 		];
 	});
-	const schemaIssues = picked.flatMap((diagnostic) =>
-		isSchemaDiagnostic(diagnostic) ? [diagnostic] : []
-	);
-	const endpoints = options.sections.includes(ENDPOINTS_SECTION)
-		? (result.endpoints?.endpoints ?? []).map((endpoint) => ({
-				controllerClass: endpoint.controllerClass,
-				handlerMethod: endpoint.handlerMethod,
-				httpMethod: endpoint.httpMethod,
-				routePath: endpoint.routePath,
-			}))
-		: undefined;
-	const schemaGraph = result.schema;
-	const schema =
-		options.sections.includes(SCHEMA_SECTION) && schemaGraph?.entities.length
-			? {
-					entities: schemaGraph.entities.map((entity) => ({
-						...entity,
-						filePath: relativePath(entity.filePath),
-					})),
-					orm: schemaGraph.orm,
-					relations: schemaGraph.relations,
-				}
-			: undefined;
-	const modules =
-		options.sections.includes(MODULES_SECTION) && graph
-			? {
-					bootstrapRoots: graph.bootstrapRoots,
-					circularDeps: graph.circularDeps,
-					edges: graph.edges,
-					modules: graph.modules.map((module) => {
-						const { hookTimings, initTimings, ...rest } = module;
-						return { ...rest, filePath: relativePath(rest.filePath) };
-					}),
-					projects: graph.projects,
-				}
-			: undefined;
-	const summary = buildSummary(picked);
-	if (
-		!summary.total &&
-		(endpoints?.length ?? 0) === 0 &&
-		!schema &&
-		!modules &&
-		!options.sections.includes(SCORE_SECTION)
-	) {
-		return null;
+	const schemaIssues: SchemaDiagnostic[] = [];
+	for (const diagnostic of picked) {
+		if (!isSchemaDiagnostic(diagnostic)) {
+			continue;
+		}
+		schemaIssues.push({
+			...diagnostic,
+			filePath: relativePath(diagnostic.filePath),
+		});
 	}
+	return { findings, schemaIssues, summary: buildSummary(picked) };
+}
 
+function sliceEndpoints(result: DiagnoseResult): SharedEndpoint[] {
+	return (result.endpoints?.endpoints ?? []).map((endpoint) => ({
+		controllerClass: endpoint.controllerClass,
+		handlerMethod: endpoint.handlerMethod,
+		httpMethod: endpoint.httpMethod,
+		routePath: endpoint.routePath,
+	}));
+}
+
+function sliceSchema(
+	result: DiagnoseResult,
+	relativePath: (filePath: string) => string
+): SharedSchema | undefined {
+	const schema = result.schema;
+	if (!schema?.entities.length) {
+		return undefined;
+	}
 	return {
-		findings,
-		generatedAt: new Date().toISOString(),
-		generator: { name: "nestjs-doctor", version },
-		includeCode: options.includeCode && findings.length > 0,
-		schemaIssues,
+		entities: schema.entities.map((entity: SerializedSchemaEntity) => ({
+			...entity,
+			filePath: relativePath(entity.filePath),
+		})),
+		orm: schema.orm,
+		relations: schema.relations,
+	};
+}
+
+function sliceModules(
+	graph: SerializedModuleGraph,
+	relativePath: (filePath: string) => string
+): SharedModules | undefined {
+	if (graph.modules.length === 0) {
+		return undefined;
+	}
+	return {
+		bootstrapRoots: graph.bootstrapRoots,
+		circularDeps: graph.circularDeps,
+		edges: graph.edges,
+		modules: graph.modules.map((module) => {
+			const { hookTimings, initTimings, ...rest } = module;
+			return { ...rest, filePath: relativePath(rest.filePath) };
+		}),
+		projects: graph.projects,
+	};
+}
+
+/**
+ * The share payload's parts, precomputed. The report page embeds this and
+ * assembles downloads by merging slices; it decides nothing about shape.
+ */
+export function buildShareManifest(
+	result: DiagnoseResult,
+	options: { graph?: SerializedModuleGraph; targetPath?: string }
+): ShareManifest {
+	const relativePath = (filePath: string): string =>
+		options.targetPath
+			? toRelativePath(options.targetPath, filePath)
+			: filePath;
+	const findingsByCategory: ShareManifest["findingsByCategory"] = {};
+	for (const category of FINDINGS_CATEGORIES) {
+		const slice = sliceCategory(result, category, relativePath);
+		if (slice.summary.total > 0) {
+			findingsByCategory[category] = slice;
+		}
+	}
+	const sections = enumerateShareSections(result, options.graph);
+	const endpoints = sliceEndpoints(result);
+	const schema = sliceSchema(result, relativePath);
+	const modules = options.graph
+		? sliceModules(options.graph, relativePath)
+		: undefined;
+	return {
+		filename: SHARED_FILENAME,
+		findingsByCategory,
+		project: result.project,
+		sections,
 		score: result.score,
-		sections: options.sections,
-		summary,
 		version: SHARED_REPORT_VERSION,
-		...(options.sections.includes(SCORE_SECTION)
-			? { project: result.project }
-			: {}),
-		...(endpoints ? { endpoints } : {}),
+		...(endpoints.length > 0 ? { endpoints } : {}),
 		...(schema ? { schema } : {}),
 		...(modules ? { modules } : {}),
 	};
+}
+
+/**
+ * Merges manifest slices into the final payload. The only assembly logic
+ * in the codebase; the report page mirrors it over precomputed data.
+ */
+export function mergeShareSlices(
+	manifest: ShareManifest,
+	options: {
+		generator: { name: "nestjs-doctor"; version: string };
+		includeCode: boolean;
+		sections: string[];
+	}
+): SharedReport | null {
+	const categories = new Set<Category>();
+	for (const section of options.sections) {
+		if (section.startsWith(FINDINGS_PREFIX)) {
+			categories.add(section.slice(FINDINGS_PREFIX.length) as Category);
+		}
+	}
+	const findings: CodeDiagnostic[] = [];
+	const schemaIssues: SchemaDiagnostic[] = [];
+	const summary = buildSummary([]);
+	for (const category of categories) {
+		const slice = manifest.findingsByCategory[category];
+		if (!slice) {
+			continue;
+		}
+		for (const diagnostic of slice.findings) {
+			if (options.includeCode) {
+				findings.push(diagnostic);
+			} else {
+				const { sourceLines, ...rest } = diagnostic;
+				findings.push(rest);
+			}
+		}
+		schemaIssues.push(...slice.schemaIssues);
+		summary.total += slice.summary.total;
+		summary.errors += slice.summary.errors;
+		summary.warnings += slice.summary.warnings;
+		summary.info += slice.summary.info;
+		for (const category of FINDINGS_CATEGORIES) {
+			summary.byCategory[category] += slice.summary.byCategory[category];
+		}
+	}
+	const has = (section: string): boolean => options.sections.includes(section);
+	if (
+		summary.total === 0 &&
+		!has(SCORE_SECTION) &&
+		!(has(ENDPOINTS_SECTION) && manifest.endpoints) &&
+		!(has(SCHEMA_SECTION) && manifest.schema) &&
+		!(has(MODULES_SECTION) && manifest.modules)
+	) {
+		return null;
+	}
+	return {
+		findings,
+		generatedAt: new Date().toISOString(),
+		generator: options.generator,
+		includeCode: options.includeCode && findings.length > 0,
+		schemaIssues,
+		score: manifest.score,
+		sections: options.sections,
+		summary,
+		version: manifest.version,
+		...(has(SCORE_SECTION) ? { project: manifest.project } : {}),
+		...(has(ENDPOINTS_SECTION) && manifest.endpoints
+			? { endpoints: manifest.endpoints }
+			: {}),
+		...(has(SCHEMA_SECTION) && manifest.schema
+			? { schema: manifest.schema }
+			: {}),
+		...(has(MODULES_SECTION) && manifest.modules
+			? { modules: manifest.modules }
+			: {}),
+	};
+}
+
+/**
+ * A shareable slice of a result, built by the same manifest the report page
+ * assembles from. The score is carried over untouched: it measures the whole
+ * project whatever the shared subset is.
+ */
+export function buildSharedReport(
+	result: DiagnoseResult,
+	options: { includeCode: boolean; sections: ShareSectionId[] },
+	version: string,
+	targetPath?: string,
+	graph?: SerializedModuleGraph
+): SharedReport | null {
+	return mergeShareSlices(buildShareManifest(result, { graph, targetPath }), {
+		generator: { name: "nestjs-doctor", version },
+		includeCode: options.includeCode,
+		sections: options.sections,
+	});
 }
 
 /** Writes the shared payload beside the scanned project unless named. */
@@ -291,9 +361,7 @@ export async function writeSharedReportFile(
 	shared: SharedReport,
 	outputPath?: string
 ): Promise<string> {
-	const outPath = outputPath
-		? outputPath
-		: join(targetPath, "nestjs-doctor-shared.json");
+	const outPath = outputPath ? outputPath : join(targetPath, SHARED_FILENAME);
 	await mkdir(dirname(outPath), { recursive: true });
 	await writeFile(outPath, `${JSON.stringify(shared, null, 2)}\n`, "utf-8");
 	return outPath;

--- a/packages/nestjs-doctor/src/report/share.ts
+++ b/packages/nestjs-doctor/src/report/share.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import type { SerializedModuleGraph } from "../common/artifact.js";
 import {
 	type Category,
 	type CodeDiagnostic,
@@ -13,6 +14,10 @@ import type {
 	DiagnoseSummary,
 	Score,
 } from "../common/result.js";
+import type {
+	SchemaRelation,
+	SerializedSchemaEntity,
+} from "../common/schema.js";
 import { toRelativePath } from "../engine/fingerprint.js";
 import { buildSummary } from "../engine/result-builder.js";
 
@@ -20,7 +25,9 @@ export const SHARED_REPORT_VERSION = 1;
 
 const FINDINGS_PREFIX = "findings:";
 export const SCORE_SECTION = "score";
+export const SCHEMA_SECTION = "schema";
 export const ENDPOINTS_SECTION = "endpoints";
+export const MODULES_SECTION = "modules";
 const FINDINGS_CATEGORIES: Category[] = [
 	"security",
 	"performance",
@@ -31,14 +38,21 @@ const FINDINGS_CATEGORIES: Category[] = [
 
 export type ShareSectionId =
 	| "score"
+	| "schema"
 	| "endpoints"
+	| "modules"
 	| `${typeof FINDINGS_PREFIX}${Category}`;
 
 /** Parses a `--share-sections` value; the string is what failed validation. */
 export function parseShareSections(
 	csv: string
 ): { sections: ShareSectionId[]; error?: undefined } | { error: string } {
-	const valid = new Set<string>([SCORE_SECTION, ENDPOINTS_SECTION]);
+	const valid = new Set<string>([
+		SCORE_SECTION,
+		SCHEMA_SECTION,
+		ENDPOINTS_SECTION,
+		MODULES_SECTION,
+	]);
 	for (const category of FINDINGS_CATEGORIES) {
 		valid.add(`${FINDINGS_PREFIX}${category}`);
 	}
@@ -99,6 +113,21 @@ export function enumerateShareSections(result: DiagnoseResult): ShareSection[] {
 			label: "HTTP endpoints",
 		});
 	}
+	const entityCount = result.schema?.entities.length ?? 0;
+	if (entityCount > 0) {
+		sections.push({
+			id: SCHEMA_SECTION,
+			count: entityCount,
+			label: "Relational schema",
+		});
+	}
+	if (result.project.moduleCount > 0) {
+		sections.push({
+			id: MODULES_SECTION,
+			count: result.project.moduleCount,
+			label: "Module graph",
+		});
+	}
 	return sections;
 }
 
@@ -109,14 +138,36 @@ interface SharedEndpoint {
 	routePath: string;
 }
 
+/** The module graph as a share exports it: no timings, relative paths. */
+interface SharedModuleGraph {
+	bootstrapRoots?: string[];
+	circularDeps: string[][];
+	edges: SerializedModuleGraph["edges"];
+	modules: Array<
+		Omit<
+			SerializedModuleGraph["modules"][number],
+			"hookTimings" | "initTimings" | "filePath"
+		> & { filePath: string }
+	>;
+	projects: string[];
+}
+
 interface SharedReport {
 	endpoints?: SharedEndpoint[];
 	findings: CodeDiagnostic[];
 	generatedAt: string;
 	generator: { name: "nestjs-doctor"; version: string };
 	includeCode: boolean;
+	modules?: SharedModuleGraph;
 	/** Present only when the score section is shared. */
 	project?: DiagnoseResult["project"];
+	schema?: {
+		entities: Array<
+			Omit<SerializedSchemaEntity, "filePath"> & { filePath: string }
+		>;
+		orm: string;
+		relations: SchemaRelation[];
+	};
 	schemaIssues: SchemaDiagnostic[];
 	score: Score;
 	sections: ShareSectionId[];
@@ -134,7 +185,8 @@ export function buildSharedReport(
 	result: DiagnoseResult,
 	options: { includeCode: boolean; sections: ShareSectionId[] },
 	version: string,
-	targetPath?: string
+	targetPath?: string,
+	graph?: SerializedModuleGraph
 ): SharedReport | null {
 	const categories = new Set<Category>();
 	for (const section of options.sections) {
@@ -178,10 +230,37 @@ export function buildSharedReport(
 				routePath: endpoint.routePath,
 			}))
 		: undefined;
+	const schemaGraph = result.schema;
+	const schema =
+		options.sections.includes(SCHEMA_SECTION) && schemaGraph?.entities.length
+			? {
+					entities: schemaGraph.entities.map((entity) => ({
+						...entity,
+						filePath: relativePath(entity.filePath),
+					})),
+					orm: schemaGraph.orm,
+					relations: schemaGraph.relations,
+				}
+			: undefined;
+	const modules =
+		options.sections.includes(MODULES_SECTION) && graph
+			? {
+					bootstrapRoots: graph.bootstrapRoots,
+					circularDeps: graph.circularDeps,
+					edges: graph.edges,
+					modules: graph.modules.map((module) => {
+						const { hookTimings, initTimings, ...rest } = module;
+						return { ...rest, filePath: relativePath(rest.filePath) };
+					}),
+					projects: graph.projects,
+				}
+			: undefined;
 	const summary = buildSummary(picked);
 	if (
 		!summary.total &&
 		(endpoints?.length ?? 0) === 0 &&
+		!schema &&
+		!modules &&
 		!options.sections.includes(SCORE_SECTION)
 	) {
 		return null;
@@ -201,6 +280,8 @@ export function buildSharedReport(
 			? { project: result.project }
 			: {}),
 		...(endpoints ? { endpoints } : {}),
+		...(schema ? { schema } : {}),
+		...(modules ? { modules } : {}),
 	};
 }
 

--- a/packages/nestjs-doctor/src/report/share.ts
+++ b/packages/nestjs-doctor/src/report/share.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import {
 	type Category,
 	type CodeDiagnostic,
+	forSurface,
 	isCodeDiagnostic,
 	isSchemaDiagnostic,
 	type SchemaDiagnostic,
@@ -12,6 +13,7 @@ import type {
 	DiagnoseSummary,
 	Score,
 } from "../common/result.js";
+import { toRelativePath } from "../engine/fingerprint.js";
 import { buildSummary } from "../engine/result-builder.js";
 
 export const SHARED_REPORT_VERSION = 1;
@@ -113,7 +115,8 @@ interface SharedReport {
 	generatedAt: string;
 	generator: { name: "nestjs-doctor"; version: string };
 	includeCode: boolean;
-	project: DiagnoseResult["project"];
+	/** Present only when the score section is shared. */
+	project?: DiagnoseResult["project"];
 	schemaIssues: SchemaDiagnostic[];
 	score: Score;
 	sections: ShareSectionId[];
@@ -123,12 +126,15 @@ interface SharedReport {
 
 /**
  * A shareable slice of a result. The score is carried over untouched: it
- * measures the whole project whatever the shared subset is.
+ * measures the whole project whatever the shared subset is. Only the cli
+ * surface's diagnostics are eligible, and finding paths are stored relative
+ * to the scanned directory.
  */
 export function buildSharedReport(
 	result: DiagnoseResult,
 	options: { includeCode: boolean; sections: ShareSectionId[] },
-	version: string
+	version: string,
+	targetPath?: string
 ): SharedReport | null {
 	const categories = new Set<Category>();
 	for (const section of options.sections) {
@@ -136,19 +142,30 @@ export function buildSharedReport(
 			categories.add(section.slice(FINDINGS_PREFIX.length) as Category);
 		}
 	}
-	const picked = result.diagnostics.filter((diagnostic) =>
+	const picked = forSurface(result.diagnostics, "cli").filter((diagnostic) =>
 		categories.has(diagnostic.category)
 	);
+	const relativePath = (filePath: string): string =>
+		targetPath ? toRelativePath(targetPath, filePath) : filePath;
 
 	const findings: CodeDiagnostic[] = picked.flatMap((diagnostic) => {
 		if (!isCodeDiagnostic(diagnostic)) {
 			return [];
 		}
-		if (options.includeCode && diagnostic.sourceLines) {
-			return [{ ...diagnostic }];
-		}
 		const { sourceLines, ...rest } = diagnostic;
-		return [rest as CodeDiagnostic];
+		return [
+			{
+				...rest,
+				filePath: relativePath(rest.filePath),
+				...(options.includeCode && diagnostic.sourceLines
+					? {
+							sourceLines: diagnostic.sourceLines.map((entry) => ({
+								...entry,
+							})),
+						}
+					: {}),
+			},
+		];
 	});
 	const schemaIssues = picked.flatMap((diagnostic) =>
 		isSchemaDiagnostic(diagnostic) ? [diagnostic] : []
@@ -175,12 +192,14 @@ export function buildSharedReport(
 		generatedAt: new Date().toISOString(),
 		generator: { name: "nestjs-doctor", version },
 		includeCode: options.includeCode && findings.length > 0,
-		project: result.project,
 		schemaIssues,
 		score: result.score,
 		sections: options.sections,
 		summary,
 		version: SHARED_REPORT_VERSION,
+		...(options.sections.includes(SCORE_SECTION)
+			? { project: result.project }
+			: {}),
 		...(endpoints ? { endpoints } : {}),
 	};
 }

--- a/packages/nestjs-doctor/src/report/ui/html.ts
+++ b/packages/nestjs-doctor/src/report/ui/html.ts
@@ -9,6 +9,7 @@ export function getReportHtml(): string {
   <div class="meta" id="header-meta"></div>
   <div class="spacer"></div>
   <div class="nav-actions">
+    <button class="nav-btn" id="nav-share" type="button">share</button>
     <a class="nav-btn" href="https://nestjs.doctor/docs" target="_blank" rel="noopener">docs</a>
     <a class="nav-btn" href="https://github.com/RoloBits/nestjs-doctor" target="_blank" rel="noopener">github</a>
   </div>

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6469,114 +6469,47 @@ switchTab("summary");
 (function() {
   var btn = document.getElementById("nav-share");
   if (!btn) return;
-  var SHARE_CATS = ["security", "performance", "correctness", "architecture", "schema"];
-  var SHARE_VERSION = 1;
-
-  function shareSections() {
-    var secs = [{id: "score", label: "Health score", count: project.score.value}];
-    for (var i = 0; i < SHARE_CATS.length; i++) {
-      var cat = SHARE_CATS[i], n = 0;
-      for (var j = 0; j < diagnostics.length; j++) {
-        if (diagnostics[j].category === cat && !diagIsNotScored(diagnostics[j])) n++;
-      }
-      if (n > 0) secs.push({id: "findings:" + cat, label: "Findings \\u00b7 " + cat, count: n});
-    }
-    if (endpoints.endpoints.length > 0) {
-      secs.push({id: "endpoints", label: "HTTP endpoints", count: endpoints.endpoints.length});
-    }
-    if (schema.entities.length > 0) {
-      secs.push({id: "schema", label: "Relational schema", count: schema.entities.length});
-    }
-    if (graph.modules.length > 0) {
-      secs.push({id: "modules", label: "Module graph", count: graph.modules.length});
-    }
-    return secs;
-  }
+  var SHARE = REPORT.share;
 
   function buildSharedJson(includeCode, picked) {
-    var cats = {};
-    for (var i = 0; i < picked.length; i++) {
-      if (picked[i].indexOf("findings:") === 0) cats[picked[i].slice(9)] = true;
-    }
-    var pickedDiags = [];
-    for (var j = 0; j < diagnostics.length; j++) {
-      if (cats[diagnostics[j].category] && !diagIsNotScored(diagnostics[j])) pickedDiags.push(diagnostics[j]);
-    }
     var findings = [];
     var schemaIssues = [];
     var counts = {total: 0, errors: 0, warnings: 0, info: 0, byCategory: {security: 0, performance: 0, correctness: 0, architecture: 0, schema: 0}};
-    for (var k = 0; k < pickedDiags.length; k++) {
-      var d = pickedDiags[k];
-      counts.total++;
-      if (d.severity === "error") counts.errors++;
-      else if (d.severity === "warning") counts.warnings++;
-      else counts.info++;
-      counts.byCategory[d.category]++;
-      if (typeof d.line === "number") {
-        if (!includeCode) {
-          var copy = {};
+    for (var i = 0; i < picked.length; i++) {
+      if (picked[i].indexOf("findings:") !== 0) continue;
+      var slice = SHARE.findingsByCategory[picked[i].slice(9)];
+      if (!slice) continue;
+      for (var f = 0; f < slice.findings.length; f++) {
+        if (includeCode) {
+          findings.push(slice.findings[f]);
+        } else {
+          var d = slice.findings[f], copy = {};
           for (var key in d) if (key !== "sourceLines") copy[key] = d[key];
           findings.push(copy);
-        } else {
-          findings.push(d);
         }
-      } else {
-        schemaIssues.push(d);
       }
+      for (var s = 0; s < slice.schemaIssues.length; s++) schemaIssues.push(slice.schemaIssues[s]);
+      counts.total += slice.summary.total;
+      counts.errors += slice.summary.errors;
+      counts.warnings += slice.summary.warnings;
+      counts.info += slice.summary.info;
+      for (var cat in counts.byCategory) counts.byCategory[cat] += slice.summary.byCategory[cat] || 0;
     }
-    var sharedEndpoints;
-    if (picked.indexOf("endpoints") >= 0) {
-      sharedEndpoints = [];
-      for (var e = 0; e < endpoints.endpoints.length; e++) {
-        var ep = endpoints.endpoints[e];
-        sharedEndpoints.push({controllerClass: ep.controllerClass, handlerMethod: ep.handlerMethod, httpMethod: ep.httpMethod, routePath: ep.routePath});
-      }
-    }
-    var sharedSchema;
-    if (picked.indexOf("schema") >= 0 && schema.entities.length > 0) {
-      var ents = [];
-      for (var s2 = 0; s2 < schema.entities.length; s2++) {
-        var ent = schema.entities[s2];
-        var entCopy = {};
-        for (var ek in ent) if (ek !== "filePath") entCopy[ek] = ent[ek];
-        ents.push(entCopy);
-      }
-      sharedSchema = {entities: ents, orm: schema.orm, relations: schema.relations};
-    }
-    var sharedModules;
-    if (picked.indexOf("modules") >= 0 && graph.modules.length > 0) {
-      var mods = [];
-      for (var m = 0; m < graph.modules.length; m++) {
-        var mod = graph.modules[m];
-        var modCopy = {};
-        for (var mk in mod) {
-          if (mk === "filePath" || mk === "hookTimings" || mk === "initTimings") continue;
-          modCopy[mk] = mod[mk];
-        }
-        mods.push(modCopy);
-      }
-      sharedModules = {
-        bootstrapRoots: graph.bootstrapRoots || [],
-        circularDeps: graph.circularDeps,
-        edges: graph.edges,
-        modules: mods,
-        projects: graph.projects
-      };
-    }
+    function has(id) { return picked.indexOf(id) >= 0; }
     return {
-      version: SHARE_VERSION,
+      version: SHARE.version,
       generator: REPORT.generator,
       generatedAt: new Date().toISOString(),
-      ...(picked.indexOf("score") >= 0 ? {project: REPORT.project} : {}),
-      score: REPORT.score,
+      ...(has("score") ? {project: SHARE.project} : {}),
+      score: SHARE.score,
       summary: counts,
       sections: picked,
       includeCode: includeCode && findings.length > 0,
       findings: findings,
       schemaIssues: schemaIssues,
-      endpoints: sharedEndpoints,
-      schema: sharedSchema,
-      modules: sharedModules
+      ...(SHARE.endpoints && has("endpoints") ? {endpoints: SHARE.endpoints} : {}),
+      ...(SHARE.schema && has("schema") ? {schema: SHARE.schema} : {}),
+      ...(SHARE.modules && has("modules") ? {modules: SHARE.modules} : {})
     };
   }
 
@@ -6588,7 +6521,7 @@ switchTab("summary");
     overlay.id = "share-overlay";
     overlay.className = "share-overlay";
 
-    var sections = shareSections();
+    var sections = SHARE.sections;
     var html = '<div id="share-panel" class="share-panel">';
     html += '<div class="share-title">Share the report</div>';
     for (var i = 0; i < sections.length; i++) {

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6484,6 +6484,12 @@ switchTab("summary");
     if (endpoints.endpoints.length > 0) {
       secs.push({id: "endpoints", label: "HTTP endpoints", count: endpoints.endpoints.length});
     }
+    if (schema.entities.length > 0) {
+      secs.push({id: "schema", label: "Relational schema", count: schema.entities.length});
+    }
+    if (graph.modules.length > 0) {
+      secs.push({id: "modules", label: "Module graph", count: graph.modules.length});
+    }
     return secs;
   }
 
@@ -6526,6 +6532,37 @@ switchTab("summary");
         sharedEndpoints.push({controllerClass: ep.controllerClass, handlerMethod: ep.handlerMethod, httpMethod: ep.httpMethod, routePath: ep.routePath});
       }
     }
+    var sharedSchema;
+    if (picked.indexOf("schema") >= 0 && schema.entities.length > 0) {
+      var ents = [];
+      for (var s2 = 0; s2 < schema.entities.length; s2++) {
+        var ent = schema.entities[s2];
+        var entCopy = {};
+        for (var ek in ent) if (ek !== "filePath") entCopy[ek] = ent[ek];
+        ents.push(entCopy);
+      }
+      sharedSchema = {entities: ents, orm: schema.orm, relations: schema.relations};
+    }
+    var sharedModules;
+    if (picked.indexOf("modules") >= 0 && graph.modules.length > 0) {
+      var mods = [];
+      for (var m = 0; m < graph.modules.length; m++) {
+        var mod = graph.modules[m];
+        var modCopy = {};
+        for (var mk in mod) {
+          if (mk === "filePath" || mk === "hookTimings" || mk === "initTimings") continue;
+          modCopy[mk] = mod[mk];
+        }
+        mods.push(modCopy);
+      }
+      sharedModules = {
+        bootstrapRoots: graph.bootstrapRoots || [],
+        circularDeps: graph.circularDeps,
+        edges: graph.edges,
+        modules: mods,
+        projects: graph.projects
+      };
+    }
     return {
       version: SHARE_VERSION,
       generator: REPORT.generator,
@@ -6537,7 +6574,9 @@ switchTab("summary");
       includeCode: includeCode && findings.length > 0,
       findings: findings,
       schemaIssues: schemaIssues,
-      endpoints: sharedEndpoints
+      endpoints: sharedEndpoints,
+      schema: sharedSchema,
+      modules: sharedModules
     };
   }
 

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6472,6 +6472,7 @@ switchTab("summary");
   var SHARE = REPORT.share;
 
   function buildSharedJson(includeCode, picked) {
+    function isNotScored(d) { return !!(d.surfaces && d.surfaces.indexOf("score") === -1); }
     var findings = [];
     var schemaIssues = [];
     var counts = {total: 0, errors: 0, warnings: 0, info: 0, byCategory: {security: 0, performance: 0, correctness: 0, architecture: 0, schema: 0}};
@@ -6480,28 +6481,39 @@ switchTab("summary");
       var slice = SHARE.findingsByCategory[picked[i].slice(9)];
       if (!slice) continue;
       for (var f = 0; f < slice.findings.length; f++) {
+        var d = slice.findings[f];
+        if (isNotScored(d)) continue;
         if (includeCode) {
-          findings.push(slice.findings[f]);
+          findings.push(d);
         } else {
-          var d = slice.findings[f], copy = {};
+          var copy = {};
           for (var key in d) if (key !== "sourceLines") copy[key] = d[key];
           findings.push(copy);
         }
+        counts.total++;
+        if (d.severity === "error") counts.errors++;
+        else if (d.severity === "warning") counts.warnings++;
+        else counts.info++;
+        counts.byCategory[d.category]++;
       }
-      for (var s = 0; s < slice.schemaIssues.length; s++) schemaIssues.push(slice.schemaIssues[s]);
-      counts.total += slice.summary.total;
-      counts.errors += slice.summary.errors;
-      counts.warnings += slice.summary.warnings;
-      counts.info += slice.summary.info;
-      for (var cat in counts.byCategory) counts.byCategory[cat] += slice.summary.byCategory[cat] || 0;
+      for (var s = 0; s < slice.schemaIssues.length; s++) {
+        var issue = slice.schemaIssues[s];
+        if (isNotScored(issue)) continue;
+        schemaIssues.push(issue);
+        counts.total++;
+        if (issue.severity === "error") counts.errors++;
+        else if (issue.severity === "warning") counts.warnings++;
+        else counts.info++;
+        counts.byCategory[issue.category]++;
+      }
     }
     function has(id) { return picked.indexOf(id) >= 0; }
     return {
       version: SHARE.version,
       generator: REPORT.generator,
       generatedAt: new Date().toISOString(),
-      ...(has("score") ? {project: SHARE.project} : {}),
-      score: SHARE.score,
+      ...(has("score") ? {project: SHARE.project, score: SHARE.score} : {}),
+      ...(SHARE.scope ? {scope: SHARE.scope} : {}),
       summary: counts,
       sections: picked,
       includeCode: includeCode && findings.length > 0,

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6463,5 +6463,132 @@ function renderEndpoints() {
   epCanvas.style.display = "none";
 }
 
-switchTab("summary");`;
+switchTab("summary");
+
+// ── Share dialog ──
+(function() {
+  var btn = document.getElementById("nav-share");
+  if (!btn) return;
+  var SHARE_CATS = ["security", "performance", "correctness", "architecture", "schema"];
+  var SHARE_VERSION = 1;
+
+  function shareSections() {
+    var secs = [{id: "score", label: "Health score", count: project.score}];
+    for (var i = 0; i < SHARE_CATS.length; i++) {
+      var cat = SHARE_CATS[i], n = 0;
+      for (var j = 0; j < diagnostics.length; j++) {
+        if (diagnostics[j].category === cat) n++;
+      }
+      if (n > 0) secs.push({id: "findings:" + cat, label: "Findings \\u00b7 " + cat, count: n});
+    }
+    if (endpoints.endpoints.length > 0) {
+      secs.push({id: "endpoints", label: "HTTP endpoints", count: endpoints.endpoints.length});
+    }
+    return secs;
+  }
+
+  function buildSharedJson(includeCode, picked) {
+    var cats = {};
+    for (var i = 0; i < picked.length; i++) {
+      if (picked[i].indexOf("findings:") === 0) cats[picked[i].slice(9)] = true;
+    }
+    var pickedDiags = [];
+    for (var j = 0; j < diagnostics.length; j++) {
+      if (cats[diagnostics[j].category]) pickedDiags.push(diagnostics[j]);
+    }
+    var findings = [];
+    var schemaIssues = [];
+    var counts = {total: 0, errors: 0, warnings: 0, info: 0, byCategory: {security: 0, performance: 0, correctness: 0, architecture: 0, schema: 0}};
+    for (var k = 0; k < pickedDiags.length; k++) {
+      var d = pickedDiags[k];
+      counts.total++;
+      if (d.severity === "error") counts.errors++;
+      else if (d.severity === "warning") counts.warnings++;
+      else counts.info++;
+      counts.byCategory[d.category]++;
+      if (typeof d.line === "number") {
+        if (!includeCode) {
+          var copy = {};
+          for (var key in d) if (key !== "sourceLines") copy[key] = d[key];
+          findings.push(copy);
+        } else {
+          findings.push(d);
+        }
+      } else {
+        schemaIssues.push(d);
+      }
+    }
+    var sharedEndpoints;
+    if (picked.indexOf("endpoints") >= 0) {
+      sharedEndpoints = [];
+      for (var e = 0; e < endpoints.endpoints.length; e++) {
+        var ep = endpoints.endpoints[e];
+        sharedEndpoints.push({controllerClass: ep.controllerClass, handlerMethod: ep.handlerMethod, httpMethod: ep.httpMethod, routePath: ep.routePath});
+      }
+    }
+    return {
+      version: SHARE_VERSION,
+      generator: REPORT.generator,
+      generatedAt: new Date().toISOString(),
+      project: REPORT.project,
+      score: REPORT.score,
+      summary: counts,
+      sections: picked,
+      includeCode: includeCode && findings.length > 0,
+      findings: findings,
+      schemaIssues: schemaIssues,
+      endpoints: sharedEndpoints
+    };
+  }
+
+  btn.addEventListener("click", function() {
+    var old = document.getElementById("share-overlay");
+    if (old) { document.body.removeChild(old); return; }
+
+    var overlay = document.createElement("div");
+    overlay.id = "share-overlay";
+    overlay.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:9999;display:flex;align-items:center;justify-content:center";
+
+    var sections = shareSections();
+    var html = '<div id="share-panel" style="background:#141420;border:1px solid #2a2a3a;border-radius:10px;padding:20px 24px;width:340px;max-width:90vw;color:#e8e8f0;font-family:var(--font);box-shadow:0 12px 40px rgba(0,0,0,0.5)">';
+    html += '<div style="font-weight:700;font-size:14px;margin-bottom:12px">Share the report</div>';
+    for (var i = 0; i < sections.length; i++) {
+      var s = sections[i];
+      html += '<label style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:13px;cursor:pointer"><input type="checkbox" class="share-section" value="' + s.id + '" checked> ' + s.label + ' (' + s.count + ')</label>';
+    }
+    html += '<label style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:13px;cursor:pointer;margin-top:4px"><input type="checkbox" id="share-code"> Include code snippets <span style="color:#8888a0">a few lines around each finding</span></label>';
+    html += '<div style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end">';
+    html += '<button id="share-download" style="padding:6px 14px;border-radius:6px;border:1px solid #ea2845;background:#ea2845;color:#fff;font-family:var(--font);font-size:13px;cursor:pointer">Download .json</button>';
+    html += '</div></div>';
+    overlay.innerHTML = html;
+
+    function close() { if (overlay.parentNode) document.body.removeChild(overlay); }
+    overlay.addEventListener("click", function(e) { if (e.target === overlay) close(); });
+    document.addEventListener("keydown", function esc(e) {
+      if (e.key === "Escape") { close(); document.removeEventListener("keydown", esc); }
+    });
+
+    overlay.querySelector("#share-download").addEventListener("click", function() {
+      var picked = [];
+      var boxes = overlay.querySelectorAll(".share-section");
+      for (var i = 0; i < boxes.length; i++) {
+        if (boxes[i].checked) picked.push(boxes[i].value);
+      }
+      if (picked.length === 0) return;
+      var includeCode = overlay.querySelector("#share-code").checked;
+      var data = buildSharedJson(includeCode, picked);
+      var blob = new Blob([JSON.stringify(data, null, 2)], {type: "application/json"});
+      var a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = project.name + "-nestjs-doctor.shared.json";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(a.href);
+      close();
+    });
+
+    document.body.appendChild(overlay);
+  });
+})();`;
 }

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6477,7 +6477,7 @@ switchTab("summary");
     for (var i = 0; i < SHARE_CATS.length; i++) {
       var cat = SHARE_CATS[i], n = 0;
       for (var j = 0; j < diagnostics.length; j++) {
-        if (diagnostics[j].category === cat) n++;
+        if (diagnostics[j].category === cat && !diagIsNotScored(diagnostics[j])) n++;
       }
       if (n > 0) secs.push({id: "findings:" + cat, label: "Findings \\u00b7 " + cat, count: n});
     }
@@ -6494,7 +6494,7 @@ switchTab("summary");
     }
     var pickedDiags = [];
     for (var j = 0; j < diagnostics.length; j++) {
-      if (cats[diagnostics[j].category]) pickedDiags.push(diagnostics[j]);
+      if (cats[diagnostics[j].category] && !diagIsNotScored(diagnostics[j])) pickedDiags.push(diagnostics[j]);
     }
     var findings = [];
     var schemaIssues = [];
@@ -6530,7 +6530,7 @@ switchTab("summary");
       version: SHARE_VERSION,
       generator: REPORT.generator,
       generatedAt: new Date().toISOString(),
-      project: REPORT.project,
+      ...(picked.indexOf("score") >= 0 ? {project: REPORT.project} : {}),
       score: REPORT.score,
       summary: counts,
       sections: picked,

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6471,8 +6471,24 @@ switchTab("summary");
   if (!btn) return;
   var SHARE = REPORT.share;
 
+  function isNotScored(d) { return !!(d.surfaces && d.surfaces.indexOf("score") === -1); }
+
+  /** What a section would actually export once not-scored findings are dropped. */
+  function scoredCount(id) {
+    if (id.indexOf("findings:") !== 0) return null;
+    var slice = SHARE.findingsByCategory[id.slice(9)];
+    if (!slice) return 0;
+    var n = 0;
+    for (var i = 0; i < slice.findings.length; i++) {
+      if (!isNotScored(slice.findings[i])) n++;
+    }
+    for (var j = 0; j < slice.schemaIssues.length; j++) {
+      if (!isNotScored(slice.schemaIssues[j])) n++;
+    }
+    return n;
+  }
+
   function buildSharedJson(includeCode, picked) {
-    function isNotScored(d) { return !!(d.surfaces && d.surfaces.indexOf("score") === -1); }
     var findings = [];
     var schemaIssues = [];
     var counts = {total: 0, errors: 0, warnings: 0, info: 0, byCategory: {security: 0, performance: 0, correctness: 0, architecture: 0, schema: 0}};
@@ -6538,7 +6554,10 @@ switchTab("summary");
     html += '<div class="share-title">Share the report</div>';
     for (var i = 0; i < sections.length; i++) {
       var s = sections[i];
-      html += '<label class="share-row"><input type="checkbox" class="share-section" value="' + s.id + '" checked> ' + s.label + ' (' + s.count + ')</label>';
+      var count = scoredCount(s.id);
+      if (count === 0) continue;
+      if (count === null) count = s.count;
+      html += '<label class="share-row"><input type="checkbox" class="share-section" value="' + s.id + '" checked> ' + s.label + ' (' + count + ')</label>';
     }
     html += '<label class="share-row" style="margin-top:4px"><input type="checkbox" id="share-code"> Include code snippets <span class="share-hint">a few lines around each finding</span></label>';
     html += '<div class="share-actions">';

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6473,7 +6473,7 @@ switchTab("summary");
   var SHARE_VERSION = 1;
 
   function shareSections() {
-    var secs = [{id: "score", label: "Health score", count: project.score}];
+    var secs = [{id: "score", label: "Health score", count: project.score.value}];
     for (var i = 0; i < SHARE_CATS.length; i++) {
       var cat = SHARE_CATS[i], n = 0;
       for (var j = 0; j < diagnostics.length; j++) {
@@ -6580,7 +6580,7 @@ switchTab("summary");
       var blob = new Blob([JSON.stringify(data, null, 2)], {type: "application/json"});
       var a = document.createElement("a");
       a.href = URL.createObjectURL(blob);
-      a.download = project.name + "-nestjs-doctor.shared.json";
+      a.download = "nestjs-doctor-shared.json";
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -6547,18 +6547,18 @@ switchTab("summary");
 
     var overlay = document.createElement("div");
     overlay.id = "share-overlay";
-    overlay.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:9999;display:flex;align-items:center;justify-content:center";
+    overlay.className = "share-overlay";
 
     var sections = shareSections();
-    var html = '<div id="share-panel" style="background:#141420;border:1px solid #2a2a3a;border-radius:10px;padding:20px 24px;width:340px;max-width:90vw;color:#e8e8f0;font-family:var(--font);box-shadow:0 12px 40px rgba(0,0,0,0.5)">';
-    html += '<div style="font-weight:700;font-size:14px;margin-bottom:12px">Share the report</div>';
+    var html = '<div id="share-panel" class="share-panel">';
+    html += '<div class="share-title">Share the report</div>';
     for (var i = 0; i < sections.length; i++) {
       var s = sections[i];
-      html += '<label style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:13px;cursor:pointer"><input type="checkbox" class="share-section" value="' + s.id + '" checked> ' + s.label + ' (' + s.count + ')</label>';
+      html += '<label class="share-row"><input type="checkbox" class="share-section" value="' + s.id + '" checked> ' + s.label + ' (' + s.count + ')</label>';
     }
-    html += '<label style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:13px;cursor:pointer;margin-top:4px"><input type="checkbox" id="share-code"> Include code snippets <span style="color:#8888a0">a few lines around each finding</span></label>';
-    html += '<div style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end">';
-    html += '<button id="share-download" style="padding:6px 14px;border-radius:6px;border:1px solid #ea2845;background:#ea2845;color:#fff;font-family:var(--font);font-size:13px;cursor:pointer">Download .json</button>';
+    html += '<label class="share-row" style="margin-top:4px"><input type="checkbox" id="share-code"> Include code snippets <span class="share-hint">a few lines around each finding</span></label>';
+    html += '<div class="share-actions">';
+    html += '<button id="share-download" class="share-download" type="button">Download .json</button>';
     html += '</div></div>';
     overlay.innerHTML = html;
 

--- a/packages/nestjs-doctor/src/report/ui/styles.ts
+++ b/packages/nestjs-doctor/src/report/ui/styles.ts
@@ -81,6 +81,7 @@ canvas:active { cursor: grabbing; }
 #header-row1 .nav-actions { display: flex; gap: 8px; flex-shrink: 0; }
 #header-row1 .nav-btn {
   display: inline-flex; align-items: center;
+  background: none; cursor: pointer; font-family: var(--font);
   text-decoration: none; color: rgba(255,255,255,0.75);
   border: 1px solid var(--border-strong);
   padding: 5px 14px;
@@ -89,6 +90,37 @@ canvas:active { cursor: grabbing; }
   transition: background 0.15s, color 0.15s, border-color 0.15s; flex-shrink: 0;
 }
 #header-row1 .nav-btn:hover { background: var(--white); border-color: var(--white); color: #000; }
+
+/* ── Share dialog ── */
+.share-overlay {
+  position: fixed; inset: 0; z-index: 9999;
+  background: rgba(0,0,0,0.7);
+  display: flex; align-items: center; justify-content: center;
+}
+.share-panel {
+  background: var(--surface); border: 1px solid var(--border-strong);
+  padding: 20px 22px; width: 360px; max-width: 90vw; max-height: 80vh; overflow: auto;
+  color: var(--text); font-family: var(--font);
+}
+.share-title {
+  font-size: 12px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.08em; margin-bottom: 14px; color: var(--text);
+}
+.share-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 5px 0; font-size: 12px; cursor: pointer; color: var(--text);
+}
+.share-row input[type="checkbox"] { accent-color: var(--nest-red); cursor: pointer; }
+.share-row .share-hint { color: var(--text-dim); }
+.share-actions { display: flex; gap: 8px; margin-top: 16px; justify-content: flex-end; }
+.share-download {
+  background: none; cursor: pointer; font-family: var(--font);
+  border: 1px solid var(--nest-red); color: var(--nest-red);
+  padding: 6px 14px; font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  transition: background 0.15s, color 0.15s;
+}
+.share-download:hover { background: var(--nest-red); color: var(--white); }
 @media (max-width: 640px) {
   #header-row1 .meta { display: none; }
 }

--- a/packages/nestjs-doctor/tests/unit/report-artifact-fixture.ts
+++ b/packages/nestjs-doctor/tests/unit/report-artifact-fixture.ts
@@ -98,6 +98,23 @@ export const EMPTY_ARTIFACT: ReportArtifact = {
 	providers: [] as ReportProvider[],
 	endpoints: { endpoints: [] },
 	schema: { entities: [], relations: [], orm: "" },
+	share: {
+		filename: "nestjs-doctor-shared.json",
+		findingsByCategory: {},
+		project: {
+			name: "app",
+			nestVersion: null,
+			orm: null,
+			framework: null,
+			fileCount: 1,
+			moduleCount: 1,
+		},
+		sections: [
+			{ count: 100, id: "score", label: "Health score and project info" },
+		],
+		score: { value: 100, label: "Excellent" },
+		version: 1,
+	},
 	examples: {},
 	sources: {},
 };

--- a/packages/nestjs-doctor/tests/unit/report-share.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-share.test.ts
@@ -1,0 +1,272 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type {
+	CodeDiagnostic,
+	Diagnostic,
+} from "../../src/common/diagnostic.js";
+import type { DiagnoseResult } from "../../src/common/result.js";
+import {
+	buildSharedReport,
+	ENDPOINTS_SECTION,
+	enumerateShareSections,
+	parseShareSections,
+	SCORE_SECTION,
+	SHARED_REPORT_VERSION,
+	writeSharedReportFile,
+} from "../../src/report/share.js";
+
+const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
+	category: "security",
+	column: 1,
+	filePath: "/repo/src/a.service.ts",
+	help: "Do better.",
+	line: 3,
+	message: "Hardcoded secret.",
+	rule: "security/hardcoded-secret",
+	severity: "error",
+	sourceLines: [
+		{ line: 2, text: "const a = 1;" },
+		{ line: 3, text: "b();" },
+	],
+	...overrides,
+});
+
+const schemaIssue = (category: "schema"): Diagnostic => ({
+	category,
+	entity: "User",
+	filePath: "/repo/prisma/schema.prisma",
+	help: "Add an index.",
+	message: "Foreign key is unindexed.",
+	rule: "schema/missing-index",
+	severity: "warning",
+});
+
+function resultWith(diagnostics: Diagnostic[]): DiagnoseResult {
+	const byCategory = {
+		security: 0,
+		performance: 0,
+		correctness: 0,
+		architecture: 0,
+		schema: 0,
+	};
+	for (const diagnostic of diagnostics) {
+		byCategory[diagnostic.category]++;
+	}
+	return {
+		diagnostics,
+		elapsedMs: 10,
+		project: {
+			name: "app",
+			nestVersion: "11.0.0",
+			orm: null,
+			framework: null,
+			fileCount: 4,
+			moduleCount: 1,
+		},
+		ruleErrors: [],
+		score: { value: 55, label: "Needs work" },
+		summary: {
+			total: diagnostics.length,
+			errors: byCategory.security,
+			warnings: diagnostics.length - byCategory.security,
+			info: 0,
+			byCategory,
+		},
+	};
+}
+
+describe("enumerateShareSections", () => {
+	it("always offers the score and only categories that have findings", () => {
+		const sections = enumerateShareSections(
+			resultWith([code({}), schemaIssue("schema")])
+		);
+
+		expect(sections.map((section) => section.id)).toEqual([
+			SCORE_SECTION,
+			"findings:security",
+			"findings:schema",
+		]);
+		expect(sections.map((section) => section.count)).toEqual([55, 1, 1]);
+	});
+
+	it("offers endpoints only when the result has them", () => {
+		const bare = enumerateShareSections(resultWith([]));
+		expect(bare).toHaveLength(1);
+
+		const withEndpoints = resultWith([]);
+		withEndpoints.endpoints = {
+			endpoints: [
+				{
+					controllerClass: "CatsController",
+					dependencies: [],
+					endLine: 9,
+					filePath: "/repo/src/cats.controller.ts",
+					handlerMethod: "findMany",
+					httpMethod: "GET",
+					line: 7,
+					returnType: null,
+					routePath: "/cats",
+					swagger: null,
+				},
+			],
+		};
+		expect(enumerateShareSections(withEndpoints)).toEqual([
+			{
+				id: SCORE_SECTION,
+				count: 55,
+				label: "Health score and project info",
+			},
+			{
+				id: ENDPOINTS_SECTION,
+				count: 1,
+				label: "HTTP endpoints",
+			},
+		]);
+	});
+});
+
+describe("buildSharedReport", () => {
+	it("narrows to the picked categories and keeps the whole-project score", () => {
+		const shared = buildSharedReport(
+			resultWith([
+				code({ category: "performance", rule: "perf/x" }),
+				code({}),
+				schemaIssue("schema"),
+			]),
+			{ includeCode: false, sections: [SCORE_SECTION, "findings:security"] },
+			"1.2.3"
+		);
+
+		expect(shared?.score).toEqual({ value: 55, label: "Needs work" });
+		expect(shared?.findings).toHaveLength(1);
+		expect(shared?.findings[0].rule).toBe("security/hardcoded-secret");
+		expect(shared?.schemaIssues).toEqual([]);
+		expect(shared?.version).toBe(SHARED_REPORT_VERSION);
+		expect(shared?.generator).toEqual({
+			name: "nestjs-doctor",
+			version: "1.2.3",
+		});
+		expect(shared?.summary.total).toBe(1);
+	});
+
+	it("strips snippets unless includeCode is set", () => {
+		const result = resultWith([code({})]);
+
+		const withoutCode = buildSharedReport(
+			result,
+			{
+				includeCode: false,
+				sections: ["findings:security"],
+			},
+			"1.2.3"
+		);
+		expect(JSON.stringify(withoutCode)).not.toContain("sourceLines");
+		expect(withoutCode?.includeCode).toBe(false);
+
+		const withCode = buildSharedReport(
+			result,
+			{
+				includeCode: true,
+				sections: ["findings:security"],
+			},
+			"1.2.3"
+		);
+		expect(withCode?.findings[0].sourceLines).toHaveLength(2);
+		expect(withCode?.includeCode).toBe(true);
+	});
+
+	it("slims shared endpoints to their route facts", () => {
+		const result = resultWith([]);
+		result.endpoints = {
+			endpoints: [
+				{
+					controllerClass: "CatsController",
+					dependencies: [],
+					endLine: 9,
+					filePath: "/repo/src/cats.controller.ts",
+					handlerMethod: "findMany",
+					httpMethod: "GET",
+					line: 7,
+					returnType: null,
+					routePath: "/cats",
+					swagger: null,
+				},
+			],
+		};
+
+		const shared = buildSharedReport(
+			result,
+			{ includeCode: false, sections: [ENDPOINTS_SECTION] },
+			"1.2.3"
+		);
+
+		expect(shared?.endpoints).toEqual([
+			{
+				controllerClass: "CatsController",
+				handlerMethod: "findMany",
+				httpMethod: "GET",
+				routePath: "/cats",
+			},
+		]);
+		const serialized = JSON.stringify(shared);
+		expect(serialized).not.toContain("dependencies");
+		expect(serialized).not.toContain("/repo/src/cats.controller.ts");
+	});
+
+	it("returns null when nothing was selected or nothing matched", () => {
+		expect(
+			buildSharedReport(
+				resultWith([]),
+				{ includeCode: false, sections: [] },
+				"1.2.3"
+			)
+		).toBeNull();
+		expect(
+			buildSharedReport(
+				resultWith([]),
+				{ includeCode: true, sections: [ENDPOINTS_SECTION] },
+				"1.2.3"
+			)
+		).toBeNull();
+	});
+});
+
+const INVALID_MESSAGE = /Invalid --share-sections/;
+const CATEGORY_HINT = /findings:security/;
+const EMPTY_LIST_MESSAGE = /no sections/;
+
+describe("parseShareSections", () => {
+	it("parses a csv and tolerates spaces", () => {
+		expect(parseShareSections(" score, findings:security,endpoints")).toEqual({
+			sections: [SCORE_SECTION, "findings:security", ENDPOINTS_SECTION],
+		});
+	});
+
+	it("rejects unknown sections and empty lists", () => {
+		expect(parseShareSections("nope").error).toMatch(INVALID_MESSAGE);
+		expect(parseShareSections("findings:nope").error).toMatch(CATEGORY_HINT);
+		expect(parseShareSections(" , ").error).toMatch(EMPTY_LIST_MESSAGE);
+	});
+});
+
+describe("writeSharedReportFile", () => {
+	it("writes beside the scanned project when no path is named", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "nd-share-"));
+		const outPath = await writeSharedReportFile(
+			dir,
+			buildSharedReport(
+				resultWith([code({})]),
+				{ includeCode: false, sections: [SCORE_SECTION] },
+				"1.2.3"
+			) as NonNullable<ReturnType<typeof buildSharedReport>>
+		);
+
+		expect(outPath).toBe(join(dir, "nestjs-doctor-shared.json"));
+		const parsed = JSON.parse(readFileSync(outPath, "utf-8")) as {
+			score: unknown;
+		};
+		expect(parsed.score).toEqual({ value: 55, label: "Needs work" });
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/report-share.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-share.test.ts
@@ -11,7 +11,9 @@ import {
 	buildSharedReport,
 	ENDPOINTS_SECTION,
 	enumerateShareSections,
+	MODULES_SECTION,
 	parseShareSections,
+	SCHEMA_SECTION,
 	SCORE_SECTION,
 	SHARED_REPORT_VERSION,
 	writeSharedReportFile,
@@ -87,13 +89,15 @@ describe("enumerateShareSections", () => {
 			SCORE_SECTION,
 			"findings:security",
 			"findings:schema",
+			MODULES_SECTION,
 		]);
-		expect(sections.map((section) => section.count)).toEqual([55, 1, 1]);
+		expect(sections.map((section) => section.count)).toEqual([55, 1, 1, 1]);
 	});
 
 	it("offers endpoints only when the result has them", () => {
-		const bare = enumerateShareSections(resultWith([]));
-		expect(bare).toHaveLength(1);
+		const projectless = resultWith([]);
+		projectless.project.moduleCount = 0;
+		expect(enumerateShareSections(projectless)).toHaveLength(1);
 
 		const withEndpoints = resultWith([]);
 		withEndpoints.endpoints = {
@@ -123,7 +127,41 @@ describe("enumerateShareSections", () => {
 				count: 1,
 				label: "HTTP endpoints",
 			},
+			{
+				id: MODULES_SECTION,
+				count: 1,
+				label: "Module graph",
+			},
 		]);
+	});
+
+	it("offers schema and modules when the result carries them", () => {
+		const result = resultWith([]);
+		result.project.moduleCount = 0;
+		result.schema = {
+			entities: [
+				{
+					columns: [],
+					filePath: "/repo/src/user.entity.ts",
+					name: "User",
+					relations: [],
+					tableName: "users",
+				},
+			],
+			orm: "prisma",
+			relations: [],
+		};
+
+		const bare = enumerateShareSections(result);
+		expect(bare.map((section) => section.id)).toEqual([
+			SCORE_SECTION,
+			SCHEMA_SECTION,
+		]);
+
+		result.project.moduleCount = 3;
+		expect(enumerateShareSections(result).map((section) => section.id)).toEqual(
+			[SCORE_SECTION, SCHEMA_SECTION, MODULES_SECTION]
+		);
 	});
 });
 
@@ -276,6 +314,91 @@ describe("buildSharedReport", () => {
 				resultWith([]),
 				{ includeCode: true, sections: [ENDPOINTS_SECTION] },
 				"1.2.3"
+			)
+		).toBeNull();
+	});
+
+	it("shares the schema with relative entity paths", () => {
+		const result = resultWith([]);
+		result.schema = {
+			entities: [
+				{
+					columns: [
+						{
+							isGenerated: false,
+							isNullable: false,
+							isPrimary: true,
+							isUnique: false,
+							name: "id",
+							type: "uuid",
+						},
+					],
+					filePath: "/repo/src/user.entity.ts",
+					name: "User",
+					relations: [],
+					tableName: "users",
+				},
+			],
+			orm: "prisma",
+			relations: [],
+		};
+
+		const shared = buildSharedReport(
+			result,
+			{ includeCode: false, sections: [SCHEMA_SECTION] },
+			"1.2.3",
+			"/repo"
+		);
+
+		expect(shared?.schema?.entities[0].filePath).toBe("src/user.entity.ts");
+		expect(shared?.schema?.orm).toBe("prisma");
+		const serialized = JSON.stringify(shared);
+		expect(serialized).not.toContain("/repo/src/user.entity.ts");
+	});
+
+	it("shares a slim module graph without timings", () => {
+		const graph = {
+			bootstrapRoots: ["AppModule"],
+			circularDepRecommendations: {},
+			circularDeps: [["A", "B"]],
+			edges: [{ from: "AppModule", to: "CatsModule" }],
+			modules: [
+				{
+					controllers: ["CatsController"],
+					exports: [],
+					filePath: "/repo/src/cats.module.ts",
+					hookTimings: [{ hook: "onModuleInit", ms: 5 } as never],
+					imports: ["AppModule"],
+					name: "CatsModule",
+					providers: [],
+				},
+			],
+			projects: [],
+			timingsTrace: { CatsModule: {} as never },
+		};
+
+		const shared = buildSharedReport(
+			resultWith([]),
+			{ includeCode: false, sections: [MODULES_SECTION] },
+			"1.2.3",
+			"/repo",
+			graph
+		);
+
+		expect(shared?.modules?.modules[0].filePath).toBe("src/cats.module.ts");
+		const serialized = JSON.stringify(shared);
+		expect(serialized).not.toContain("hookTimings");
+		expect(serialized).not.toContain("timingsTrace");
+		expect(serialized).not.toContain("circularDepRecommendations");
+	});
+
+	it("omits the modules payload when no graph was handed over", () => {
+		expect(
+			buildSharedReport(
+				resultWith([]),
+				{ includeCode: false, sections: [MODULES_SECTION] },
+				"1.2.3",
+				"/repo"
 			)
 		).toBeNull();
 	});

--- a/packages/nestjs-doctor/tests/unit/report-share.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-share.test.ts
@@ -83,20 +83,18 @@ function resultWith(diagnostics: Diagnostic[]): DiagnoseResult {
 }
 
 describe("enumerateShareSections", () => {
-	const noGraph = undefined;
-
 	it("always offers the score and only categories that have findings", () => {
 		const sections = enumerateShareSections(
-			resultWith([code({}), schemaIssue("schema")]),
-			noGraph
+			resultWith([code({}), schemaIssue("schema")])
 		);
 
 		expect(sections.map((section) => section.id)).toEqual([
 			SCORE_SECTION,
 			"findings:security",
 			"findings:schema",
+			MODULES_SECTION,
 		]);
-		expect(sections.map((section) => section.count)).toEqual([55, 1, 1]);
+		expect(sections.map((section) => section.count)).toEqual([55, 1, 1, 1]);
 	});
 
 	it("offers endpoints only when the result has them", () => {
@@ -117,7 +115,7 @@ describe("enumerateShareSections", () => {
 				},
 			],
 		};
-		expect(enumerateShareSections(withEndpoints, noGraph)).toEqual([
+		expect(enumerateShareSections(withEndpoints)).toEqual([
 			{
 				id: SCORE_SECTION,
 				count: 55,
@@ -128,11 +126,17 @@ describe("enumerateShareSections", () => {
 				count: 1,
 				label: "HTTP endpoints",
 			},
+			{
+				id: MODULES_SECTION,
+				count: 1,
+				label: "Module graph",
+			},
 		]);
 	});
 
-	it("offers schema and modules when the result carries them", () => {
+	it("offers schema and modules without touching any graph", () => {
 		const result = resultWith([]);
+		result.project.moduleCount = 0;
 		result.schema = {
 			entities: [
 				{
@@ -147,32 +151,16 @@ describe("enumerateShareSections", () => {
 			relations: [],
 		};
 
-		const bare = enumerateShareSections(result, noGraph);
+		const bare = enumerateShareSections(result);
 		expect(bare.map((section) => section.id)).toEqual([
 			SCORE_SECTION,
 			SCHEMA_SECTION,
 		]);
 
-		const graph = {
-			bootstrapRoots: [],
-			circularDepRecommendations: {},
-			circularDeps: [],
-			edges: [],
-			modules: [
-				{
-					controllers: [],
-					exports: [],
-					filePath: "/repo/src/app.module.ts",
-					imports: [],
-					name: "AppModule",
-					providers: [],
-				},
-			],
-			projects: [],
-		};
-		expect(
-			enumerateShareSections(result, graph).map((section) => section.id)
-		).toEqual([SCORE_SECTION, SCHEMA_SECTION, MODULES_SECTION]);
+		result.project.moduleCount = 3;
+		expect(enumerateShareSections(result).map((section) => section.id)).toEqual(
+			[SCORE_SECTION, SCHEMA_SECTION, MODULES_SECTION]
+		);
 	});
 });
 
@@ -213,7 +201,7 @@ describe("buildSharedReport", () => {
 		expect(shared?.findings[0].filePath).toBe("src/deep/a.service.ts");
 	});
 
-	it("drops project info when the score section is not picked", () => {
+	it("drops score and project info when the score section is not picked", () => {
 		const shared = buildSharedReport(
 			resultWith([code({})]),
 			{ includeCode: false, sections: ["findings:security"] },
@@ -222,7 +210,31 @@ describe("buildSharedReport", () => {
 		);
 
 		expect(shared?.project).toBeUndefined();
-		expect(shared?.score).toEqual({ value: 55, label: "Needs work" });
+		expect(shared?.score).toBeUndefined();
+	});
+
+	it("carries the scan scope so a narrowed share reads as narrowed", () => {
+		const result = resultWith([code({})]);
+		result.scope = { changedFiles: 1, mode: "changed" };
+
+		const shared = buildSharedReport(
+			result,
+			{ includeCode: false, sections: ["findings:security"] },
+			"1.2.3",
+			"/repo"
+		);
+
+		expect(shared?.scope).toEqual(result.scope);
+		expect(
+			buildSharedReport(
+				resultWith([]),
+				{
+					includeCode: false,
+					sections: [SCORE_SECTION],
+				},
+				"1.2.3"
+			)?.scope
+		).toBeUndefined();
 	});
 
 	it("never shares diagnostics outside the cli surface", () => {

--- a/packages/nestjs-doctor/tests/unit/report-share.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-share.test.ts
@@ -136,10 +136,12 @@ describe("buildSharedReport", () => {
 				schemaIssue("schema"),
 			]),
 			{ includeCode: false, sections: [SCORE_SECTION, "findings:security"] },
-			"1.2.3"
+			"1.2.3",
+			"/repo"
 		);
 
 		expect(shared?.score).toEqual({ value: 55, label: "Needs work" });
+		expect(shared?.project).toEqual(resultWith([]).project);
 		expect(shared?.findings).toHaveLength(1);
 		expect(shared?.findings[0].rule).toBe("security/hardcoded-secret");
 		expect(shared?.schemaIssues).toEqual([]);
@@ -149,6 +151,52 @@ describe("buildSharedReport", () => {
 			version: "1.2.3",
 		});
 		expect(shared?.summary.total).toBe(1);
+	});
+
+	it("relativises finding paths against the scanned directory", () => {
+		const shared = buildSharedReport(
+			resultWith([code({ filePath: "/repo/src/deep/a.service.ts" })]),
+			{ includeCode: false, sections: ["findings:security"] },
+			"1.2.3",
+			"/repo"
+		);
+
+		expect(shared?.findings[0].filePath).toBe("src/deep/a.service.ts");
+	});
+
+	it("drops project info when the score section is not picked", () => {
+		const shared = buildSharedReport(
+			resultWith([code({})]),
+			{ includeCode: false, sections: ["findings:security"] },
+			"1.2.3",
+			"/repo"
+		);
+
+		expect(shared?.project).toBeUndefined();
+		expect(shared?.score).toEqual({ value: 55, label: "Needs work" });
+	});
+
+	it("never shares diagnostics outside the cli surface", () => {
+		const shared = buildSharedReport(
+			resultWith([
+				code({}),
+				code({
+					category: "correctness",
+					rule: "correctness/pr-comment-only",
+					filePath: "/repo/src/b.service.ts",
+					surfaces: ["prComment"],
+				}),
+			]),
+			{
+				includeCode: false,
+				sections: ["findings:security", "findings:correctness"],
+			},
+			"1.2.3",
+			"/repo"
+		);
+
+		expect(shared?.findings).toHaveLength(1);
+		expect(shared?.findings[0].filePath).not.toContain("b.service");
 	});
 
 	it("strips snippets unless includeCode is set", () => {
@@ -268,5 +316,21 @@ describe("writeSharedReportFile", () => {
 			score: unknown;
 		};
 		expect(parsed.score).toEqual({ value: 55, label: "Needs work" });
+	});
+
+	it("honors a named output path", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "nd-share-named-"));
+		const outPath = await writeSharedReportFile(
+			"/somme/other/place",
+			buildSharedReport(
+				resultWith([]),
+				{ includeCode: false, sections: [SCORE_SECTION] },
+				"1.2.3"
+			) as NonNullable<ReturnType<typeof buildSharedReport>>,
+			join(dir, "custom.json")
+		);
+
+		expect(outPath).toBe(join(dir, "custom.json"));
+		expect(readFileSync(outPath, "utf-8")).toContain("nestjs-doctor");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-share.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-share.test.ts
@@ -7,11 +7,14 @@ import type {
 	Diagnostic,
 } from "../../src/common/diagnostic.js";
 import type { DiagnoseResult } from "../../src/common/result.js";
+import { buildReportArtifact } from "../../src/report/artifact.js";
 import {
 	buildSharedReport,
+	buildShareManifest,
 	ENDPOINTS_SECTION,
 	enumerateShareSections,
 	MODULES_SECTION,
+	mergeShareSlices,
 	parseShareSections,
 	SCHEMA_SECTION,
 	SCORE_SECTION,
@@ -80,25 +83,23 @@ function resultWith(diagnostics: Diagnostic[]): DiagnoseResult {
 }
 
 describe("enumerateShareSections", () => {
+	const noGraph = undefined;
+
 	it("always offers the score and only categories that have findings", () => {
 		const sections = enumerateShareSections(
-			resultWith([code({}), schemaIssue("schema")])
+			resultWith([code({}), schemaIssue("schema")]),
+			noGraph
 		);
 
 		expect(sections.map((section) => section.id)).toEqual([
 			SCORE_SECTION,
 			"findings:security",
 			"findings:schema",
-			MODULES_SECTION,
 		]);
-		expect(sections.map((section) => section.count)).toEqual([55, 1, 1, 1]);
+		expect(sections.map((section) => section.count)).toEqual([55, 1, 1]);
 	});
 
 	it("offers endpoints only when the result has them", () => {
-		const projectless = resultWith([]);
-		projectless.project.moduleCount = 0;
-		expect(enumerateShareSections(projectless)).toHaveLength(1);
-
 		const withEndpoints = resultWith([]);
 		withEndpoints.endpoints = {
 			endpoints: [
@@ -116,7 +117,7 @@ describe("enumerateShareSections", () => {
 				},
 			],
 		};
-		expect(enumerateShareSections(withEndpoints)).toEqual([
+		expect(enumerateShareSections(withEndpoints, noGraph)).toEqual([
 			{
 				id: SCORE_SECTION,
 				count: 55,
@@ -127,17 +128,11 @@ describe("enumerateShareSections", () => {
 				count: 1,
 				label: "HTTP endpoints",
 			},
-			{
-				id: MODULES_SECTION,
-				count: 1,
-				label: "Module graph",
-			},
 		]);
 	});
 
 	it("offers schema and modules when the result carries them", () => {
 		const result = resultWith([]);
-		result.project.moduleCount = 0;
 		result.schema = {
 			entities: [
 				{
@@ -152,16 +147,32 @@ describe("enumerateShareSections", () => {
 			relations: [],
 		};
 
-		const bare = enumerateShareSections(result);
+		const bare = enumerateShareSections(result, noGraph);
 		expect(bare.map((section) => section.id)).toEqual([
 			SCORE_SECTION,
 			SCHEMA_SECTION,
 		]);
 
-		result.project.moduleCount = 3;
-		expect(enumerateShareSections(result).map((section) => section.id)).toEqual(
-			[SCORE_SECTION, SCHEMA_SECTION, MODULES_SECTION]
-		);
+		const graph = {
+			bootstrapRoots: [],
+			circularDepRecommendations: {},
+			circularDeps: [],
+			edges: [],
+			modules: [
+				{
+					controllers: [],
+					exports: [],
+					filePath: "/repo/src/app.module.ts",
+					imports: [],
+					name: "AppModule",
+					providers: [],
+				},
+			],
+			projects: [],
+		};
+		expect(
+			enumerateShareSections(result, graph).map((section) => section.id)
+		).toEqual([SCORE_SECTION, SCHEMA_SECTION, MODULES_SECTION]);
 	});
 });
 
@@ -419,6 +430,144 @@ describe("parseShareSections", () => {
 		expect(parseShareSections("nope").error).toMatch(INVALID_MESSAGE);
 		expect(parseShareSections("findings:nope").error).toMatch(CATEGORY_HINT);
 		expect(parseShareSections(" , ").error).toMatch(EMPTY_LIST_MESSAGE);
+	});
+});
+
+describe("manifest parity", () => {
+	const graph = {
+		bootstrapRoots: ["AppModule"],
+		circularDepRecommendations: {},
+		circularDeps: [["A", "B"]] as string[][],
+		edges: [{ from: "AppModule", to: "CatsModule" }],
+		modules: [
+			{
+				controllers: [],
+				exports: [],
+				filePath: "/repo/src/cats.module.ts",
+				imports: [],
+				name: "CatsModule",
+				providers: [],
+			},
+		],
+		projects: [],
+	};
+
+	const sample = (): DiagnoseResult => {
+		const result = resultWith([
+			code({}),
+			code({ category: "performance", rule: "perf/x" }),
+			schemaIssue("schema"),
+		]);
+		result.endpoints = {
+			endpoints: [
+				{
+					controllerClass: "CatsController",
+					dependencies: [],
+					endLine: 9,
+					filePath: "/repo/src/cats.controller.ts",
+					handlerMethod: "findMany",
+					httpMethod: "GET",
+					line: 7,
+					returnType: null,
+					routePath: "/cats",
+					swagger: null,
+				},
+			],
+		};
+		result.schema = {
+			entities: [
+				{
+					columns: [],
+					filePath: "/repo/src/user.entity.ts",
+					name: "User",
+					relations: [],
+					tableName: "users",
+				},
+			],
+			orm: "prisma",
+			relations: [],
+		};
+		return result;
+	};
+
+	const ALL_SECTIONS = [
+		SCORE_SECTION,
+		"findings:security",
+		"findings:performance",
+		"findings:schema",
+		ENDPOINTS_SECTION,
+		SCHEMA_SECTION,
+		MODULES_SECTION,
+	];
+
+	it("merging the manifest equals building directly", () => {
+		const result = sample();
+		const manifest = buildShareManifest(result, {
+			graph,
+			targetPath: "/repo",
+		});
+
+		for (const includeCode of [false, true]) {
+			const direct = buildSharedReport(
+				result,
+				{ includeCode, sections: ALL_SECTIONS },
+				"1.2.3",
+				"/repo",
+				graph
+			);
+			const merged = mergeShareSlices(manifest, {
+				generator: { name: "nestjs-doctor", version: "1.2.3" },
+				includeCode,
+				sections: ALL_SECTIONS,
+			});
+			const strip = (value: unknown) => {
+				const parsed = JSON.parse(JSON.stringify(value)) as Record<
+					string,
+					unknown
+				>;
+				const { generatedAt, ...rest } = parsed;
+				return rest;
+			};
+			expect(strip(merged)).toEqual(strip(direct));
+		}
+	});
+
+	it("the artifact embeds the manifest the share flow consumes", () => {
+		const result = sample();
+		const moduleNode = {
+			controllers: [],
+			exports: [],
+			filePath: "/repo/src/cats.module.ts",
+			forwardRefImports: new Set<string>(),
+			imports: [],
+			isGlobal: false,
+			name: "CatsModule",
+			providers: [],
+		};
+		const moduleGraph = {
+			edges: new Map([["AppModule", new Set(["CatsModule"])]]),
+			modules: new Map([["CatsModule", moduleNode]]),
+			providerToModule: new Map(),
+		};
+		const artifact = buildReportArtifact({
+			moduleGraph,
+			result,
+			targetPath: "/repo",
+			version: "1.2.3",
+		});
+
+		expect(artifact.share).toEqual(
+			buildShareManifest(result, {
+				graph: artifact.graph,
+				targetPath: "/repo",
+			})
+		);
+		expect(artifact.share.sections.map((section) => section.id)).toEqual(
+			ALL_SECTIONS
+		);
+		expect(artifact.share.modules?.modules[0].filePath).toBe(
+			"src/cats.module.ts"
+		);
 	});
 });
 

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -40,6 +40,8 @@ Options:
   --report              Generate an interactive HTML report (--graph also works)
   --timings <path>      SerializedGraph dump to overlay bootstrap init times on the report
   --sources <mode>      How much source text the report carries: all (default), touched (only files with findings), none
+  --share-sections <csv> Write nestjs-doctor-shared.json beside the project with only these sections: score, endpoints, schema, modules, findings:<category>
+  --share-code          With --share-sections, include a few lines of code around each shared finding
   --config <p>          Path to config file
   --force               Overwrite an existing file (with ci install)
   --list-rules          List every built-in rule and exit
@@ -54,8 +56,10 @@ report-json, sarif, gitlab, and markdown formats.
 
 Exit codes: 0 = pass, 1 = a gate failed (min-score or blocking), 2 = bad input,
 130 = cancelled with Ctrl+C.
-`--report` writes HTML, so combining it with `--format`, `--json` or `--score`
-exits 2 rather than writing anything.
+`--report` writes HTML, so combining it with `--format`, `--json`, `--score` or
+`--share-sections` exits 2 rather than writing anything. `--share-sections` also
+refuses `--output`, and is ignored with a warning under `--score` and
+`--format report-json`.
 
 ## Scoping to a change
 
@@ -103,6 +107,31 @@ directives cannot silence either rule; use `ignore.rules`.
 The graph is decorator text, not a running app. Two `@Module()` classes with the same name in different directories collapse into one node outside a monorepo. A module produced only by a factory returning a `DynamicModule` never becomes an edge. `--report` ignores `--scope`, `--base`, `--staged`, `--min-score`, and `--blocking`, and always exits 0.
 
 Docs: https://nestjs.doctor/docs/report/module-graph
+
+## Sharing a slice
+
+`--share-sections` writes nestjs-doctor-shared.json beside the scanned project,
+carrying only the sections named: `score`, `endpoints`, `schema`, `modules`, and
+`findings:<category>` for security, performance, correctness, architecture, and
+schema. `schema` is the relational schema; `findings:schema` is what the schema
+rules reported. An unknown section exits 2. Sections with no content are skipped,
+and a run whose sections are all empty writes nothing and warns.
+
+`--share-code` adds a few lines of source around each shared finding; without it
+findings carry location and message only. File paths in the payload are relative
+to the scanned directory. The payload always carries version, generator,
+generatedAt, sections, summary, findings, schemaIssues and includeCode; project
+and score ride along only with the `score` section, scope only when the scan was
+narrowed, and endpoints, schema and modules only with theirs.
+
+The post-scan menu's "Share the report" action and the HTML report's share button
+write the same file, the second built in the browser. They differ in one way: the
+CLI and the menu share every finding on the `cli` surface, while the report's
+dialog also drops any finding whose surfaces omit `score`, which today means
+`correctness/no-async-without-await`, `correctness/prefer-readonly-injection` and
+`security/no-advisory-nestjs-packages`.
+
+Docs: https://nestjs.doctor/docs/report/share
 
 ## Boot trace
 

--- a/packages/website/src/app/docs/custom-rules/page.mdx
+++ b/packages/website/src/app/docs/custom-rules/page.mdx
@@ -39,7 +39,7 @@ A rule appears on four surfaces by default:
 
 | Surface | Where |
 | ------- | ----- |
-| `cli` | The console report and the HTML report |
+| `cli` | The console report, the HTML report, and [a shared report](/docs/report/share) |
 | `prComment` | The pull request summary, its inline review comments, the GitHub annotations, `--format sarif` and `--format gitlab` |
 | `score` | The 0-100 number |
 | `ciFailure` | `--blocking` |

--- a/packages/website/src/app/docs/pipeline/output/page.mdx
+++ b/packages/website/src/app/docs/pipeline/output/page.mdx
@@ -90,9 +90,10 @@ SCORE=$(npx nestjs-doctor . --score)
 ### Report artifact (`--format report-json`)
 
 The document the HTML report embeds, as versioned JSON: score, findings,
-summary, module graph, providers, endpoints, schema, rule examples, and source
-text. Written to `nestjs-doctor-report.json` beside the scanned project, or
-wherever `--output` points:
+summary, module graph, providers, endpoints, schema, rule examples, source text,
+and the slices behind [Sharing a report](/docs/report/share). Written to
+`nestjs-doctor-report.json` beside the scanned project, or wherever `--output`
+points:
 
 ```bash
 npx nestjs-doctor . --format report-json
@@ -103,6 +104,19 @@ The HTML report is rendered from the same artifact, so the two always agree.
 `--sources` controls how much source text it carries: `all` (default), `touched`
 (only files with findings), or `none`. `--timings` embeds boot timings in the
 graph the same way it does for `--report`.
+
+### Shared slice (`--share-sections`)
+
+A slice of the same result for someone else to read, limited to the sections you
+name. Written to `nestjs-doctor-shared.json` beside the scanned project:
+
+```bash
+npx nestjs-doctor . --share-sections score,findings:security
+```
+
+It runs alongside whichever format produced the report, rather than replacing
+it, and the notice naming the file goes to stderr. See
+[Sharing a report](/docs/report/share).
 
 ### Monorepo report
 

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -67,17 +67,20 @@ compares against the base revision rather than the file list.
 | `--report` | Build the interactive HTML report. `--graph` is an alias |
 | `--timings <path>` | Overlay boot timings on the report's module graph; with `--format report-json`, embeds them in the artifact. See [Boot trace](/docs/report/boot-trace) |
 | `--sources <mode>` | How much source text the report carries: `all` (default), `touched` (only files with findings), `none` |
+| `--share-sections <csv>` | Write a shareable slice as `nestjs-doctor-shared.json`. See [Sharing a report](/docs/report/share) |
+| `--share-code` | With `--share-sections`, include a few lines of code around each shared finding |
 
-`--format report-json` writes the same document the HTML report embeds — score,
-findings, module graph, providers, endpoints, schema, rule examples, and source
-text — as versioned JSON for another tool to load. It writes
+`--format report-json` writes the same document the HTML report embeds, as
+versioned JSON for another tool to load: the score, findings, module graph,
+providers, endpoints, schema, rule examples, source text, and the slices behind
+[Sharing a report](/docs/report/share). It writes
 `nestjs-doctor-report.json` beside the scanned project, or wherever `--output`
 points, and replaces the console report. The HTML report and the JSON artifact
 are built from that one document, so they always agree.
 
 `--report` writes HTML rather than a payload, so it refuses to share a run with
-`--format`, `--json` or `--score`. Any of those combinations exits `2` and names
-the flag. Run them as separate commands.
+`--format`, `--json`, `--score` or `--share-sections`. Any of those combinations
+exits `2` and names the flag. Run them as separate commands.
 
 Only the payload goes to stdout, so a machine-readable one stays parseable.
 Warnings print on stderr.
@@ -92,8 +95,12 @@ either stream.
 A console scan in a terminal ends on a score screen: the nest, the score with
 its bar, the severity counts, and a short action menu. Review the findings,
 open the HTML report, hand off to a coding agent, scaffold the GitHub Actions
-workflow when it is missing, or copy the findings as markdown. Everything comes
-from the scan that just ran, so nothing is scanned twice.
+workflow when it is missing, copy the findings as markdown, or share a slice of
+the report. Everything comes from the scan that just ran, so nothing is scanned
+twice.
+
+**Share the report** opens a checkbox picker over the sections the scan
+produced. See [Sharing a report](/docs/report/share).
 
 In a monorepo the breakdown is a two-pane browser. Sub-projects list worst score
 first. The left pane is the scrollable project list, and the right pane is the

--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -46,6 +46,9 @@ Endpoints and Relational Schema stay hidden until there is data. A project with
 no controllers and no ORM entities sees four tabs. The Endpoints tab is badged
 `Beta`.
 
+A **share** button in the nav writes a slice of the report as JSON, built in the
+browser. See [Sharing a report](/docs/report/share).
+
 [Module graph](/docs/report/module-graph) covers reading that tab: cycles,
 blast radius, and the toggles.
 

--- a/packages/website/src/app/docs/report/share/page.mdx
+++ b/packages/website/src/app/docs/report/share/page.mdx
@@ -1,0 +1,119 @@
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { docsMetadata } from "@/lib/docs-metadata";
+export const metadata = docsMetadata["/docs/report/share"];
+
+<BreadcrumbJsonLd path="/docs/report/share" />
+
+# Sharing a report
+
+A scan can write part of its result as JSON, so a teammate reads the parts that
+matter without the whole report. You pick the sections, and the file carries
+those and nothing else.
+
+Write one from the command line:
+
+```bash
+npx nestjs-doctor@latest . --share-sections score,findings:security
+```
+
+The file lands at `nestjs-doctor-shared.json` beside the scanned project. That
+path is fixed: `--share-sections` refuses `--output` and exits `2`, because the
+two would write over each other.
+
+## Sections
+
+| Section | Carries |
+|---|---|
+| `score` | The score and the project info behind it |
+| `findings:<category>` | Findings in one category: `security`, `performance`, `correctness`, `architecture`, `schema` |
+| `endpoints` | The traced HTTP routes, one entry per handler |
+| `schema` | The entities extracted from your ORM and their relations |
+| `modules` | The module graph: modules, edges, cycles, and bootstrap roots |
+
+`schema` and `findings:schema` are different sections. The first is the
+relational schema, the second is what the schema rules reported about it.
+
+An unknown section, an unknown category, or an empty list exits `2` and lists
+what is valid. A section with nothing behind it is skipped instead, and a run
+whose sections are all empty warns on stderr and writes no file.
+
+## Code snippets
+
+A shared finding carries its file, line, rule and message, never the source
+around it, unless you ask for it:
+
+```bash
+npx nestjs-doctor@latest . --share-sections findings:security --share-code
+```
+
+Each finding then carries a few lines of context. `--share-code` on its own is
+inert and silent, because there is no share for it to add them to.
+
+## From the menu and the report
+
+A console scan in a terminal ends on the score screen, whose **Share the
+report** action opens the same picker: one checkbox per section with its count,
+one for code snippets, `enter` to save. It writes the same
+`nestjs-doctor-shared.json` beside the project. See
+[The menu](/docs/reference/cli#the-menu).
+
+The HTML report carries a **share** button in its nav. The dialog builds the
+file in the browser and downloads it, so a report someone mailed you shares
+without a scan and without a network request.
+
+## What the file holds
+
+| Key | Present |
+|---|---|
+| `version`, `generator`, `generatedAt` | Always |
+| `sections` | Always. The ids you picked |
+| `summary` | Always. Totals across the shared categories only |
+| `findings`, `schemaIssues` | Always, possibly empty |
+| `includeCode` | Always. True only when code snippets were asked for and a finding carried them |
+| `project`, `score` | Only with the `score` section |
+| `scope` | Only when the scan was narrowed, so a thin share reads as narrowed |
+| `endpoints`, `schema`, `modules` | Only with that section, and only when it had content |
+
+File paths inside are relative to the scanned directory, so the file names no
+absolute path from your machine. The module graph is stripped of boot timings.
+
+Both gates run after the file is written, so a run that fails `--min-score` or
+`--blocking` still leaves the share behind.
+
+## Which findings reach the file
+
+`--share-sections` and the menu share every finding the console reported,
+meaning every finding on the `cli` surface. The report's share button is
+stricter: it drops any finding that does not also carry the `score` surface,
+and offers no row for a category whose findings are all dropped.
+
+Three built-in rules differ between the two, along with anything a `surfaces`
+override narrows:
+
+| Rule | Surfaces |
+|---|---|
+| `correctness/no-async-without-await` | `cli` |
+| `correctness/prefer-readonly-injection` | `cli` |
+| `security/no-advisory-nestjs-packages` | `cli`, `prComment` |
+
+A project whose only correctness findings come from those two rules offers no
+correctness row in the report's dialog, while `--share-sections
+findings:correctness` writes them. See
+[Findings that do not score](/docs/report#findings-that-do-not-score) and
+[Surfaces](/docs/custom-rules#surfaces).
+
+## What it does not combine with
+
+| Flag | Result |
+|---|---|
+| `--output` | Exits `2`. The path is not configurable |
+| `--report` | Exits `2`. `--report` writes HTML instead of a payload |
+| `--score` | Warns on stderr, writes nothing, continues at `0` |
+| `--format report-json` | Warns on stderr, writes nothing, continues at `0` |
+
+Every other format runs the share alongside its own output. The notice naming
+the written file goes to stderr, so a piped payload stays parseable:
+
+```bash
+npx nestjs-doctor@latest . --format json --share-sections score | jq .score
+```

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -32,6 +32,11 @@ export const DOCS_PAGES: Record<string, PageCopy> = {
 		description:
 			"Overlay real per-class construction times on the report's module graph: the main.ts change that captures a NestJS boot, and how to read the result.",
 	},
+	"/docs/report/share": {
+		title: "Sharing a report",
+		description:
+			"Write part of a scan as JSON: pick the score, a findings category, the endpoints, the schema or the module graph, from the CLI, the post-scan menu, or the HTML report.",
+	},
 	"/docs/coding-agents": {
 		title: "Coding agents",
 		description:

--- a/packages/website/src/lib/docs-navigation.ts
+++ b/packages/website/src/lib/docs-navigation.ts
@@ -17,6 +17,7 @@ export const DOCS_NAV: NavSection[] = [
 			{ title: "The report", href: "/docs/report" },
 			{ title: "Module graph", href: "/docs/report/module-graph" },
 			{ title: "Boot trace", href: "/docs/report/boot-trace" },
+			{ title: "Sharing a report", href: "/docs/report/share" },
 		],
 	},
 	{


### PR DESCRIPTION
## Context

The scan produces a health score, findings, and a full HTML report, but none of it travels well: the console output is terminal-bound, and the HTML report embeds everything — including all source text by default — so pasting or forwarding it shares far more than intended. A second effort (a loader that lets users share and browse each other's reports) needs a small, structured payload to consume.

## Problem

There is no way to export a *subset* of a scan. The machine-readable outputs are all-or-nothing (`--format json`, `report-json`), and the artifact shape carries the module graph, providers, and source text — the wrong weight and the wrong privacy posture for sharing.

## Possible flows

| Flow into report data | Affected |
|---|---|
| TUI post-scan menu → actions | Yes — new "Share the report" action + picker screen |
| Non-interactive CLI run (CI, pipes) | Yes — new `--share-sections` / `--share-code` flags on the main path |
| HTML report opened in a browser | Yes — share button in the nav + overlay, downloads JSON client-side |
| `--format json/sarif/gitlab/markdown/report-json` | No — payload untouched; share is additive at the end of `emit()` |
| Worker scan path | Yes, trivially — new `PipelineOptions` fields pinned inert at the worker |

## Solution

The Node builder is the single share-format authority. `buildReportArtifact` computes a share manifest at scan time: sections with counts (score, findings per category, endpoints, relational schema, module graph), per-category diagnostic slices with paths relativized against the scan root, slimmed endpoints (route facts only), schema (no absolute paths), and a module graph slice with timings stripped. `buildSharedReport` composes the same manifest through the same merge, so CLI, TUI, and page run one assembly path; the page's dialog just merges picked slices from `REPORT.share` and decides nothing about shape.

Payload rules: `project` and `score` ship only when the score section is picked; snippet windows ride along only with `--share-code` / the include-code toggle; `scope` is carried whenever the scan ran narrowed, so a scoped share never reads as a clean full run. Both surfaces write `{version: 1, ...}` as `nestjs-doctor-shared.json`.

Guard rails: `--share-sections` cannot combine with `--output` (the share JSON would overwrite the format payload), `--report`, `--score`, or `--format report-json` — fatal for the first two, warned for the rest. The share notice goes to stderr, keeping `--format json | jq` parseable. A parity test pins merge(manifest) to equal the direct build; a live check proved the page's download is byte-identical to the CLI's file.

Deliberately not done: markdown rendering in the browser, clipboard copy of the payload, any upload service, deduplicating the manifest against the artifact's top-level blocks (that would reintroduce client-side shape logic the refactor removed).

## Before vs after

| Path | Before | After |
|---|---|---|
| Post-scan menu | Copy-all markdown only | Sectioned `.shared.json` via picker |
| CI run | Full-report formats only | `--share-sections score,findings:security --share-code` |
| HTML report | Static page, exports nothing | Share button → identical JSON via Blob download |
| Share format | Two writers (Node + page JS twin) that drifted | One builder; page merges precomputed slices |
| Scoped scans | — | Share carries `scope`, reads as narrowed |

## Example

```
$ nestjs-doctor . --share-sections "score,findings:security,endpoints"
Shared report written to ./nestjs-doctor-shared.json
```

```json
{
  "version": 1,
  "sections": ["score", "findings:security", "endpoints"],
  "includeCode": false,
  "score": { "value": 66, "label": "Fair" },
  "summary": { "total": 3, "errors": 1 },
  "findings": [ { "rule": "security/no-hardcoded-secrets", "filePath": "src/app.controller.ts" } ],
  "endpoints": [ { "httpMethod": "GET", "routePath": "/cats" } ]
}
```
