### PR TITLE
docs(report): the share button merges precomputed slices, it does not build them

### DIFF
--- a/packages/website/src/app/docs/report/page.mdx
+++ b/packages/website/src/app/docs/report/page.mdx
@@ -46,8 +46,9 @@ Endpoints and Relational Schema stay hidden until there is data. A project with
 no controllers and no ORM entities sees four tabs. The Endpoints tab is badged
 `Beta`.
 
-A **share** button in the nav writes a slice of the report as JSON, built in the
-browser. See [Sharing a report](/docs/report/share).
+A **share** button in the nav picks sections of the report and downloads them
+as JSON. The scan precomputes every slice, so the page only merges what you
+tick. See [Sharing a report](/docs/report/share).
 
 [Module graph](/docs/report/module-graph) covers reading that tab: cycles,
 blast radius, and the toggles.


### PR DESCRIPTION
## Context

The share feature's docs describe how the page produces the JSON. The manifest refactor (PR #311) moved payload assembly to the Node side: the artifact embeds a precomputed share manifest, and the page only merges the slices the user ticks.

## Problem

The report overview page still said the JSON is *built in the browser* — accurate for the first implementation, false since the refactor. This is exactly the stale-claim class the docs pipeline guards against.

## Solution

Reworded to say the scan precomputes every slice and the page merges what is ticked, keeping the link to the sharing page.

## Before vs after

| | Text |
|---|---|
| Before | writes a slice of the report as JSON, built in the browser |
| After | picks sections and downloads them as JSON; the scan precomputes every slice, the page only merges what you tick |

## Example

docs/report/page.mdx, share paragraph, verified against src/report/share.ts and the dialog in scripts.ts.