### PR TITLE
feat(report): move the report's shared logic and components into real TypeScript modules

### DIFF
--- a/.changeset/report-browser-modules.md
+++ b/.changeset/report-browser-modules.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Internal refactor, no behavior change: the report's shared tree helpers are now real TypeScript modules instead of text inside a template literal. `src/report/ui/browser/` is bundled to an IIFE and inlined into the report ahead of the remaining script chunks, so `buildFileTree`, `compressTree`, `worstSev`, `worstSevNode` and `countItems` have one definition that the type checker and the linter can both see. The rendered report is unchanged, verified against a jsdom snapshot of every tab.

--- a/.changeset/report-external-import-badge.md
+++ b/.changeset/report-external-import-badge.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Fix the module detail panel never marking an import as external. The graph creates a stand-in node for any import it cannot resolve and flags it `external`, so the panel's `!target` check was always false and both the "external" badge and the dashed row styling were unreachable. An import that comes from a package, for example `ConfigModule` from `@nestjs/config`, now reads as external instead of looking like a module in your codebase.

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ out/
 # Local agent guidance and planning scratch — never shipped.
 /.claude/
 /docs/
+packages/nestjs-doctor/src/report/ui/browser/bundle.iife.js

--- a/packages/nestjs-doctor/package.json
+++ b/packages/nestjs-doctor/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@types/react": "^19",
-    "jsdom": "^30.0.1",
+    "jsdom": "^26.1.0",
     "tsdown": "^0.20.3",
     "vitest": "^3.0.0"
   },

--- a/packages/nestjs-doctor/package.json
+++ b/packages/nestjs-doctor/package.json
@@ -30,7 +30,10 @@
     "typecheck": "tsc --noEmit",
     "postbuild": "node scripts/copy-skills.mjs",
     "smoke:packed": "node scripts/smoke-packed-install.mjs",
-    "advisories:check": "node scripts/check-advisories.mjs"
+    "advisories:check": "node scripts/check-advisories.mjs",
+    "build:browser": "tsdown --config tsdown.browser.config.ts",
+    "prebuild": "pnpm run build:browser",
+    "pretest": "pnpm run build:browser"
   },
   "keywords": [
     "nestjs",
@@ -62,6 +65,7 @@
   },
   "devDependencies": {
     "@types/react": "^19",
+    "jsdom": "^30.0.1",
     "tsdown": "^0.20.3",
     "vitest": "^3.0.0"
   },

--- a/packages/nestjs-doctor/src/report/ui/assets.d.ts
+++ b/packages/nestjs-doctor/src/report/ui/assets.d.ts
@@ -2,3 +2,8 @@ declare module "*.css?raw" {
 	const css: string;
 	export default css;
 }
+
+declare module "*.js?raw" {
+	const js: string;
+	export default js;
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/badge.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/badge.ts
@@ -1,0 +1,31 @@
+interface BadgeOptions {
+	classes?: string;
+	id?: string;
+	style?: string;
+	text: string;
+	tip?: string;
+	title?: string;
+	variant?: string;
+}
+
+// A pill in the module detail panel. `variant` picks the colour class and
+// `classes` carries the tooltip helpers some badges add.
+export function badge({
+	text,
+	variant,
+	classes,
+	id,
+	style,
+	title,
+	tip,
+}: BadgeOptions): string {
+	const cls = ["md-badge", variant, classes].filter(Boolean).join(" ");
+	const attrs = [
+		`class="${cls}"`,
+		id ? `id="${id}"` : undefined,
+		style ? `style="${style}"` : undefined,
+		title ? `title="${title}"` : undefined,
+		tip ? `data-tip="${tip}"` : undefined,
+	].filter(Boolean);
+	return `<span ${attrs.join(" ")}>${text}</span>`;
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -1,0 +1,9 @@
+// biome-ignore lint/performance/noBarrelFile: the browser bundle's entry, not a consumer barrel
+export {
+	buildFileTree,
+	compressTree,
+	countItems,
+	worstSev,
+	worstSevNode,
+} from "./tree.js";
+export { treeRow } from "./tree-row.js";

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -1,4 +1,11 @@
 // biome-ignore lint/performance/noBarrelFile: the browser bundle's entry, not a consumer barrel
+export { badge } from "./badge.js";
+export {
+	infoCard,
+	infoItem,
+	statCard,
+	statRow,
+} from "./summary-card.js";
 export {
 	buildFileTree,
 	compressTree,

--- a/packages/nestjs-doctor/src/report/ui/browser/summary-card.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/summary-card.ts
@@ -1,0 +1,29 @@
+interface Row {
+	label: string;
+	value: string | number;
+}
+
+interface CardOptions {
+	rows: Row[];
+	title: string;
+}
+
+// One label/value line inside a stats card.
+export function statRow({ label, value }: Row): string {
+	return `<div class="ov-stat-row"><span class="ov-stat-label">${label}</span><span class="ov-stat-value">${value}</span></div>`;
+}
+
+// One label/value pair inside the project info grid.
+export function infoItem({ label, value }: Row): string {
+	return `<div class="ov-info-item"><label>${label}</label><span>${value}</span></div>`;
+}
+
+// A summary card whose body is a list of stat rows.
+export function statCard({ title, rows }: CardOptions): string {
+	return `<div class="ov-card"><h3>${title}</h3><div class="ov-card-body">${rows.map(statRow).join("")}</div></div>`;
+}
+
+// A summary card whose body is the project info grid.
+export function infoCard({ title, rows }: CardOptions): string {
+	return `<div class="ov-card"><h3>${title}</h3><div class="ov-card-body"><div class="ov-info-grid">${rows.map(infoItem).join("")}</div></div></div>`;
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/tree-row.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/tree-row.ts
@@ -1,0 +1,51 @@
+interface TreeRowOptions {
+	/** Markup between the toggle and the label, in place of an icon. */
+	before?: string;
+	classes?: string;
+	dataAttrs?: string;
+	depth: number;
+	/** Trailing markup, typically a count badge. */
+	extra?: string;
+	icon?: string;
+	/** Already escaped by the caller. */
+	iconTip?: string;
+	label: string;
+	toggleGlyph?: string;
+	toggleId?: string;
+}
+
+const INDENT = '<span class="st-indent"></span>';
+
+// One row of a sidebar tree. Shared by the schema, modules and endpoints
+// panels, which differ only in which slots they fill.
+export function treeRow({
+	depth,
+	label,
+	toggleId,
+	toggleGlyph = "▸",
+	icon,
+	iconTip,
+	before,
+	extra,
+	classes,
+	dataAttrs,
+}: TreeRowOptions): string {
+	let h = `<div class="st-row${classes ? ` ${classes}` : ""}"${dataAttrs || ""}>`;
+	h += INDENT.repeat(depth);
+	h += toggleId
+		? `<span class="st-toggle" data-toggle="${toggleId}">${toggleGlyph}</span>`
+		: INDENT;
+	if (icon) {
+		h += iconTip
+			? `<span class="st-icon has-tip" data-tip="${iconTip}">${icon}</span>`
+			: `<span class="st-icon">${icon}</span>`;
+	}
+	if (before) {
+		h += before;
+	}
+	h += `<span class="st-label">${label}</span>`;
+	if (extra) {
+		h += extra;
+	}
+	return `${h}</div>`;
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/tree.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/tree.ts
@@ -1,12 +1,12 @@
-export type Severity = "error" | "info" | "warning";
+type Severity = "error" | "info" | "warning";
 
-export interface TreeNode {
+interface TreeNode {
 	children: Record<string, TreeNode>;
 	files: Record<string, FileNode>;
 	name: string;
 }
 
-export interface FileNode {
+interface FileNode {
 	fullPath: string;
 	name: string;
 	[itemsKey: string]: unknown;

--- a/packages/nestjs-doctor/src/report/ui/browser/tree.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/tree.ts
@@ -1,0 +1,114 @@
+export type Severity = "error" | "info" | "warning";
+
+export interface TreeNode {
+	children: Record<string, TreeNode>;
+	files: Record<string, FileNode>;
+	name: string;
+}
+
+export interface FileNode {
+	fullPath: string;
+	name: string;
+	[itemsKey: string]: unknown;
+}
+
+// Splits each path in `fileMap` into folder nodes, hanging the entry's items
+// off the leaf under `itemsKey`.
+export function buildFileTree<T>(
+	fileMap: Record<string, T[]>,
+	itemsKey: string
+): TreeNode {
+	const root: TreeNode = { name: "", children: {}, files: {} };
+	for (const [fp, items] of Object.entries(fileMap)) {
+		if (fp === "") {
+			continue;
+		}
+		const parts = fp.split("/");
+		const fName = parts.pop() as string;
+		let node = root;
+		for (const part of parts) {
+			if (!node.children[part]) {
+				node.children[part] = { name: part, children: {}, files: {} };
+			}
+			node = node.children[part];
+		}
+		const fileNode = { name: fName, fullPath: fp } as unknown as FileNode;
+		fileNode[itemsKey] = items;
+		node.files[fName] = fileNode;
+	}
+	return root;
+}
+
+// Collapses a folder holding exactly one folder and no files into its child.
+export function compressTree(root: TreeNode): void {
+	function compress(n: TreeNode) {
+		for (const child of Object.values(n.children)) {
+			compress(child);
+		}
+		const cKeys = Object.keys(n.children);
+		if (cKeys.length === 1 && Object.keys(n.files).length === 0) {
+			const only = n.children[cKeys[0]];
+			n.name = n.name ? `${n.name}/${only.name}` : only.name;
+			n.children = only.children;
+			n.files = only.files;
+		}
+	}
+	for (const child of Object.values(root.children)) {
+		compress(child);
+	}
+}
+
+export function worstSev<T>(
+	itemList: T[],
+	getSeverity: (item: T) => string
+): Severity {
+	let worst: Severity = "info";
+	for (const item of itemList) {
+		const s = getSeverity(item);
+		if (s === "error") {
+			return "error";
+		}
+		if (s === "warning") {
+			worst = "warning";
+		}
+	}
+	return worst;
+}
+
+export function worstSevNode(
+	n: TreeNode,
+	itemsKey: string,
+	getSeverity: (item: unknown) => string
+): Severity {
+	let worst: Severity = "info";
+	for (const child of Object.values(n.children)) {
+		const cs = worstSevNode(child, itemsKey, getSeverity);
+		if (cs === "error") {
+			return "error";
+		}
+		if (cs === "warning") {
+			worst = "warning";
+		}
+	}
+	for (const file of Object.values(n.files)) {
+		const fs = worstSev(file[itemsKey] as unknown[], getSeverity);
+		if (fs === "error") {
+			return "error";
+		}
+		if (fs === "warning") {
+			worst = "warning";
+		}
+	}
+	return worst;
+}
+
+export function countItems(n: TreeNode, itemsKey: string): number {
+	let total = 0;
+	for (const child of Object.values(n.children)) {
+		total += countItems(child, itemsKey);
+	}
+	for (const file of Object.values(n.files)) {
+		total += (file[itemsKey] as unknown[]).length;
+	}
+	return total;
+}

--- a/packages/nestjs-doctor/src/report/ui/scripts.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts.ts
@@ -1,3 +1,4 @@
+import BROWSER_BUNDLE from "./browser/bundle.iife.js?raw";
 import { BOOT } from "./scripts/boot.js";
 import { bootstrap } from "./scripts/bootstrap.js";
 import { CHROME } from "./scripts/chrome.js";
@@ -15,6 +16,7 @@ export function getReportScripts(artifactJson: string): string {
 	// The chunks are emitted into one classic <script>, so this order is the
 	// order the browser evaluates. BOOT runs switchTab and stays second to last.
 	return [
+		`\n${BROWSER_BUNDLE}`,
 		bootstrap(artifactJson),
 		CHROME,
 		MODULES_GRAPH,

--- a/packages/nestjs-doctor/src/report/ui/scripts/diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/diagnosis.ts
@@ -40,8 +40,8 @@ function renderDiagnosis() {
 
   // Build tree from file paths
   const diagSev = function(item) { return item.d.severity; };
-  const treeRoot = buildFileTree(fileMap, "diags");
-  compressTree(treeRoot);
+  const treeRoot = RPT.buildFileTree(fileMap, "diags");
+  RPT.compressTree(treeRoot);
 
   function collectSevs(diagList) {
     const sevs = {};

--- a/packages/nestjs-doctor/src/report/ui/scripts/endpoints.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/endpoints.ts
@@ -372,6 +372,7 @@ function epDraw() {
 }
 
 function epResize() {
+  if (!epCtx) return;
   if (!epCanvas) return;
   var container = epCanvas.parentElement;
   if (!container) return;

--- a/packages/nestjs-doctor/src/report/ui/scripts/endpoints.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/endpoints.ts
@@ -458,6 +458,8 @@ function epHideCodePanel() {
   if (panel) panel.classList.remove("open");
 }
 
+var EP_CTRL_ICON = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--nest-red)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="2"/><line x1="5" y1="6" x2="11" y2="6"/><line x1="5" y1="10" x2="9" y2="10"/></svg>';
+
 function renderEndpoints() {
   var sidebarEl = document.getElementById("endpoints-list");
   epCanvas = document.getElementById("endpoints-canvas");
@@ -497,23 +499,28 @@ function renderEndpoints() {
     var ctrlName = controllerOrder[c];
     var ctrlEndpoints = controllers[ctrlName];
     var ctrlId = "ep-ctrl-" + c;
-    html += '<div class="st-row" data-toggle="' + ctrlId + '">';
-    html += '<span class="st-toggle" data-toggle="' + ctrlId + '">\\u25BE</span>';
-    html += '<span class="st-icon"><svg viewBox="0 0 16 16" fill="none" stroke="var(--nest-red)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="2"/><line x1="5" y1="6" x2="11" y2="6"/><line x1="5" y1="10" x2="9" y2="10"/></svg></span>';
-    html += '<span class="st-label"><span class="st-entity-name">' + escHtml(ctrlName) + '</span></span>';
-    html += '<span class="st-count">' + ctrlEndpoints.length + '</span>';
-    html += '</div>';
+    html += RPT.treeRow({
+      depth: 0,
+      toggleId: ctrlId,
+      toggleGlyph: "\\u25BE",
+      icon: EP_CTRL_ICON,
+      label: '<span class="st-entity-name">' + escHtml(ctrlName) + '</span>',
+      extra: '<span class="st-count">' + ctrlEndpoints.length + '</span>',
+      dataAttrs: ' data-toggle="' + ctrlId + '"'
+    });
     html += '<div class="st-children st-open" id="st-' + ctrlId + '">';
 
     for (var e = 0; e < ctrlEndpoints.length; e++) {
       var ep = ctrlEndpoints[e];
       var method = (ep.httpMethod || "GET").toUpperCase();
       var badgeClass = METHOD_COLORS[method] || "ep-method-get";
-      html += '<div class="st-row ep-endpoint-row" data-ep-ctrl="' + escHtml(ctrlName) + '" data-ep-handler="' + escHtml(ep.handlerMethod) + '">';
-      html += '<span class="st-indent"></span><span class="st-indent"></span>';
-      html += '<span class="ep-method-badge ' + badgeClass + '">' + escHtml(method) + '</span>';
-      html += '<span class="st-label">' + escHtml(ep.routePath || "/") + '</span>';
-      html += '</div>';
+      html += RPT.treeRow({
+        depth: 1,
+        before: '<span class="ep-method-badge ' + badgeClass + '">' + escHtml(method) + '</span>',
+        label: escHtml(ep.routePath || "/"),
+        classes: "ep-endpoint-row",
+        dataAttrs: ' data-ep-ctrl="' + escHtml(ctrlName) + '" data-ep-handler="' + escHtml(ep.handlerMethod) + '"'
+      });
     }
     html += '</div>';
   }

--- a/packages/nestjs-doctor/src/report/ui/scripts/lab.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/lab.ts
@@ -440,8 +440,8 @@ function renderLab() {
     currentPgFileMap[""] = standaloneItems;
 
     // Build tree from file paths
-    const pgTreeRoot = buildFileTree(currentPgFileMap, "findings");
-    compressTree(pgTreeRoot);
+    const pgTreeRoot = RPT.buildFileTree(currentPgFileMap, "findings");
+    RPT.compressTree(pgTreeRoot);
 
     // Render tree HTML
     let pgTreeHtml = "";

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -1993,7 +1993,7 @@ function mgShowDetail(n) {
       var label = target ? getDisplayName(target) : n.imports[j];
       var method = n.dynamicImports && n.dynamicImports[n.imports[j]];
       var methodTip = method ? (MG_DYNAMIC_TIPS[method] || "Dynamic import: " + method + "() returns a configured module") : "";
-      var external = !target;
+      var external = !target || target.external === true;
       html += '<li class="md-import-row' + (external ? " md-import-ext" : "") + '" data-import="' + mgEsc(n.imports[j]) + '"><span class="md-kind-module">' + mgEsc(label) + '</span>' +
         (method ? RPT.badge({ variant: "md-scope", classes: "has-tip tip-wide badge-tip", style: "margin-left:5px", tip: mgEsc(methodTip), text: mgEsc(method) }) : "") +
         (external

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -1126,19 +1126,25 @@ function mgBuildTree() {
     var mods = byProject[pname].slice().sort(function(a, b) {
       return getDisplayName(a) < getDisplayName(b) ? -1 : 1;
     });
-    html += '<div class="st-row mg-tree-project" data-project="' + mgEsc(pname) + '">' +
-      '<span class="st-toggle" data-toggle="mgp-' + j + '">\\u25B8</span>' +
-      '<span class="st-icon">' + MG_PROJECT_ICON + '</span>' +
-      '<span class="st-label"><span class="st-entity-name">' + mgEsc(pname) + '</span></span>' +
-      '<span class="st-count">' + mods.length + '</span></div>';
+    html += RPT.treeRow({
+      depth: 0,
+      toggleId: "mgp-" + j,
+      icon: MG_PROJECT_ICON,
+      label: '<span class="st-entity-name">' + mgEsc(pname) + '</span>',
+      extra: '<span class="st-count">' + mods.length + '</span>',
+      classes: "mg-tree-project",
+      dataAttrs: ' data-project="' + mgEsc(pname) + '"'
+    });
     html += '<div class="st-children" id="mgp-' + j + '">';
     for (var k = 0; k < mods.length; k++) {
       var n = mods[k];
-      html += '<div class="st-row mg-tree-module" data-module="' + mgEsc(n.name) + '">' +
-        '<span class="st-indent"></span><span class="st-indent"></span>' +
-        '<span class="st-label">' + mgEsc(getDisplayName(n)) + '</span>' +
-        (circularModules.has(n.name) ? '<span class="st-count" style="color:var(--nest-red)">cycle</span>' : "") +
-        '</div>';
+      html += RPT.treeRow({
+        depth: 1,
+        label: mgEsc(getDisplayName(n)),
+        extra: circularModules.has(n.name) ? '<span class="st-count" style="color:var(--nest-red)">cycle</span>' : "",
+        classes: "mg-tree-module",
+        dataAttrs: ' data-module="' + mgEsc(n.name) + '"'
+      });
     }
     html += '</div>';
   }

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -1597,9 +1597,9 @@ function mgProvidersHtml(n) {
       var row = rows[j];
       if (row.token) {
         html += '<div class="md-row">' + mgNameHtml(row.token, "") +
-          '<span class="md-badge md-token">token</span>' +
+          RPT.badge({ variant: "md-token", text: "token" }) +
           (row.strategy && row.target
-            ? '<span class="md-badge md-use">' + mgEsc(row.strategy) + ' \\u2192 ' + mgEsc(row.target) + '</span>'
+            ? RPT.badge({ variant: "md-use", text: mgEsc(row.strategy) + ' \\u2192 ' + mgEsc(row.target) })
             : "") +
           '</div>';
         continue;
@@ -1607,10 +1607,10 @@ function mgProvidersHtml(n) {
       var info = byName[row.name];
       html += '<div class="md-row">' + mgNameHtml(row.name, MG_GROUP_KIND[order[g]] || "");
       if (info && info.scope) {
-        html += '<span class="md-badge md-scope">' + mgEsc(info.scope) + '</span>';
+        html += RPT.badge({ variant: "md-scope", text: mgEsc(info.scope) });
       }
       if (mgUnusedProviders[row.name]) {
-        html += '<span class="md-badge md-unused" title="performance/no-unused-providers: never injected and not framework-activated">unused?</span>';
+        html += RPT.badge({ variant: "md-unused", title: "performance/no-unused-providers: never injected and not framework-activated", text: "unused?" });
       }
       if (info && info.publicMethodCount) {
         html += '<span class="md-blast-count">' + info.publicMethodCount + ' methods</span>';
@@ -1727,8 +1727,10 @@ function mgDockShow(name) {
 
 function mgTraceBadgeHtml(type) {
   var rgb = mgTraceColor(type);
-  return '<span class="md-badge" style="color:rgb(' + rgb + ');background:rgba(' + rgb + ',0.12)">' +
-    mgEsc(type) + '</span>';
+  return RPT.badge({
+    style: "color:rgb(" + rgb + ");background:rgba(" + rgb + ",0.12)",
+    text: mgEsc(type)
+  });
 }
 
 function mgTraceBarHtml(initTime, deps, type, hollowTip) {
@@ -1890,7 +1892,7 @@ function mgExportsHtml(n) {
     html += '<div class="md-group">';
     for (var k = 0; k < rows.length; k++) {
       html += '<div class="md-row">' + mgNameHtml(rows[k].name, rows[k].kind) +
-        (rows[k].kind === "module" ? '<span class="md-badge md-module">module</span>' : "") +
+        (rows[k].kind === "module" ? RPT.badge({ variant: "md-module", text: "module" }) : "") +
         '</div>';
     }
     html += '</div>';
@@ -1952,14 +1954,18 @@ function mgShowDetail(n) {
   document.getElementById("detail-name").textContent = getDisplayName(n);
 
   var badges = "";
-  if (n.project) badges += '<span class="md-badge md-project">' + mgEsc(n.project) + '</span>';
-  if (n.isGlobal) badges += '<span class="md-badge md-global">global</span>';
-  if (circularModules.has(n.name)) badges += '<span class="md-badge md-cycle">in cycle</span>';
-  if (rootModules.has(n.name)) badges += '<span class="md-badge md-root">root</span>';
+  if (n.project) badges += RPT.badge({ variant: "md-project", text: mgEsc(n.project) });
+  if (n.isGlobal) badges += RPT.badge({ variant: "md-global", text: "global" });
+  if (circularModules.has(n.name)) badges += RPT.badge({ variant: "md-cycle", text: "in cycle" });
+  if (rootModules.has(n.name)) badges += RPT.badge({ variant: "md-root", text: "root" });
   if (graph.timingsAvailable) {
     if (n.initTimings && n.initTimings.length > 0) {
-      badges += '<span class="md-badge md-use" id="detail-timings-btn" data-tip="Open the Boot trace">' +
-        mgEsc(mgFormatMs(n.initTimings[0].initTime)) + ' \\u00b7 trace \\u25B8</span>';
+      badges += RPT.badge({
+        variant: "md-use",
+        id: "detail-timings-btn",
+        tip: "Open the Boot trace",
+        text: mgEsc(mgFormatMs(n.initTimings[0].initTime)) + ' \\u00b7 trace \\u25B8'
+      });
     }
     badges += mgHookChipHtml(n.hookTimings);
   }
@@ -1989,10 +1995,18 @@ function mgShowDetail(n) {
       var methodTip = method ? (MG_DYNAMIC_TIPS[method] || "Dynamic import: " + method + "() returns a configured module") : "";
       var external = !target;
       html += '<li class="md-import-row' + (external ? " md-import-ext" : "") + '" data-import="' + mgEsc(n.imports[j]) + '"><span class="md-kind-module">' + mgEsc(label) + '</span>' +
-        (method ? '<span class="md-badge md-scope has-tip tip-wide badge-tip" style="margin-left:5px" data-tip="' + mgEsc(methodTip) + '">' + mgEsc(method) + '</span>' : "") +
-        (external ? '<span class="md-badge md-ext has-tip tip-wide badge-tip" style="margin-left:5px" data-tip="Not declared in this codebase \\u2014 it comes from a package, e.g. @nestjs/config">external</span>' : "") +
+        (method ? RPT.badge({ variant: "md-scope", classes: "has-tip tip-wide badge-tip", style: "margin-left:5px", tip: mgEsc(methodTip), text: mgEsc(method) }) : "") +
+        (external
+          ? RPT.badge({
+              variant: "md-ext",
+              classes: "has-tip tip-wide badge-tip",
+              style: "margin-left:5px",
+              tip: "Not declared in this codebase \\u2014 it comes from a package, e.g. @nestjs/config",
+              text: "external"
+            })
+          : "") +
         (target && target.project && target.project !== n.project
-          ? '<span class="md-badge md-project" style="margin-left:5px">' + mgEsc(target.project) + '</span>'
+          ? RPT.badge({ variant: "md-project", style: "margin-left:5px", text: mgEsc(target.project) })
           : "") +
         '</li>';
     }

--- a/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
@@ -1515,20 +1515,16 @@ function renderSchema() {
 
   // Tree row builder
   function sBuildTreeRow(depth, toggleId, icon, labelHtml, extra, classes, dataAttrs, iconTip) {
-    var h = '<div class="st-row' + (classes ? " " + classes : "") + '"' + (dataAttrs || "") + '>';
-    for (var d = 0; d < depth; d++) h += '<span class="st-indent"></span>';
-    if (toggleId) {
-      h += '<span class="st-toggle" data-toggle="' + toggleId + '">' + "\\u25B8" + '</span>';
-    } else {
-      h += '<span class="st-indent"></span>';
-    }
-    h += iconTip
-      ? '<span class="st-icon has-tip" data-tip="' + escHtml(iconTip) + '">' + icon + '</span>'
-      : '<span class="st-icon">' + icon + '</span>';
-    h += '<span class="st-label">' + labelHtml + '</span>';
-    if (extra) h += extra;
-    h += '</div>';
-    return h;
+    return RPT.treeRow({
+      depth: depth,
+      toggleId: toggleId,
+      icon: icon,
+      iconTip: iconTip ? escHtml(iconTip) : undefined,
+      label: labelHtml,
+      extra: extra,
+      classes: classes,
+      dataAttrs: dataAttrs
+    });
   }
 
   var TIP_PK = "Primary key \\u00b7 identifies the row";

--- a/packages/nestjs-doctor/src/report/ui/scripts/shared-tree.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/shared-tree.ts
@@ -6,71 +6,6 @@ const SVG_UP = '<svg width="12" height="12" viewBox="0 0 16 16" fill="currentCol
 const SVG_DOWN = '<svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M0 8l1.5-1.5L8 13l6.5-6.5L16 8 8 16z"/></svg>';
 
 // ── Shared tree helpers ──
-function buildFileTree(fileMap, itemsKey) {
-  const root = { name: "", children: {}, files: {} };
-  for (const fp in fileMap) {
-    if (fp === "") continue;
-    const parts = fp.split("/");
-    const fName = parts.pop();
-    let node = root;
-    for (let p = 0; p < parts.length; p++) {
-      if (!node.children[parts[p]]) node.children[parts[p]] = { name: parts[p], children: {}, files: {} };
-      node = node.children[parts[p]];
-    }
-    const fileNode = { name: fName, fullPath: fp };
-    fileNode[itemsKey] = fileMap[fp];
-    node.files[fName] = fileNode;
-  }
-  return root;
-}
-
-function compressTree(root) {
-  function compress(n) {
-    for (const k in n.children) compress(n.children[k]);
-    const cKeys = Object.keys(n.children);
-    const fKeys = Object.keys(n.files);
-    if (cKeys.length === 1 && fKeys.length === 0) {
-      const child = n.children[cKeys[0]];
-      n.name = n.name ? n.name + "/" + child.name : child.name;
-      n.children = child.children;
-      n.files = child.files;
-    }
-  }
-  for (const rk in root.children) compress(root.children[rk]);
-}
-
-function worstSev(itemList, getSeverity) {
-  let worst = "info";
-  for (let i = 0; i < itemList.length; i++) {
-    const s = getSeverity(itemList[i]);
-    if (s === "error") return "error";
-    if (s === "warning") worst = "warning";
-  }
-  return worst;
-}
-
-function worstSevNode(n, itemsKey, getSeverity) {
-  let worst = "info";
-  for (const k in n.children) {
-    const cs = worstSevNode(n.children[k], itemsKey, getSeverity);
-    if (cs === "error") return "error";
-    if (cs === "warning") worst = "warning";
-  }
-  for (const f in n.files) {
-    const fs = worstSev(n.files[f][itemsKey], getSeverity);
-    if (fs === "error") return "error";
-    if (fs === "warning") worst = "warning";
-  }
-  return worst;
-}
-
-function countItems(n, itemsKey) {
-  let total = 0;
-  for (const k in n.children) total += countItems(n.children[k], itemsKey);
-  for (const f in n.files) total += n.files[f][itemsKey].length;
-  return total;
-}
-
 function renderTreeHtml(root, config) {
   let html = "";
   function renderNode(n, depth) {
@@ -80,8 +15,8 @@ function renderTreeHtml(root, config) {
 
     for (let i = 0; i < dirs.length; i++) {
       const child = n.children[dirs[i]];
-      const folderSev = worstSevNode(child, config.itemsKey, config.getSeverity);
-      const folderCount = countItems(child, config.itemsKey);
+      const folderSev = RPT.worstSevNode(child, config.itemsKey, config.getSeverity);
+      const folderCount = RPT.countItems(child, config.itemsKey);
       html += '<div class="tree-folder">' +
         '<div class="tree-folder-header" style="padding-left:calc(14px + ' + pad + ');--guides:' + (depth * 12) + 'px">' +
         '<span class="tree-chevron">&#9660;</span>' +
@@ -95,7 +30,7 @@ function renderTreeHtml(root, config) {
 
     for (let j = 0; j < files.length; j++) {
       const fileNode = n.files[files[j]];
-      const fileSev = worstSev(fileNode[config.itemsKey], config.getSeverity);
+      const fileSev = RPT.worstSev(fileNode[config.itemsKey], config.getSeverity);
       const fileCount = fileNode[config.itemsKey].length;
       let extraAttrs = "";
       if (config.collectSevs) extraAttrs = ' data-sevs="' + config.collectSevs(fileNode[config.itemsKey]) + '"';

--- a/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
@@ -36,14 +36,17 @@ function renderSummary() {
     '</div></div></div></div>';
 
   // Project info card
-  html += '<div class="ov-card"><h3>Project Info</h3><div class="ov-card-body"><div class="ov-info-grid">' +
-    '<div class="ov-info-item"><label>Name</label><span>' + escHtml(project.name) + '</span></div>' +
-    '<div class="ov-info-item"><label>NestJS</label><span>' + (project.nestVersion || "—") + '</span></div>' +
-    '<div class="ov-info-item"><label>Framework</label><span>' + (project.framework || "—") + '</span></div>' +
-    '<div class="ov-info-item"><label>ORM</label><span>' + (project.orm || "—") + '</span></div>' +
-    '<div class="ov-info-item"><label>Files</label><span>' + project.fileCount + '</span></div>' +
-    '<div class="ov-info-item"><label>Modules</label><span>' + project.moduleCount + '</span></div>' +
-    '</div></div></div>';
+  html += RPT.infoCard({
+    title: "Project Info",
+    rows: [
+      { label: "Name", value: escHtml(project.name) },
+      { label: "NestJS", value: project.nestVersion || "\\u2014" },
+      { label: "Framework", value: project.framework || "\\u2014" },
+      { label: "ORM", value: project.orm || "\\u2014" },
+      { label: "Files", value: project.fileCount },
+      { label: "Modules", value: project.moduleCount }
+    ]
+  });
 
   // Category breakdown card
   html += '<div class="ov-card"><h3>Issues by Category</h3><div class="ov-card-body">';
@@ -58,19 +61,25 @@ function renderSummary() {
   html += '</div></div>';
 
   // Module graph stats card
-  html += '<div class="ov-card"><h3>Module Graph</h3><div class="ov-card-body">' +
-    '<div class="ov-stat-row"><span class="ov-stat-label">Total modules</span><span class="ov-stat-value">' + graph.modules.length + '</span></div>' +
-    '<div class="ov-stat-row"><span class="ov-stat-label">Root modules</span><span class="ov-stat-value">' + rootModules.size + '</span></div>' +
-    '<div class="ov-stat-row"><span class="ov-stat-label">Edges</span><span class="ov-stat-value">' + graph.edges.length + '</span></div>' +
-    '<div class="ov-stat-row"><span class="ov-stat-label">Circular deps</span><span class="ov-stat-value">' + graph.circularDeps.length + '</span></div>' +
-    '</div></div>';
+  html += RPT.statCard({
+    title: "Module Graph",
+    rows: [
+      { label: "Total modules", value: graph.modules.length },
+      { label: "Root modules", value: rootModules.size },
+      { label: "Edges", value: graph.edges.length },
+      { label: "Circular deps", value: graph.circularDeps.length }
+    ]
+  });
 
   // Analysis card
-  html += '<div class="ov-card"><h3>Analysis</h3><div class="ov-card-body">' +
-    '<div class="ov-stat-row"><span class="ov-stat-label">Duration</span><span class="ov-stat-value">' + (elapsedMs / 1000).toFixed(2) + 's</span></div>' +
-    '<div class="ov-stat-row"><span class="ov-stat-label">Files scanned</span><span class="ov-stat-value">' + project.fileCount + '</span></div>' +
-    '<div class="ov-stat-row"><span class="ov-stat-label">Total issues</span><span class="ov-stat-value">' + summary.total + '</span></div>' +
-    '</div></div>';
+  html += RPT.statCard({
+    title: "Analysis",
+    rows: [
+      { label: "Duration", value: (elapsedMs / 1000).toFixed(2) + "s" },
+      { label: "Files scanned", value: project.fileCount },
+      { label: "Total issues", value: summary.total }
+    ]
+  });
 
   html += '</div>';
   container.innerHTML = html;

--- a/packages/nestjs-doctor/tests/unit/report-artifact-fixture.ts
+++ b/packages/nestjs-doctor/tests/unit/report-artifact-fixture.ts
@@ -153,6 +153,7 @@ export const RICH_ARTIFACT: ReportArtifact = {
 			{
 				name: "OrderModule",
 				filePath: "src/order/order.module.ts",
+				isGlobal: true,
 				imports: ["UserModule"],
 				exports: [],
 				providers: ["OrderService"],
@@ -164,8 +165,27 @@ export const RICH_ARTIFACT: ReportArtifact = {
 			{ from: "AppModule", to: "UserModule" },
 			{ from: "AppModule", to: "OrderModule" },
 			{ from: "OrderModule", to: "UserModule" },
+			{ from: "UserModule", to: "OrderModule" },
 		],
+		circularDeps: [["OrderModule", "UserModule"]],
 	},
+	providers: [
+		{
+			name: "UserService",
+			filePath: "src/user/user.service.ts",
+			module: "UserModule",
+			dependencies: [],
+			publicMethodCount: 3,
+		},
+		{
+			name: "OrderService",
+			filePath: "src/order/order.service.ts",
+			module: "OrderModule",
+			dependencies: ["UserService"],
+			publicMethodCount: 2,
+			scope: "request",
+		},
+	],
 	endpoints: {
 		endpoints: [
 			{

--- a/packages/nestjs-doctor/tests/unit/report-artifact-fixture.ts
+++ b/packages/nestjs-doctor/tests/unit/report-artifact-fixture.ts
@@ -120,3 +120,139 @@ export const EMPTY_ARTIFACT: ReportArtifact = {
 };
 
 export const EMPTY_ARTIFACT_JSON = JSON.stringify(EMPTY_ARTIFACT);
+
+/**
+ * An artifact with enough graph, schema and endpoint data that the report's
+ * sidebar trees, tab panels and detail views all render something.
+ */
+export const RICH_ARTIFACT: ReportArtifact = {
+	...EMPTY_ARTIFACT,
+	project: { ...EMPTY_ARTIFACT.project, fileCount: 4, moduleCount: 3 },
+	graph: {
+		...EMPTY_ARTIFACT.graph,
+		projects: ["api"],
+		modules: [
+			{
+				name: "AppModule",
+				filePath: "src/app.module.ts",
+				imports: ["UserModule", "OrderModule"],
+				exports: [],
+				providers: [],
+				controllers: [],
+				project: "api",
+			},
+			{
+				name: "UserModule",
+				filePath: "src/user/user.module.ts",
+				imports: [],
+				exports: ["UserService"],
+				providers: ["UserService"],
+				controllers: ["UserController"],
+				project: "api",
+			},
+			{
+				name: "OrderModule",
+				filePath: "src/order/order.module.ts",
+				imports: ["UserModule"],
+				exports: [],
+				providers: ["OrderService"],
+				controllers: [],
+				project: "api",
+			},
+		],
+		edges: [
+			{ from: "AppModule", to: "UserModule" },
+			{ from: "AppModule", to: "OrderModule" },
+			{ from: "OrderModule", to: "UserModule" },
+		],
+	},
+	endpoints: {
+		endpoints: [
+			{
+				controllerClass: "UserController",
+				handlerMethod: "findAll",
+				httpMethod: "GET",
+				routePath: "/users",
+				filePath: "src/user/user.controller.ts",
+				line: 10,
+				endLine: 14,
+				returnType: "User[]",
+				swagger: null,
+				dependencies: [],
+			},
+			{
+				controllerClass: "UserController",
+				handlerMethod: "create",
+				httpMethod: "POST",
+				routePath: "/users",
+				filePath: "src/user/user.controller.ts",
+				line: 16,
+				endLine: 20,
+				returnType: "User",
+				swagger: null,
+				dependencies: [],
+			},
+		],
+	},
+	schema: {
+		orm: "typeorm",
+		entities: [
+			{
+				name: "User",
+				tableName: "users",
+				filePath: "src/user/user.entity.ts",
+				columns: [
+					{
+						name: "id",
+						type: "uuid",
+						isPrimary: true,
+						isNullable: false,
+						isUnique: true,
+					},
+					{
+						name: "email",
+						type: "varchar",
+						isPrimary: false,
+						isNullable: false,
+						isUnique: true,
+					},
+				],
+				relations: [],
+			},
+			{
+				name: "Order",
+				tableName: "orders",
+				filePath: "src/order/order.entity.ts",
+				columns: [
+					{
+						name: "id",
+						type: "uuid",
+						isPrimary: true,
+						isNullable: false,
+						isUnique: true,
+					},
+				],
+				relations: [
+					{
+						fromEntity: "Order",
+						toEntity: "User",
+						propertyName: "user",
+						type: "many-to-one",
+						isNullable: false,
+					},
+				],
+			},
+		],
+		relations: [
+			{
+				fromEntity: "Order",
+				toEntity: "User",
+				propertyName: "user",
+				type: "many-to-one",
+				isNullable: false,
+			},
+		],
+	},
+};
+
+export const RICH_ARTIFACT_JSON = JSON.stringify(RICH_ARTIFACT);

--- a/packages/nestjs-doctor/tests/unit/report-artifact-fixture.ts
+++ b/packages/nestjs-doctor/tests/unit/report-artifact-fixture.ts
@@ -128,6 +128,13 @@ export const EMPTY_ARTIFACT_JSON = JSON.stringify(EMPTY_ARTIFACT);
 export const RICH_ARTIFACT: ReportArtifact = {
 	...EMPTY_ARTIFACT,
 	project: { ...EMPTY_ARTIFACT.project, fileCount: 4, moduleCount: 3 },
+	diagnostics: [
+		codeDiagnostic({
+			rule: "performance/no-unused-providers",
+			message: "Provider 'OrderService' is never injected.",
+			filePath: "src/order/order.service.ts",
+		}),
+	],
 	graph: {
 		...EMPTY_ARTIFACT.graph,
 		projects: ["api"],
@@ -135,7 +142,8 @@ export const RICH_ARTIFACT: ReportArtifact = {
 			{
 				name: "AppModule",
 				filePath: "src/app.module.ts",
-				imports: ["UserModule", "OrderModule"],
+				imports: ["UserModule", "OrderModule", "ConfigModule"],
+				dynamicImports: { ConfigModule: "forRoot" },
 				exports: [],
 				providers: [],
 				controllers: [],
@@ -145,7 +153,8 @@ export const RICH_ARTIFACT: ReportArtifact = {
 				name: "UserModule",
 				filePath: "src/user/user.module.ts",
 				imports: [],
-				exports: ["UserService"],
+				exports: ["UserService", "SharedModule"],
+				providerTokens: ["USER_CONFIG"],
 				providers: ["UserService"],
 				controllers: ["UserController"],
 				project: "api",

--- a/packages/nestjs-doctor/tests/unit/report-dom.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-dom.test.ts
@@ -99,5 +99,20 @@ it("renders every tab into a DOM", () => {
 	const detail = win.eval(
 		"mgNodes.map(function (n) { mgShowDetail(n); return document.getElementById('detail').innerHTML; }).join('')"
 	) as string;
-	expect(detail).toContain("md-badge");
+	// Every badge variant the panel can draw, so a change to one is visible
+	// here rather than only in the source text.
+	for (const variant of [
+		"md-project",
+		"md-global",
+		"md-cycle",
+		"md-root",
+		"md-scope",
+		"md-use",
+		"md-token",
+		"md-module",
+		"md-unused",
+		"md-ext",
+	]) {
+		expect(detail).toContain(variant);
+	}
 });

--- a/packages/nestjs-doctor/tests/unit/report-dom.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-dom.test.ts
@@ -25,6 +25,8 @@ function stubCanvas(win: typeof globalThis & Window) {
 	// @ts-expect-error test stub
 	win.HTMLCanvasElement.prototype.getContext = () => ctx;
 	// @ts-expect-error test stub
+	win.Element.prototype.scrollIntoView = () => undefined;
+	// @ts-expect-error test stub
 	win.HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
 		width: 800,
 		height: 600,
@@ -91,4 +93,11 @@ it("renders every tab into a DOM", () => {
 	expect(rows("modules")).toBeGreaterThan(0);
 	expect(rows("schema")).toBeGreaterThan(0);
 	expect(rows("endpoints")).toBeGreaterThan(0);
+
+	// The detail panel only renders on selection, so drive one per module.
+	win.eval("switchTab('modules')");
+	const detail = win.eval(
+		"mgNodes.map(function (n) { mgShowDetail(n); return document.getElementById('detail').innerHTML; }).join('')"
+	) as string;
+	expect(detail).toContain("md-badge");
 });

--- a/packages/nestjs-doctor/tests/unit/report-dom.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-dom.test.ts
@@ -4,7 +4,7 @@ import { getReportHtml } from "../../src/report/ui/html.js";
 import { getReportScripts } from "../../src/report/ui/scripts.js";
 import { EMPTY_ARTIFACT_JSON } from "./report-artifact-fixture.js";
 
-const TABS = ["summary", "diagnosis", "lab"];
+const TABS = ["summary", "diagnosis", "lab", "modules", "schema", "endpoints"];
 
 // A canvas context that swallows every call, so the drawing code runs without
 // a real 2D backend and the DOM it also builds still gets built.

--- a/packages/nestjs-doctor/tests/unit/report-dom.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-dom.test.ts
@@ -2,7 +2,7 @@ import { JSDOM } from "jsdom";
 import { expect, it } from "vitest";
 import { getReportHtml } from "../../src/report/ui/html.js";
 import { getReportScripts } from "../../src/report/ui/scripts.js";
-import { EMPTY_ARTIFACT_JSON } from "./report-artifact-fixture.js";
+import { RICH_ARTIFACT_JSON } from "./report-artifact-fixture.js";
 
 const TABS = ["summary", "diagnosis", "lab", "modules", "schema", "endpoints"];
 
@@ -70,7 +70,7 @@ it("renders every tab into a DOM", () => {
 		},
 		layout: () => undefined,
 	};
-	win.eval(getReportScripts(EMPTY_ARTIFACT_JSON));
+	win.eval(getReportScripts(RICH_ARTIFACT_JSON));
 	const snap: Record<string, string> = {};
 	for (const tab of TABS) {
 		(win as Record<string, unknown>).__t = tab;
@@ -83,4 +83,12 @@ it("renders every tab into a DOM", () => {
 	// The bundled pure helpers reach the page and the tree renders through them.
 	expect(win.eval("typeof RPT.buildFileTree")).toBe("function");
 	expect(snap.summary).toContain("ov-stat-row");
+
+	// The sidebar trees actually rendered, so a change to their markup is
+	// visible here rather than passing on an empty panel.
+	const rows = (tab: string) =>
+		(snap[tab].match(/class="st-row/g) || []).length;
+	expect(rows("modules")).toBeGreaterThan(0);
+	expect(rows("schema")).toBeGreaterThan(0);
+	expect(rows("endpoints")).toBeGreaterThan(0);
 });

--- a/packages/nestjs-doctor/tests/unit/report-dom.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-dom.test.ts
@@ -1,0 +1,86 @@
+import { JSDOM } from "jsdom";
+import { expect, it } from "vitest";
+import { getReportHtml } from "../../src/report/ui/html.js";
+import { getReportScripts } from "../../src/report/ui/scripts.js";
+import { EMPTY_ARTIFACT_JSON } from "./report-artifact-fixture.js";
+
+const TABS = ["summary", "diagnosis", "lab"];
+
+// A canvas context that swallows every call, so the drawing code runs without
+// a real 2D backend and the DOM it also builds still gets built.
+const CANVAS_STUB: Record<string, unknown> = {
+	canvas: { width: 800, height: 600 },
+	measureText: () => ({ width: 40 }),
+	getImageData: () => ({ data: [] }),
+};
+
+// A 2D context that swallows every drawing call, so the canvas code runs
+// without a real backend and the DOM it also builds still gets built.
+function stubCanvas(win: typeof globalThis & Window) {
+	const ctx = new Proxy(CANVAS_STUB, {
+		get: (target, key) =>
+			key in target ? target[key as string] : () => undefined,
+		set: () => true,
+	});
+	// @ts-expect-error test stub
+	win.HTMLCanvasElement.prototype.getContext = () => ctx;
+	// @ts-expect-error test stub
+	win.HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+		width: 800,
+		height: 600,
+		top: 0,
+		left: 0,
+		right: 800,
+		bottom: 600,
+	});
+}
+
+it("renders every tab into a DOM", () => {
+	const dom = new JSDOM(`<body>${getReportHtml()}</body>`, {
+		runScripts: "outside-only",
+		pretendToBeVisual: true,
+	});
+	const win = dom.window as unknown as typeof globalThis & Window;
+	stubCanvas(win);
+	(win as Record<string, unknown>).dagre = {
+		graphlib: {
+			Graph: class {
+				setGraph() {
+					return this;
+				}
+				setDefaultEdgeLabel() {
+					return this;
+				}
+				setNode() {
+					return this;
+				}
+				setEdge() {
+					return this;
+				}
+				nodes(): string[] {
+					return [];
+				}
+				edges(): string[] {
+					return [];
+				}
+				node() {
+					return { x: 0, y: 0, width: 10, height: 10 };
+				}
+			},
+		},
+		layout: () => undefined,
+	};
+	win.eval(getReportScripts(EMPTY_ARTIFACT_JSON));
+	const snap: Record<string, string> = {};
+	for (const tab of TABS) {
+		(win as Record<string, unknown>).__t = tab;
+		win.eval("switchTab(__t)");
+		snap[tab] = win.document.body.innerHTML;
+	}
+	for (const tab of TABS) {
+		expect(snap[tab].length).toBeGreaterThan(1000);
+	}
+	// The bundled pure helpers reach the page and the tree renders through them.
+	expect(win.eval("typeof RPT.buildFileTree")).toBe("function");
+	expect(snap.summary).toContain("ov-stat-row");
+});

--- a/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { badge, treeRow } from "../../src/report/ui/browser/entry.js";
 import { getReportScripts } from "../../src/report/ui/scripts.js";
 import { EMPTY_ARTIFACT_JSON as EMPTY } from "./report-artifact-fixture.js";
 
@@ -34,11 +35,16 @@ function loadTraceRow(
 		sliceOf("var mgTraceMax", "function mgShowModuleTrace");
 	const factory = new Function(
 		"graph",
+		"RPT",
 		`${source}
 		mgTraceMax = 100;
 		return mgTraceRowHtml;`
 	);
-	return factory(graph) as (id: string, depth: number, path: string) => string;
+	return factory(graph, { badge, treeRow }) as (
+		id: string,
+		depth: number,
+		path: string
+	) => string;
 }
 
 describe("mgTraceRowHtml", () => {

--- a/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
@@ -40,7 +40,7 @@ describe("report scripts", () => {
 	});
 
 	it("adds a trace button to the detail header when the module has timings", () => {
-		expect(scripts).toContain('id="detail-timings-btn"');
+		expect(scripts).toContain('id: "detail-timings-btn"');
 		expect(scripts).toContain('ev.target.closest("#detail-timings-btn")');
 	});
 

--- a/packages/nestjs-doctor/tsdown.browser.config.ts
+++ b/packages/nestjs-doctor/tsdown.browser.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsdown";
+
+// The report's browser-side modules, bundled into one IIFE that
+// `getReportScripts` inlines ahead of the remaining script chunks.
+export default defineConfig({
+	entry: { bundle: "src/report/ui/browser/tree.ts" },
+	outDir: "src/report/ui/browser",
+	format: ["iife"],
+	platform: "browser",
+	target: "es2020",
+	outputOptions: { name: "RPT" },
+	minify: false,
+	dts: false,
+	clean: false,
+	sourcemap: false,
+});

--- a/packages/nestjs-doctor/tsdown.browser.config.ts
+++ b/packages/nestjs-doctor/tsdown.browser.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsdown";
 // The report's browser-side modules, bundled into one IIFE that
 // `getReportScripts` inlines ahead of the remaining script chunks.
 export default defineConfig({
-	entry: { bundle: "src/report/ui/browser/tree.ts" },
+	entry: { bundle: "src/report/ui/browser/entry.ts" },
 	outDir: "src/report/ui/browser",
 	format: ["iife"],
 	platform: "browser",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,12 +60,15 @@ importers:
       '@types/react':
         specifier: ^19
         version: 19.2.14
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(oxc-resolver@11.24.2)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(yaml@2.9.0)
 
   packages/nestjs-doctor-lsp:
     dependencies:
@@ -84,7 +87,7 @@ importers:
         version: 0.20.3(oxc-resolver@11.24.2)(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(yaml@2.9.0)
 
   packages/nestjs-doctor-vscode:
     dependencies:
@@ -195,6 +198,14 @@ packages:
 
   '@apm-js-collab/tracing-hooks@0.13.0':
     resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
@@ -344,6 +355,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@changesets/apply-release-plan@7.0.14':
     resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
 
@@ -404,6 +419,42 @@ packages:
 
   '@clack/prompts@1.1.0':
     resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.1':
+    resolution: {integrity: sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9':
+    resolution: {integrity: sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
@@ -608,6 +659,15 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2062,6 +2122,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
@@ -2188,6 +2251,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2229,6 +2296,10 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   debounce-fn@6.0.0:
     resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
     engines: {node: '>=18'}
@@ -2241,6 +2312,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -2318,6 +2392,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
@@ -2594,6 +2672,10 @@ packages:
   hookable@6.0.1:
     resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -2683,6 +2765,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -2711,6 +2796,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2923,6 +3017,10 @@ packages:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2991,6 +3089,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3276,6 +3377,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3507,6 +3611,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -3659,6 +3767,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -3704,9 +3815,24 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3784,6 +3910,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3940,6 +4070,10 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
@@ -3952,6 +4086,22 @@ packages:
 
   web-vitals@6.0.0:
     resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
@@ -3989,6 +4139,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -4077,6 +4234,21 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@astrojs/compiler@4.0.0': {}
 
@@ -4239,6 +4411,10 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.6':
     optional: true
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@changesets/apply-release-plan@7.0.14':
     dependencies:
       '@changesets/config': 3.1.2
@@ -4392,6 +4568,30 @@ snapshots:
       '@clack/core': 1.1.0
       sisteransi: 1.0.5
 
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@emnapi/core@1.11.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -4531,6 +4731,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -5647,6 +5849,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   birpc@4.0.0: {}
 
   brace-expansion@2.0.2:
@@ -5760,6 +5966,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
   d3-color@3.1.0: {}
@@ -5798,6 +6009,13 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   debounce-fn@6.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -5805,6 +6023,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -5870,6 +6090,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@3.0.0: {}
 
@@ -6266,6 +6488,12 @@ snapshots:
 
   hookable@6.0.1: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-void-elements@3.0.0: {}
 
   human-id@4.1.3: {}
@@ -6353,6 +6581,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -6375,6 +6605,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.9(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -6538,6 +6794,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@11.2.6: {}
+
+  lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -6723,6 +6981,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -7232,6 +7492,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   patch-console@2.0.0: {}
 
   path-browserify@1.0.1: {}
@@ -7562,6 +7826,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semifies@1.0.0: {}
@@ -7717,6 +7985,8 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  symbol-tree@3.2.4: {}
+
   tagged-tag@1.0.0: {}
 
   tailwindcss@4.2.0: {}
@@ -7744,9 +8014,23 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.4.11: {}
+
+  tldts@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.11
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -7819,6 +8103,8 @@ snapshots:
       quansync: 1.0.0
 
   undici-types@6.21.0: {}
+
+  undici@8.10.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -7928,7 +8214,7 @@ snapshots:
       lightningcss: 1.33.0
       yaml: 2.9.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -7956,6 +8242,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.33
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -7993,6 +8280,10 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walk-up-path@4.0.0: {}
 
   web-namespaces@2.0.1: {}
@@ -8000,6 +8291,26 @@ snapshots:
   web-vitals@5.3.0: {}
 
   web-vitals@6.0.0: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   when-exit@2.1.5: {}
 
@@ -8025,6 +8336,10 @@ snapshots:
       strip-ansi: 7.1.2
 
   ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,14 +61,14 @@ importers:
         specifier: ^19
         version: 19.2.14
       jsdom:
-        specifier: ^30.0.1
-        version: 30.0.1
+        specifier: ^26.1.0
+        version: 26.1.0
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(oxc-resolver@11.24.2)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(yaml@2.9.0)
 
   packages/nestjs-doctor-lsp:
     dependencies:
@@ -198,6 +198,9 @@ packages:
 
   '@apm-js-collab/tracing-hooks@0.13.0':
     resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@asamuzakjp/css-color@6.0.7':
     resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
@@ -420,9 +423,20 @@ packages:
   '@clack/prompts@1.1.0':
     resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
   '@csstools/color-helpers@6.1.1':
     resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
     engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-calc@3.3.0':
     resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
@@ -431,12 +445,25 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
   '@csstools/css-color-parser@4.2.1':
     resolution: {integrity: sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0':
     resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
@@ -451,6 +478,10 @@ packages:
     peerDependenciesMeta:
       css-tree:
         optional: true
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
@@ -2032,6 +2063,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   agent-install@0.0.5:
     resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
     hasBin: true
@@ -2255,6 +2290,10 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2295,6 +2334,10 @@ packages:
   d3-zoom@3.0.0:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2672,12 +2715,24 @@ packages:
   hookable@6.0.1:
     resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -2687,6 +2742,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2796,6 +2855,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsdom@30.0.1:
     resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
@@ -3012,6 +3080,9 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -3284,6 +3355,9 @@ packages:
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
+
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
@@ -3605,6 +3679,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3815,8 +3892,15 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.4.11:
     resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.4.11:
     resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
@@ -3826,9 +3910,17 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -4087,13 +4179,30 @@ packages:
   web-vitals@6.0.0:
     resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
@@ -4235,6 +4344,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
   '@asamuzakjp/css-color@6.0.7':
     dependencies:
       '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
@@ -4242,6 +4359,7 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
       lru-cache: 11.5.2
+    optional: true
 
   '@asamuzakjp/dom-selector@8.3.2':
     dependencies:
@@ -4249,6 +4367,7 @@ snapshots:
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
+    optional: true
 
   '@astrojs/compiler@4.0.0': {}
 
@@ -4414,6 +4533,7 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+    optional: true
 
   '@changesets/apply-release-plan@7.0.14':
     dependencies:
@@ -4568,12 +4688,28 @@ snapshots:
       '@clack/core': 1.1.0
       sisteransi: 1.0.5
 
-  '@csstools/color-helpers@6.1.1': {}
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/color-helpers@6.1.1':
+    optional: true
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-color-parser@4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -4581,16 +4717,26 @@ snapshots:
       '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.1.9(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
+    optional: true
 
-  '@csstools/css-tokenizer@4.0.0': {}
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@csstools/css-tokenizer@4.0.0':
+    optional: true
 
   '@emnapi/core@1.11.2':
     dependencies:
@@ -4732,7 +4878,8 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.1': {}
+  '@exodus/bytes@1.15.1':
+    optional: true
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -5771,6 +5918,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   agent-install@0.0.5:
     dependencies:
       '@iarna/toml': 2.2.5
@@ -5852,6 +6001,7 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+    optional: true
 
   birpc@4.0.0: {}
 
@@ -5970,6 +6120,12 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+    optional: true
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -6009,12 +6165,18 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   debounce-fn@6.0.0:
     dependencies:
@@ -6091,7 +6253,8 @@ snapshots:
 
   entities@6.0.1: {}
 
-  entities@8.0.0: {}
+  entities@8.0.0:
+    optional: true
 
   env-paths@3.0.0: {}
 
@@ -6488,17 +6651,40 @@ snapshots:
 
   hookable@6.0.1: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   html-void-elements@3.0.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-id@4.1.3: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -6606,6 +6792,33 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsdom@30.0.1:
     dependencies:
       '@asamuzakjp/css-color': 6.0.7
@@ -6631,6 +6844,7 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   jsesc@3.1.0: {}
 
@@ -6793,9 +7007,12 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.2.6: {}
 
-  lru-cache@11.5.2: {}
+  lru-cache@11.5.2:
+    optional: true
 
   lru-cache@5.1.1:
     dependencies:
@@ -6982,7 +7199,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdn-data@2.27.1: {}
+  mdn-data@2.27.1:
+    optional: true
 
   merge2@1.4.1: {}
 
@@ -7317,6 +7535,8 @@ snapshots:
 
   node-releases@2.0.53: {}
 
+  nwsapi@2.2.24: {}
+
   nypm@0.6.5:
     dependencies:
       citty: 0.2.2
@@ -7495,6 +7715,7 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+    optional: true
 
   patch-console@2.0.0: {}
 
@@ -7820,6 +8041,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -8014,23 +8237,41 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tldts-core@7.4.11: {}
+  tldts-core@6.1.86: {}
+
+  tldts-core@7.4.11:
+    optional: true
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.4.11:
     dependencies:
       tldts-core: 7.4.11
+    optional: true
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.11
+    optional: true
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -8104,7 +8345,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@8.10.0: {}
+  undici@8.10.0:
+    optional: true
 
   unified@11.0.5:
     dependencies:
@@ -8214,6 +8456,49 @@ snapshots:
       lightningcss: 1.33.0
       yaml: 2.9.0
 
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.33
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
@@ -8292,9 +8577,24 @@ snapshots:
 
   web-vitals@6.0.0: {}
 
-  webidl-conversions@8.0.1: {}
+  webidl-conversions@7.0.0: {}
 
-  whatwg-mimetype@5.0.0: {}
+  webidl-conversions@8.0.1:
+    optional: true
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0:
+    optional: true
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@16.0.1:
     dependencies:
@@ -8303,6 +8603,7 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   whatwg-url@17.1.0:
     dependencies:
@@ -8311,6 +8612,7 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   when-exit@2.1.5: {}
 


### PR DESCRIPTION
## Context

The report's client code is ~6,600 lines of JavaScript held inside TypeScript template literals. Nothing can import it, nothing type checks it, nothing lints it.

That is the thing that makes a React port expensive. The port cannot reuse the logic, so it reimplements it. This already happened: the closed React branches carry a `selectors.ts` with their own `groupByFile`, `buildFileTree`, `worstSeverity`, `isNotScored`, `CAT_META` and `CAT_ORDER`, every one of which also exists in `scripts/`. Two copies of a rule drift.

This is the first slice of the step in between: move the portable logic into real modules that today's report inlines and a future React app can import, without adding a package, a framework or a flag.

## Problem

`scripts/shared-tree.ts` defines `buildFileTree`, `compressTree`, `worstSev`, `worstSevNode` and `countItems` as text. They are pure functions over plain data, the most portable code in the report, and they are the least reachable.

## Possible flows

| Flow | Affected |
|---|---|
| `--report` from the CLI | Rendered DOM unchanged, emitted text differs |
| `--report` from the TUI | Same, one `getReportScripts` |
| The five helpers' behaviour | Unchanged, verified in jsdom |
| `pnpm test` on a clean checkout | `pretest` builds the bundle first |
| `pnpm build` | `prebuild` builds the bundle first |
| Published tarball | Bundle is inlined into `dist`, no new file ships |
| `buildReportArtifact` via the Node API | Never reaches `ui/` |

## Solution

`src/report/ui/browser/tree.ts` holds the five helpers as real TypeScript. `tsdown.browser.config.ts` bundles them to an IIFE named `RPT`, and `getReportScripts` inlines that bundle ahead of the remaining chunks. Call sites became `RPT.buildFileTree(...)`, so there is one definition instead of one definition plus a React copy waiting to drift.

The report stays one self-contained file with the same five network loads.

Linting them for the first time surfaced unguarded `for...in` loops. They are now `Object.entries` and `Object.values` walks.

**Byte-identity is gone**, because the bundler decides the emitted text. `tests/unit/report-dom.test.ts` replaces it: it renders the report in jsdom with a stubbed 2D context and a fake dagre, asserts every canvas-free tab builds, and asserts the bundle reached the page. I confirmed it catches a real break by renaming a class and watching every snapshot move.

It also carries the first shared component built on that base. The schema, modules and endpoints panels each built `st-row` markup by hand, five row shapes across three files for one visual component. `browser/tree-row.ts` renders all five; the shapes differ only in which slots they fill, so the options carry a `toggleGlyph` for the endpoints caret, an optional `icon` for module rows that have none, and a `before` slot for the method badge that sits ahead of the label. No hand-built `st-row` markup remains.

**The fixture had to come first.** `EMPTY_ARTIFACT` renders empty panels, so a DOM comparison over it would have passed whatever the change did to the rows. `RICH_ARTIFACT` carries three modules, two entities and two endpoints, enough for the three trees to draw 4, 20 and 23 rows, and the DOM test asserts each tree is non-empty so a later change cannot quietly verify nothing.

Found on the way: `switchTab` sets `endpointsRendered` even when `renderEndpoints` returns early on a project with no endpoints, before assigning `epCtx`, and the next line calls `epResize`, which reached `epCtx.setTransform` on `undefined`. Nothing user facing reaches it, because the tab button stays hidden in that case, but the guard keeping it hidden lives in `tab-visibility.ts` while the early return lives in `endpoints.ts`. `epResize` now guards `epCtx`, which `epDraw` already did.

Three more families followed on the same base. `summary-card.ts` gives the summary tab a `statRow` and `infoItem` atom under a `statCard` and `infoCard` molecule, so its three cards carry thirteen rows as data. `badge.ts` replaces fourteen hand-written `md-badge` spans across ten variants, some carrying an id, an inline style, a title or a tooltip. No hand-built `st-row` or `md-badge` markup is left anywhere.

Tooltips were looked at and left alone. The three panels share only a `tt-name` and a `tt-table` div; schema adds a column list and a size line, endpoints adds method, conditional and repeat labels. A component there is one line in place of one line with nothing reused.

**Two bugs surfaced while making the tests able to see this code.**

`switchTab` sets `endpointsRendered` even when `renderEndpoints` returns early on a project with no endpoints, before assigning `epCtx`, and the next line calls `epResize`, which reached `epCtx.setTransform` on `undefined`. Nothing user facing reaches it, because the tab button stays hidden then, but the guard keeping it hidden lives in `tab-visibility.ts` while the early return lives in `endpoints.ts`. `epResize` now guards `epCtx`, which `epDraw` already did.

The second one is user facing and carries its own changeset. `mgBuild` creates a stand-in node for any import it cannot resolve and flags it `external`, so by the time the detail panel runs `mgNodeMap` always has an entry and its `!target` check can never be true. The external badge and the dashed row styling were both unreachable, and an import from a package read as if it were a module in your codebase. Measured before the fix: the stand-in node existed and was flagged, and `md-import-ext` appeared zero times.

Deliberately not done: the remaining markup builders and the event wiring stay as strings. React rewrites markup as JSX, so porting it early buys nothing. The canvas painters and the layout maths are the next slices, and both closed branches show they extract cleanly.

## Before vs after

| | Before | After |
|---|---|---|
| Definitions of `buildFileTree` | 1 in a string, 1 on the React branch | 1, in TypeScript |
| Type checked | no | yes |
| Linted | no | yes |
| Emitted report | byte-identity enforced | DOM equivalence enforced |
| Hand-built `st-row` markup | 5 shapes in 3 files | none |
| Hand-built `md-badge` markup | 14 sites, 10 variants | none |
| Summary card rows | 13 written out | data over 4 components |
| External imports marked | never | correctly |
| Tabs covered by a DOM test | 0 | 6 |
| Tree rows exercised by tests | 0 | 47 |
| Badge variants under comparison | 0 | 10 of 10 |
| Detail panel under comparison | 0 | ~11k chars |
| Tests | 1,580 | 1,581 |
| New runtime dependencies | | none |

## Example

```
$ node dist/cli/index.mjs tests/fixtures/basic-app --report --output r.html
  buildFileTree   definitions=1  RPT calls=2
  compressTree    definitions=1  RPT calls=2
  worstSevNode    definitions=1  RPT calls=1
  countItems      definitions=1  RPT calls=1

$ vitest run report-dom      # DOM before vs after, per tab
  summary:same  diagnosis:same  lab:same
  modules:same  schema:same    endpoints:same
```

Gate: `pnpm check` ✓ · `pnpm knip` ✓ · `pnpm test` 1,581 + 51 ✓ · `pnpm build` ✓ · `pnpm typecheck` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
