### PR TITLE
refactor(report): render search, checkbox, and zoom controls from components

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/atoms/search-input.ts
+++ b/packages/nestjs-doctor/src/report/ui/atoms/search-input.ts
@@ -1,0 +1,15 @@
+interface SearchInputOptions {
+	id: string;
+	indent?: number;
+	placeholder: string;
+}
+
+// Renders one search box with the report's shared input attributes.
+export function searchInput({
+	id,
+	placeholder,
+	indent = 8,
+}: SearchInputOptions): string {
+	const pad = " ".repeat(indent);
+	return `${pad}<input type="search" id="${id}" placeholder="${placeholder}" spellcheck="false" autocomplete="off">`;
+}

--- a/packages/nestjs-doctor/src/report/ui/molecules/checkbox-row.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/checkbox-row.ts
@@ -1,0 +1,32 @@
+interface CheckboxRowOptions {
+	checked?: boolean;
+	id: string;
+	indent?: number;
+	label: string;
+	rowId?: string;
+	tip?: string;
+}
+
+// A `schema-sync` label wrapping a checkbox and its caption. `tip` adds the
+// has-tip class the floating tooltip binds to.
+export function checkboxRow({
+	id,
+	label,
+	checked,
+	tip,
+	rowId,
+	indent = 6,
+}: CheckboxRowOptions): string {
+	const pad = " ".repeat(indent);
+	const attrs = [
+		`class="schema-sync${tip ? " has-tip" : ""}"`,
+		rowId ? `id="${rowId}"` : undefined,
+		tip ? `data-tip="${tip}"` : undefined,
+	].filter(Boolean);
+	return [
+		`${pad}<label ${attrs.join(" ")}>`,
+		`${pad}  <input type="checkbox" id="${id}"${checked ? " checked" : ""}>`,
+		`${pad}  <span>${label}</span>`,
+		`${pad}</label>`,
+	].join("\n");
+}

--- a/packages/nestjs-doctor/src/report/ui/molecules/zoom-bar.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/zoom-bar.ts
@@ -1,0 +1,37 @@
+import { iconButton } from "../atoms/button.js";
+
+interface ZoomBarOptions {
+	indent?: number;
+	prefix: string;
+	subject: string;
+}
+
+// The zoom-out / range / zoom-in / value cluster shared by the schema and
+// modules-graph canvases. `subject` names what the fit tip resizes.
+export function zoomBar({
+	prefix,
+	subject,
+	indent = 6,
+}: ZoomBarOptions): string {
+	const pad = " ".repeat(indent);
+	return [
+		`${pad}<div id="${prefix}-zoombar">`,
+		iconButton({
+			id: `${prefix}-zoom-out`,
+			icon: "zoomOut",
+			modifier: "schema-zoom-btn",
+			ariaLabel: "Zoom out",
+			tip: "Zoom out",
+		}),
+		`${pad}  <input type="range" id="${prefix}-zoom-range" min="5" max="500" step="1" value="100" aria-label="Zoom">`,
+		iconButton({
+			id: `${prefix}-zoom-in`,
+			icon: "zoomIn",
+			modifier: "schema-zoom-btn",
+			ariaLabel: "Zoom in",
+			tip: "Zoom in",
+		}),
+		`${pad}  <button class="schema-zoom-value has-tip" id="${prefix}-zoom-value" aria-label="100% · fit to view" data-tip="Fit · size the ${subject} to the window">100%</button>`,
+		`${pad}</div>`,
+	].join("\n");
+}

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
@@ -1,4 +1,6 @@
 import { iconButton } from "../atoms/button.js";
+import { searchInput } from "../atoms/search-input.js";
+import { checkboxRow } from "../molecules/checkbox-row.js";
 import { pillGroup } from "../molecules/pill-group.js";
 
 export const TAB_DIAGNOSIS = `
@@ -14,12 +16,9 @@ ${iconButton({ id: "diag-expand-all", icon: "expandAll", ariaLabel: "Expand all"
 ${iconButton({ id: "diag-collapse-all", icon: "collapseAll", ariaLabel: "Collapse all", tip: "Collapse all \u00b7 close every folder in the list" })}
       </div>
       <div class="mg-side-search">
-        <input type="search" id="diag-search" placeholder="Search files" spellcheck="false" autocomplete="off">
+${searchInput({ id: "diag-search", placeholder: "Search files" })}
       </div>
-      <label class="schema-sync" id="diag-notscored-row">
-        <input type="checkbox" id="diag-show-notscored">
-        <span>Show not scored</span>
-      </label>
+${checkboxRow({ id: "diag-show-notscored", label: "Show not scored", rowId: "diag-notscored-row" })}
       <hr class="diag-divider" id="diag-notscored-divider">
       <button class="diag-filters-toggle" id="diag-filters-toggle" aria-expanded="false">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
@@ -1,5 +1,8 @@
 import { iconButton } from "../atoms/button.js";
+import { searchInput } from "../atoms/search-input.js";
+import { checkboxRow } from "../molecules/checkbox-row.js";
 import { legend } from "../molecules/legend.js";
+import { zoomBar } from "../molecules/zoom-bar.js";
 
 export const TAB_MODULES_GRAPH = `
 <!-- ── Tab: Modules Graph ── -->
@@ -15,17 +18,11 @@ ${iconButton({ id: "mg-collapse-all", icon: "collapseAll", ariaLabel: "Collapse 
 ${iconButton({ id: "mg-sidebar-collapse", icon: "sidebarCollapse", ariaLabel: "Hide the project list", tip: "Hide list · give the graph the whole width" })}
       </div>
       <div class="mg-side-search">
-        <input type="search" id="mg-search" placeholder="Search projects and modules" spellcheck="false" autocomplete="off">
+${searchInput({ id: "mg-search", placeholder: "Search projects and modules" })}
       </div>
       <div class="mg-toggle-row">
-        <label class="schema-sync">
-          <input type="checkbox" id="mg-globals">
-          <span>Show @Global() reach</span>
-        </label>
-        <label class="schema-sync">
-          <input type="checkbox" id="mg-show-external">
-          <span>Show external modules</span>
-        </label>
+${checkboxRow({ id: "mg-globals", label: "Show @Global() reach", indent: 8 })}
+${checkboxRow({ id: "mg-show-external", label: "Show external modules", indent: 8 })}
       </div>
     </div>
     <div id="mg-tree"></div>
@@ -42,12 +39,7 @@ ${iconButton({ id: "mg-sidebar-collapse", icon: "sidebarCollapse", ariaLabel: "H
   <div id="mg-wrap">
 ${iconButton({ id: "mg-sidebar-show", icon: "sidebarShow", ariaLabel: "Show the project list", tip: "Show list · bring the project list back", indent: 4 })}
     <div id="mg-toolbar">
-      <div id="mg-zoombar">
-${iconButton({ id: "mg-zoom-out", icon: "zoomOut", modifier: "schema-zoom-btn", ariaLabel: "Zoom out", tip: "Zoom out" })}
-        <input type="range" id="mg-zoom-range" min="5" max="500" step="1" value="100" aria-label="Zoom">
-${iconButton({ id: "mg-zoom-in", icon: "zoomIn", modifier: "schema-zoom-btn", ariaLabel: "Zoom in", tip: "Zoom in" })}
-        <button class="schema-zoom-value has-tip" id="mg-zoom-value" aria-label="100% · fit to view" data-tip="Fit · size the graph to the window">100%</button>
-      </div>
+${zoomBar({ prefix: "mg", subject: "graph" })}
 ${iconButton({ id: "mg-recenter", icon: "recenter", modifier: "schema-diagram-btn", ariaLabel: "Re-center graph", tip: "Re-center · bring the graph back into view", indent: 6 })}
 ${iconButton({ id: "mg-info", icon: "info", modifier: "schema-diagram-btn", ariaLabel: "Legend and concepts", tip: "Info · legend and NestJS concepts", indent: 6 })}
     </div>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
@@ -1,4 +1,7 @@
 import { iconButton } from "../atoms/button.js";
+import { searchInput } from "../atoms/search-input.js";
+import { checkboxRow } from "../molecules/checkbox-row.js";
+import { zoomBar } from "../molecules/zoom-bar.js";
 
 export const TAB_SCHEMA = `
 <!-- ── Tab: Schema ── -->
@@ -14,12 +17,9 @@ ${iconButton({ id: "schema-collapse-all", icon: "collapseAll", ariaLabel: "Colla
 ${iconButton({ id: "schema-sidebar-collapse", icon: "sidebarCollapse", ariaLabel: "Hide the table list", tip: "Hide list \u00b7 give the diagram the whole width" })}
       </div>
       <div class="mg-side-search">
-        <input type="search" id="schema-search" placeholder="Search tables" spellcheck="false" autocomplete="off">
+${searchInput({ id: "schema-search", placeholder: "Search tables" })}
       </div>
-      <label class="schema-sync has-tip" data-tip="Sync \u00b7 the list follows the table you pick in the diagram">
-        <input type="checkbox" id="schema-sync-sidebar" checked>
-        <span>Sync with diagram</span>
-      </label>
+${checkboxRow({ id: "schema-sync-sidebar", label: "Sync with diagram", checked: true, tip: "Sync \u00b7 the list follows the table you pick in the diagram" })}
       <div class="schema-disclaimer">Schema inferred from source code — may not reflect the actual database.</div>
     </div>
     <div id="schema-entity-list"></div>
@@ -36,12 +36,7 @@ ${iconButton({ id: "schema-sidebar-show", icon: "sidebarShow", ariaLabel: "Show 
         <button class="st-btn schema-empty-action" id="schema-show-all">Show all tables</button>
       </div>
       <div id="schema-toolbar">
-      <div id="schema-zoombar">
-${iconButton({ id: "schema-zoom-out", icon: "zoomOut", modifier: "schema-zoom-btn", ariaLabel: "Zoom out", tip: "Zoom out" })}
-        <input type="range" id="schema-zoom-range" min="5" max="500" step="1" value="100" aria-label="Zoom">
-${iconButton({ id: "schema-zoom-in", icon: "zoomIn", modifier: "schema-zoom-btn", ariaLabel: "Zoom in", tip: "Zoom in" })}
-        <button class="schema-zoom-value has-tip" id="schema-zoom-value" aria-label="100% \u00b7 fit to view" data-tip="Fit \u00b7 size the diagram to the window">100%</button>
-      </div>
+${zoomBar({ prefix: "schema", subject: "diagram" })}
 ${iconButton({ id: "schema-toggle-view", icon: "toggleView", modifier: "schema-diagram-btn", ariaLabel: "Show all tables", tip: "All tables \u00b7 lay out the whole schema at once" })}
 ${iconButton({ id: "schema-recenter", icon: "recenter", modifier: "schema-diagram-btn", ariaLabel: "Re-center diagram", tip: "Re-center \u00b7 bring the diagram back into view" })}
 ${iconButton({ id: "schema-expand-tables", icon: "expandTables", modifier: "schema-diagram-btn", ariaLabel: "Expand tables", tip: "Expand \u00b7 show the columns inside each table" })}


### PR DESCRIPTION
## Context

Since #320 the static tiers (atoms, molecules, templates) render buttons, pills, selects, legends, and tabs through component functions. #322 moved the six tab sections into `templates/`.

## Problem

Nine sites in the templates still hand-write markup that exists in near-identical copies elsewhere. The zoom bar is the sharpest case: `tab-schema.ts` and `tab-modules-graph.ts` carry the same six-line block, differing only in id prefix and one word in the tooltip, and the modules-graph copy already borrows the schema copy's class names (`schema-zoom-btn`, `schema-zoom-value`). The four checkbox rows and three search inputs repeat the same way.

## Possible flows

| Pattern | Sites | Files |
|---|---|---|
| Search input | 3 | tab-diagnosis, tab-modules-graph, tab-schema |
| Checkbox row (`label.schema-sync`) | 4 | tab-diagnosis, tab-modules-graph ×2, tab-schema |
| Zoom bar | 2 | tab-modules-graph, tab-schema |

No other file renders these patterns; the runtime scripts and browser bundle are untouched.

## Solution

Three new components following the existing options-object and `indent` conventions: `atoms/search-input.ts`, `molecules/checkbox-row.ts` (optional `checked`, `tip`, `rowId` cover the four variations), and `molecules/zoom-bar.ts` (composes the two `iconButton` calls plus range and value button). The nine sites now call them.

Not done: the Rule Lab's two text inputs (both one-off, no shared shape) and the header nav (two anchors plus one button, no common element).

## Before vs after

| | Before | After |
|---|---|---|
| Raw copies of the three patterns | 9 | 0 |
| `templates/tab-modules-graph.ts` | 143 lines | 135 lines |
| Emitted report | — | Byte-identical (verified below) |

## Example

Both builds scanning `tests/fixtures/basic-app`, masking `generatedAt` and `elapsedMs`:

```
$ cmp after.masked after2.masked && echo BYTE-IDENTICAL
BYTE-IDENTICAL
```

