### PR TITLE
refactor(report): render every button through the button atom

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/atoms/button.ts
+++ b/packages/nestjs-doctor/src/report/ui/atoms/button.ts
@@ -37,3 +37,51 @@ export function iconButton({
 		.join("\n");
 	return `${pad}<button class="${classes.join(" ")}" ${attrs.join(" ")}>\n${glyph}\n${pad}</button>`;
 }
+
+interface TextButtonOptions {
+	ariaExpanded?: boolean;
+	ariaLabel?: string;
+	classes?: string;
+	content?: string;
+	id: string;
+	indent?: number;
+	label?: string;
+	tip?: string;
+	type?: string;
+}
+
+// Renders one text button. `label` is inline content; `content` is multi-line
+// inner HTML emitted on its own lines. `tip` adds the has-tip class.
+export function textButton({
+	id,
+	label = "",
+	content,
+	classes,
+	type,
+	ariaLabel,
+	ariaExpanded,
+	tip,
+	indent = 6,
+}: TextButtonOptions): string {
+	const cls = [classes, tip ? "has-tip" : undefined].filter(Boolean).join(" ");
+	const attrs = [
+		cls ? `class="${cls}"` : undefined,
+		`id="${id}"`,
+		type ? `type="${type}"` : undefined,
+		ariaLabel ? `aria-label="${ariaLabel}"` : undefined,
+		ariaExpanded === undefined ? undefined : `aria-expanded="${ariaExpanded}"`,
+		tip ? `data-tip="${tip}"` : undefined,
+	].filter(Boolean);
+	const pad = " ".repeat(indent);
+	if (content === undefined) {
+		return `${pad}<button ${attrs.join(" ")}>${label}</button>`;
+	}
+	return `${pad}<button ${attrs.join(" ")}>\n${content}\n${pad}</button>`;
+}
+
+// A dismiss button: the same text button, always rendering the times glyph.
+export function closeButton(
+	options: Omit<TextButtonOptions, "content" | "label">
+): string {
+	return textButton({ ...options, label: "&times;" });
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -1,4 +1,5 @@
 // biome-ignore lint/performance/noBarrelFile: the browser bundle's entry, not a consumer barrel
+export { textButton } from "../atoms/button.js";
 export { badge } from "./badge.js";
 export {
 	infoCard,

--- a/packages/nestjs-doctor/src/report/ui/molecules/zoom-bar.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/zoom-bar.ts
@@ -1,4 +1,4 @@
-import { iconButton } from "../atoms/button.js";
+import { iconButton, textButton } from "../atoms/button.js";
 
 interface ZoomBarOptions {
 	indent?: number;
@@ -31,7 +31,14 @@ export function zoomBar({
 			ariaLabel: "Zoom in",
 			tip: "Zoom in",
 		}),
-		`${pad}  <button class="schema-zoom-value has-tip" id="${prefix}-zoom-value" aria-label="100% · fit to view" data-tip="Fit · size the ${subject} to the window">100%</button>`,
+		textButton({
+			id: `${prefix}-zoom-value`,
+			classes: "schema-zoom-value",
+			label: "100%",
+			ariaLabel: "100% · fit to view",
+			tip: `Fit · size the ${subject} to the window`,
+			indent: indent + 2,
+		}),
 		`${pad}</div>`,
 	].join("\n");
 }

--- a/packages/nestjs-doctor/src/report/ui/organisms/header-row1.ts
+++ b/packages/nestjs-doctor/src/report/ui/organisms/header-row1.ts
@@ -1,3 +1,5 @@
+import { textButton } from "../atoms/button.js";
+
 export const HEADER_ROW1 = `
 <!-- ── Header Row 1 ── -->
 <div id="header-row1">
@@ -8,7 +10,7 @@ export const HEADER_ROW1 = `
   <div class="meta" id="header-meta"></div>
   <div class="spacer"></div>
   <div class="nav-actions">
-    <button class="nav-btn" id="nav-share" type="button">share</button>
+${textButton({ id: "nav-share", classes: "nav-btn", type: "button", label: "share", indent: 4 })}
     <a class="nav-btn" href="https://nestjs.doctor/docs" target="_blank" rel="noopener">docs</a>
     <a class="nav-btn" href="https://github.com/RoloBits/nestjs-doctor" target="_blank" rel="noopener">github</a>
   </div>

--- a/packages/nestjs-doctor/src/report/ui/scripts/share.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/share.ts
@@ -95,7 +95,7 @@ export const SHARE = `
     }
     html += '<label class="share-row" style="margin-top:4px"><input type="checkbox" id="share-code"> Include code snippets <span class="share-hint">a few lines around each finding</span></label>';
     html += '<div class="share-actions">';
-    html += '<button id="share-download" class="share-download" type="button">Download .json</button>';
+    html += RPT.textButton({ id: "share-download", classes: "share-download", type: "button", label: "Download .json", indent: 0 });
     html += '</div></div>';
     overlay.innerHTML = html;
 

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
@@ -1,4 +1,4 @@
-import { iconButton } from "../atoms/button.js";
+import { iconButton, textButton } from "../atoms/button.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { pillGroup } from "../molecules/pill-group.js";
@@ -20,12 +20,15 @@ ${searchInput({ id: "diag-search", placeholder: "Search files" })}
       </div>
 ${checkboxRow({ id: "diag-show-notscored", label: "Show not scored", rowId: "diag-notscored-row" })}
       <hr class="diag-divider" id="diag-notscored-divider">
-      <button class="diag-filters-toggle" id="diag-filters-toggle" aria-expanded="false">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+${textButton({
+	id: "diag-filters-toggle",
+	classes: "diag-filters-toggle",
+	ariaExpanded: false,
+	content: `        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
         Filters
         <span class="diag-filters-count" id="diag-filters-count" style="display:none"></span>
-        <span class="diag-filters-caret">\u25B8</span>
-      </button>
+        <span class="diag-filters-caret">\u25B8</span>`,
+})}
       <div class="filter-rows" id="diag-filters-body">
         <div class="sev-filters">
           <span class="filter-label">Severity</span>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-endpoints.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-endpoints.ts
@@ -1,4 +1,4 @@
-import { iconButton } from "../atoms/button.js";
+import { closeButton, iconButton } from "../atoms/button.js";
 
 export const TAB_ENDPOINTS = `
 <!-- ── Tab: Endpoints ── -->
@@ -10,7 +10,7 @@ export const TAB_ENDPOINTS = `
         <span class="ep-code-panel-method" id="ep-code-panel-method"></span>
       </div>
       <div class="ep-code-panel-path" id="ep-code-panel-path"></div>
-      <button class="ep-code-panel-close" id="ep-code-panel-close">&times;</button>
+${closeButton({ id: "ep-code-panel-close", classes: "ep-code-panel-close" })}
     </div>
     <div class="ep-code-panel-body" id="ep-code-panel-body"></div>
     <div class="ep-code-panel-resize" id="ep-code-panel-resize"></div>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
@@ -1,3 +1,4 @@
+import { textButton } from "../atoms/button.js";
 import { selectField } from "../molecules/select-field.js";
 
 export const TAB_LAB = `
@@ -82,7 +83,7 @@ for (let i = 0; i < lines.length; i++) {
   }
 }</script>
     <div class="playground-actions">
-      <button id="pg-run-btn">&#9654; Run Rule</button>
+${textButton({ id: "pg-run-btn", label: "&#9654; Run Rule" })}
     </div>
     <div id="pg-error" class="playground-error" style="display:none"></div>
   </div>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
@@ -1,4 +1,4 @@
-import { iconButton } from "../atoms/button.js";
+import { closeButton, iconButton } from "../atoms/button.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { legend } from "../molecules/legend.js";
@@ -27,7 +27,7 @@ ${checkboxRow({ id: "mg-show-external", label: "Show external modules", indent: 
     </div>
     <div id="mg-tree"></div>
     <div id="detail">
-      <button class="close-btn" id="close-detail">&times;</button>
+${closeButton({ id: "close-detail", classes: "close-btn" })}
       <h2 id="detail-name"></h2>
       <div id="detail-badges"></div>
       <div class="filepath" id="detail-path"></div>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
@@ -1,4 +1,4 @@
-import { iconButton } from "../atoms/button.js";
+import { iconButton, textButton } from "../atoms/button.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { zoomBar } from "../molecules/zoom-bar.js";
@@ -33,7 +33,7 @@ ${iconButton({ id: "schema-sidebar-show", icon: "sidebarShow", ariaLabel: "Show 
           <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
         </svg>
         <p>Select an entity from the sidebar to explore its schema</p>
-        <button class="st-btn schema-empty-action" id="schema-show-all">Show all tables</button>
+${textButton({ id: "schema-show-all", classes: "st-btn schema-empty-action", label: "Show all tables", indent: 8 })}
       </div>
       <div id="schema-toolbar">
 ${zoomBar({ prefix: "schema", subject: "diagram" })}


### PR DESCRIPTION
## Context

The report's static tiers render controls through component functions (#320, #323). crocova's `ui-v3` keeps every button inside the button atom, expressed as variants of one component. Ours had `iconButton` only, so anything that wasn't an icon button was hand-written markup.

## Problem

Eight sites wrote a `<button>` tag outside `atoms/`: the zoom value, the Rule Lab run button, two close buttons, the schema empty-state action, the diagnosis filters toggle, the header share button, and the share overlay's download button built at runtime in `scripts/share.ts`. Each re-decided attribute order and tooltip wiring on its own.

## Possible flows

| Site | Tier | Now renders via |
|---|---|---|
| Zoom value (schema + modules graph) | molecule | `textButton` |
| Run Rule, schema Show all, header share | template / organism | `textButton` |
| Filters toggle (multi-line content) | template | `textButton` with `content` |
| Detail close, code-panel close | template | `closeButton` |
| Share overlay download | runtime script | `RPT.textButton` via the browser bundle |

## Solution

Two variants added to `atoms/button.ts`: `textButton` (optional `classes`, `type`, `ariaLabel`, `ariaExpanded`, `tip`, and `content` for multi-line inner HTML) and `closeButton`, a thin wrapper that always renders `&times;`. The browser bundle's entry re-exports `textButton`, so the runtime share chunk calls `RPT.textButton` instead of concatenating markup. Zero raw `<button>` tags remain outside `atoms/`.

Not done: the header's two `nav-btn` links stay raw, they are `<a>` elements, not buttons.

## Before vs after

| | Before | After |
|---|---|---|
| Raw `<button>` outside atoms | 8 | 0 |
| Static markup | — | Byte-identical |
| Share overlay button | `id class type` attribute order | `class id type`, same rendered DOM |

## Example

Diffing the emitted report before and after (masking `generatedAt`/`elapsedMs`) leaves exactly three regions, all inside the script: the bundled `textButton` source, its export, and

```
A: html += '<button id="share-download" class="share-download" ...>Download .json</button>';
B: html += RPT.textButton({ id: "share-download", classes: "share-download", type: "button", label: "Download .json", indent: 0 });
```
