### PR TITLE
refactor(report): render headings and the preset dropdown through atoms

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/atoms/heading.ts
+++ b/packages/nestjs-doctor/src/report/ui/atoms/heading.ts
@@ -1,0 +1,31 @@
+interface HeadingOptions {
+	classes?: string;
+	id?: string;
+	indent?: number;
+	level: 1 | 2 | 3 | 4 | 5 | 6;
+	style?: string;
+	text?: string;
+	tip?: string;
+}
+
+// Renders one heading. `text` is inner HTML the caller has already escaped;
+// `tip` adds the has-tip class the floating tooltip binds to.
+export function heading({
+	level,
+	text = "",
+	id,
+	classes,
+	style,
+	tip,
+	indent = 0,
+}: HeadingOptions): string {
+	const cls = [classes, tip ? "has-tip" : undefined].filter(Boolean).join(" ");
+	const attrs = [
+		cls ? ` class="${cls}"` : "",
+		id ? ` id="${id}"` : "",
+		style ? ` style="${style}"` : "",
+		tip ? ` data-tip="${tip}"` : "",
+	].join("");
+	const pad = " ".repeat(indent);
+	return `${pad}<h${level}${attrs}>${text}</h${level}>`;
+}

--- a/packages/nestjs-doctor/src/report/ui/atoms/select.ts
+++ b/packages/nestjs-doctor/src/report/ui/atoms/select.ts
@@ -4,20 +4,44 @@ export interface SelectOption {
 	value: string;
 }
 
-interface SelectOptions {
-	id: string;
-	indent?: number;
+export interface SelectGroup {
+	label: string;
 	options: SelectOption[];
 }
 
-// Renders a `<select>` and its options, each line indented from `indent`.
-export function select({ id, options, indent = 0 }: SelectOptions): string {
+interface SelectOptions {
+	groups?: SelectGroup[];
+	id: string;
+	indent?: number;
+	options?: SelectOption[];
+}
+
+// Renders a `<select>` from flat options or labelled optgroups, each line
+// indented from `indent`.
+export function select({
+	id,
+	options = [],
+	groups,
+	indent = 0,
+}: SelectOptions): string {
 	const pad = " ".repeat(indent);
-	const rendered = options
-		.map(
-			(o) =>
-				`${pad}  <option value="${o.value}"${o.selected ? " selected" : ""}>${o.label}</option>`
-		)
-		.join("\n");
-	return [`${pad}<select id="${id}">`, rendered, `${pad}</select>`].join("\n");
+	const renderOptions = (opts: SelectOption[], depth: string) =>
+		opts
+			.map(
+				(o) =>
+					`${depth}<option value="${o.value}"${o.selected ? " selected" : ""}>${o.label}</option>`
+			)
+			.join("\n");
+	const body = groups
+		? groups
+				.map((g) =>
+					[
+						`${pad}  <optgroup label="${g.label}">`,
+						renderOptions(g.options, `${pad}    `),
+						`${pad}  </optgroup>`,
+					].join("\n")
+				)
+				.join("\n")
+		: renderOptions(options, `${pad}  `);
+	return [`${pad}<select id="${id}">`, body, `${pad}</select>`].join("\n");
 }

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -1,5 +1,6 @@
 // biome-ignore lint/performance/noBarrelFile: the browser bundle's entry, not a consumer barrel
 export { textButton } from "../atoms/button.js";
+export { heading } from "../atoms/heading.js";
 export { badge } from "./badge.js";
 export {
 	infoCard,

--- a/packages/nestjs-doctor/src/report/ui/browser/summary-card.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/summary-card.ts
@@ -1,3 +1,5 @@
+import { heading } from "../atoms/heading.js";
+
 interface Row {
 	label: string;
 	value: string | number;
@@ -20,10 +22,10 @@ export function infoItem({ label, value }: Row): string {
 
 // A summary card whose body is a list of stat rows.
 export function statCard({ title, rows }: CardOptions): string {
-	return `<div class="ov-card"><h3>${title}</h3><div class="ov-card-body">${rows.map(statRow).join("")}</div></div>`;
+	return `<div class="ov-card">${heading({ level: 3, text: title })}<div class="ov-card-body">${rows.map(statRow).join("")}</div></div>`;
 }
 
 // A summary card whose body is the project info grid.
 export function infoCard({ title, rows }: CardOptions): string {
-	return `<div class="ov-card"><h3>${title}</h3><div class="ov-card-body"><div class="ov-info-grid">${rows.map(infoItem).join("")}</div></div></div>`;
+	return `<div class="ov-card">${heading({ level: 3, text: title })}<div class="ov-card-body"><div class="ov-info-grid">${rows.map(infoItem).join("")}</div></div></div>`;
 }

--- a/packages/nestjs-doctor/src/report/ui/molecules/select-field.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/select-field.ts
@@ -1,10 +1,16 @@
-import { type SelectOption, select } from "../atoms/select.js";
+import {
+	type SelectGroup,
+	type SelectOption,
+	select,
+} from "../atoms/select.js";
 
 interface SelectFieldOptions {
+	groups?: SelectGroup[];
 	id: string;
 	indent?: number;
 	label: string;
-	options: SelectOption[];
+	options?: SelectOption[];
+	wide?: boolean;
 }
 
 // Pairs a label with a select inside the Rule Lab's field wrapper.
@@ -12,13 +18,18 @@ export function selectField({
 	id,
 	label,
 	options,
+	groups,
+	wide,
 	indent = 8,
 }: SelectFieldOptions): string {
 	const pad = " ".repeat(indent);
+	const cls = wide
+		? "playground-field playground-field-wide"
+		: "playground-field";
 	return [
-		`${pad}<div class="playground-field">`,
+		`${pad}<div class="${cls}">`,
 		`${pad}  <label for="${id}">${label}</label>`,
-		select({ id, options, indent: indent + 2 }),
+		select({ id, options, groups, indent: indent + 2 }),
 		`${pad}</div>`,
 	].join("\n");
 }

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -1313,9 +1313,9 @@ function mgEsc(s) {
 var MG_INFO_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>';
 
 function mgSection(title, count, tip) {
-  var attrs = tip ? ' class="has-tip tip-wide" data-tip="' + mgEsc(tip) + '"' : "";
   var info = tip ? ' <span class="md-info">' + MG_INFO_ICON + '</span>' : "";
-  return '<h4' + attrs + '>' + mgEsc(title) + (count === undefined ? "" : " (" + count + ")") + info + '</h4>';
+  return RPT.heading({ level: 4, classes: tip ? "tip-wide" : undefined, tip: tip ? mgEsc(tip) : undefined,
+    text: mgEsc(title) + (count === undefined ? "" : " (" + count + ")") + info });
 }
 
 function mgWiringTree(deps, depth) {
@@ -1902,7 +1902,7 @@ function mgExportsHtml(n) {
 
 function mgCyclesHtml(n) {
   if (!circularModules.has(n.name)) return "";
-  var html = '<h4 style="color:#ea2845">Circular dependencies</h4>';
+  var html = RPT.heading({ level: 4, style: "color:#ea2845", text: "Circular dependencies" });
   for (var i = 0; i < graph.circularDeps.length; i++) {
     var cycle = graph.circularDeps[i];
     if (cycle.indexOf(n.name) < 0) continue;

--- a/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
@@ -12,7 +12,7 @@ function renderSummary() {
   var notScoredCount = (diagnostics || []).filter(function (d) {
     return d.surfaces && d.surfaces.indexOf('score') === -1;
   }).length;
-  html += '<div class="ov-card full-width"><h3>Health Score</h3><div class="ov-card-body">' +
+  html += '<div class="ov-card full-width">' + RPT.heading({ level: 3, text: "Health Score" }) + '<div class="ov-card-body">' +
     '<div class="ov-score-row">' +
     '<div class="ov-score-ring">' + makeScoreRingSvg(120, 6, sv) + '</div>' +
     '<div class="ov-score-details">' +
@@ -49,7 +49,7 @@ function renderSummary() {
   });
 
   // Category breakdown card
-  html += '<div class="ov-card"><h3>Issues by Category</h3><div class="ov-card-body">';
+  html += '<div class="ov-card">' + RPT.heading({ level: 3, text: "Issues by Category" }) + '<div class="ov-card-body">';
   for (const cat of CAT_ORDER) {
     const m = CAT_META[cat];
     const count = (summary.byCategory && summary.byCategory[cat]) || 0;

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
@@ -51,20 +51,29 @@ ${selectField({
 	],
 })}
       <div class="playground-preset-sep"></div>
-      <div class="playground-field playground-field-wide">
-        <label for="pg-preset">Load example</label>
-        <select id="pg-preset">
-        <optgroup label="File rules">
-          <option value="todo">Find TODO comments</option>
-          <option value="console-log">Find console.log statements</option>
-          <option value="large-file">Detect large files</option>
-        </optgroup>
-        <optgroup label="Project rules">
-          <option value="orphan-modules">Find orphan modules</option>
-          <option value="unused-providers">Find unused providers</option>
-        </optgroup>
-      </select>
-      </div>
+${selectField({
+	id: "pg-preset",
+	label: "Load example",
+	wide: true,
+	indent: 6,
+	groups: [
+		{
+			label: "File rules",
+			options: [
+				{ value: "todo", label: "Find TODO comments" },
+				{ value: "console-log", label: "Find console.log statements" },
+				{ value: "large-file", label: "Detect large files" },
+			],
+		},
+		{
+			label: "Project rules",
+			options: [
+				{ value: "orphan-modules", label: "Find orphan modules" },
+				{ value: "unused-providers", label: "Find unused providers" },
+			],
+		},
+	],
+})}
     </div>
     <div class="playground-section-label">CHECK FUNCTION</div>
     <div id="pg-cm-editor" class="pg-cm-wrap"></div>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
@@ -1,4 +1,5 @@
 import { closeButton, iconButton } from "../atoms/button.js";
+import { heading } from "../atoms/heading.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { legend } from "../molecules/legend.js";
@@ -28,7 +29,7 @@ ${checkboxRow({ id: "mg-show-external", label: "Show external modules", indent: 
     <div id="mg-tree"></div>
     <div id="detail">
 ${closeButton({ id: "close-detail", classes: "close-btn" })}
-      <h2 id="detail-name"></h2>
+${heading({ level: 2, id: "detail-name", indent: 6 })}
       <div id="detail-badges"></div>
       <div class="filepath" id="detail-path"></div>
       <div id="detail-sections"></div>
@@ -68,7 +69,7 @@ ${iconButton({ id: "mg-info", icon: "info", modifier: "schema-diagram-btn", aria
     <div id="mg-trace-body"></div>
   </div>
   <div id="mg-info-pop">
-  <h3>Legend</h3>
+${heading({ level: 3, text: "Legend", indent: 2 })}
 ${legend([
 	{
 		kind: "color",


### PR DESCRIPTION
## Context

crocova's `ui-v3` has a `Heading` atom where `level` picks the tag, and every screen renders titles through it. After #324 our report had that discipline for buttons but not for headings or the Rule Lab's preset dropdown.

## Problem

Ten heading tags were hand-written across four layers (a template, a browser module, and two runtime chunks), and the preset dropdown wrote a raw `<select>` with optgroups because the select atom only knew flat option lists. The runtime copies each re-decided attribute order and tooltip wiring.

## Possible flows

| Site | Layer | Now renders via |
|---|---|---|
| Detail panel `h2`, Legend `h3` | template | `heading` |
| Card titles (`statCard`, `infoCard` `h3`) | browser module | `heading` |
| Health Score, Issues by Category `h3` | runtime summary chunk | `RPT.heading` |
| `mgSection` `h4` (tooltip variant), Circular dependencies `h4` | runtime modules-graph chunk | `RPT.heading` |
| Preset dropdown with optgroups | template | `selectField` |

## Solution

New `atoms/heading.ts` (`level` 1–6, optional `id`, `classes`, `style`, `tip`, `text` as caller-escaped inner HTML), re-exported through the browser bundle for the runtime chunks. The select atom gained a `groups` option and `selectField` a `wide` flag, so the preset dropdown is the fourth `selectField` call instead of fourteen raw lines.

## Before vs after

| | Before | After |
|---|---|---|
| Raw `<h1>`–`<h6>` outside atoms | 10 | 0 |
| Raw `<select>` outside atoms | 1 | 0 |
| Static markup | — | Byte-identical except indentation inside the preset `<select>` (verified whitespace-only) |
| `mgSection` tooltip class | `has-tip tip-wide` | `tip-wide has-tip`, same rendered DOM |

## Example

The emitted report diff has ten regions: one whitespace-only reindent of the preset options, and nine inside the script, e.g.

```
A: html += '<div class="ov-card full-width"><h3>Health Score</h3><div class="ov-card-body">' +
B: html += '<div class="ov-card full-width">' + RPT.heading({ level: 3, text: "Health Score" }) + '<div class="ov-card-body">' +
```
