### PR TITLE
refactor(report): render every icon from the icon atom by name

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/atoms/icon.ts
+++ b/packages/nestjs-doctor/src/report/ui/atoms/icon.ts
@@ -47,6 +47,111 @@ export const ICONS = {
   <line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="10" x2="20" y2="10"/>
   <line x1="4" y1="14" x2="20" y2="14"/><line x1="4" y1="18" x2="20" y2="18"/>
 </svg>`,
+
+	pencil: `<svg viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/>
+</svg>`,
+
+	activity: `<svg viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+</svg>`,
+
+	fileText: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+  <polyline points="14 2 14 8 20 8"/>
+  <line x1="16" y1="13" x2="8" y2="13"/>
+  <line x1="16" y1="17" x2="8" y2="17"/>
+  <polyline points="10 9 9 9 8 9"/>
+</svg>`,
+
+	file: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>`,
+
+	folder: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>`,
+
+	caretUp: `<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8l1.5 1.5L8 3l6.5 6.5L16 8 8 0z"/></svg>`,
+
+	caretDown: `<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 8l1.5-1.5L8 13l6.5-6.5L16 8 8 16z"/></svg>`,
+
+	chevronSmall: `<svg viewBox="0 0 10 10"><path d="M3 1l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+
+	infoDot: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>`,
+
+	filter: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>`,
+
+	box: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>`,
+
+	checkCircle: `<svg viewBox="0 0 24 24" fill="none" stroke="var(--score-green)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>`,
+
+	controller: `<svg viewBox="0 0 16 16" fill="none" stroke="var(--nest-red)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="2"/><line x1="5" y1="6" x2="11" y2="6"/><line x1="5" y1="10" x2="9" y2="10"/></svg>`,
+
+	schemaTable: `<svg viewBox="0 0 16 16" fill="none" stroke="var(--white)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="1.5"/><line x1="2" y1="5.5" x2="14" y2="5.5"/><line x1="6" y1="5.5" x2="6" y2="14"/></svg>`,
+
+	schemaTableOpen: `<svg viewBox="0 0 16 16" fill="none" stroke="var(--white)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="1.5"/><rect x="2" y="2" width="12" height="3.5" rx="1.5" fill="var(--white)" opacity="0.35"/><line x1="2" y1="5.5" x2="14" y2="5.5"/><line x1="6" y1="5.5" x2="6" y2="14"/></svg>`,
+
+	schemaFolder: `<svg viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" stroke-width="1.2"><path d="M2 4.5h4l1.5-1.5H14v10H2z"/></svg>`,
+
+	schemaFolderOpen: `<svg viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" stroke-width="1.2"><path d="M2 4.5h4l1.5-1.5H14v2H4L2 13V4.5z"/><path d="M4 7h11l-2 6H2z"/></svg>`,
+
+	schemaKey: `<svg viewBox="0 0 16 16" fill="none" stroke="#ea2845" stroke-width="1.3"><circle cx="5.5" cy="6.5" r="2.5"/><line x1="8" y1="6.5" x2="14" y2="6.5"/><line x1="12" y1="6.5" x2="12" y2="9"/><line x1="14" y1="6.5" x2="14" y2="9"/></svg>`,
+
+	schemaColumn: `<svg viewBox="0 0 16 16" fill="none" stroke="var(--text-dim)" stroke-width="1.2"><rect x="4" y="3" width="8" height="10" rx="1"/><line x1="6" y1="6" x2="10" y2="6"/><line x1="6" y1="8.5" x2="10" y2="8.5"/></svg>`,
+
+	schemaFk: `<svg viewBox="0 0 16 16" fill="none" stroke="var(--cat-architecture)" stroke-width="1.2"><circle cx="5" cy="8" r="2.5"/><line x1="7.5" y1="8" x2="14" y2="8"/><polyline points="11,5.5 14,8 11,10.5"/></svg>`,
+
+	schemaIndex: `<svg viewBox="0 0 16 16" fill="none" stroke="var(--cat-performance)" stroke-width="1.2"><line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="8" x2="10" y2="8"/><line x1="3" y1="12" x2="7" y2="12"/></svg>`,
 } as const;
 
 export type IconName = keyof typeof ICONS;
+
+const STROKE_ATTR = /stroke="[^"]*"/;
+const STROKE_WIDTH_ATTR = /stroke-width="[^"]*"/;
+
+interface IconOptions {
+	ariaHidden?: boolean;
+	classes?: string;
+	id?: string;
+	indent?: number;
+	name: IconName;
+	size?: number;
+	stroke?: string;
+	strokeWidth?: string;
+}
+
+// Renders one named icon, splicing the optional attributes into the stored
+// tag and indenting every line by `indent`.
+export function icon({
+	name,
+	size,
+	stroke,
+	strokeWidth,
+	classes,
+	id,
+	ariaHidden,
+	indent = 0,
+}: IconOptions): string {
+	let svg: string = ICONS[name];
+	const inserted = [
+		classes ? `class="${classes}"` : undefined,
+		id ? `id="${id}"` : undefined,
+		size === undefined ? undefined : `width="${size}" height="${size}"`,
+	]
+		.filter(Boolean)
+		.join(" ");
+	if (inserted) {
+		svg = svg.replace("<svg ", `<svg ${inserted} `);
+	}
+	if (stroke) {
+		svg = svg.replace(STROKE_ATTR, `stroke="${stroke}"`);
+	}
+	if (strokeWidth) {
+		svg = svg.replace(STROKE_WIDTH_ATTR, `stroke-width="${strokeWidth}"`);
+	}
+	if (ariaHidden) {
+		svg = svg.replace(">", ' aria-hidden="true">');
+	}
+	const pad = " ".repeat(indent);
+	return svg
+		.split("\n")
+		.map((line) => (line ? pad + line : line))
+		.join("\n");
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -1,6 +1,7 @@
 // biome-ignore lint/performance/noBarrelFile: the browser bundle's entry, not a consumer barrel
 export { textButton } from "../atoms/button.js";
 export { heading } from "../atoms/heading.js";
+export { icon } from "../atoms/icon.js";
 export { badge } from "./badge.js";
 export {
 	infoCard,

--- a/packages/nestjs-doctor/src/report/ui/scripts/diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/diagnosis.ts
@@ -19,7 +19,7 @@ function renderDiagnosis() {
     mainEl.style.left = "0";
     mainEl.innerHTML =
       '<div class="diagnosis-clean">' +
-      '<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--score-green)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>' +
+      RPT.icon({ name: "checkCircle", size: 48 }) +
       '<p>No issues found</p>' +
       '<span>Your project passed all checks.</span>' +
       '</div>';

--- a/packages/nestjs-doctor/src/report/ui/scripts/endpoints.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/endpoints.ts
@@ -458,7 +458,7 @@ function epHideCodePanel() {
   if (panel) panel.classList.remove("open");
 }
 
-var EP_CTRL_ICON = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--nest-red)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="2"/><line x1="5" y1="6" x2="11" y2="6"/><line x1="5" y1="10" x2="9" y2="10"/></svg>';
+var EP_CTRL_ICON = RPT.icon({ name: "controller" });
 
 function renderEndpoints() {
   var sidebarEl = document.getElementById("endpoints-list");

--- a/packages/nestjs-doctor/src/report/ui/scripts/lab.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/lab.ts
@@ -415,9 +415,9 @@ function renderLab() {
 
     if (results.length === 0) {
       if (isMonorepo && scope === "file") {
-        resultEmpty.innerHTML = '<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg><p>No source files available in monorepo reports.<br><span style="opacity:0.7;font-size:0.92em">Run <code>npx nestjs-doctor &lt;package-path&gt; --report</code> on a single package to use the Lab with file rules.</span></p>';
+        resultEmpty.innerHTML = RPT.icon({ name: "pencil", size: 40 }) + '<p>No source files available in monorepo reports.<br><span style="opacity:0.7;font-size:0.92em">Run <code>npx nestjs-doctor &lt;package-path&gt; --report</code> on a single package to use the Lab with file rules.</span></p>';
       } else {
-        resultEmpty.innerHTML = '<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg><p>Write a check function and click Run</p>';
+        resultEmpty.innerHTML = RPT.icon({ name: "pencil", size: 40 }) + '<p>Write a check function and click Run</p>';
       }
       resultEmpty.style.display = "flex";
       return;

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -1105,7 +1105,7 @@ function mgBindEvents() {
 }
 
 // ── Modules graph: schema-style sidebar tree ──
-var MG_PROJECT_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>';
+var MG_PROJECT_ICON = RPT.icon({ name: "box" });
 
 function mgBuildTree() {
   var treeEl = document.getElementById("mg-tree");
@@ -1310,7 +1310,7 @@ function mgEsc(s) {
     .replace(/"/g, "&quot;");
 }
 
-var MG_INFO_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>';
+var MG_INFO_ICON = RPT.icon({ name: "info" });
 
 function mgSection(title, count, tip) {
   var info = tip ? ' <span class="md-info">' + MG_INFO_ICON + '</span>' : "";

--- a/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
@@ -1504,14 +1504,14 @@ function renderSchema() {
   }
 
   // SVG icon constants
-  var ICON_TABLE = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--white)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="1.5"/><line x1="2" y1="5.5" x2="14" y2="5.5"/><line x1="6" y1="5.5" x2="6" y2="14"/></svg>';
-  var ICON_TABLE_OPEN = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--white)" stroke-width="1.2"><rect x="2" y="2" width="12" height="12" rx="1.5"/><rect x="2" y="2" width="12" height="3.5" rx="1.5" fill="var(--white)" opacity="0.35"/><line x1="2" y1="5.5" x2="14" y2="5.5"/><line x1="6" y1="5.5" x2="6" y2="14"/></svg>';
-  var ICON_FOLDER_CLOSED = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" stroke-width="1.2"><path d="M2 4.5h4l1.5-1.5H14v10H2z"/></svg>';
-  var ICON_FOLDER_OPEN = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" stroke-width="1.2"><path d="M2 4.5h4l1.5-1.5H14v2H4L2 13V4.5z"/><path d="M4 7h11l-2 6H2z"/></svg>';
-  var ICON_KEY = '<svg viewBox="0 0 16 16" fill="none" stroke="#ea2845" stroke-width="1.3"><circle cx="5.5" cy="6.5" r="2.5"/><line x1="8" y1="6.5" x2="14" y2="6.5"/><line x1="12" y1="6.5" x2="12" y2="9"/><line x1="14" y1="6.5" x2="14" y2="9"/></svg>';
-  var ICON_COLUMN = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--text-dim)" stroke-width="1.2"><rect x="4" y="3" width="8" height="10" rx="1"/><line x1="6" y1="6" x2="10" y2="6"/><line x1="6" y1="8.5" x2="10" y2="8.5"/></svg>';
-  var ICON_FK = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--cat-architecture)" stroke-width="1.2"><circle cx="5" cy="8" r="2.5"/><line x1="7.5" y1="8" x2="14" y2="8"/><polyline points="11,5.5 14,8 11,10.5"/></svg>';
-  var ICON_INDEX = '<svg viewBox="0 0 16 16" fill="none" stroke="var(--cat-performance)" stroke-width="1.2"><line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="8" x2="10" y2="8"/><line x1="3" y1="12" x2="7" y2="12"/></svg>';
+  var ICON_TABLE = RPT.icon({ name: "schemaTable" });
+  var ICON_TABLE_OPEN = RPT.icon({ name: "schemaTableOpen" });
+  var ICON_FOLDER_CLOSED = RPT.icon({ name: "schemaFolder" });
+  var ICON_FOLDER_OPEN = RPT.icon({ name: "schemaFolderOpen" });
+  var ICON_KEY = RPT.icon({ name: "schemaKey" });
+  var ICON_COLUMN = RPT.icon({ name: "schemaColumn" });
+  var ICON_FK = RPT.icon({ name: "schemaFk" });
+  var ICON_INDEX = RPT.icon({ name: "schemaIndex" });
 
   // Tree row builder
   function sBuildTreeRow(depth, toggleId, icon, labelHtml, extra, classes, dataAttrs, iconTip) {

--- a/packages/nestjs-doctor/src/report/ui/scripts/shared-tree.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/shared-tree.ts
@@ -1,9 +1,9 @@
 export const SHARED_TREE = `
 // ── Shared SVG icons ──
-const SVG_FOLDER = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>';
-const SVG_FILE = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>';
-const SVG_UP = '<svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M0 8l1.5 1.5L8 3l6.5 6.5L16 8 8 0z"/></svg>';
-const SVG_DOWN = '<svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M0 8l1.5-1.5L8 13l6.5-6.5L16 8 8 16z"/></svg>';
+const SVG_FOLDER = RPT.icon({ name: "folder", size: 14 });
+const SVG_FILE = RPT.icon({ name: "file", size: 14 });
+const SVG_UP = RPT.icon({ name: "caretUp", size: 12 });
+const SVG_DOWN = RPT.icon({ name: "caretDown", size: 12 });
 
 // ── Shared tree helpers ──
 function renderTreeHtml(root, config) {

--- a/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
@@ -28,8 +28,7 @@ function renderSummary() {
       ? '<div class="ov-notscored">' + notScoredCount + ' of ' + (summary.total || 0) +
         ' not scored' +
         '<span class="ov-info has-tip" tabindex="0" role="img" aria-label="' + NOT_SCORED_HELP + '" data-tip="' + NOT_SCORED_HELP + '">' +
-        '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
-        '<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>' +
+        RPT.icon({ name: "infoDot", size: 13, ariaHidden: true }) +
         '</span>' +
         '</div>'
       : '') +

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
@@ -1,4 +1,5 @@
 import { iconButton, textButton } from "../atoms/button.js";
+import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { pillGroup } from "../molecules/pill-group.js";
@@ -24,7 +25,7 @@ ${textButton({
 	id: "diag-filters-toggle",
 	classes: "diag-filters-toggle",
 	ariaExpanded: false,
-	content: `        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+	content: `${icon({ name: "filter", ariaHidden: true, indent: 8 })}
         Filters
         <span class="diag-filters-count" id="diag-filters-count" style="display:none"></span>
         <span class="diag-filters-caret">\u25B8</span>`,
@@ -76,13 +77,7 @@ ${pillGroup({
   </div>
   <div id="diagnosis-main">
     <div id="diagnosis-empty-state">
-      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-        <polyline points="14 2 14 8 20 8"/>
-        <line x1="16" y1="13" x2="8" y2="13"/>
-        <line x1="16" y1="17" x2="8" y2="17"/>
-        <polyline points="10 9 9 9 8 9"/>
-      </svg>
+${icon({ name: "fileText", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5", indent: 6 })}
       <p>Select a file to view its diagnostics</p>
     </div>
     <div id="diagnosis-file-view" style="display:none">

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-endpoints.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-endpoints.ts
@@ -1,4 +1,5 @@
 import { closeButton, iconButton } from "../atoms/button.js";
+import { icon } from "../atoms/icon.js";
 
 export const TAB_ENDPOINTS = `
 <!-- ── Tab: Endpoints ── -->
@@ -28,9 +29,7 @@ ${closeButton({ id: "ep-code-panel-close", classes: "ep-code-panel-close" })}
   <div id="endpoints-main">
     <div id="endpoints-canvas-wrap">
       <div id="endpoints-empty-state">
-        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
-        </svg>
+${icon({ name: "activity", size: 48, indent: 8 })}
         <p>Select an endpoint from the sidebar to view its dependency graph</p>
       </div>
       <div id="endpoints-toolbar">

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
@@ -1,4 +1,5 @@
 import { textButton } from "../atoms/button.js";
+import { icon } from "../atoms/icon.js";
 import { selectField } from "../molecules/select-field.js";
 
 export const TAB_LAB = `
@@ -104,9 +105,7 @@ ${textButton({ id: "pg-run-btn", label: "&#9654; Run Rule" })}
     </div>
     <div id="pg-result-list"></div>
     <div id="pg-result-empty" class="playground-empty">
-      <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/>
-      </svg>
+${icon({ name: "pencil", size: 40, indent: 6 })}
       <p>Write a check function and click Run</p>
     </div>
   </div>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
@@ -1,5 +1,6 @@
 import { closeButton, iconButton } from "../atoms/button.js";
 import { heading } from "../atoms/heading.js";
+import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { legend } from "../molecules/legend.js";
@@ -47,10 +48,7 @@ ${iconButton({ id: "mg-info", icon: "info", modifier: "schema-diagram-btn", aria
     <canvas id="graph"></canvas>
     <div id="mg-tooltip" class="schema-tooltip" style="display:none"></div>
     <div id="mg-empty-state">
-      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
-        <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
-      </svg>
+${icon({ name: "toggleView", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5", indent: 6 })}
       <p>No modules were found in this project</p>
     </div>
   </div>
@@ -59,7 +57,7 @@ ${iconButton({ id: "mg-info", icon: "info", modifier: "schema-diagram-btn", aria
       <span class="mg-dock-tab" id="mg-dock-tab-problems" data-dock-tab="problems">Module problems <span class="schema-entity-count" id="mg-problems-count"></span></span>
       <span class="mg-dock-tab" id="mg-dock-tab-trace" data-dock-tab="trace" style="display:none">Boot trace <span class="schema-entity-count" id="mg-trace-ms"></span></span>
       <span class="mg-trace-info" tabindex="0" role="img" aria-label="How to read the trace" data-tip="How to read the trace&#10;\u2022 bars scale to the slowest row&#10;\u2022 yellow segment \u2248 the class's own work&#10;\u2022 dimmed hollow bar = reused, built earlier&#10;\u2022 rows are the create phase&#10;\u2022 +ms chips = lifecycle hooks">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+${icon({ name: "infoDot", size: 13, ariaHidden: true, indent: 10 })}
         </span>
       <span style="flex:1"></span>
       <span class="mg-problems-chevron" id="mg-dock-chevron">▴</span>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
@@ -1,4 +1,5 @@
 import { iconButton, textButton } from "../atoms/button.js";
+import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { zoomBar } from "../molecules/zoom-bar.js";
@@ -28,10 +29,7 @@ ${checkboxRow({ id: "schema-sync-sidebar", label: "Sync with diagram", checked: 
     <div id="schema-canvas-wrap">
 ${iconButton({ id: "schema-sidebar-show", icon: "sidebarShow", ariaLabel: "Show the table list", tip: "Show list \u00b7 bring the table list back", indent: 6 })}
       <div id="schema-empty-state">
-        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-dim)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
-          <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
-        </svg>
+${icon({ name: "toggleView", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5", indent: 8 })}
         <p>Select an entity from the sidebar to explore its schema</p>
 ${textButton({ id: "schema-show-all", classes: "st-btn schema-empty-action", label: "Show all tables", indent: 8 })}
       </div>
@@ -49,7 +47,7 @@ ${iconButton({ id: "schema-toggle-cols", icon: "toggleColumns", modifier: "schem
     </div>
     <div id="schema-diag-panel">
       <div id="schema-diag-header">
-        <svg class="schema-diag-chevron" id="schema-diag-chevron" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+${icon({ name: "chevronSmall", classes: "schema-diag-chevron", id: "schema-diag-chevron", size: 10, indent: 8 })}
         <span class="schema-diag-title">Problems</span>
         <span class="schema-diag-count" id="schema-diag-count">0</span>
       </div>


### PR DESCRIPTION
## Context

`atoms/icon.ts` held twelve named SVG bodies, but only `iconButton` could use them. Every other icon in the report was a hand-written `<svg>` string. After #324 and #325 this was the last element type drawn outside the atoms.

## Problem

Twenty-eight raw `<svg>` sites across templates and runtime chunks. Three pictures existed twice: the pencil (Lab empty state, once static and twice at runtime), the four-rect grid (`toggleView` icon plus two empty states), and the info circle (`MG_INFO_ICON` duplicated the `info` atom line for line). A picture edit had to find every copy.

## Possible flows

| Sites | Layer | Now render via |
|---|---|---|
| 8 template icons (empty states, chevron, trace info, filters funnel) | static | `icon()` |
| 8 schema tree icons, `MG_PROJECT_ICON`, `MG_INFO_ICON`, `EP_CTRL_ICON` | runtime vars | `RPT.icon` |
| 4 shared-tree icons, 2 Lab empties, summary info, diagnosis check | runtime | `RPT.icon` |
| Score ring in `chrome.ts`, tab-bar icons | runtime / static | unchanged, parameterized drawings, not named icons |

## Solution

`icon({ name, size, stroke, strokeWidth, classes, id, ariaHidden, indent })` in the icon atom, re-exported through the browser bundle. Name picks the stored SVG; `size` sets `width`/`height`; the rest splice into the tag only when a site needs them. Twenty entries added (`pencil`, `activity`, `fileText`, `box`, `checkCircle`, the eight `schema*` tree icons, the four tree carets and files, `filter`, `infoDot`, `chevronSmall`), and the grid empty states reuse the existing `toggleView` entry with a stroke override.

Name plus size covers 22 of the 28 sites; the other six also need one of `stroke`, `classes`/`id`, or `ariaHidden`, which is why those exist as options rather than more names.

## Before vs after

| | Before | After |
|---|---|---|
| Raw `<svg>` outside atoms | 28 | 0 (score ring and tab-bar excluded by design) |
| Static markup | — | Byte-identical |
| Pictures stored twice | 3 | 0 |

## Example

The emitted report diff has eleven regions, all inside the script, e.g.

```
A: var MG_INFO_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" ... </svg>';
B: var MG_INFO_ICON = RPT.icon({ name: "info" });
```
