### PR TITLE
refactor(report): render the sidebar tree toolbars from one molecule

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/molecules/tree-toolbar.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/tree-toolbar.ts
@@ -1,0 +1,61 @@
+import { iconButton } from "../atoms/button.js";
+
+interface TreeToolbarOptions {
+	noun: string;
+	prefix: string;
+	subject?: string;
+}
+
+// The expand-all / collapse-all cluster on a sidebar tree, plus the hide
+// button when `subject` names what gains the reclaimed width.
+export function treeToolbar({
+	prefix,
+	noun,
+	subject,
+}: TreeToolbarOptions): string {
+	const buttons = [
+		iconButton({
+			id: `${prefix}-expand-all`,
+			icon: "expandAll",
+			ariaLabel: "Expand all",
+			tip: `Expand all · open every ${noun} in the list`,
+		}),
+		iconButton({
+			id: `${prefix}-collapse-all`,
+			icon: "collapseAll",
+			ariaLabel: "Collapse all",
+			tip: `Collapse all · close every ${noun} in the list`,
+		}),
+	];
+	if (subject) {
+		buttons.push(
+			iconButton({
+				id: `${prefix}-sidebar-collapse`,
+				icon: "sidebarCollapse",
+				ariaLabel: `Hide the ${noun} list`,
+				tip: `Hide list · give the ${subject} the whole width`,
+			})
+		);
+	}
+	return buttons.join("\n");
+}
+
+// The matching bring-the-list-back button, rendered where the sidebar
+// reappears from.
+export function sidebarShowButton({
+	prefix,
+	noun,
+	indent,
+}: {
+	indent: number;
+	noun: string;
+	prefix: string;
+}): string {
+	return iconButton({
+		id: `${prefix}-sidebar-show`,
+		icon: "sidebarShow",
+		ariaLabel: `Show the ${noun} list`,
+		tip: `Show list · bring the ${noun} list back`,
+		indent,
+	});
+}

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
@@ -1,8 +1,9 @@
-import { iconButton, textButton } from "../atoms/button.js";
+import { textButton } from "../atoms/button.js";
 import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { pillGroup } from "../molecules/pill-group.js";
+import { treeToolbar } from "../molecules/tree-toolbar.js";
 
 export const TAB_DIAGNOSIS = `
 <!-- ── Tab: Diagnosis ── -->
@@ -13,8 +14,7 @@ export const TAB_DIAGNOSIS = `
         <span class="schema-sidebar-title">Files</span>
         <span class="schema-entity-count" id="diag-file-count"></span>
         <span style="flex:1"></span>
-${iconButton({ id: "diag-expand-all", icon: "expandAll", ariaLabel: "Expand all", tip: "Expand all \u00b7 open every folder in the list" })}
-${iconButton({ id: "diag-collapse-all", icon: "collapseAll", ariaLabel: "Collapse all", tip: "Collapse all \u00b7 close every folder in the list" })}
+${treeToolbar({ prefix: "diag", noun: "folder" })}
       </div>
       <div class="mg-side-search">
 ${searchInput({ id: "diag-search", placeholder: "Search files" })}

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
@@ -4,6 +4,7 @@ import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { legend } from "../molecules/legend.js";
+import { sidebarShowButton, treeToolbar } from "../molecules/tree-toolbar.js";
 import { zoomBar } from "../molecules/zoom-bar.js";
 
 export const TAB_MODULES_GRAPH = `
@@ -15,9 +16,7 @@ export const TAB_MODULES_GRAPH = `
         <span class="schema-sidebar-title">Projects</span>
         <span class="schema-entity-count" id="mg-project-count"></span>
         <span style="flex:1"></span>
-${iconButton({ id: "mg-expand-all", icon: "expandAll", ariaLabel: "Expand all", tip: "Expand all · open every project in the list" })}
-${iconButton({ id: "mg-collapse-all", icon: "collapseAll", ariaLabel: "Collapse all", tip: "Collapse all · close every project in the list" })}
-${iconButton({ id: "mg-sidebar-collapse", icon: "sidebarCollapse", ariaLabel: "Hide the project list", tip: "Hide list · give the graph the whole width" })}
+${treeToolbar({ prefix: "mg", noun: "project", subject: "graph" })}
       </div>
       <div class="mg-side-search">
 ${searchInput({ id: "mg-search", placeholder: "Search projects and modules" })}
@@ -39,7 +38,7 @@ ${heading({ level: 2, id: "detail-name", indent: 6 })}
   <div id="mg-resizer"></div>
   <div id="mg-main">
   <div id="mg-wrap">
-${iconButton({ id: "mg-sidebar-show", icon: "sidebarShow", ariaLabel: "Show the project list", tip: "Show list · bring the project list back", indent: 4 })}
+${sidebarShowButton({ prefix: "mg", noun: "project", indent: 4 })}
     <div id="mg-toolbar">
 ${zoomBar({ prefix: "mg", subject: "graph" })}
 ${iconButton({ id: "mg-recenter", icon: "recenter", modifier: "schema-diagram-btn", ariaLabel: "Re-center graph", tip: "Re-center · bring the graph back into view", indent: 6 })}

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
@@ -2,6 +2,7 @@ import { iconButton, textButton } from "../atoms/button.js";
 import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
+import { sidebarShowButton, treeToolbar } from "../molecules/tree-toolbar.js";
 import { zoomBar } from "../molecules/zoom-bar.js";
 
 export const TAB_SCHEMA = `
@@ -13,9 +14,7 @@ export const TAB_SCHEMA = `
         <span class="schema-sidebar-title" id="schema-sidebar-title">Tables</span>
         <span class="schema-entity-count" id="schema-entity-count"></span>
         <span style="flex:1"></span>
-${iconButton({ id: "schema-expand-all", icon: "expandAll", ariaLabel: "Expand all", tip: "Expand all \u00b7 open every table in the list" })}
-${iconButton({ id: "schema-collapse-all", icon: "collapseAll", ariaLabel: "Collapse all", tip: "Collapse all \u00b7 close every table in the list" })}
-${iconButton({ id: "schema-sidebar-collapse", icon: "sidebarCollapse", ariaLabel: "Hide the table list", tip: "Hide list \u00b7 give the diagram the whole width" })}
+${treeToolbar({ prefix: "schema", noun: "table", subject: "diagram" })}
       </div>
       <div class="mg-side-search">
 ${searchInput({ id: "schema-search", placeholder: "Search tables" })}
@@ -27,7 +26,7 @@ ${checkboxRow({ id: "schema-sync-sidebar", label: "Sync with diagram", checked: 
   </div>
   <div id="schema-main">
     <div id="schema-canvas-wrap">
-${iconButton({ id: "schema-sidebar-show", icon: "sidebarShow", ariaLabel: "Show the table list", tip: "Show list \u00b7 bring the table list back", indent: 6 })}
+${sidebarShowButton({ prefix: "schema", noun: "table", indent: 6 })}
       <div id="schema-empty-state">
 ${icon({ name: "toggleView", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5", indent: 8 })}
         <p>Select an entity from the sidebar to explore its schema</p>


### PR DESCRIPTION
## Context

Three sidebar trees (schema tables, modules-graph projects, diagnosis files) each carry the same toolbar: expand all, collapse all, and on the two canvas tabs a hide-the-list button, with a matching show button where the sidebar reappears from. All of them already rendered through `iconButton`; the duplication was one level up, in the composition and the tip wording.

## Problem

Eight `iconButton` calls repeated the same tip sentences with only the noun changed ("open every table/project/folder in the list"). Changing the wording meant finding every copy; #323's zoom bar had the same shape.

## Possible flows

| Site | Cluster |
|---|---|
| tab-schema | expand + collapse + hide, show button (noun "table", subject "diagram") |
| tab-modules-graph | expand + collapse + hide, show button (noun "project", subject "graph") |
| tab-diagnosis | expand + collapse only (noun "folder", no canvas to hand width to) |

## Solution

`molecules/tree-toolbar.ts` with `treeToolbar({ prefix, noun, subject? })` — ids derive from the prefix, tips from the noun, and the hide button renders only when `subject` names what gains the width — plus `sidebarShowButton({ prefix, noun, indent })` for the counterpart. This is a molecule, not an atom: the buttons and icons already exist as atoms; what repeats is the cluster.

Not done: the three recenter buttons stay individual `iconButton` calls — the endpoints one uses `title` with no tooltip while the other two use `ariaLabel` plus `tip`, so there is no shared shape yet.

## Before vs after

| | Before | After |
|---|---|---|
| Toolbar `iconButton` calls in templates | 8 | 0 (3 `treeToolbar` + 2 `sidebarShowButton` calls) |
| Tip sentences stored | 8 | 4 templates in one file |
| Emitted report | — | Byte-identical (verified) |

## Example

```
$ cmp after5.masked after6.masked && echo BYTE-IDENTICAL
BYTE-IDENTICAL
```
