### PR TITLE
refactor(report): render the summary cards through one card component

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/atoms/icon.ts
+++ b/packages/nestjs-doctor/src/report/ui/atoms/icon.ts
@@ -106,7 +106,7 @@ export type IconName = keyof typeof ICONS;
 const STROKE_ATTR = /stroke="[^"]*"/;
 const STROKE_WIDTH_ATTR = /stroke-width="[^"]*"/;
 
-interface IconOptions {
+export interface IconOptions {
 	ariaHidden?: boolean;
 	classes?: string;
 	id?: string;

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -2,7 +2,9 @@
 export { textButton } from "../atoms/button.js";
 export { heading } from "../atoms/heading.js";
 export { icon } from "../atoms/icon.js";
+export { emptyState } from "../molecules/empty-state.js";
 export { badge } from "./badge.js";
+export { escapeHtml } from "./escape.js";
 export {
 	infoCard,
 	infoItem,

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -6,6 +6,7 @@ export { emptyState } from "../molecules/empty-state.js";
 export { badge } from "./badge.js";
 export { escapeHtml } from "./escape.js";
 export {
+	card,
 	infoCard,
 	infoItem,
 	statCard,

--- a/packages/nestjs-doctor/src/report/ui/browser/escape.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/escape.ts
@@ -1,0 +1,8 @@
+// Escapes a value for embedding in HTML text or a double-quoted attribute.
+export function escapeHtml(value: unknown): string {
+	return String(value == null ? "" : value)
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/summary-card.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/summary-card.ts
@@ -20,12 +20,28 @@ export function infoItem({ label, value }: Row): string {
 	return `<div class="ov-info-item"><label>${label}</label><span>${value}</span></div>`;
 }
 
+// A summary card: a heading over an arbitrary body.
+export function card({
+	title,
+	body,
+	fullWidth,
+}: {
+	body: string;
+	fullWidth?: boolean;
+	title: string;
+}): string {
+	return `<div class="ov-card${fullWidth ? " full-width" : ""}">${heading({ level: 3, text: title })}<div class="ov-card-body">${body}</div></div>`;
+}
+
 // A summary card whose body is a list of stat rows.
 export function statCard({ title, rows }: CardOptions): string {
-	return `<div class="ov-card">${heading({ level: 3, text: title })}<div class="ov-card-body">${rows.map(statRow).join("")}</div></div>`;
+	return card({ title, body: rows.map(statRow).join("") });
 }
 
 // A summary card whose body is the project info grid.
 export function infoCard({ title, rows }: CardOptions): string {
-	return `<div class="ov-card">${heading({ level: 3, text: title })}<div class="ov-card-body"><div class="ov-info-grid">${rows.map(infoItem).join("")}</div></div></div>`;
+	return card({
+		title,
+		body: `<div class="ov-info-grid">${rows.map(infoItem).join("")}</div>`,
+	});
 }

--- a/packages/nestjs-doctor/src/report/ui/molecules/empty-state.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/empty-state.ts
@@ -1,0 +1,37 @@
+import { type IconOptions, icon } from "../atoms/icon.js";
+
+interface EmptyStateOptions {
+	classes?: string;
+	extra?: string;
+	icon: Omit<IconOptions, "indent">;
+	id?: string;
+	indent?: number;
+	text: string;
+}
+
+// An empty-state panel: an icon over a one-line message, with an optional
+// trailing element.
+export function emptyState({
+	id,
+	classes,
+	icon: iconOptions,
+	text,
+	extra,
+	indent = 4,
+}: EmptyStateOptions): string {
+	const pad = " ".repeat(indent);
+	const attrs = [
+		id ? ` id="${id}"` : "",
+		classes ? ` class="${classes}"` : "",
+	].join("");
+	const lines = [
+		`${pad}<div${attrs}>`,
+		icon({ ...iconOptions, indent: indent + 2 }),
+		`${pad}  <p>${text}</p>`,
+	];
+	if (extra) {
+		lines.push(`${pad}  ${extra}`);
+	}
+	lines.push(`${pad}</div>`);
+	return lines.join("\n");
+}

--- a/packages/nestjs-doctor/src/report/ui/molecules/sidebar-header.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/sidebar-header.ts
@@ -1,0 +1,33 @@
+interface SidebarHeaderOptions {
+	classes?: string;
+	countId: string;
+	indent?: number;
+	title: string;
+	titleId?: string;
+	toolbar?: string;
+}
+
+// A sidebar's header row: title, entity count, spacer, and the optional
+// toolbar cluster after them.
+export function sidebarHeader({
+	title,
+	titleId,
+	countId,
+	toolbar,
+	classes = "schema-sidebar-header",
+	indent = 6,
+}: SidebarHeaderOptions): string {
+	const pad = " ".repeat(indent);
+	const titleAttr = titleId ? ` id="${titleId}"` : "";
+	const lines = [
+		`${pad}<div class="${classes}">`,
+		`${pad}  <span class="schema-sidebar-title"${titleAttr}>${title}</span>`,
+		`${pad}  <span class="schema-entity-count" id="${countId}"></span>`,
+		`${pad}  <span style="flex:1"></span>`,
+	];
+	if (toolbar) {
+		lines.push(toolbar);
+	}
+	lines.push(`${pad}</div>`);
+	return lines.join("\n");
+}

--- a/packages/nestjs-doctor/src/report/ui/scripts/diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/diagnosis.ts
@@ -17,12 +17,13 @@ function renderDiagnosis() {
   if (diagnostics.length === 0) {
     sidebarEl.style.display = "none";
     mainEl.style.left = "0";
-    mainEl.innerHTML =
-      '<div class="diagnosis-clean">' +
-      RPT.icon({ name: "checkCircle", size: 48 }) +
-      '<p>No issues found</p>' +
-      '<span>Your project passed all checks.</span>' +
-      '</div>';
+    mainEl.innerHTML = RPT.emptyState({
+      classes: "diagnosis-clean",
+      icon: { name: "checkCircle", size: 48 },
+      text: "No issues found",
+      extra: "<span>Your project passed all checks.</span>",
+      indent: 0,
+    });
     return;
   }
 
@@ -559,6 +560,6 @@ function renderDiagnosis() {
 }
 
 function escHtml(s) {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return RPT.escapeHtml(s);
 }
 `;

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -1305,9 +1305,7 @@ function renderModules() {
 
 // ── Modules graph: detail panel ──
 function mgEsc(s) {
-  return String(s == null ? "" : s)
-    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+  return RPT.escapeHtml(s);
 }
 
 var MG_INFO_ICON = RPT.icon({ name: "info" });

--- a/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
@@ -12,8 +12,7 @@ function renderSummary() {
   var notScoredCount = (diagnostics || []).filter(function (d) {
     return d.surfaces && d.surfaces.indexOf('score') === -1;
   }).length;
-  html += '<div class="ov-card full-width">' + RPT.heading({ level: 3, text: "Health Score" }) + '<div class="ov-card-body">' +
-    '<div class="ov-score-row">' +
+  var scoreBody = '<div class="ov-score-row">' +
     '<div class="ov-score-ring">' + makeScoreRingSvg(120, 6, sv) + '</div>' +
     '<div class="ov-score-details">' +
     '<div class="ov-score-label">' + sv + ' / 100</div>' +
@@ -32,7 +31,8 @@ function renderSummary() {
         '</span>' +
         '</div>'
       : '') +
-    '</div></div></div></div>';
+    '</div></div>';
+  html += RPT.card({ title: "Health Score", fullWidth: true, body: scoreBody });
 
   // Project info card
   html += RPT.infoCard({
@@ -48,16 +48,16 @@ function renderSummary() {
   });
 
   // Category breakdown card
-  html += '<div class="ov-card">' + RPT.heading({ level: 3, text: "Issues by Category" }) + '<div class="ov-card-body">';
+  var catBody = '';
   for (const cat of CAT_ORDER) {
     const m = CAT_META[cat];
     const count = (summary.byCategory && summary.byCategory[cat]) || 0;
-    html += '<div class="ov-cat-row">' +
+    catBody += '<div class="ov-cat-row">' +
       '<div class="ov-cat-icon" style="background:' + m.color + '"></div>' +
       '<span class="ov-cat-name">' + m.label + '</span>' +
       '<span class="ov-cat-count">' + count + '</span></div>';
   }
-  html += '</div></div>';
+  html += RPT.card({ title: "Issues by Category", body: catBody });
 
   // Module graph stats card
   html += RPT.statCard({

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
@@ -2,7 +2,9 @@ import { textButton } from "../atoms/button.js";
 import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
+import { emptyState } from "../molecules/empty-state.js";
 import { pillGroup } from "../molecules/pill-group.js";
+import { sidebarHeader } from "../molecules/sidebar-header.js";
 import { treeToolbar } from "../molecules/tree-toolbar.js";
 
 export const TAB_DIAGNOSIS = `
@@ -10,12 +12,11 @@ export const TAB_DIAGNOSIS = `
 <div class="tab-content" id="tab-diagnosis">
   <div id="diagnosis-sidebar">
     <div class="diagnosis-toolbar">
-      <div class="schema-sidebar-header">
-        <span class="schema-sidebar-title">Files</span>
-        <span class="schema-entity-count" id="diag-file-count"></span>
-        <span style="flex:1"></span>
-${treeToolbar({ prefix: "diag", noun: "folder" })}
-      </div>
+${sidebarHeader({
+	title: "Files",
+	countId: "diag-file-count",
+	toolbar: treeToolbar({ prefix: "diag", noun: "folder" }),
+})}
       <div class="mg-side-search">
 ${searchInput({ id: "diag-search", placeholder: "Search files" })}
       </div>
@@ -76,10 +77,7 @@ ${pillGroup({
     <div id="diagnosis-rule-list"></div>
   </div>
   <div id="diagnosis-main">
-    <div id="diagnosis-empty-state">
-${icon({ name: "fileText", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5", indent: 6 })}
-      <p>Select a file to view its diagnostics</p>
-    </div>
+${emptyState({ id: "diagnosis-empty-state", icon: { name: "fileText", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5" }, text: "Select a file to view its diagnostics" })}
     <div id="diagnosis-file-view" style="display:none">
       <div id="diagnosis-file-header"></div>
       <div id="diagnosis-file-code"></div>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-endpoints.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-endpoints.ts
@@ -1,5 +1,6 @@
 import { closeButton, iconButton } from "../atoms/button.js";
-import { icon } from "../atoms/icon.js";
+import { emptyState } from "../molecules/empty-state.js";
+import { sidebarHeader } from "../molecules/sidebar-header.js";
 
 export const TAB_ENDPOINTS = `
 <!-- ── Tab: Endpoints ── -->
@@ -18,20 +19,13 @@ ${closeButton({ id: "ep-code-panel-close", classes: "ep-code-panel-close" })}
   </div>
   <div id="endpoints-sidebar">
     <div class="endpoints-sidebar-sticky">
-      <div class="endpoints-sidebar-header">
-        <span class="schema-sidebar-title">Endpoints</span>
-        <span class="schema-entity-count" id="endpoints-count"></span>
-        <span style="flex:1"></span>
-      </div>
+${sidebarHeader({ title: "Endpoints", countId: "endpoints-count", classes: "endpoints-sidebar-header" })}
     </div>
     <div id="endpoints-list"></div>
   </div>
   <div id="endpoints-main">
     <div id="endpoints-canvas-wrap">
-      <div id="endpoints-empty-state">
-${icon({ name: "activity", size: 48, indent: 8 })}
-        <p>Select an endpoint from the sidebar to view its dependency graph</p>
-      </div>
+${emptyState({ id: "endpoints-empty-state", icon: { name: "activity", size: 48 }, indent: 6, text: "Select an endpoint from the sidebar to view its dependency graph" })}
       <div id="endpoints-toolbar">
 ${iconButton({ id: "endpoints-recenter", icon: "recenter", modifier: "schema-diagram-btn", title: "Re-center diagram" })}
       </div>

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
@@ -1,5 +1,5 @@
 import { textButton } from "../atoms/button.js";
-import { icon } from "../atoms/icon.js";
+import { emptyState } from "../molecules/empty-state.js";
 import { selectField } from "../molecules/select-field.js";
 
 export const TAB_LAB = `
@@ -104,10 +104,7 @@ ${textButton({ id: "pg-run-btn", label: "&#9654; Run Rule" })}
       <div id="pg-file-code" class="playground-code-body"></div>
     </div>
     <div id="pg-result-list"></div>
-    <div id="pg-result-empty" class="playground-empty">
-${icon({ name: "pencil", size: 40, indent: 6 })}
-      <p>Write a check function and click Run</p>
-    </div>
+${emptyState({ id: "pg-result-empty", classes: "playground-empty", icon: { name: "pencil", size: 40 }, text: "Write a check function and click Run" })}
   </div>
 </div>
 `;

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
@@ -3,7 +3,9 @@ import { heading } from "../atoms/heading.js";
 import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
+import { emptyState } from "../molecules/empty-state.js";
 import { legend } from "../molecules/legend.js";
+import { sidebarHeader } from "../molecules/sidebar-header.js";
 import { sidebarShowButton, treeToolbar } from "../molecules/tree-toolbar.js";
 import { zoomBar } from "../molecules/zoom-bar.js";
 
@@ -12,12 +14,11 @@ export const TAB_MODULES_GRAPH = `
 <div class="tab-content" id="tab-modules">
   <div id="mg-sidebar">
     <div class="schema-sidebar-sticky">
-      <div class="schema-sidebar-header">
-        <span class="schema-sidebar-title">Projects</span>
-        <span class="schema-entity-count" id="mg-project-count"></span>
-        <span style="flex:1"></span>
-${treeToolbar({ prefix: "mg", noun: "project", subject: "graph" })}
-      </div>
+${sidebarHeader({
+	title: "Projects",
+	countId: "mg-project-count",
+	toolbar: treeToolbar({ prefix: "mg", noun: "project", subject: "graph" }),
+})}
       <div class="mg-side-search">
 ${searchInput({ id: "mg-search", placeholder: "Search projects and modules" })}
       </div>
@@ -46,10 +47,7 @@ ${iconButton({ id: "mg-info", icon: "info", modifier: "schema-diagram-btn", aria
     </div>
     <canvas id="graph"></canvas>
     <div id="mg-tooltip" class="schema-tooltip" style="display:none"></div>
-    <div id="mg-empty-state">
-${icon({ name: "toggleView", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5", indent: 6 })}
-      <p>No modules were found in this project</p>
-    </div>
+${emptyState({ id: "mg-empty-state", icon: { name: "toggleView", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5" }, text: "No modules were found in this project" })}
   </div>
   <div id="mg-dock" data-active="problems">
     <div id="mg-dock-header">

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
@@ -2,6 +2,8 @@ import { iconButton, textButton } from "../atoms/button.js";
 import { icon } from "../atoms/icon.js";
 import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
+import { emptyState } from "../molecules/empty-state.js";
+import { sidebarHeader } from "../molecules/sidebar-header.js";
 import { sidebarShowButton, treeToolbar } from "../molecules/tree-toolbar.js";
 import { zoomBar } from "../molecules/zoom-bar.js";
 
@@ -10,12 +12,12 @@ export const TAB_SCHEMA = `
 <div class="tab-content" id="tab-schema">
   <div id="schema-sidebar">
     <div class="schema-sidebar-sticky">
-      <div class="schema-sidebar-header">
-        <span class="schema-sidebar-title" id="schema-sidebar-title">Tables</span>
-        <span class="schema-entity-count" id="schema-entity-count"></span>
-        <span style="flex:1"></span>
-${treeToolbar({ prefix: "schema", noun: "table", subject: "diagram" })}
-      </div>
+${sidebarHeader({
+	title: "Tables",
+	titleId: "schema-sidebar-title",
+	countId: "schema-entity-count",
+	toolbar: treeToolbar({ prefix: "schema", noun: "table", subject: "diagram" }),
+})}
       <div class="mg-side-search">
 ${searchInput({ id: "schema-search", placeholder: "Search tables" })}
       </div>
@@ -27,11 +29,23 @@ ${checkboxRow({ id: "schema-sync-sidebar", label: "Sync with diagram", checked: 
   <div id="schema-main">
     <div id="schema-canvas-wrap">
 ${sidebarShowButton({ prefix: "schema", noun: "table", indent: 6 })}
-      <div id="schema-empty-state">
-${icon({ name: "toggleView", size: 48, stroke: "var(--text-dim)", strokeWidth: "1.5", indent: 8 })}
-        <p>Select an entity from the sidebar to explore its schema</p>
-${textButton({ id: "schema-show-all", classes: "st-btn schema-empty-action", label: "Show all tables", indent: 8 })}
-      </div>
+${emptyState({
+	id: "schema-empty-state",
+	icon: {
+		name: "toggleView",
+		size: 48,
+		stroke: "var(--text-dim)",
+		strokeWidth: "1.5",
+	},
+	text: "Select an entity from the sidebar to explore its schema",
+	extra: textButton({
+		id: "schema-show-all",
+		classes: "st-btn schema-empty-action",
+		label: "Show all tables",
+		indent: 0,
+	}),
+	indent: 6,
+})}
       <div id="schema-toolbar">
 ${zoomBar({ prefix: "schema", subject: "diagram" })}
 ${iconButton({ id: "schema-toggle-view", icon: "toggleView", modifier: "schema-diagram-btn", ariaLabel: "Show all tables", tip: "All tables \u00b7 lay out the whole schema at once" })}

--- a/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { badge, treeRow } from "../../src/report/ui/browser/entry.js";
+import {
+	badge,
+	escapeHtml,
+	treeRow,
+} from "../../src/report/ui/browser/entry.js";
 import { getReportScripts } from "../../src/report/ui/scripts.js";
 import { EMPTY_ARTIFACT_JSON as EMPTY } from "./report-artifact-fixture.js";
 
@@ -40,7 +44,7 @@ function loadTraceRow(
 		mgTraceMax = 100;
 		return mgTraceRowHtml;`
 	);
-	return factory(graph, { badge, treeRow }) as (
+	return factory(graph, { badge, escapeHtml, treeRow }) as (
 		id: string,
 		depth: number,
 		path: string


### PR DESCRIPTION
## Context

`browser/summary-card.ts` has `statCard` and `infoCard`, but both bake the `ov-card` wrapper into their template, and the two summary cards whose bodies aren't row lists (Health Score, Issues by Category) hand-built the same wrapper in `scripts/summary.ts`.

## Problem

Four copies of the card shell. A change to the card chrome (the heading level, a class) meant editing two files in four places.

## Possible flows

| Card | Before | After |
|---|---|---|
| Project Info, stat cards | `infoCard` / `statCard` with inlined shell | same API, shell from `card()` |
| Health Score (full width) | hand-built concatenation | `RPT.card({ fullWidth: true, body })` |
| Issues by Category | hand-built concatenation around a loop | loop fills `catBody`, then `RPT.card` |

## Solution

One `card({ title, body, fullWidth? })` in `summary-card.ts`; `statCard` and `infoCard` become one-line callers, and the two runtime cards build their body into a variable and wrap it. No API change for existing callers.

## Before vs after

| | Before | After |
|---|---|---|
| `ov-card` shells written out | 4 | 1 |
| Static markup | — | unchanged (summary renders at runtime) |
| Rendered DOM | — | identical, same tags in the same order |

## Example

```
A: html += '<div class="ov-card">' + RPT.heading({ level: 3, text: "Issues by Category" }) + '<div class="ov-card-body">';
B: html += RPT.card({ title: "Issues by Category", body: catBody });
```
