### PR TITLE
refactor(report): wrap the search boxes and Lab text inputs in field molecules

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/molecules/search-field.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/search-field.ts
@@ -1,0 +1,21 @@
+import { searchInput } from "../atoms/search-input.js";
+
+interface SearchFieldOptions {
+	id: string;
+	indent?: number;
+	placeholder: string;
+}
+
+// A sidebar search box inside its `mg-side-search` wrapper.
+export function searchField({
+	id,
+	placeholder,
+	indent = 6,
+}: SearchFieldOptions): string {
+	const pad = " ".repeat(indent);
+	return [
+		`${pad}<div class="mg-side-search">`,
+		searchInput({ id, placeholder, indent: indent + 2 }),
+		`${pad}</div>`,
+	].join("\n");
+}

--- a/packages/nestjs-doctor/src/report/ui/molecules/text-field.ts
+++ b/packages/nestjs-doctor/src/report/ui/molecules/text-field.ts
@@ -1,0 +1,36 @@
+interface TextFieldOptions {
+	id: string;
+	indent?: number;
+	label: string;
+	placeholder?: string;
+	value?: string;
+	wide?: boolean;
+}
+
+// Pairs a label with a text input inside the Rule Lab's field wrapper.
+export function textField({
+	id,
+	label,
+	value,
+	placeholder,
+	wide,
+	indent = 8,
+}: TextFieldOptions): string {
+	const pad = " ".repeat(indent);
+	const cls = wide
+		? "playground-field playground-field-wide"
+		: "playground-field";
+	const attrs = [
+		`id="${id}"`,
+		value === undefined ? undefined : `value="${value}"`,
+		placeholder === undefined ? undefined : `placeholder="${placeholder}"`,
+	]
+		.filter(Boolean)
+		.join(" ");
+	return [
+		`${pad}<div class="${cls}">`,
+		`${pad}  <label for="${id}">${label}</label>`,
+		`${pad}  <input type="text" ${attrs} spellcheck="false">`,
+		`${pad}</div>`,
+	].join("\n");
+}

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-diagnosis.ts
@@ -1,9 +1,9 @@
 import { textButton } from "../atoms/button.js";
 import { icon } from "../atoms/icon.js";
-import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { emptyState } from "../molecules/empty-state.js";
 import { pillGroup } from "../molecules/pill-group.js";
+import { searchField } from "../molecules/search-field.js";
 import { sidebarHeader } from "../molecules/sidebar-header.js";
 import { treeToolbar } from "../molecules/tree-toolbar.js";
 
@@ -17,9 +17,7 @@ ${sidebarHeader({
 	countId: "diag-file-count",
 	toolbar: treeToolbar({ prefix: "diag", noun: "folder" }),
 })}
-      <div class="mg-side-search">
-${searchInput({ id: "diag-search", placeholder: "Search files" })}
-      </div>
+${searchField({ id: "diag-search", placeholder: "Search files" })}
 ${checkboxRow({ id: "diag-show-notscored", label: "Show not scored", rowId: "diag-notscored-row" })}
       <hr class="diag-divider" id="diag-notscored-divider">
 ${textButton({

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-lab.ts
@@ -1,6 +1,7 @@
 import { textButton } from "../atoms/button.js";
 import { emptyState } from "../molecules/empty-state.js";
 import { selectField } from "../molecules/select-field.js";
+import { textField } from "../molecules/text-field.js";
 
 export const TAB_LAB = `
 <!-- ── Tab: Lab ── -->
@@ -10,10 +11,7 @@ export const TAB_LAB = `
     <p class="playground-subtitle">Write and test <a href="https://www.nestjs.doctor/docs/rules/custom" target="_blank" rel="noopener">custom rules</a> against your project. Use <code>/nestjs-doctor-create-rule</code> with an AI agent to <a href="https://www.nestjs.doctor/docs/coding-agents" target="_blank" rel="noopener">scaffold rules automatically</a>.</p>
     <div class="playground-form">
       <div class="playground-form-row">
-        <div class="playground-field">
-          <label for="pg-rule-id">Rule ID</label>
-          <input type="text" id="pg-rule-id" value="my-rule" spellcheck="false">
-        </div>
+${textField({ id: "pg-rule-id", label: "Rule ID", value: "my-rule" })}
 ${selectField({
 	id: "pg-category",
 	label: "Category",
@@ -35,10 +33,7 @@ ${selectField({
 })}
       </div>
       <div class="playground-form-row">
-        <div class="playground-field playground-field-wide">
-          <label for="pg-description">Description</label>
-          <input type="text" id="pg-description" placeholder="What does this rule check?" spellcheck="false">
-        </div>
+${textField({ id: "pg-description", label: "Description", placeholder: "What does this rule check?", wide: true })}
       </div>
     </div>
     <div class="playground-preset">

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-modules-graph.ts
@@ -1,10 +1,10 @@
 import { closeButton, iconButton } from "../atoms/button.js";
 import { heading } from "../atoms/heading.js";
 import { icon } from "../atoms/icon.js";
-import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { emptyState } from "../molecules/empty-state.js";
 import { legend } from "../molecules/legend.js";
+import { searchField } from "../molecules/search-field.js";
 import { sidebarHeader } from "../molecules/sidebar-header.js";
 import { sidebarShowButton, treeToolbar } from "../molecules/tree-toolbar.js";
 import { zoomBar } from "../molecules/zoom-bar.js";
@@ -19,9 +19,7 @@ ${sidebarHeader({
 	countId: "mg-project-count",
 	toolbar: treeToolbar({ prefix: "mg", noun: "project", subject: "graph" }),
 })}
-      <div class="mg-side-search">
-${searchInput({ id: "mg-search", placeholder: "Search projects and modules" })}
-      </div>
+${searchField({ id: "mg-search", placeholder: "Search projects and modules" })}
       <div class="mg-toggle-row">
 ${checkboxRow({ id: "mg-globals", label: "Show @Global() reach", indent: 8 })}
 ${checkboxRow({ id: "mg-show-external", label: "Show external modules", indent: 8 })}

--- a/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/templates/tab-schema.ts
@@ -1,8 +1,8 @@
 import { iconButton, textButton } from "../atoms/button.js";
 import { icon } from "../atoms/icon.js";
-import { searchInput } from "../atoms/search-input.js";
 import { checkboxRow } from "../molecules/checkbox-row.js";
 import { emptyState } from "../molecules/empty-state.js";
+import { searchField } from "../molecules/search-field.js";
 import { sidebarHeader } from "../molecules/sidebar-header.js";
 import { sidebarShowButton, treeToolbar } from "../molecules/tree-toolbar.js";
 import { zoomBar } from "../molecules/zoom-bar.js";
@@ -18,9 +18,7 @@ ${sidebarHeader({
 	countId: "schema-entity-count",
 	toolbar: treeToolbar({ prefix: "schema", noun: "table", subject: "diagram" }),
 })}
-      <div class="mg-side-search">
-${searchInput({ id: "schema-search", placeholder: "Search tables" })}
-      </div>
+${searchField({ id: "schema-search", placeholder: "Search tables" })}
 ${checkboxRow({ id: "schema-sync-sidebar", label: "Sync with diagram", checked: true, tip: "Sync \u00b7 the list follows the table you pick in the diagram" })}
       <div class="schema-disclaimer">Schema inferred from source code — may not reflect the actual database.</div>
     </div>


### PR DESCRIPTION
## Context

After #328 the sidebars render their header, toolbar, checkbox rows, and empty states from molecules. Two wrapper patterns still repeated around otherwise-componentized controls.

## Problem

The `<div class="mg-side-search">` wrapper around `searchInput` was copied identically in three templates, and the Rule Lab's two text inputs hand-wrote the `playground-field` label-plus-input pair that `selectField` already models for selects.

## Possible flows

| Pattern | Sites |
|---|---|
| Search wrapper | tab-diagnosis, tab-modules-graph, tab-schema |
| Text field | Rule ID, Description (wide) in tab-lab |

## Solution

`molecules/search-field.ts` (wraps the search-input atom) and `molecules/text-field.ts` (mirrors `selectField`, including its `wide` flag). No raw form controls remain outside atoms and molecules.

## Before vs after

| | Before | After |
|---|---|---|
| Hand-written search wrappers | 3 | 0 |
| Hand-written text fields | 2 | 0 |
| Emitted report | — | Byte-identical (verified) |

## Example

```
$ cmp after8.masked after9.masked && echo BYTE-IDENTICAL
BYTE-IDENTICAL
```
