### PR TITLE
refactor(report): move the boot-trace row rendering into a real module

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -13,6 +13,12 @@ export {
 	statRow,
 } from "./summary-card.js";
 export {
+	formatMs,
+	hookChipHtml,
+	traceNode,
+	traceRowHtml,
+} from "./trace.js";
+export {
 	buildFileTree,
 	compressTree,
 	countItems,

--- a/packages/nestjs-doctor/src/report/ui/browser/trace.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/trace.ts
@@ -1,0 +1,190 @@
+import { badge } from "./badge.js";
+import { escapeHtml } from "./escape.js";
+
+interface TraceHook {
+	count?: number;
+	hook: string;
+	ms: number;
+}
+
+export interface TraceNode {
+	deps: string[];
+	hooks?: TraceHook[];
+	initTime: number;
+	name: string;
+	type: string;
+}
+
+export type TraceMap = Record<string, TraceNode>;
+
+const TRACE_COLORS: Record<string, string> = {
+	provider: "34,211,238",
+	controller: "167,139,250",
+	injectable: "52,211,153",
+	middleware: "244,114,182",
+};
+
+const HOOK_META: Record<string, { label: string; rgb: string }> = {
+	onModuleInit: { label: "init", rgb: "52,211,153" },
+	onApplicationBootstrap: { label: "bootstrap", rgb: "167,139,250" },
+};
+
+export function formatMs(ms: number): string {
+	const r = Math.round(ms * 10) / 10;
+	if (r < 1) {
+		return "<1ms";
+	}
+	if (r < 10) {
+		return `${r.toFixed(1)}ms`;
+	}
+	return `${Math.round(ms)}ms`;
+}
+
+export function traceNode(trace: TraceMap, id: string): TraceNode | null {
+	return Object.hasOwn(trace, id) ? trace[id] : null;
+}
+
+function traceColor(type: string): string {
+	return Object.hasOwn(TRACE_COLORS, type) ? TRACE_COLORS[type] : "107,114,128";
+}
+
+export function hookChipHtml(hooks: TraceHook[] | undefined): string {
+	if (!hooks || hooks.length === 0) {
+		return "";
+	}
+	let html = "";
+	for (const h of hooks) {
+		const meta = Object.hasOwn(HOOK_META, h.hook)
+			? HOOK_META[h.hook]
+			: { label: h.hook, rgb: "107,114,128" };
+		const times = h.count && h.count > 1 ? ` across ${h.count} instances` : "";
+		html +=
+			`<span class="mg-trace-hook" style="color:rgb(${meta.rgb});background:rgba(${meta.rgb},0.12)"` +
+			` data-tip="${escapeHtml(`${h.hook} took ${formatMs(h.ms)}${times}`)}">+` +
+			`${escapeHtml(formatMs(h.ms))} ${escapeHtml(meta.label)}` +
+			`${h.count && h.count > 1 ? ` ×${h.count}` : ""}</span>`;
+	}
+	return html;
+}
+
+function traceBadgeHtml(type: string): string {
+	const rgb = traceColor(type);
+	return badge({
+		style: `color:rgb(${rgb});background:rgba(${rgb},0.12)`,
+		text: escapeHtml(type),
+	});
+}
+
+function traceBarHtml(
+	trace: TraceMap,
+	traceMax: number,
+	initTime: number,
+	deps: string[],
+	type: string,
+	hollowTip: string | null
+): string {
+	const frac = Math.max(0, Math.min(1, initTime / traceMax));
+	const width = (frac * 100).toFixed(2);
+	if (hollowTip) {
+		return (
+			`<span class="mg-trace-track" data-tip="${escapeHtml(`${formatMs(initTime)} total — ${hollowTip}`)}">` +
+			`<span class="mg-trace-bar" style="width:${width}%;background:transparent;box-shadow:inset 0 0 0 1px rgba(${traceColor(type)},0.5)"></span>` +
+			"</span>"
+		);
+	}
+	// Slowest dep this class could actually have waited on: a dep slower than
+	// the class itself was pre-built, so it never entered this class's clock.
+	let slowestDep = 0;
+	for (const d of deps) {
+		const dep = traceNode(trace, d);
+		if (dep && dep.initTime <= initTime) {
+			slowestDep = dep.initTime;
+			break;
+		}
+	}
+	const selfFrac = Math.max(
+		0,
+		Math.min(frac, (initTime - slowestDep) / traceMax)
+	);
+	const tip =
+		`${formatMs(initTime)} total` +
+		(slowestDep > 0
+			? ` — ≈${formatMs(slowestDep)} waiting on dependencies, ≈${formatMs(Math.max(0, initTime - slowestDep))} own work`
+			: " — all own work");
+	return (
+		`<span class="mg-trace-track" data-tip="${escapeHtml(tip)}">` +
+		`<span class="mg-trace-bar" style="width:${width}%;background:rgba(${traceColor(type)},0.4)"></span>` +
+		(selfFrac > 0.002
+			? `<span class="mg-trace-self" style="left:${((frac - selfFrac) * 100).toFixed(2)}%;width:${(selfFrac * 100).toFixed(2)}%"></span>`
+			: "") +
+		"</span>"
+	);
+}
+
+export function traceRowHtml(
+	trace: TraceMap,
+	traceMax: number,
+	id: string,
+	depth: number,
+	path: string,
+	mode?: string | null
+): string {
+	const node = traceNode(trace, id);
+	if (!node) {
+		return "";
+	}
+	const ancestors = path.split("/");
+	ancestors.pop();
+	const cyc = ancestors.indexOf(id) >= 0;
+	const expandable = !cyc && depth < 20 && node.deps.length > 0;
+	// Slower than its consumer means the dep already existed when the consumer loaded.
+	const parent =
+		ancestors.length > 0 ? traceNode(trace, ancestors.at(-1) as string) : null;
+	const reused =
+		mode === "reused" || (parent !== null && node.initTime > parent.initTime);
+	const listed = !reused && mode === "listed";
+	let mark: { bar: string; cls: string; tag: string; tip: string } | null =
+		null;
+	if (reused) {
+		mark = {
+			cls: " mg-trace-reused",
+			tag: "reused",
+			tip: "Already built when this parent loaded — its cost is counted at its first consumer",
+			bar: "already built for an earlier consumer; not paid here",
+		};
+	} else if (listed) {
+		mark = {
+			cls: " mg-trace-reused",
+			tag: "listed above",
+			tip: "Has its own row at the top of this trace — the cost is detailed there",
+			bar: "detailed in its own row at the top of this trace",
+		};
+	}
+	return (
+		`<div class="mg-trace-row${expandable ? " mg-trace-expandable" : ""}${mark ? mark.cls : ""}"` +
+		` data-trace="${escapeHtml(id)}" data-path="${escapeHtml(path)}" data-depth="${depth}"` +
+		`${mark ? ` data-mark="${reused ? "reused" : "listed"}"` : ""}>` +
+		`<span class="mg-trace-label" style="padding-left:${Math.min(depth, 8) * 16}px">` +
+		`<span class="mg-trace-caret">${expandable ? "▸" : ""}</span>` +
+		`<span class="mg-trace-name" data-tip="${escapeHtml(node.name)}">${escapeHtml(node.name)}</span>` +
+		traceBadgeHtml(node.type) +
+		hookChipHtml(node.hooks) +
+		(mark
+			? `<span class="mg-trace-reused-tag" data-tip="${mark.tip}">${mark.tag}</span>`
+			: "") +
+		(cyc
+			? '<span class="mg-trace-cycle" data-tip="circular dependency">↻</span>'
+			: "") +
+		"</span>" +
+		traceBarHtml(
+			trace,
+			traceMax,
+			node.initTime,
+			node.deps,
+			node.type,
+			mark ? mark.bar : null
+		) +
+		`<span class="mg-trace-time">${escapeHtml(formatMs(node.initTime))}</span>` +
+		"</div>"
+	);
+}

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -283,10 +283,7 @@ function mgEndpointsOf(controllerClass) {
 
 // ── Modules graph: build ──
 function mgFormatMs(ms) {
-  var r = Math.round(ms * 10) / 10;
-  if (r < 1) return "<1ms";
-  if (r < 10) return r.toFixed(1) + "ms";
-  return Math.round(ms) + "ms";
+  return RPT.formatMs(ms);
 }
 
 function mgMeasureNode(n) {
@@ -1081,7 +1078,7 @@ function mgBindEvents() {
       }
     } else {
       row.classList.add("expanded");
-      var node = mgTraceNode(row.dataset.trace);
+      var node = RPT.traceNode(graph.timingsTrace, row.dataset.trace);
       if (!node) return;
       var depth = parseInt(row.dataset.depth, 10) + 1;
       var parentMark = row.dataset.mark || null;
@@ -1621,45 +1618,6 @@ function mgProvidersHtml(n) {
 }
 
 var mgTraceMax = 1;
-var MG_TRACE_COLORS = {
-  provider: "34,211,238",
-  controller: "167,139,250",
-  injectable: "52,211,153",
-  middleware: "244,114,182"
-};
-
-function mgTraceNode(id) {
-  return Object.prototype.hasOwnProperty.call(graph.timingsTrace, id)
-    ? graph.timingsTrace[id] : null;
-}
-
-function mgTraceColor(type) {
-  return Object.prototype.hasOwnProperty.call(MG_TRACE_COLORS, type)
-    ? MG_TRACE_COLORS[type] : "107,114,128";
-}
-
-var MG_HOOK_META = {
-  onModuleInit: { label: "init", rgb: "52,211,153" },
-  onApplicationBootstrap: { label: "bootstrap", rgb: "167,139,250" }
-};
-
-function mgHookChipHtml(hooks) {
-  if (!hooks || hooks.length === 0) return "";
-  var html = "";
-  for (var i = 0; i < hooks.length; i++) {
-    var h = hooks[i];
-    var meta = Object.prototype.hasOwnProperty.call(MG_HOOK_META, h.hook)
-      ? MG_HOOK_META[h.hook]
-      : { label: h.hook, rgb: "107,114,128" };
-    var times = h.count && h.count > 1 ? " across " + h.count + " instances" : "";
-    html += '<span class="mg-trace-hook" style="color:rgb(' + meta.rgb + ');background:rgba(' + meta.rgb + ',0.12)"' +
-      ' data-tip="' + mgEsc(h.hook + " took " + mgFormatMs(h.ms) + times) + '">+' +
-      mgEsc(mgFormatMs(h.ms)) + ' ' + mgEsc(meta.label) +
-      (h.count && h.count > 1 ? ' \\u00d7' + h.count : '') + '</span>';
-  }
-  return html;
-}
-
 function mgPhaseParts() {
   var p = graph.phases;
   // Without createMs the earlier boundaries are unknown, so segments would mislabel.
@@ -1723,69 +1681,8 @@ function mgDockShow(name) {
   mgResize();
 }
 
-function mgTraceBadgeHtml(type) {
-  var rgb = mgTraceColor(type);
-  return RPT.badge({
-    style: "color:rgb(" + rgb + ");background:rgba(" + rgb + ",0.12)",
-    text: mgEsc(type)
-  });
-}
-
-function mgTraceBarHtml(initTime, deps, type, hollowTip) {
-  var frac = Math.max(0, Math.min(1, initTime / mgTraceMax));
-  var width = (frac * 100).toFixed(2);
-  if (hollowTip) {
-    return '<span class="mg-trace-track" data-tip="' + mgEsc(mgFormatMs(initTime) + " total \\u2014 " + hollowTip) + '">' +
-      '<span class="mg-trace-bar" style="width:' + width + '%;background:transparent;box-shadow:inset 0 0 0 1px rgba(' + mgTraceColor(type) + ',0.5)"></span>' +
-      '</span>';
-  }
-  // Slowest dep this class could actually have waited on: a dep slower than
-  // the class itself was pre-built, so it never entered this class's clock.
-  var slowestDep = 0;
-  for (var d = 0; d < deps.length; d++) {
-    var dep = mgTraceNode(deps[d]);
-    if (dep && dep.initTime <= initTime) { slowestDep = dep.initTime; break; }
-  }
-  var selfFrac = Math.max(0, Math.min(frac, (initTime - slowestDep) / mgTraceMax));
-  var tip = mgFormatMs(initTime) + " total" +
-    (slowestDep > 0 ? " \\u2014 \\u2248" + mgFormatMs(slowestDep) + " waiting on dependencies, \\u2248" + mgFormatMs(Math.max(0, initTime - slowestDep)) + " own work" : " \\u2014 all own work");
-  return '<span class="mg-trace-track" data-tip="' + mgEsc(tip) + '">' +
-    '<span class="mg-trace-bar" style="width:' + width + '%;background:rgba(' + mgTraceColor(type) + ',0.4)"></span>' +
-    (selfFrac > 0.002 ? '<span class="mg-trace-self" style="left:' + ((frac - selfFrac) * 100).toFixed(2) + '%;width:' + (selfFrac * 100).toFixed(2) + '%"></span>' : '') +
-    '</span>';
-}
-
 function mgTraceRowHtml(id, depth, path, mode) {
-  var node = mgTraceNode(id);
-  if (!node) return "";
-  var ancestors = path.split("/");
-  ancestors.pop();
-  var cyc = ancestors.indexOf(id) >= 0;
-  var expandable = !cyc && depth < 20 && node.deps.length > 0;
-  // Slower than its consumer means the dep already existed when the consumer loaded.
-  var parent = ancestors.length > 0 ? mgTraceNode(ancestors[ancestors.length - 1]) : null;
-  var reused = mode === "reused" || (parent !== null && node.initTime > parent.initTime);
-  var listed = !reused && mode === "listed";
-  var mark = reused
-    ? { cls: " mg-trace-reused", tag: "reused", tip: "Already built when this parent loaded \\u2014 its cost is counted at its first consumer", bar: "already built for an earlier consumer; not paid here" }
-    : listed
-      ? { cls: " mg-trace-reused", tag: "listed above", tip: "Has its own row at the top of this trace \\u2014 the cost is detailed there", bar: "detailed in its own row at the top of this trace" }
-      : null;
-  return '<div class="mg-trace-row' + (expandable ? ' mg-trace-expandable' : '') +
-    (mark ? mark.cls : '') + '"' +
-    ' data-trace="' + mgEsc(id) + '" data-path="' + mgEsc(path) + '" data-depth="' + depth + '"' +
-    (mark ? ' data-mark="' + (reused ? "reused" : "listed") + '"' : '') + '>' +
-    '<span class="mg-trace-label" style="padding-left:' + (Math.min(depth, 8) * 16) + 'px">' +
-    '<span class="mg-trace-caret">' + (expandable ? "\\u25B8" : "") + '</span>' +
-    '<span class="mg-trace-name" data-tip="' + mgEsc(node.name) + '">' + mgEsc(node.name) + '</span>' +
-    mgTraceBadgeHtml(node.type) +
-    mgHookChipHtml(node.hooks) +
-    (mark ? '<span class="mg-trace-reused-tag" data-tip="' + mark.tip + '">' + mark.tag + '</span>' : '') +
-    (cyc ? '<span class="mg-trace-cycle" data-tip="circular dependency">\\u21BB</span>' : '') +
-    '</span>' +
-    mgTraceBarHtml(node.initTime, node.deps, node.type, mark ? mark.bar : null) +
-    '<span class="mg-trace-time">' + mgEsc(mgFormatMs(node.initTime)) + '</span>' +
-    '</div>';
+  return RPT.traceRowHtml(graph.timingsTrace, mgTraceMax, id, depth, path, mode);
 }
 
 var mgTraceTopIds = {};
@@ -1965,7 +1862,7 @@ function mgShowDetail(n) {
         text: mgEsc(mgFormatMs(n.initTimings[0].initTime)) + ' \\u00b7 trace \\u25B8'
       });
     }
-    badges += mgHookChipHtml(n.hookTimings);
+    badges += RPT.hookChipHtml(n.hookTimings);
   }
   document.getElementById("detail-badges").innerHTML = badges;
   mgSyncTraceDrawer(n);

--- a/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
@@ -1,74 +1,27 @@
 import { describe, expect, it } from "vitest";
 import {
-	badge,
-	escapeHtml,
-	treeRow,
-} from "../../src/report/ui/browser/entry.js";
-import { getReportScripts } from "../../src/report/ui/scripts.js";
-import { EMPTY_ARTIFACT_JSON as EMPTY } from "./report-artifact-fixture.js";
+	formatMs,
+	type TraceMap,
+	traceRowHtml,
+} from "../../src/report/ui/browser/trace.js";
 
-/** Pulls mgFormatMs out of the emitted script and runs the real emitted source. */
-function loadFormatMs(): (ms: number) => string {
-	const scripts = getReportScripts(EMPTY);
-	const start = scripts.indexOf("function mgFormatMs");
-	const end = scripts.indexOf("function mgMeasureNode");
-	if (start < 0 || end <= start) {
-		throw new Error("mgFormatMs not found in the emitted report script");
-	}
-	const factory = new Function(`${scripts.slice(start, end)}
-		return mgFormatMs;`);
-	return factory() as (ms: number) => string;
-}
-
-/** Pulls the trace row builder out of the emitted script and runs it. */
-function loadTraceRow(
-	graph: unknown
-): (id: string, depth: number, path: string) => string {
-	const scripts = getReportScripts(EMPTY);
-	const sliceOf = (start: string, end: string) => {
-		const a = scripts.indexOf(start);
-		const b = scripts.indexOf(end);
-		if (a < 0 || b <= a) {
-			throw new Error(`slice ${start} not found in the emitted report script`);
-		}
-		return scripts.slice(a, b);
-	};
-	const source =
-		sliceOf("function mgFormatMs", "function mgMeasureNode") +
-		sliceOf("function mgEsc", "var MG_INFO_ICON") +
-		sliceOf("var mgTraceMax", "function mgShowModuleTrace");
-	const factory = new Function(
-		"graph",
-		"RPT",
-		`${source}
-		mgTraceMax = 100;
-		return mgTraceRowHtml;`
-	);
-	return factory(graph, { badge, escapeHtml, treeRow }) as (
-		id: string,
-		depth: number,
-		path: string
-	) => string;
-}
-
-describe("mgTraceRowHtml", () => {
-	const graph = {
-		timingsTrace: {
-			ta: {
-				name: "BookingController",
-				type: "controller",
-				initTime: 0.9,
-				deps: ["tb"],
-			},
-			tb: {
-				name: "SchedulingService",
-				type: "provider",
-				initTime: 67,
-				deps: [],
-			},
+describe("traceRowHtml", () => {
+	const trace: TraceMap = {
+		ta: {
+			name: "BookingController",
+			type: "controller",
+			initTime: 0.9,
+			deps: ["tb"],
+		},
+		tb: {
+			name: "SchedulingService",
+			type: "provider",
+			initTime: 67,
+			deps: [],
 		},
 	};
-	const row = loadTraceRow(graph);
+	const row = (id: string, depth: number, path: string) =>
+		traceRowHtml(trace, 100, id, depth, path);
 
 	it("marks a dep slower than its parent as reused", () => {
 		const html = row("tb", 1, "ta/tb");
@@ -82,28 +35,26 @@ describe("mgTraceRowHtml", () => {
 	});
 });
 
-describe("mgFormatMs", () => {
-	const format = loadFormatMs();
-
+describe("formatMs", () => {
 	it("rounds to the nearest millisecond at 10ms and above", () => {
-		expect(format(210.4)).toBe("210ms");
-		expect(format(10)).toBe("10ms");
+		expect(formatMs(210.4)).toBe("210ms");
+		expect(formatMs(10)).toBe("10ms");
 	});
 
 	it("keeps one decimal between 1ms and 10ms", () => {
-		expect(format(4.55)).toBe("4.6ms");
-		expect(format(1)).toBe("1.0ms");
+		expect(formatMs(4.55)).toBe("4.6ms");
+		expect(formatMs(1)).toBe("1.0ms");
 	});
 
 	it("floors sub-millisecond timings to <1ms instead of rounding to 0", () => {
-		expect(format(0.4)).toBe("<1ms");
+		expect(formatMs(0.4)).toBe("<1ms");
 	});
 
 	it("treats exactly 0ms the same as sub-millisecond, never printing 0ms", () => {
-		expect(format(0)).toBe("<1ms");
+		expect(formatMs(0)).toBe("<1ms");
 	});
 
 	it("rounds 9.96ms up cleanly rather than printing 10.0ms", () => {
-		expect(format(9.96)).toBe("10ms");
+		expect(formatMs(9.96)).toBe("10ms");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
@@ -50,8 +50,8 @@ describe("report scripts", () => {
 	});
 
 	it("colors trace bars and badges by class type", () => {
-		expect(scripts).toContain("MG_TRACE_COLORS");
-		expect(scripts).toContain("function mgTraceColor");
+		expect(scripts).toContain("TRACE_COLORS");
+		expect(scripts).toContain("function traceColor");
 	});
 
 	it("marks a dep slower than its parent as reused with a hollow bar", () => {
@@ -66,9 +66,7 @@ describe("report scripts", () => {
 	});
 
 	it("guards trace lookups against inherited object keys", () => {
-		expect(scripts).toContain(
-			"Object.prototype.hasOwnProperty.call(graph.timingsTrace, id)"
-		);
+		expect(scripts).toContain("Object.hasOwn(trace, id)");
 	});
 
 	it("shows time-to-start when the dump has startupMs, else the slowest chain", () => {
@@ -89,8 +87,8 @@ describe("report scripts", () => {
 	});
 
 	it("shows per-class hook durations as chips on trace rows", () => {
-		expect(scripts).toContain("function mgHookChipHtml");
-		expect(scripts).toContain("mgHookChipHtml(node.hooks)");
-		expect(scripts).toContain("mgHookChipHtml(n.hookTimings)");
+		expect(scripts).toContain("function hookChipHtml");
+		expect(scripts).toContain("hookChipHtml(node.hooks)");
+		expect(scripts).toContain("RPT.hookChipHtml(n.hookTimings)");
 	});
 });


### PR DESCRIPTION
## Context

The boot-trace drawer's row rendering lived inside the `modules-graph` script chunk — a string the browser evaluates. `tests/unit/report-module-timings.test.ts` could only test it by slicing the emitted script with `indexOf` between named declarations and evaluating the slice with `new Function`, with a hand-maintained `RPT` stub. The memory note in `scripts.ts`'s history calls this the fragile part: a new declaration landing between two markers silently makes a slice swallow foreign source.

## Problem

The logic is pure (trace map in, HTML string out) but untestable directly, and its helpers (`mgTraceColor`, `mgHookChipHtml`, `mgTraceBarHtml`) duplicated escape and badge wiring the browser modules already have.

## Possible flows

| Caller | Before | After |
|---|---|---|
| Trace drawer rows | `mgTraceRowHtml` in the chunk | thin wrapper over `RPT.traceRowHtml` |
| Row expansion | `mgTraceNode` in the chunk | `RPT.traceNode` |
| Detail-panel hook chips | `mgHookChipHtml` in the chunk | `RPT.hookChipHtml` |
| `mgFormatMs` callers (5 sites) | chunk implementation | thin wrapper over `RPT.formatMs` |

## Solution

`browser/trace.ts`: `formatMs`, `traceNode`, `hookChipHtml`, `traceRowHtml` (typed, taking the trace map and max as parameters instead of chunk globals), exported through the bundle. The chunk keeps two-line wrappers so its call sites and evaluation order don't change. The timings test now imports the functions directly — no more script slicing or `RPT` stub for this subsystem.

Three string-presence assertions in `report-scripts.test.ts` were updated to the moved names, including `Object.hasOwn` (Biome's rewrite of the `hasOwnProperty` guard; same inherited-key protection).

## Before vs after

| | Before | After |
|---|---|---|
| Trace rendering testable | only via script slicing | direct import |
| `indexOf` slices in the timings test | 3 | 0 |
| Static markup | — | unchanged; all 10 emitted-diff regions in the script |
| Rendered trace DOM | — | identical strings, same class names and tips |

## Example

```
- sliceOf("function mgFormatMs", "function mgMeasureNode") + ... new Function(...)
+ import { formatMs, traceRowHtml } from "../../src/report/ui/browser/trace.js";
```
