### PR TITLE
refactor(report): move the schema layout maths into a real module

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -6,6 +6,17 @@ export { emptyState } from "../molecules/empty-state.js";
 export { badge } from "./badge.js";
 export { escapeHtml } from "./escape.js";
 export {
+	computeComponents,
+	computeOverviewLayout,
+	layoutComponent,
+	layoutIsolatedBlock,
+	nodeHeight,
+	packBoxes,
+	SCHEMA_BOX_W,
+	SCHEMA_DEFAULT_MAX_COLS,
+	visibleColCount,
+} from "./schema-layout.js";
+export {
 	card,
 	infoCard,
 	infoItem,

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -13,6 +13,12 @@ export {
 	statRow,
 } from "./summary-card.js";
 export {
+	formatMs,
+	hookChipHtml,
+	traceNode,
+	traceRowHtml,
+} from "./trace.js";
+export {
 	buildFileTree,
 	compressTree,
 	countItems,

--- a/packages/nestjs-doctor/src/report/ui/browser/schema-layout.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/schema-layout.ts
@@ -1,0 +1,413 @@
+interface SchemaRelation {
+	fromEntity: string;
+	toEntity: string;
+}
+
+interface SchemaLayoutNode {
+	_comp?: number;
+	h: number;
+	name: string;
+	w: number;
+	x: number;
+	y: number;
+}
+
+interface SizedNode {
+	entity: { columns: unknown[] };
+}
+
+export const SCHEMA_BOX_W = 180;
+export const SCHEMA_DEFAULT_MAX_COLS = 7;
+const COL_GAP = 110;
+const ROW_GAP = 44;
+const COL_CAP = 2400;
+
+// Groups nodes into connected components via union-find over the relations.
+export function computeComponents<N extends SchemaLayoutNode>(
+	relations: SchemaRelation[],
+	nodes: N[]
+): N[][] {
+	const index: Record<string, number> = {};
+	const parent: number[] = [];
+	for (let i = 0; i < nodes.length; i++) {
+		index[nodes[i].name] = i;
+		parent.push(i);
+	}
+	function find(start: number): number {
+		let a = start;
+		while (parent[a] !== a) {
+			parent[a] = parent[parent[a]];
+			a = parent[a];
+		}
+		return a;
+	}
+	for (const rel of relations) {
+		if (rel.fromEntity === rel.toEntity) {
+			continue;
+		}
+		const a = index[rel.fromEntity];
+		const b = index[rel.toEntity];
+		if (a === undefined || b === undefined) {
+			continue;
+		}
+		const ra = find(a);
+		const rb = find(b);
+		if (ra !== rb) {
+			parent[rb] = ra;
+		}
+	}
+	const groups: Record<number, N[]> = {};
+	for (let i = 0; i < nodes.length; i++) {
+		const root = find(i);
+		if (!groups[root]) {
+			groups[root] = [];
+		}
+		groups[root].push(nodes[i]);
+	}
+	return Object.values(groups);
+}
+
+// Positions one component from its own origin: layered left-to-right, ordered
+// by neighbor barycenter, over-tall columns split, three relax passes.
+export function layoutComponent(
+	relations: SchemaRelation[],
+	nodes: SchemaLayoutNode[]
+): { h: number; w: number } {
+	if (nodes.length === 1) {
+		nodes[0].x = nodes[0].w / 2;
+		nodes[0].y = nodes[0].h / 2;
+		return { w: nodes[0].w, h: nodes[0].h };
+	}
+	const idx: Record<string, number> = {};
+	for (let i = 0; i < nodes.length; i++) {
+		idx[nodes[i].name] = i;
+	}
+	const n = nodes.length;
+	const out: number[][] = [];
+	const und: number[][] = [];
+	for (let i = 0; i < n; i++) {
+		out.push([]);
+		und.push([]);
+	}
+	const seenE: Record<string, boolean> = {};
+	for (const rel of relations) {
+		if (rel.fromEntity === rel.toEntity) {
+			continue;
+		}
+		const ea = idx[rel.fromEntity];
+		const eb = idx[rel.toEntity];
+		if (ea === undefined || eb === undefined) {
+			continue;
+		}
+		const ek = ea < eb ? `${ea}|${eb}` : `${eb}|${ea}`;
+		if (seenE[ek]) {
+			continue;
+		}
+		seenE[ek] = true;
+		out[ea].push(eb);
+		und[ea].push(eb);
+		und[eb].push(ea);
+	}
+
+	// Break cycles: depth-first, back edges are dropped from the working copy
+	const color: number[] = [];
+	const acyc: number[][] = [];
+	for (let i = 0; i < n; i++) {
+		color.push(0);
+		acyc.push([]);
+	}
+	function dfsBreak(u: number): void {
+		color[u] = 1;
+		for (const v of out[u]) {
+			if (color[v] === 1) {
+				continue;
+			}
+			acyc[u].push(v);
+			if (color[v] === 0) {
+				dfsBreak(v);
+			}
+		}
+		color[u] = 2;
+	}
+	for (let i = 0; i < n; i++) {
+		if (color[i] === 0) {
+			dfsBreak(i);
+		}
+	}
+
+	// Layer by longest path from sinks: referenced hubs land in column 0
+	const layer: number[] = [];
+	for (let i = 0; i < n; i++) {
+		layer.push(-1);
+	}
+	function assignLayer(u: number): number {
+		if (layer[u] >= 0) {
+			return layer[u];
+		}
+		layer[u] = 0;
+		let best = 0;
+		for (const e of acyc[u]) {
+			const d = assignLayer(e) + 1;
+			if (d > best) {
+				best = d;
+			}
+		}
+		layer[u] = best;
+		return best;
+	}
+	for (let i = 0; i < n; i++) {
+		assignLayer(i);
+	}
+
+	// Order each column by neighbor barycenter, four alternating sweeps
+	let maxLayer = 0;
+	for (let i = 0; i < n; i++) {
+		if (layer[i] > maxLayer) {
+			maxLayer = layer[i];
+		}
+	}
+	const cols: number[][] = [];
+	for (let i = 0; i <= maxLayer; i++) {
+		cols.push([]);
+	}
+	for (let i = 0; i < n; i++) {
+		cols[layer[i]].push(i);
+	}
+	function sweepPair(fixed: number[], moving: number[]): void {
+		const pos: Record<number, number> = {};
+		for (let p = 0; p < fixed.length; p++) {
+			pos[fixed[p]] = p;
+		}
+		const keyed: { k: number; o: number; u: number }[] = [];
+		for (let p = 0; p < moving.length; p++) {
+			const u = moving[p];
+			let sum = 0;
+			let cnt = 0;
+			for (const q of und[u]) {
+				if (pos[q] !== undefined) {
+					sum += pos[q];
+					cnt++;
+				}
+			}
+			keyed.push({ u, k: cnt ? sum / cnt : p, o: p });
+		}
+		keyed.sort((x, y) => x.k - y.k || x.o - y.o);
+		for (let p = 0; p < keyed.length; p++) {
+			moving[p] = keyed[p].u;
+		}
+	}
+	for (let t = 0; t < 4; t++) {
+		for (let i = 1; i < cols.length; i++) {
+			sweepPair(cols[i - 1], cols[i]);
+		}
+		for (let i = cols.length - 2; i >= 0; i--) {
+			sweepPair(cols[i + 1], cols[i]);
+		}
+	}
+
+	// Split an over-tall column into side-by-side runs, keeping the order
+	const phys: number[][] = [];
+	for (const col of cols) {
+		let run: number[] = [];
+		let runH = 0;
+		for (const u2 of col) {
+			const hh = nodes[u2].h + ROW_GAP;
+			if (runH > 0 && runH + hh > COL_CAP) {
+				phys.push(run);
+				run = [];
+				runH = 0;
+			}
+			run.push(u2);
+			runH += hh;
+		}
+		if (run.length > 0) {
+			phys.push(run);
+		}
+	}
+
+	// Coordinates: fixed-width columns, stacked rows, then three relax passes
+	let xCur = 0;
+	for (const col of phys) {
+		let yCur = 0;
+		for (const u of col) {
+			const nd = nodes[u];
+			nd.x = xCur + nd.w / 2;
+			nd.y = yCur + nd.h / 2;
+			yCur += nd.h + ROW_GAP;
+		}
+		xCur += SCHEMA_BOX_W + COL_GAP;
+	}
+	for (let t = 0; t < 3; t++) {
+		for (const col of phys) {
+			const want: number[] = [];
+			for (const u3 of col) {
+				let s2 = 0;
+				let c2 = 0;
+				for (const q of und[u3]) {
+					s2 += nodes[q].y;
+					c2++;
+				}
+				want.push(c2 > 0 ? s2 / c2 : nodes[u3].y);
+			}
+			for (let j = 0; j < col.length; j++) {
+				nodes[col[j]].y = want[j];
+			}
+			// The top-down sweep resolves overlaps without reordering the column
+			let floorY = Number.NEGATIVE_INFINITY;
+			for (const u4 of col) {
+				const nd2 = nodes[u4];
+				const top = Math.max(nd2.y - nd2.h / 2, floorY);
+				nd2.y = top + nd2.h / 2;
+				floorY = top + nd2.h + ROW_GAP;
+			}
+		}
+	}
+
+	// Normalize to origin and report the extent
+	let minX = Number.POSITIVE_INFINITY;
+	let minY = Number.POSITIVE_INFINITY;
+	let maxX = Number.NEGATIVE_INFINITY;
+	let maxY = Number.NEGATIVE_INFINITY;
+	for (const nd of nodes) {
+		minX = Math.min(minX, nd.x - nd.w / 2);
+		maxX = Math.max(maxX, nd.x + nd.w / 2);
+		minY = Math.min(minY, nd.y - nd.h / 2);
+		maxY = Math.max(maxY, nd.y + nd.h / 2);
+	}
+	for (const nd of nodes) {
+		nd.x -= minX;
+		nd.y -= minY;
+	}
+	return { w: maxX - minX, h: maxY - minY };
+}
+
+// Lays isolated tables out in a near-square grid.
+export function layoutIsolatedBlock(
+	nodes: SchemaLayoutNode[],
+	gutter: number
+): { h: number; w: number } {
+	const cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+	let cellW = 0;
+	let cellH = 0;
+	for (const nd of nodes) {
+		if (nd.w > cellW) {
+			cellW = nd.w;
+		}
+		if (nd.h > cellH) {
+			cellH = nd.h;
+		}
+	}
+	const rows = Math.ceil(nodes.length / cols);
+	for (let j = 0; j < nodes.length; j++) {
+		nodes[j].x = (j % cols) * (cellW + gutter) + cellW / 2;
+		nodes[j].y = Math.floor(j / cols) * (cellH + gutter) + cellH / 2;
+	}
+	return {
+		w: cols * cellW + (cols - 1) * gutter,
+		h: rows * cellH + (rows - 1) * gutter,
+	};
+}
+
+interface PackedBox {
+	h: number;
+	ox?: number;
+	oy?: number;
+	w: number;
+}
+
+// Shelf-packs component boxes into a roughly square area.
+export function packBoxes(
+	boxes: PackedBox[],
+	targetW: number,
+	gutter: number
+): void {
+	let x = 0;
+	let y = 0;
+	let shelfH = 0;
+	for (const box of boxes) {
+		if (x > 0 && x + box.w > targetW) {
+			x = 0;
+			y += shelfH + gutter;
+			shelfH = 0;
+		}
+		box.ox = x;
+		box.oy = y;
+		x += box.w + gutter;
+		if (box.h > shelfH) {
+			shelfH = box.h;
+		}
+	}
+}
+
+// Positions every node of the overview: components laid out individually,
+// isolated tables gathered into one grid block, blocks shelf-packed.
+export function computeOverviewLayout(
+	relations: SchemaRelation[],
+	nodes: SchemaLayoutNode[]
+): void {
+	const GUTTER = 80;
+	const components = computeComponents(relations, nodes);
+	const boxes: (PackedBox & { nodes: SchemaLayoutNode[] })[] = [];
+	const isolated: SchemaLayoutNode[] = [];
+
+	for (let i = 0; i < components.length; i++) {
+		if (components[i].length === 1) {
+			components[i][0]._comp = -1;
+			isolated.push(components[i][0]);
+			continue;
+		}
+		for (const nd of components[i]) {
+			nd._comp = i;
+		}
+		const size = layoutComponent(relations, components[i]);
+		boxes.push({ nodes: components[i], w: size.w, h: size.h });
+	}
+
+	boxes.sort((a, b) => b.h - a.h || b.w - a.w);
+
+	if (isolated.length > 0) {
+		const isoSize = layoutIsolatedBlock(isolated, 28);
+		boxes.push({ nodes: isolated, w: isoSize.w, h: isoSize.h });
+	}
+
+	let area = 0;
+	for (const box of boxes) {
+		area += box.w * box.h;
+	}
+	const targetW = Math.max(900, Math.sqrt(area) * 1.6);
+	packBoxes(boxes, targetW, GUTTER);
+
+	for (const placed of boxes) {
+		for (const nd of placed.nodes) {
+			nd.x += placed.ox as number;
+			nd.y += placed.oy as number;
+		}
+	}
+}
+
+// Columns rendered for a table: capped unless every column is shown.
+export function visibleColCount(
+	node: SizedNode,
+	showCols: boolean,
+	showAllCols: boolean
+): number {
+	if (!showCols) {
+		return 0;
+	}
+	const total = node.entity.columns.length;
+	return showAllCols ? total : Math.min(total, SCHEMA_DEFAULT_MAX_COLS);
+}
+
+// Header, one row per visible column, the "+N more" row only while capped.
+export function nodeHeight(
+	node: SizedNode,
+	showCols: boolean,
+	showAllCols: boolean
+): number {
+	if (!showCols) {
+		return 52;
+	}
+	const visible = visibleColCount(node, showCols, showAllCols);
+	const hidden = node.entity.columns.length - visible;
+	return 24 + visible * 16 + (hidden > 0 ? 16 : 0) + 8;
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/trace.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/trace.ts
@@ -1,0 +1,190 @@
+import { badge } from "./badge.js";
+import { escapeHtml } from "./escape.js";
+
+interface TraceHook {
+	count?: number;
+	hook: string;
+	ms: number;
+}
+
+export interface TraceNode {
+	deps: string[];
+	hooks?: TraceHook[];
+	initTime: number;
+	name: string;
+	type: string;
+}
+
+export type TraceMap = Record<string, TraceNode>;
+
+const TRACE_COLORS: Record<string, string> = {
+	provider: "34,211,238",
+	controller: "167,139,250",
+	injectable: "52,211,153",
+	middleware: "244,114,182",
+};
+
+const HOOK_META: Record<string, { label: string; rgb: string }> = {
+	onModuleInit: { label: "init", rgb: "52,211,153" },
+	onApplicationBootstrap: { label: "bootstrap", rgb: "167,139,250" },
+};
+
+export function formatMs(ms: number): string {
+	const r = Math.round(ms * 10) / 10;
+	if (r < 1) {
+		return "<1ms";
+	}
+	if (r < 10) {
+		return `${r.toFixed(1)}ms`;
+	}
+	return `${Math.round(ms)}ms`;
+}
+
+export function traceNode(trace: TraceMap, id: string): TraceNode | null {
+	return Object.hasOwn(trace, id) ? trace[id] : null;
+}
+
+function traceColor(type: string): string {
+	return Object.hasOwn(TRACE_COLORS, type) ? TRACE_COLORS[type] : "107,114,128";
+}
+
+export function hookChipHtml(hooks: TraceHook[] | undefined): string {
+	if (!hooks || hooks.length === 0) {
+		return "";
+	}
+	let html = "";
+	for (const h of hooks) {
+		const meta = Object.hasOwn(HOOK_META, h.hook)
+			? HOOK_META[h.hook]
+			: { label: h.hook, rgb: "107,114,128" };
+		const times = h.count && h.count > 1 ? ` across ${h.count} instances` : "";
+		html +=
+			`<span class="mg-trace-hook" style="color:rgb(${meta.rgb});background:rgba(${meta.rgb},0.12)"` +
+			` data-tip="${escapeHtml(`${h.hook} took ${formatMs(h.ms)}${times}`)}">+` +
+			`${escapeHtml(formatMs(h.ms))} ${escapeHtml(meta.label)}` +
+			`${h.count && h.count > 1 ? ` ×${h.count}` : ""}</span>`;
+	}
+	return html;
+}
+
+function traceBadgeHtml(type: string): string {
+	const rgb = traceColor(type);
+	return badge({
+		style: `color:rgb(${rgb});background:rgba(${rgb},0.12)`,
+		text: escapeHtml(type),
+	});
+}
+
+function traceBarHtml(
+	trace: TraceMap,
+	traceMax: number,
+	initTime: number,
+	deps: string[],
+	type: string,
+	hollowTip: string | null
+): string {
+	const frac = Math.max(0, Math.min(1, initTime / traceMax));
+	const width = (frac * 100).toFixed(2);
+	if (hollowTip) {
+		return (
+			`<span class="mg-trace-track" data-tip="${escapeHtml(`${formatMs(initTime)} total — ${hollowTip}`)}">` +
+			`<span class="mg-trace-bar" style="width:${width}%;background:transparent;box-shadow:inset 0 0 0 1px rgba(${traceColor(type)},0.5)"></span>` +
+			"</span>"
+		);
+	}
+	// Slowest dep this class could actually have waited on: a dep slower than
+	// the class itself was pre-built, so it never entered this class's clock.
+	let slowestDep = 0;
+	for (const d of deps) {
+		const dep = traceNode(trace, d);
+		if (dep && dep.initTime <= initTime) {
+			slowestDep = dep.initTime;
+			break;
+		}
+	}
+	const selfFrac = Math.max(
+		0,
+		Math.min(frac, (initTime - slowestDep) / traceMax)
+	);
+	const tip =
+		`${formatMs(initTime)} total` +
+		(slowestDep > 0
+			? ` — ≈${formatMs(slowestDep)} waiting on dependencies, ≈${formatMs(Math.max(0, initTime - slowestDep))} own work`
+			: " — all own work");
+	return (
+		`<span class="mg-trace-track" data-tip="${escapeHtml(tip)}">` +
+		`<span class="mg-trace-bar" style="width:${width}%;background:rgba(${traceColor(type)},0.4)"></span>` +
+		(selfFrac > 0.002
+			? `<span class="mg-trace-self" style="left:${((frac - selfFrac) * 100).toFixed(2)}%;width:${(selfFrac * 100).toFixed(2)}%"></span>`
+			: "") +
+		"</span>"
+	);
+}
+
+export function traceRowHtml(
+	trace: TraceMap,
+	traceMax: number,
+	id: string,
+	depth: number,
+	path: string,
+	mode?: string | null
+): string {
+	const node = traceNode(trace, id);
+	if (!node) {
+		return "";
+	}
+	const ancestors = path.split("/");
+	ancestors.pop();
+	const cyc = ancestors.indexOf(id) >= 0;
+	const expandable = !cyc && depth < 20 && node.deps.length > 0;
+	// Slower than its consumer means the dep already existed when the consumer loaded.
+	const parent =
+		ancestors.length > 0 ? traceNode(trace, ancestors.at(-1) as string) : null;
+	const reused =
+		mode === "reused" || (parent !== null && node.initTime > parent.initTime);
+	const listed = !reused && mode === "listed";
+	let mark: { bar: string; cls: string; tag: string; tip: string } | null =
+		null;
+	if (reused) {
+		mark = {
+			cls: " mg-trace-reused",
+			tag: "reused",
+			tip: "Already built when this parent loaded — its cost is counted at its first consumer",
+			bar: "already built for an earlier consumer; not paid here",
+		};
+	} else if (listed) {
+		mark = {
+			cls: " mg-trace-reused",
+			tag: "listed above",
+			tip: "Has its own row at the top of this trace — the cost is detailed there",
+			bar: "detailed in its own row at the top of this trace",
+		};
+	}
+	return (
+		`<div class="mg-trace-row${expandable ? " mg-trace-expandable" : ""}${mark ? mark.cls : ""}"` +
+		` data-trace="${escapeHtml(id)}" data-path="${escapeHtml(path)}" data-depth="${depth}"` +
+		`${mark ? ` data-mark="${reused ? "reused" : "listed"}"` : ""}>` +
+		`<span class="mg-trace-label" style="padding-left:${Math.min(depth, 8) * 16}px">` +
+		`<span class="mg-trace-caret">${expandable ? "▸" : ""}</span>` +
+		`<span class="mg-trace-name" data-tip="${escapeHtml(node.name)}">${escapeHtml(node.name)}</span>` +
+		traceBadgeHtml(node.type) +
+		hookChipHtml(node.hooks) +
+		(mark
+			? `<span class="mg-trace-reused-tag" data-tip="${mark.tip}">${mark.tag}</span>`
+			: "") +
+		(cyc
+			? '<span class="mg-trace-cycle" data-tip="circular dependency">↻</span>'
+			: "") +
+		"</span>" +
+		traceBarHtml(
+			trace,
+			traceMax,
+			node.initTime,
+			node.deps,
+			node.type,
+			mark ? mark.bar : null
+		) +
+		`<span class="mg-trace-time">${escapeHtml(formatMs(node.initTime))}</span>` +
+		"</div>"
+	);
+}

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -283,10 +283,7 @@ function mgEndpointsOf(controllerClass) {
 
 // ── Modules graph: build ──
 function mgFormatMs(ms) {
-  var r = Math.round(ms * 10) / 10;
-  if (r < 1) return "<1ms";
-  if (r < 10) return r.toFixed(1) + "ms";
-  return Math.round(ms) + "ms";
+  return RPT.formatMs(ms);
 }
 
 function mgMeasureNode(n) {
@@ -1081,7 +1078,7 @@ function mgBindEvents() {
       }
     } else {
       row.classList.add("expanded");
-      var node = mgTraceNode(row.dataset.trace);
+      var node = RPT.traceNode(graph.timingsTrace, row.dataset.trace);
       if (!node) return;
       var depth = parseInt(row.dataset.depth, 10) + 1;
       var parentMark = row.dataset.mark || null;
@@ -1621,45 +1618,6 @@ function mgProvidersHtml(n) {
 }
 
 var mgTraceMax = 1;
-var MG_TRACE_COLORS = {
-  provider: "34,211,238",
-  controller: "167,139,250",
-  injectable: "52,211,153",
-  middleware: "244,114,182"
-};
-
-function mgTraceNode(id) {
-  return Object.prototype.hasOwnProperty.call(graph.timingsTrace, id)
-    ? graph.timingsTrace[id] : null;
-}
-
-function mgTraceColor(type) {
-  return Object.prototype.hasOwnProperty.call(MG_TRACE_COLORS, type)
-    ? MG_TRACE_COLORS[type] : "107,114,128";
-}
-
-var MG_HOOK_META = {
-  onModuleInit: { label: "init", rgb: "52,211,153" },
-  onApplicationBootstrap: { label: "bootstrap", rgb: "167,139,250" }
-};
-
-function mgHookChipHtml(hooks) {
-  if (!hooks || hooks.length === 0) return "";
-  var html = "";
-  for (var i = 0; i < hooks.length; i++) {
-    var h = hooks[i];
-    var meta = Object.prototype.hasOwnProperty.call(MG_HOOK_META, h.hook)
-      ? MG_HOOK_META[h.hook]
-      : { label: h.hook, rgb: "107,114,128" };
-    var times = h.count && h.count > 1 ? " across " + h.count + " instances" : "";
-    html += '<span class="mg-trace-hook" style="color:rgb(' + meta.rgb + ');background:rgba(' + meta.rgb + ',0.12)"' +
-      ' data-tip="' + mgEsc(h.hook + " took " + mgFormatMs(h.ms) + times) + '">+' +
-      mgEsc(mgFormatMs(h.ms)) + ' ' + mgEsc(meta.label) +
-      (h.count && h.count > 1 ? ' \\u00d7' + h.count : '') + '</span>';
-  }
-  return html;
-}
-
 function mgPhaseParts() {
   var p = graph.phases;
   // Without createMs the earlier boundaries are unknown, so segments would mislabel.
@@ -1723,69 +1681,8 @@ function mgDockShow(name) {
   mgResize();
 }
 
-function mgTraceBadgeHtml(type) {
-  var rgb = mgTraceColor(type);
-  return RPT.badge({
-    style: "color:rgb(" + rgb + ");background:rgba(" + rgb + ",0.12)",
-    text: mgEsc(type)
-  });
-}
-
-function mgTraceBarHtml(initTime, deps, type, hollowTip) {
-  var frac = Math.max(0, Math.min(1, initTime / mgTraceMax));
-  var width = (frac * 100).toFixed(2);
-  if (hollowTip) {
-    return '<span class="mg-trace-track" data-tip="' + mgEsc(mgFormatMs(initTime) + " total \\u2014 " + hollowTip) + '">' +
-      '<span class="mg-trace-bar" style="width:' + width + '%;background:transparent;box-shadow:inset 0 0 0 1px rgba(' + mgTraceColor(type) + ',0.5)"></span>' +
-      '</span>';
-  }
-  // Slowest dep this class could actually have waited on: a dep slower than
-  // the class itself was pre-built, so it never entered this class's clock.
-  var slowestDep = 0;
-  for (var d = 0; d < deps.length; d++) {
-    var dep = mgTraceNode(deps[d]);
-    if (dep && dep.initTime <= initTime) { slowestDep = dep.initTime; break; }
-  }
-  var selfFrac = Math.max(0, Math.min(frac, (initTime - slowestDep) / mgTraceMax));
-  var tip = mgFormatMs(initTime) + " total" +
-    (slowestDep > 0 ? " \\u2014 \\u2248" + mgFormatMs(slowestDep) + " waiting on dependencies, \\u2248" + mgFormatMs(Math.max(0, initTime - slowestDep)) + " own work" : " \\u2014 all own work");
-  return '<span class="mg-trace-track" data-tip="' + mgEsc(tip) + '">' +
-    '<span class="mg-trace-bar" style="width:' + width + '%;background:rgba(' + mgTraceColor(type) + ',0.4)"></span>' +
-    (selfFrac > 0.002 ? '<span class="mg-trace-self" style="left:' + ((frac - selfFrac) * 100).toFixed(2) + '%;width:' + (selfFrac * 100).toFixed(2) + '%"></span>' : '') +
-    '</span>';
-}
-
 function mgTraceRowHtml(id, depth, path, mode) {
-  var node = mgTraceNode(id);
-  if (!node) return "";
-  var ancestors = path.split("/");
-  ancestors.pop();
-  var cyc = ancestors.indexOf(id) >= 0;
-  var expandable = !cyc && depth < 20 && node.deps.length > 0;
-  // Slower than its consumer means the dep already existed when the consumer loaded.
-  var parent = ancestors.length > 0 ? mgTraceNode(ancestors[ancestors.length - 1]) : null;
-  var reused = mode === "reused" || (parent !== null && node.initTime > parent.initTime);
-  var listed = !reused && mode === "listed";
-  var mark = reused
-    ? { cls: " mg-trace-reused", tag: "reused", tip: "Already built when this parent loaded \\u2014 its cost is counted at its first consumer", bar: "already built for an earlier consumer; not paid here" }
-    : listed
-      ? { cls: " mg-trace-reused", tag: "listed above", tip: "Has its own row at the top of this trace \\u2014 the cost is detailed there", bar: "detailed in its own row at the top of this trace" }
-      : null;
-  return '<div class="mg-trace-row' + (expandable ? ' mg-trace-expandable' : '') +
-    (mark ? mark.cls : '') + '"' +
-    ' data-trace="' + mgEsc(id) + '" data-path="' + mgEsc(path) + '" data-depth="' + depth + '"' +
-    (mark ? ' data-mark="' + (reused ? "reused" : "listed") + '"' : '') + '>' +
-    '<span class="mg-trace-label" style="padding-left:' + (Math.min(depth, 8) * 16) + 'px">' +
-    '<span class="mg-trace-caret">' + (expandable ? "\\u25B8" : "") + '</span>' +
-    '<span class="mg-trace-name" data-tip="' + mgEsc(node.name) + '">' + mgEsc(node.name) + '</span>' +
-    mgTraceBadgeHtml(node.type) +
-    mgHookChipHtml(node.hooks) +
-    (mark ? '<span class="mg-trace-reused-tag" data-tip="' + mark.tip + '">' + mark.tag + '</span>' : '') +
-    (cyc ? '<span class="mg-trace-cycle" data-tip="circular dependency">\\u21BB</span>' : '') +
-    '</span>' +
-    mgTraceBarHtml(node.initTime, node.deps, node.type, mark ? mark.bar : null) +
-    '<span class="mg-trace-time">' + mgEsc(mgFormatMs(node.initTime)) + '</span>' +
-    '</div>';
+  return RPT.traceRowHtml(graph.timingsTrace, mgTraceMax, id, depth, path, mode);
 }
 
 var mgTraceTopIds = {};
@@ -1965,7 +1862,7 @@ function mgShowDetail(n) {
         text: mgEsc(mgFormatMs(n.initTimings[0].initTime)) + ' \\u00b7 trace \\u25B8'
       });
     }
-    badges += mgHookChipHtml(n.hookTimings);
+    badges += RPT.hookChipHtml(n.hookTimings);
   }
   document.getElementById("detail-badges").innerHTML = badges;
   mgSyncTraceDrawer(n);

--- a/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
@@ -620,262 +620,10 @@ function sPolylineMidpoint(points) {
 }
 
 /** Groups nodes into connected components using the relation edges. */
-function sComputeComponents(nodes) {
-  var index = {};
-  var parent = [];
-  for (var i = 0; i < nodes.length; i++) {
-    index[nodes[i].name] = i;
-    parent.push(i);
-  }
-  function find(a) {
-    while (parent[a] !== a) {
-      parent[a] = parent[parent[a]];
-      a = parent[a];
-    }
-    return a;
-  }
-  for (var i = 0; i < schema.relations.length; i++) {
-    var rel = schema.relations[i];
-    if (rel.fromEntity === rel.toEntity) continue;
-    var a = index[rel.fromEntity];
-    var b = index[rel.toEntity];
-    if (a === undefined || b === undefined) continue;
-    var ra = find(a), rb = find(b);
-    if (ra !== rb) parent[rb] = ra;
-  }
-  var groups = {};
-  for (var i = 0; i < nodes.length; i++) {
-    var root = find(i);
-    if (!groups[root]) groups[root] = [];
-    groups[root].push(nodes[i]);
-  }
-  var out = [];
-  for (var key in groups) {
-    if (Object.prototype.hasOwnProperty.call(groups, key)) out.push(groups[key]);
-  }
-  return out;
-}
-
-/** Positions one component from its own origin: layered left-to-right. */
-var S_BOX_W = 180;
-var S_COL_GAP = 110;
-var S_ROW_GAP = 44;
-var S_COL_CAP = 2400;
-
-function sLayoutComponent(nodes) {
-  var i, j, t, p, q;
-  if (nodes.length === 1) {
-    nodes[0].x = nodes[0].w / 2;
-    nodes[0].y = nodes[0].h / 2;
-    return { w: nodes[0].w, h: nodes[0].h };
-  }
-  var idx = {};
-  for (i = 0; i < nodes.length; i++) idx[nodes[i].name] = i;
-  var n = nodes.length;
-  var out = [], und = [];
-  for (i = 0; i < n; i++) { out.push([]); und.push([]); }
-  var seenE = {};
-  for (i = 0; i < schema.relations.length; i++) {
-    var rel = schema.relations[i];
-    if (rel.fromEntity === rel.toEntity) continue;
-    var ea = idx[rel.fromEntity], eb = idx[rel.toEntity];
-    if (ea === undefined || eb === undefined) continue;
-    var ek = ea < eb ? ea + "|" + eb : eb + "|" + ea;
-    if (seenE[ek]) continue;
-    seenE[ek] = true;
-    out[ea].push(eb);
-    und[ea].push(eb); und[eb].push(ea);
-  }
-
-  // Break cycles: depth-first, back edges are dropped from the working copy
-  var color = [], acyc = [];
-  for (i = 0; i < n; i++) { color.push(0); acyc.push([]); }
-  function dfsBreak(u) {
-    color[u] = 1;
-    for (var e = 0; e < out[u].length; e++) {
-      var v = out[u][e];
-      if (color[v] === 1) continue;
-      acyc[u].push(v);
-      if (color[v] === 0) dfsBreak(v);
-    }
-    color[u] = 2;
-  }
-  for (i = 0; i < n; i++) if (color[i] === 0) dfsBreak(i);
-
-  // Layer by longest path from sinks: referenced hubs land in column 0
-  var layer = [];
-  for (i = 0; i < n; i++) layer.push(-1);
-  function assignLayer(u) {
-    if (layer[u] >= 0) return layer[u];
-    layer[u] = 0;
-    var best = 0;
-    for (var e = 0; e < acyc[u].length; e++) {
-      var d = assignLayer(acyc[u][e]) + 1;
-      if (d > best) best = d;
-    }
-    layer[u] = best;
-    return best;
-  }
-  for (i = 0; i < n; i++) assignLayer(i);
-
-  // Order each column by neighbor barycenter, four alternating sweeps
-  var maxLayer = 0;
-  for (i = 0; i < n; i++) if (layer[i] > maxLayer) maxLayer = layer[i];
-  var cols = [];
-  for (i = 0; i <= maxLayer; i++) cols.push([]);
-  for (i = 0; i < n; i++) cols[layer[i]].push(i);
-  function sweepPair(fixed, moving) {
-    var pos = {};
-    for (p = 0; p < fixed.length; p++) pos[fixed[p]] = p;
-    var keyed = [];
-    for (p = 0; p < moving.length; p++) {
-      var u = moving[p], sum = 0, cnt = 0;
-      for (q = 0; q < und[u].length; q++) {
-        if (pos[und[u][q]] !== undefined) { sum += pos[und[u][q]]; cnt++; }
-      }
-      keyed.push({ u: u, k: cnt ? sum / cnt : p, o: p });
-    }
-    keyed.sort(function(x, y) { return x.k - y.k || x.o - y.o; });
-    for (p = 0; p < keyed.length; p++) moving[p] = keyed[p].u;
-  }
-  for (t = 0; t < 4; t++) {
-    for (i = 1; i < cols.length; i++) sweepPair(cols[i - 1], cols[i]);
-    for (i = cols.length - 2; i >= 0; i--) sweepPair(cols[i + 1], cols[i]);
-  }
-
-  // Split an over-tall column into side-by-side runs, keeping the order
-  var phys = [];
-  for (i = 0; i < cols.length; i++) {
-    var run = [], runH = 0;
-    for (j = 0; j < cols[i].length; j++) {
-      var u2 = cols[i][j];
-      var hh = nodes[u2].h + S_ROW_GAP;
-      if (runH > 0 && runH + hh > S_COL_CAP) { phys.push(run); run = []; runH = 0; }
-      run.push(u2);
-      runH += hh;
-    }
-    if (run.length > 0) phys.push(run);
-  }
-
-  // Coordinates: fixed-width columns, stacked rows, then three relax passes
-  var xCur = 0;
-  for (i = 0; i < phys.length; i++) {
-    var yCur = 0;
-    for (j = 0; j < phys[i].length; j++) {
-      var nd = nodes[phys[i][j]];
-      nd.x = xCur + nd.w / 2;
-      nd.y = yCur + nd.h / 2;
-      yCur += nd.h + S_ROW_GAP;
-    }
-    xCur += S_BOX_W + S_COL_GAP;
-  }
-  for (t = 0; t < 3; t++) {
-    for (i = 0; i < phys.length; i++) {
-      var want = [];
-      for (j = 0; j < phys[i].length; j++) {
-        var u3 = phys[i][j];
-        var s2 = 0, c2 = 0;
-        for (q = 0; q < und[u3].length; q++) { s2 += nodes[und[u3][q]].y; c2++; }
-        want.push(c2 > 0 ? s2 / c2 : nodes[u3].y);
-      }
-      for (j = 0; j < phys[i].length; j++) nodes[phys[i][j]].y = want[j];
-      // The top-down sweep resolves overlaps without reordering the column
-      var floorY = -Infinity;
-      for (j = 0; j < phys[i].length; j++) {
-        var nd2 = nodes[phys[i][j]];
-        var top = Math.max(nd2.y - nd2.h / 2, floorY);
-        nd2.y = top + nd2.h / 2;
-        floorY = top + nd2.h + S_ROW_GAP;
-      }
-    }
-  }
-
-  // Normalize to origin and report the extent
-  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-  for (i = 0; i < n; i++) {
-    minX = Math.min(minX, nodes[i].x - nodes[i].w / 2);
-    maxX = Math.max(maxX, nodes[i].x + nodes[i].w / 2);
-    minY = Math.min(minY, nodes[i].y - nodes[i].h / 2);
-    maxY = Math.max(maxY, nodes[i].y + nodes[i].h / 2);
-  }
-  for (i = 0; i < n; i++) { nodes[i].x -= minX; nodes[i].y -= minY; }
-  return { w: maxX - minX, h: maxY - minY };
-}
-
-/** Packs unrelated tables into a compact grid instead of one long rank. */
-function sLayoutIsolatedBlock(nodes, gutter) {
-  var cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
-  var cellW = 0, cellH = 0;
-  for (var i = 0; i < nodes.length; i++) {
-    if (nodes[i].w > cellW) cellW = nodes[i].w;
-    if (nodes[i].h > cellH) cellH = nodes[i].h;
-  }
-  var rows = Math.ceil(nodes.length / cols);
-  for (var j = 0; j < nodes.length; j++) {
-    nodes[j].x = (j % cols) * (cellW + gutter) + cellW / 2;
-    nodes[j].y = Math.floor(j / cols) * (cellH + gutter) + cellH / 2;
-  }
-  return {
-    w: cols * cellW + (cols - 1) * gutter,
-    h: rows * cellH + (rows - 1) * gutter
-  };
-}
-
-/** Shelf-packs component boxes into a roughly square area. */
-function sPackBoxes(boxes, targetW, gutter) {
-  var x = 0, y = 0, shelfH = 0;
-  for (var i = 0; i < boxes.length; i++) {
-    var box = boxes[i];
-    if (x > 0 && x + box.w > targetW) {
-      x = 0;
-      y += shelfH + gutter;
-      shelfH = 0;
-    }
-    box.ox = x;
-    box.oy = y;
-    x += box.w + gutter;
-    if (box.h > shelfH) shelfH = box.h;
-  }
-}
+var S_BOX_W = RPT.SCHEMA_BOX_W;
 
 function sComputeOverviewLayout() {
-  var GUTTER = 80;
-  var components = sComputeComponents(sNodes);
-  var boxes = [];
-  var isolated = [];
-  var i;
-
-  for (i = 0; i < components.length; i++) {
-    if (components[i].length === 1) {
-      components[i][0]._comp = -1;
-      isolated.push(components[i][0]);
-      continue;
-    }
-    for (var ci = 0; ci < components[i].length; ci++) components[i][ci]._comp = i;
-    var size = sLayoutComponent(components[i]);
-    boxes.push({ nodes: components[i], w: size.w, h: size.h });
-  }
-
-  boxes.sort(function(a, b) { return b.h - a.h || b.w - a.w; });
-
-  if (isolated.length > 0) {
-    var isoSize = sLayoutIsolatedBlock(isolated, 28);
-    boxes.push({ nodes: isolated, w: isoSize.w, h: isoSize.h });
-  }
-
-  var area = 0;
-  for (i = 0; i < boxes.length; i++) area += boxes[i].w * boxes[i].h;
-  var targetW = Math.max(900, Math.sqrt(area) * 1.6);
-  sPackBoxes(boxes, targetW, GUTTER);
-
-  for (i = 0; i < boxes.length; i++) {
-    var placed = boxes[i];
-    for (var j = 0; j < placed.nodes.length; j++) {
-      placed.nodes[j].x += placed.ox;
-      placed.nodes[j].y += placed.oy;
-    }
-  }
-
+  RPT.computeOverviewLayout(schema.relations, sNodes);
   sBuildGrids();
   sRouteAllEdges();
 }
@@ -947,7 +695,7 @@ function sComputeStarLayout(centerName) {
 }
 
 /** Columns drawn per table before the "+N more" line, unless all are shown. */
-var S_DEFAULT_MAX_COLS = 7;
+var S_DEFAULT_MAX_COLS = RPT.SCHEMA_DEFAULT_MAX_COLS;
 
 var S_PK_COLOR = "#ea2845";
 var S_FK_COLOR = "#8b5cf6";
@@ -1024,16 +772,11 @@ function sDrawColumnIcon(ctx, kind, cx, cy) {
 }
 
 function sVisibleColCount(node, showCols) {
-  if (!showCols) return 0;
-  var total = node.entity.columns.length;
-  return sShowAllCols ? total : Math.min(total, S_DEFAULT_MAX_COLS);
+  return RPT.visibleColCount(node, showCols, sShowAllCols);
 }
 
 function sNodeHeight(node, showCols) {
-  if (!showCols) return 52;
-  var visible = sVisibleColCount(node, showCols);
-  var hidden = node.entity.columns.length - visible;
-  return 24 + visible * 16 + (hidden > 0 ? 16 : 0) + 8;
+  return RPT.nodeHeight(node, showCols, sShowAllCols);
 }
 
 /** The overview shows columns; a focused star shows them for a small set. */

--- a/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
@@ -1,74 +1,27 @@
 import { describe, expect, it } from "vitest";
 import {
-	badge,
-	escapeHtml,
-	treeRow,
-} from "../../src/report/ui/browser/entry.js";
-import { getReportScripts } from "../../src/report/ui/scripts.js";
-import { EMPTY_ARTIFACT_JSON as EMPTY } from "./report-artifact-fixture.js";
+	formatMs,
+	type TraceMap,
+	traceRowHtml,
+} from "../../src/report/ui/browser/trace.js";
 
-/** Pulls mgFormatMs out of the emitted script and runs the real emitted source. */
-function loadFormatMs(): (ms: number) => string {
-	const scripts = getReportScripts(EMPTY);
-	const start = scripts.indexOf("function mgFormatMs");
-	const end = scripts.indexOf("function mgMeasureNode");
-	if (start < 0 || end <= start) {
-		throw new Error("mgFormatMs not found in the emitted report script");
-	}
-	const factory = new Function(`${scripts.slice(start, end)}
-		return mgFormatMs;`);
-	return factory() as (ms: number) => string;
-}
-
-/** Pulls the trace row builder out of the emitted script and runs it. */
-function loadTraceRow(
-	graph: unknown
-): (id: string, depth: number, path: string) => string {
-	const scripts = getReportScripts(EMPTY);
-	const sliceOf = (start: string, end: string) => {
-		const a = scripts.indexOf(start);
-		const b = scripts.indexOf(end);
-		if (a < 0 || b <= a) {
-			throw new Error(`slice ${start} not found in the emitted report script`);
-		}
-		return scripts.slice(a, b);
-	};
-	const source =
-		sliceOf("function mgFormatMs", "function mgMeasureNode") +
-		sliceOf("function mgEsc", "var MG_INFO_ICON") +
-		sliceOf("var mgTraceMax", "function mgShowModuleTrace");
-	const factory = new Function(
-		"graph",
-		"RPT",
-		`${source}
-		mgTraceMax = 100;
-		return mgTraceRowHtml;`
-	);
-	return factory(graph, { badge, escapeHtml, treeRow }) as (
-		id: string,
-		depth: number,
-		path: string
-	) => string;
-}
-
-describe("mgTraceRowHtml", () => {
-	const graph = {
-		timingsTrace: {
-			ta: {
-				name: "BookingController",
-				type: "controller",
-				initTime: 0.9,
-				deps: ["tb"],
-			},
-			tb: {
-				name: "SchedulingService",
-				type: "provider",
-				initTime: 67,
-				deps: [],
-			},
+describe("traceRowHtml", () => {
+	const trace: TraceMap = {
+		ta: {
+			name: "BookingController",
+			type: "controller",
+			initTime: 0.9,
+			deps: ["tb"],
+		},
+		tb: {
+			name: "SchedulingService",
+			type: "provider",
+			initTime: 67,
+			deps: [],
 		},
 	};
-	const row = loadTraceRow(graph);
+	const row = (id: string, depth: number, path: string) =>
+		traceRowHtml(trace, 100, id, depth, path);
 
 	it("marks a dep slower than its parent as reused", () => {
 		const html = row("tb", 1, "ta/tb");
@@ -82,28 +35,26 @@ describe("mgTraceRowHtml", () => {
 	});
 });
 
-describe("mgFormatMs", () => {
-	const format = loadFormatMs();
-
+describe("formatMs", () => {
 	it("rounds to the nearest millisecond at 10ms and above", () => {
-		expect(format(210.4)).toBe("210ms");
-		expect(format(10)).toBe("10ms");
+		expect(formatMs(210.4)).toBe("210ms");
+		expect(formatMs(10)).toBe("10ms");
 	});
 
 	it("keeps one decimal between 1ms and 10ms", () => {
-		expect(format(4.55)).toBe("4.6ms");
-		expect(format(1)).toBe("1.0ms");
+		expect(formatMs(4.55)).toBe("4.6ms");
+		expect(formatMs(1)).toBe("1.0ms");
 	});
 
 	it("floors sub-millisecond timings to <1ms instead of rounding to 0", () => {
-		expect(format(0.4)).toBe("<1ms");
+		expect(formatMs(0.4)).toBe("<1ms");
 	});
 
 	it("treats exactly 0ms the same as sub-millisecond, never printing 0ms", () => {
-		expect(format(0)).toBe("<1ms");
+		expect(formatMs(0)).toBe("<1ms");
 	});
 
 	it("rounds 9.96ms up cleanly rather than printing 10.0ms", () => {
-		expect(format(9.96)).toBe("10ms");
+		expect(formatMs(9.96)).toBe("10ms");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-layout.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getReportScripts } from "../../src/report/ui/scripts.js";
-import { EMPTY_ARTIFACT_JSON as EMPTY } from "./report-artifact-fixture.js";
+import {
+	computeOverviewLayout,
+	nodeHeight,
+	visibleColCount,
+} from "../../src/report/ui/browser/schema-layout.js";
 
 interface Node {
 	h: number;
@@ -13,44 +16,6 @@ interface Node {
 interface Relation {
 	fromEntity: string;
 	toEntity: string;
-}
-
-function edgeKey(from: string, to: string): string {
-	return from < to ? `${from}|${to}` : `${to}|${from}`;
-}
-
-/**
- * Pulls the layout functions out of the emitted script and runs them against a
- * synthetic schema. The report has no DOM harness, so this executes the real
- * emitted source rather than a copy.
- */
-function runOverviewLayout(relations: Relation[], nodes: Node[]): void {
-	const scripts = getReportScripts(EMPTY);
-	const start = scripts.indexOf("function sComputeComponents");
-	const end = scripts.indexOf("function sComputeStarLayout");
-	if (start < 0 || end <= start) {
-		throw new Error("layout functions not found in the emitted report script");
-	}
-
-	const factory = new Function(
-		"schema",
-		"sNodes",
-		"sEdgeKey",
-		"sRouteAllEdges",
-		"sBuildGrids",
-		`${scripts.slice(start, end)}\nreturn sComputeOverviewLayout;`
-	);
-	factory(
-		{ relations },
-		nodes,
-		edgeKey,
-		() => {
-			// Edge routing is not under test.
-		},
-		() => {
-			// Grid building is not under test.
-		}
-	)();
 }
 
 function overlaps(a: Node, b: Node): boolean {
@@ -100,7 +65,7 @@ function buildSchema(): { nodes: Node[]; relations: Relation[] } {
 describe("schema overview layout", () => {
 	it("separates every table", () => {
 		const { nodes, relations } = buildSchema();
-		runOverviewLayout(relations, nodes);
+		computeOverviewLayout(relations, nodes);
 
 		expect(nodes).toHaveLength(34);
 		expect(findOverlap(nodes)).toBeNull();
@@ -108,7 +73,7 @@ describe("schema overview layout", () => {
 
 	it("groups unrelated tables instead of stringing them out", () => {
 		const { nodes, relations } = buildSchema();
-		runOverviewLayout(relations, nodes);
+		computeOverviewLayout(relations, nodes);
 
 		const isolated = nodes.filter((n) => n.name.startsWith("isolated"));
 		const rows = new Set(isolated.map((n) => n.y));
@@ -118,30 +83,16 @@ describe("schema overview layout", () => {
 	});
 
 	it("sizes a table to every column only when all columns are shown", () => {
-		const scripts = getReportScripts(EMPTY);
-		const start = scripts.indexOf("var S_DEFAULT_MAX_COLS");
-		const end = scripts.indexOf("function sCacheNodeLabels");
-		if (start < 0 || end <= start) {
-			throw new Error("sizing helpers not found in the emitted report script");
-		}
-		const factory = new Function(
-			"sShowAllCols",
-			"sShowCols",
-			`${scripts.slice(start, end)}\nreturn { sNodeHeight: sNodeHeight, sVisibleColCount: sVisibleColCount };`
-		);
 		const wide = {
 			entity: { columns: new Array(24).fill({ type: "String" }) },
 		};
 
-		const capped = factory(false, true);
-		const all = factory(true, true);
-
-		expect(capped.sVisibleColCount(wide, true)).toBe(7);
-		expect(all.sVisibleColCount(wide, true)).toBe(24);
+		expect(visibleColCount(wide, true, false)).toBe(7);
+		expect(visibleColCount(wide, true, true)).toBe(24);
 		// Header, one row per column, the "+N more" row only while capped.
-		expect(capped.sNodeHeight(wide, true)).toBe(24 + 7 * 16 + 16 + 8);
-		expect(all.sNodeHeight(wide, true)).toBe(24 + 24 * 16 + 8);
-		expect(all.sNodeHeight(wide, false)).toBe(52);
+		expect(nodeHeight(wide, true, false)).toBe(24 + 7 * 16 + 16 + 8);
+		expect(nodeHeight(wide, true, true)).toBe(24 + 24 * 16 + 8);
+		expect(nodeHeight(wide, false, true)).toBe(52);
 	});
 
 	it("keeps a single connected schema in one block", () => {
@@ -154,7 +105,7 @@ describe("schema overview layout", () => {
 			{ fromEntity: "a", toEntity: "b" },
 			{ fromEntity: "b", toEntity: "c" },
 		];
-		runOverviewLayout(relations, nodes);
+		computeOverviewLayout(relations, nodes);
 
 		expect(findOverlap(nodes)).toBeNull();
 	});

--- a/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
@@ -50,8 +50,8 @@ describe("report scripts", () => {
 	});
 
 	it("colors trace bars and badges by class type", () => {
-		expect(scripts).toContain("MG_TRACE_COLORS");
-		expect(scripts).toContain("function mgTraceColor");
+		expect(scripts).toContain("TRACE_COLORS");
+		expect(scripts).toContain("function traceColor");
 	});
 
 	it("marks a dep slower than its parent as reused with a hollow bar", () => {
@@ -66,9 +66,7 @@ describe("report scripts", () => {
 	});
 
 	it("guards trace lookups against inherited object keys", () => {
-		expect(scripts).toContain(
-			"Object.prototype.hasOwnProperty.call(graph.timingsTrace, id)"
-		);
+		expect(scripts).toContain("Object.hasOwn(trace, id)");
 	});
 
 	it("shows time-to-start when the dump has startupMs, else the slowest chain", () => {
@@ -89,8 +87,8 @@ describe("report scripts", () => {
 	});
 
 	it("shows per-class hook durations as chips on trace rows", () => {
-		expect(scripts).toContain("function mgHookChipHtml");
-		expect(scripts).toContain("mgHookChipHtml(node.hooks)");
-		expect(scripts).toContain("mgHookChipHtml(n.hookTimings)");
+		expect(scripts).toContain("function hookChipHtml");
+		expect(scripts).toContain("hookChipHtml(node.hooks)");
+		expect(scripts).toContain("RPT.hookChipHtml(n.hookTimings)");
 	});
 });


### PR DESCRIPTION
## Context

Same move as the boot-trace PR, for the schema tab: the ER diagram's layout maths (connected components, layered placement with barycenter ordering, isolated-table grid, shelf packing, and the column-count sizing rules) lived inside the `schema` script chunk, testable only by slicing the emitted script between named declarations.

## Problem

`report-schema-layout.test.ts` carried two `indexOf` harnesses with five injected stubs (`sNodes`, `sEdgeKey`, `sRouteAllEdges`, `sBuildGrids`, plus the column toggles) to reach pure functions.

## Possible flows

| Caller | Before | After |
|---|---|---|
| Overview layout | `sComputeOverviewLayout` computed in the chunk | wrapper: `RPT.computeOverviewLayout(schema.relations, sNodes)` then grids and edge routing |
| Table sizing | `sVisibleColCount` / `sNodeHeight` reading `sShowAllCols` | wrappers passing the toggle to `RPT.visibleColCount` / `RPT.nodeHeight` |
| Grid builder's box width, "first N columns" UI text | chunk constants | `RPT.SCHEMA_BOX_W` / `RPT.SCHEMA_DEFAULT_MAX_COLS` |

## Solution

`browser/schema-layout.ts` with `computeComponents`, `layoutComponent`, `layoutIsolatedBlock`, `packBoxes`, `computeOverviewLayout`, `visibleColCount`, `nodeHeight`, and the two shared constants. Bodies ported verbatim with `var` modernised; relations and nodes are parameters instead of chunk globals. The chunk keeps thin wrappers, so evaluation order and every call site are unchanged. The test now imports the functions directly — both slicing harnesses and all five stubs are gone, and the overlap/grouping assertions run against the same code the browser executes.

Deliberately not moved: `sColumnsShown` and `sApplyNodeSizes` (they read three more UI-state globals), the star layout, edge routing, and everything touching the canvas.

## Before vs after

| | Before | After |
|---|---|---|
| `indexOf` slices in the schema test | 2 (plus 5 stubs) | 0 |
| Layout maths testable | only via script slicing | direct import |
| Static markup | — | unchanged; all 10 emitted-diff regions in the script |

## Example

```
- const factory = new Function("schema", "sNodes", "sEdgeKey", "sRouteAllEdges", "sBuildGrids", `${scripts.slice(start, end)}...`);
+ import { computeOverviewLayout } from "../../src/report/ui/browser/schema-layout.js";
```
