### PR TITLE
refactor(report): move the module graph layout into a real module

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -6,6 +6,12 @@ export { emptyState } from "../molecules/empty-state.js";
 export { badge } from "./badge.js";
 export { escapeHtml } from "./escape.js";
 export {
+	blastRadius,
+	buildClusters,
+	computeLayout,
+	reverseIndex,
+} from "./module-layout.js";
+export {
 	computeComponents,
 	computeOverviewLayout,
 	layoutComponent,

--- a/packages/nestjs-doctor/src/report/ui/browser/module-layout.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/module-layout.ts
@@ -1,0 +1,278 @@
+interface ModuleNode {
+	h: number;
+	name: string;
+	project?: string;
+	w: number;
+	x: number;
+	y: number;
+}
+
+interface ModuleEdge {
+	from: string;
+	to: string;
+}
+
+interface Cluster {
+	h: number;
+	header: number;
+	innerX: number;
+	innerY: number;
+	key: string;
+	nodes: ModuleNode[];
+	w: number;
+	x: number;
+	y: number;
+}
+
+interface DagreLike {
+	graphlib: {
+		Graph: new () => {
+			node(name: string): { x: number; y: number } | undefined;
+			setDefaultEdgeLabel(fn: () => object): void;
+			setEdge(from: string, to: string): void;
+			setGraph(options: object): void;
+			setNode(name: string, size: { height: number; width: number }): void;
+		};
+	};
+	layout(g: object): void;
+}
+
+// Groups modules into one cluster per project, keeping first-seen order.
+export function buildClusters(modules: ModuleNode[]): Cluster[] {
+	const order: Cluster[] = [];
+	const byKey: Record<string, Cluster> = {};
+	for (const mod of modules) {
+		const key = mod.project || "";
+		if (!byKey[key]) {
+			byKey[key] = {
+				key,
+				nodes: [],
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
+				innerX: 0,
+				innerY: 0,
+				header: 0,
+			};
+			order.push(byKey[key]);
+		}
+		byKey[key].nodes.push(mod);
+	}
+	return order;
+}
+
+// Packs nodes into a compact grid, used when dagre is absent.
+function gridLayout(
+	nodes: ModuleNode[],
+	gutter: number
+): { h: number; w: number } {
+	const cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+	let cellW = 0;
+	let cellH = 0;
+	for (const nd of nodes) {
+		if (nd.w > cellW) {
+			cellW = nd.w;
+		}
+		if (nd.h > cellH) {
+			cellH = nd.h;
+		}
+	}
+	const rows = Math.ceil(nodes.length / cols);
+	for (let i = 0; i < nodes.length; i++) {
+		nodes[i].x = (i % cols) * (cellW + gutter) + cellW / 2;
+		nodes[i].y = Math.floor(i / cols) * (cellH + gutter) + cellH / 2;
+	}
+	return {
+		w: cols * cellW + (cols - 1) * gutter,
+		h: rows * cellH + (rows - 1) * gutter,
+	};
+}
+
+// Ranks one cluster from its own origin, with dagre or a grid fallback.
+function layoutCluster(
+	nodes: ModuleNode[],
+	edges: ModuleEdge[],
+	dagre: DagreLike | undefined
+): { h: number; w: number } {
+	if (nodes.length === 1 || dagre === undefined) {
+		return gridLayout(nodes, 30);
+	}
+
+	const present: Record<string, boolean> = {};
+	for (const nd of nodes) {
+		present[nd.name] = true;
+	}
+
+	const g = new dagre.graphlib.Graph();
+	g.setGraph({
+		rankdir: "TB",
+		nodesep: 26,
+		ranksep: 58,
+		marginx: 0,
+		marginy: 0,
+	});
+	g.setDefaultEdgeLabel(() => ({}));
+	for (const nd of nodes) {
+		g.setNode(nd.name, { width: nd.w, height: nd.h });
+	}
+
+	const seen: Record<string, boolean> = {};
+	for (const e of edges) {
+		if (e.from === e.to) {
+			continue;
+		}
+		if (!(present[e.from] && present[e.to])) {
+			continue;
+		}
+		const key = `${e.from}->${e.to}`;
+		if (seen[key]) {
+			continue;
+		}
+		seen[key] = true;
+		g.setEdge(e.from, e.to);
+	}
+
+	dagre.layout(g);
+
+	let minX = Number.POSITIVE_INFINITY;
+	let minY = Number.POSITIVE_INFINITY;
+	let maxX = Number.NEGATIVE_INFINITY;
+	let maxY = Number.NEGATIVE_INFINITY;
+	for (const nd of nodes) {
+		const laid = g.node(nd.name);
+		if (!laid) {
+			continue;
+		}
+		nd.x = laid.x;
+		nd.y = laid.y;
+		minX = Math.min(minX, laid.x - nd.w / 2);
+		maxX = Math.max(maxX, laid.x + nd.w / 2);
+		minY = Math.min(minY, laid.y - nd.h / 2);
+		maxY = Math.max(maxY, laid.y + nd.h / 2);
+	}
+	if (minX === Number.POSITIVE_INFINITY) {
+		return gridLayout(nodes, 30);
+	}
+	for (const nd of nodes) {
+		nd.x -= minX;
+		nd.y -= minY;
+	}
+	return { w: maxX - minX, h: maxY - minY };
+}
+
+// Shelf-packs cluster boxes into a roughly square area.
+function packClusterBoxes(
+	boxes: Cluster[],
+	targetW: number,
+	gutter: number
+): void {
+	let x = 0;
+	let y = 0;
+	let shelfH = 0;
+	for (const box of boxes) {
+		if (x > 0 && x + box.w > targetW) {
+			x = 0;
+			y += shelfH + gutter;
+			shelfH = 0;
+		}
+		box.x = x;
+		box.y = y;
+		x += box.w + gutter;
+		if (box.h > shelfH) {
+			shelfH = box.h;
+		}
+	}
+}
+
+// Lays every module out inside its project container, then packs the
+// containers. Nodes must already carry w and h.
+export function computeLayout(
+	modules: ModuleNode[],
+	edges: ModuleEdge[],
+	dagre: DagreLike | undefined
+): Cluster[] {
+	const GUTTER = 64;
+	const PAD = 20;
+	const HEADER = 26;
+	const clusters = buildClusters(modules);
+
+	for (const c of clusters) {
+		const header = c.key ? HEADER : 0;
+		const size = layoutCluster(c.nodes, edges, dagre);
+		c.innerX = PAD;
+		c.innerY = PAD + header;
+		c.header = header;
+		c.w = size.w + PAD * 2;
+		c.h = size.h + PAD * 2 + header;
+	}
+
+	clusters.sort((a, b) => b.h - a.h || b.w - a.w);
+
+	let area = 0;
+	for (const c of clusters) {
+		area += c.w * c.h;
+	}
+	const targetW = Math.max(1000, Math.sqrt(area) * 1.7);
+	packClusterBoxes(clusters, targetW, GUTTER);
+
+	for (const box of clusters) {
+		for (const nd of box.nodes) {
+			nd.x += box.x + box.innerX;
+			nd.y += box.y + box.innerY;
+		}
+	}
+	return clusters;
+}
+
+// Maps each module to the modules that import it.
+export function reverseIndex(edges: ModuleEdge[]): Record<string, string[]> {
+	const idx: Record<string, string[]> = {};
+	for (const e of edges) {
+		if (!idx[e.to]) {
+			idx[e.to] = [];
+		}
+		if (idx[e.to].indexOf(e.from) < 0) {
+			idx[e.to].push(e.from);
+		}
+	}
+	return idx;
+}
+
+// Every module that transitively imports this one, counted per project.
+export function blastRadius(
+	name: string,
+	incoming: Record<string, string[]>,
+	projectOf: (name: string) => string | undefined
+): {
+	byProject: Record<string, number>;
+	names: string[];
+	projectCount: number;
+} {
+	const seen: Record<string, boolean> = {};
+	seen[name] = true;
+	const queue = [name];
+	const names: string[] = [];
+	const byProject: Record<string, number> = {};
+	let projectCount = 0;
+	while (queue.length > 0) {
+		const cur = queue.shift() as string;
+		const sources = incoming[cur] || [];
+		for (const src of sources) {
+			if (seen[src]) {
+				continue;
+			}
+			seen[src] = true;
+			names.push(src);
+			queue.push(src);
+			const p = projectOf(src) || "";
+			if (byProject[p] === undefined) {
+				byProject[p] = 0;
+				projectCount++;
+			}
+			byProject[p]++;
+		}
+	}
+	names.sort();
+	return { names, byProject, projectCount };
+}

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -62,175 +62,6 @@ function mgScheduleRedraw() {
 
 // ── Modules graph: layout ──
 /** Groups modules by owning project, keeping first-seen order. */
-function mgBuildClusters(modules) {
-  var order = [], byKey = {};
-  for (var i = 0; i < modules.length; i++) {
-    var key = modules[i].project || "";
-    if (!byKey[key]) {
-      byKey[key] = { key: key, nodes: [], x: 0, y: 0, w: 0, h: 0, innerX: 0, innerY: 0 };
-      order.push(byKey[key]);
-    }
-    byKey[key].nodes.push(modules[i]);
-  }
-  return order;
-}
-
-/** Packs nodes into a compact grid, used when dagre is absent. */
-function mgGridLayout(nodes, gutter) {
-  var cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
-  var cellW = 0, cellH = 0, i;
-  for (i = 0; i < nodes.length; i++) {
-    if (nodes[i].w > cellW) cellW = nodes[i].w;
-    if (nodes[i].h > cellH) cellH = nodes[i].h;
-  }
-  var rows = Math.ceil(nodes.length / cols);
-  for (i = 0; i < nodes.length; i++) {
-    nodes[i].x = (i % cols) * (cellW + gutter) + cellW / 2;
-    nodes[i].y = Math.floor(i / cols) * (cellH + gutter) + cellH / 2;
-  }
-  return {
-    w: cols * cellW + (cols - 1) * gutter,
-    h: rows * cellH + (rows - 1) * gutter
-  };
-}
-
-/** Ranks one cluster from its own origin, with dagre or a grid fallback. */
-function mgLayoutCluster(nodes, edges) {
-  var i;
-  if (nodes.length === 1 || typeof dagre === "undefined") {
-    return mgGridLayout(nodes, 30);
-  }
-
-  var present = {};
-  for (i = 0; i < nodes.length; i++) present[nodes[i].name] = true;
-
-  var g = new dagre.graphlib.Graph();
-  g.setGraph({ rankdir: "TB", nodesep: 26, ranksep: 58, marginx: 0, marginy: 0 });
-  g.setDefaultEdgeLabel(function() { return {}; });
-  for (i = 0; i < nodes.length; i++) {
-    g.setNode(nodes[i].name, { width: nodes[i].w, height: nodes[i].h });
-  }
-
-  var seen = {};
-  for (i = 0; i < edges.length; i++) {
-    var e = edges[i];
-    if (e.from === e.to) continue;
-    if (!present[e.from] || !present[e.to]) continue;
-    var key = e.from + "->" + e.to;
-    if (seen[key]) continue;
-    seen[key] = true;
-    g.setEdge(e.from, e.to);
-  }
-
-  dagre.layout(g);
-
-  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-  for (i = 0; i < nodes.length; i++) {
-    var laid = g.node(nodes[i].name);
-    if (!laid) continue;
-    nodes[i].x = laid.x;
-    nodes[i].y = laid.y;
-    minX = Math.min(minX, laid.x - nodes[i].w / 2);
-    maxX = Math.max(maxX, laid.x + nodes[i].w / 2);
-    minY = Math.min(minY, laid.y - nodes[i].h / 2);
-    maxY = Math.max(maxY, laid.y + nodes[i].h / 2);
-  }
-  if (minX === Infinity) return mgGridLayout(nodes, 30);
-  for (i = 0; i < nodes.length; i++) {
-    nodes[i].x -= minX;
-    nodes[i].y -= minY;
-  }
-  return { w: maxX - minX, h: maxY - minY };
-}
-
-/** Shelf-packs cluster boxes into a roughly square area. */
-function mgPackBoxes(boxes, targetW, gutter) {
-  var x = 0, y = 0, shelfH = 0;
-  for (var i = 0; i < boxes.length; i++) {
-    var box = boxes[i];
-    if (x > 0 && x + box.w > targetW) {
-      x = 0;
-      y += shelfH + gutter;
-      shelfH = 0;
-    }
-    box.x = x;
-    box.y = y;
-    x += box.w + gutter;
-    if (box.h > shelfH) shelfH = box.h;
-  }
-}
-
-/**
- * Lays every module out inside its project container, then packs the
- * containers. Nodes must already carry w and h.
- */
-function mgComputeLayout(modules, edges) {
-  var GUTTER = 64, PAD = 20, HEADER = 26;
-  var clusters = mgBuildClusters(modules);
-  var i, j;
-
-  for (i = 0; i < clusters.length; i++) {
-    var c = clusters[i];
-    var header = c.key ? HEADER : 0;
-    var size = mgLayoutCluster(c.nodes, edges);
-    c.innerX = PAD;
-    c.innerY = PAD + header;
-    c.header = header;
-    c.w = size.w + PAD * 2;
-    c.h = size.h + PAD * 2 + header;
-  }
-
-  clusters.sort(function(a, b) { return b.h - a.h || b.w - a.w; });
-
-  var area = 0;
-  for (i = 0; i < clusters.length; i++) area += clusters[i].w * clusters[i].h;
-  var targetW = Math.max(1000, Math.sqrt(area) * 1.7);
-  mgPackBoxes(clusters, targetW, GUTTER);
-
-  for (i = 0; i < clusters.length; i++) {
-    var box = clusters[i];
-    for (j = 0; j < box.nodes.length; j++) {
-      box.nodes[j].x += box.x + box.innerX;
-      box.nodes[j].y += box.y + box.innerY;
-    }
-  }
-  return clusters;
-}
-
-/** Maps each module to the modules that import it. */
-function mgReverseIndex(edges) {
-  var idx = {};
-  for (var i = 0; i < edges.length; i++) {
-    var e = edges[i];
-    if (!idx[e.to]) idx[e.to] = [];
-    if (idx[e.to].indexOf(e.from) < 0) idx[e.to].push(e.from);
-  }
-  return idx;
-}
-
-/** Every module that transitively imports this one, counted per project. */
-function mgBlastRadius(name, reverseIndex, projectOf) {
-  var seen = {};
-  seen[name] = true;
-  var queue = [name], names = [], byProject = {}, projectCount = 0;
-  while (queue.length > 0) {
-    var cur = queue.shift();
-    var incoming = reverseIndex[cur] || [];
-    for (var i = 0; i < incoming.length; i++) {
-      var src = incoming[i];
-      if (seen[src]) continue;
-      seen[src] = true;
-      names.push(src);
-      queue.push(src);
-      var p = projectOf(src) || "";
-      if (byProject[p] === undefined) { byProject[p] = 0; projectCount++; }
-      byProject[p]++;
-    }
-  }
-  names.sort();
-  return { names: names, byProject: byProject, projectCount: projectCount };
-}
-
 // ── Modules graph: joins into the other payloads ──
 function mgProvidersOf(moduleName) {
   var out = [];
@@ -378,8 +209,8 @@ function mgBuild() {
     });
   }
 
-  mgImporters = mgReverseIndex(allEdges);
-  mgClusters = mgComputeLayout(mgNodes, allEdges);
+  mgImporters = RPT.reverseIndex(allEdges);
+  mgClusters = RPT.computeLayout(mgNodes, allEdges, typeof dagre === "undefined" ? undefined : dagre);
 }
 
 // ── Modules graph: camera ──
@@ -1410,7 +1241,7 @@ function mgUsedByHtml(n) {
 }
 
 function mgBlastHtml(n) {
-  var blast = mgBlastRadius(n.name, mgImporters, function(name) {
+  var blast = RPT.blastRadius(n.name, mgImporters, function(name) {
     var node = mgNodeMap[name];
     return node ? node.project : "";
   });

--- a/packages/nestjs-doctor/tests/unit/report-module-layout.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-module-layout.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getReportScripts } from "../../src/report/ui/scripts.js";
-import { EMPTY_ARTIFACT_JSON as EMPTY } from "./report-artifact-fixture.js";
+import {
+	blastRadius,
+	computeLayout,
+	reverseIndex,
+} from "../../src/report/ui/browser/module-layout.js";
 
 interface ModuleNode {
 	h: number;
@@ -21,28 +24,6 @@ interface Cluster {
 	w: number;
 	x: number;
 	y: number;
-}
-
-interface Blast {
-	byProject: Record<string, number>;
-	names: string[];
-	projectCount: number;
-}
-
-interface LayoutApi {
-	mgBlastRadius: (
-		name: string,
-		reverseIndex: Record<string, string[]>,
-		projectOf: (n: string) => string
-	) => Blast;
-	mgBuildClusters: (modules: ModuleNode[]) => Cluster[];
-	mgComputeLayout: (
-		modules: ModuleNode[],
-		edges: Array<{ from: string; to: string }>
-	) => Cluster[];
-	mgReverseIndex: (
-		edges: Array<{ from: string; to: string }>
-	) => Record<string, string[]>;
 }
 
 /** Fake dagre that ranks nodes along a diagonal, enough to exercise packing. */
@@ -80,31 +61,6 @@ const fakeDagre = {
 		// Positions are assigned in setNode.
 	},
 };
-
-/**
- * Pulls the module-graph layout functions out of the emitted script and runs
- * them. The report has no DOM harness, so this executes the real emitted
- * source rather than a copy of it.
- */
-function loadLayout(dagreImpl: unknown): LayoutApi {
-	const scripts = getReportScripts(EMPTY);
-	const start = scripts.indexOf("function mgBuildClusters");
-	const end = scripts.indexOf("function mgProvidersOf");
-	if (start < 0 || end <= start) {
-		throw new Error("layout functions not found in the emitted report script");
-	}
-	const factory = new Function(
-		"dagre",
-		`${scripts.slice(start, end)}
-		return {
-			mgBuildClusters: mgBuildClusters,
-			mgComputeLayout: mgComputeLayout,
-			mgReverseIndex: mgReverseIndex,
-			mgBlastRadius: mgBlastRadius
-		};`
-	);
-	return factory(dagreImpl) as LayoutApi;
-}
 
 function overlaps(
 	a: { h: number; w: number; x: number; y: number },
@@ -179,15 +135,13 @@ function buildMonorepo(): {
 
 describe("module graph clustered layout", () => {
 	it("survives a project with no modules", () => {
-		const api = loadLayout(fakeDagre);
-		expect(api.mgComputeLayout([], [])).toEqual([]);
-		expect(api.mgReverseIndex([])).toEqual({});
+		expect(computeLayout([], [], fakeDagre)).toEqual([]);
+		expect(reverseIndex([])).toEqual({});
 	});
 
 	it("puts every module in its project's cluster", () => {
-		const api = loadLayout(fakeDagre);
 		const { modules, edges } = buildMonorepo();
-		const clusters = api.mgComputeLayout(modules, edges);
+		const clusters = computeLayout(modules, edges, fakeDagre);
 
 		expect(clusters.map((c) => c.key).sort()).toEqual([
 			"api",
@@ -203,18 +157,16 @@ describe("module graph clustered layout", () => {
 	});
 
 	it("keeps clusters and modules from overlapping", () => {
-		const api = loadLayout(fakeDagre);
 		const { modules, edges } = buildMonorepo();
-		const clusters = api.mgComputeLayout(modules, edges);
+		const clusters = computeLayout(modules, edges, fakeDagre);
 
 		expect(findClusterOverlap(clusters)).toBeNull();
 		expect(findNodeOverlap(modules)).toBeNull();
 	});
 
 	it("keeps every module inside its own container", () => {
-		const api = loadLayout(fakeDagre);
 		const { modules, edges } = buildMonorepo();
-		const clusters = api.mgComputeLayout(modules, edges);
+		const clusters = computeLayout(modules, edges, fakeDagre);
 
 		for (const cluster of clusters) {
 			for (const node of cluster.nodes) {
@@ -224,23 +176,23 @@ describe("module graph clustered layout", () => {
 	});
 
 	it("still separates everything with no dagre on the page", () => {
-		const api = loadLayout(undefined);
 		const { modules, edges } = buildMonorepo();
-		const clusters = api.mgComputeLayout(modules, edges);
+		const clusters = computeLayout(modules, edges, undefined);
 
 		expect(findClusterOverlap(clusters)).toBeNull();
 		expect(findNodeOverlap(modules)).toBeNull();
 	});
 
 	it("gives a single-project scan one unlabelled cluster with no header", () => {
-		const api = loadLayout(fakeDagre);
 		const modules: ModuleNode[] = [
 			{ name: "AppModule", x: 0, y: 0, w: 140, h: 40 },
 			{ name: "UsersModule", x: 0, y: 0, w: 140, h: 40 },
 		];
-		const clusters = api.mgComputeLayout(modules, [
-			{ from: "AppModule", to: "UsersModule" },
-		]);
+		const clusters = computeLayout(
+			modules,
+			[{ from: "AppModule", to: "UsersModule" }],
+			fakeDagre
+		);
 
 		expect(clusters).toHaveLength(1);
 		expect(clusters[0].key).toBe("");
@@ -251,8 +203,7 @@ describe("module graph clustered layout", () => {
 
 describe("module graph blast radius", () => {
 	it("collapses duplicate import edges", () => {
-		const api = loadLayout(fakeDagre);
-		const index = api.mgReverseIndex([
+		const index = reverseIndex([
 			{ from: "a", to: "c" },
 			{ from: "a", to: "c" },
 			{ from: "b", to: "c" },
@@ -261,13 +212,12 @@ describe("module graph blast radius", () => {
 	});
 
 	it("counts transitive dependents per project", () => {
-		const api = loadLayout(fakeDagre);
 		const { modules, edges } = buildMonorepo();
 		const projectOf = (name: string) =>
 			modules.find((m) => m.name === name)?.project ?? "";
-		const blast = api.mgBlastRadius(
+		const blast = blastRadius(
 			"shared/CoreModule",
-			api.mgReverseIndex(edges),
+			reverseIndex(edges),
 			projectOf
 		);
 
@@ -282,11 +232,10 @@ describe("module graph blast radius", () => {
 	});
 
 	it("reports an empty radius for a module nothing imports", () => {
-		const api = loadLayout(fakeDagre);
 		const { edges } = buildMonorepo();
-		const blast = api.mgBlastRadius(
+		const blast = blastRadius(
 			"tools/ScriptsModule",
-			api.mgReverseIndex(edges),
+			reverseIndex(edges),
 			() => "tools"
 		);
 
@@ -295,10 +244,9 @@ describe("module graph blast radius", () => {
 	});
 
 	it("terminates on a cycle instead of looping", () => {
-		const api = loadLayout(fakeDagre);
-		const blast = api.mgBlastRadius(
+		const blast = blastRadius(
 			"A",
-			api.mgReverseIndex([
+			reverseIndex([
 				{ from: "A", to: "B" },
 				{ from: "B", to: "A" },
 			]),


### PR DESCRIPTION
## Context

The last of the three script-slicing subsystems: the modules-graph tab's clustered layout (per-project clusters, dagre ranking with a grid fallback, shelf packing) and the blast-radius traversal lived in the `modules-graph` chunk, tested through an `indexOf` slice with an injected fake dagre.

## Problem

`report-module-layout.test.ts` rebuilt the functions with `new Function` on every load, and `mgLayoutCluster` reached the page's `dagre` through a bare global that the harness had to shadow with a parameter.

## Possible flows

| Caller | Before | After |
|---|---|---|
| Graph build | `mgReverseIndex` / `mgComputeLayout` in the chunk | `RPT.reverseIndex` / `RPT.computeLayout(mgNodes, allEdges, dagre-or-undefined)` |
| Detail panel blast radius | `mgBlastRadius` | `RPT.blastRadius` (same projectOf callback) |
| dagre missing on the page | `typeof dagre === "undefined"` inside the layout | the chunk passes `undefined`, the module takes it as a parameter |

## Solution

`browser/module-layout.ts` with `buildClusters`, `computeLayout`, `reverseIndex`, `blastRadius` (plus the private grid/dagre/packing helpers), dagre injected as a typed parameter. The seven chunk functions are deleted and the three call sites call the bundle. The test imports directly; the `loadLayout` harness, the `LayoutApi` shim, and the script slicing are gone — the fake dagre now typechecks structurally against the module's parameter.

With this, no test slices the emitted script for logic any more: all three layout/timing subsystems are real modules.

## Before vs after

| | Before | After |
|---|---|---|
| `indexOf` logic slices across the test suite | 1 remaining | 0 |
| dagre dependency | bare global inside the maths | explicit parameter |
| Static markup | — | unchanged; all 7 emitted-diff regions in the script |

## Example

```
- const factory = new Function("dagre", `${scripts.slice(start, end)} return {...}`);
+ import { blastRadius, computeLayout, reverseIndex } from "../../src/report/ui/browser/module-layout.js";
```
