### PR TITLE
refactor(report): move the star layout into the schema layout module

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -14,6 +14,7 @@ export {
 export {
 	computeComponents,
 	computeOverviewLayout,
+	computeStarLayout,
 	layoutComponent,
 	layoutIsolatedBlock,
 	nodeHeight,

--- a/packages/nestjs-doctor/src/report/ui/browser/schema-layout.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/schema-layout.ts
@@ -411,3 +411,85 @@ export function nodeHeight(
 	const hidden = node.entity.columns.length - visible;
 	return 24 + visible * 16 + (hidden > 0 ? 16 : 0) + 8;
 }
+
+// Focused mode: the selected table centred, neighbours on an ellipse around
+// it (or beside it when there are only one or two).
+export function computeStarLayout(
+	nodes: SchemaLayoutNode[],
+	centerName: string,
+	width: number,
+	height: number
+): void {
+	const center = nodes.find((n) => n.name === centerName);
+	if (!center) {
+		return;
+	}
+	const cx = width / 2;
+	const cy = height / 2;
+	center.x = cx;
+	center.y = cy;
+
+	const neighbors = nodes.filter((n) => n.name !== centerName);
+	if (neighbors.length === 0) {
+		return;
+	}
+
+	let maxW = 180;
+	let maxH = 52;
+	for (const nd of nodes) {
+		if (nd.w > maxW) {
+			maxW = nd.w;
+		}
+		if (nd.h > maxH) {
+			maxH = nd.h;
+		}
+	}
+
+	const isLandscape = width >= height;
+
+	if (neighbors.length === 1) {
+		if (isLandscape) {
+			neighbors[0].x = cx + maxW + 100;
+			neighbors[0].y = cy;
+		} else {
+			neighbors[0].x = cx;
+			neighbors[0].y = cy + maxH + 80;
+		}
+		return;
+	}
+
+	if (neighbors.length === 2) {
+		if (isLandscape) {
+			const hGap = maxW + 100;
+			neighbors[0].x = cx - hGap;
+			neighbors[0].y = cy;
+			neighbors[1].x = cx + hGap;
+			neighbors[1].y = cy;
+		} else {
+			const vGap = maxH + 80;
+			neighbors[0].x = cx;
+			neighbors[0].y = cy - vGap;
+			neighbors[1].x = cx;
+			neighbors[1].y = cy + vGap;
+		}
+		return;
+	}
+
+	let rx = width * 0.4 - maxW / 2;
+	let ry = height * 0.4 - maxH / 2;
+	const minR = maxW / 2 + maxH / 2 + 40;
+	if (rx < minR) {
+		rx = minR;
+	}
+	if (ry < minR) {
+		ry = minR;
+	}
+
+	const startAngle = isLandscape ? 0 : -Math.PI / 2;
+
+	for (let i = 0; i < neighbors.length; i++) {
+		const angle = startAngle + (2 * Math.PI * i) / neighbors.length;
+		neighbors[i].x = cx + rx * Math.cos(angle);
+		neighbors[i].y = cy + ry * Math.sin(angle);
+	}
+}

--- a/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
@@ -240,69 +240,7 @@ function sComputeOverviewLayout() {
 }
 
 function sComputeStarLayout(centerName) {
-  var center = sNodeMap[centerName];
-  if (!center) return;
-  var cx = sW / 2;
-  var cy = sH / 2;
-  center.x = cx;
-  center.y = cy;
-
-  var neighbors = [];
-  for (var i = 0; i < sNodes.length; i++) {
-    if (sNodes[i].name !== centerName) neighbors.push(sNodes[i]);
-  }
-  if (neighbors.length === 0) return;
-
-  var maxW = 180;
-  var maxH = 52;
-  for (var i = 0; i < sNodes.length; i++) {
-    if (sNodes[i].w > maxW) maxW = sNodes[i].w;
-    if (sNodes[i].h > maxH) maxH = sNodes[i].h;
-  }
-
-  var isLandscape = sW >= sH;
-
-  if (neighbors.length === 1) {
-    if (isLandscape) {
-      neighbors[0].x = cx + maxW + 100;
-      neighbors[0].y = cy;
-    } else {
-      neighbors[0].x = cx;
-      neighbors[0].y = cy + maxH + 80;
-    }
-    return;
-  }
-
-  if (neighbors.length === 2) {
-    if (isLandscape) {
-      var hGap = maxW + 100;
-      neighbors[0].x = cx - hGap;
-      neighbors[0].y = cy;
-      neighbors[1].x = cx + hGap;
-      neighbors[1].y = cy;
-    } else {
-      var vGap = maxH + 80;
-      neighbors[0].x = cx;
-      neighbors[0].y = cy - vGap;
-      neighbors[1].x = cx;
-      neighbors[1].y = cy + vGap;
-    }
-    return;
-  }
-
-  var rx = sW * 0.4 - maxW / 2;
-  var ry = sH * 0.4 - maxH / 2;
-  var minR = maxW / 2 + maxH / 2 + 40;
-  if (rx < minR) rx = minR;
-  if (ry < minR) ry = minR;
-
-  var startAngle = isLandscape ? 0 : -Math.PI / 2;
-
-  for (var i = 0; i < neighbors.length; i++) {
-    var angle = startAngle + (2 * Math.PI * i) / neighbors.length;
-    neighbors[i].x = cx + rx * Math.cos(angle);
-    neighbors[i].y = cy + ry * Math.sin(angle);
-  }
+  RPT.computeStarLayout(sNodes, centerName, sW, sH);
 }
 
 /** Columns drawn per table before the "+N more" line, unless all are shown. */


### PR DESCRIPTION
## Context

`sComputeStarLayout` positions the focused table at the viewport centre with its neighbours beside it or on an ellipse. It was the last layout function still living in the `schema` chunk after #332 moved the overview layout.

## Problem

Same as its sibling: pure geometry reading four chunk globals (`sNodeMap`, `sNodes`, `sW`, `sH`), untestable directly.

## Possible flows

| Path | Affected |
|---|---|
| Selecting an entity in focused mode | wrapper: `RPT.computeStarLayout(sNodes, centerName, sW, sH)` |
| Overview mode, routing, drawing | untouched |

## Solution

`computeStarLayout(nodes, centerName, width, height)` added to `browser/schema-layout.ts`; the centre lookup is a `find` over the nodes instead of the `sNodeMap` global, with the same silent return when the name is unknown. The chunk keeps a one-line wrapper.

## Before vs after

| | Before | After |
|---|---|---|
| Layout functions in the schema chunk | 1 | 0 |
| Static markup | — | unchanged; all 3 emitted-diff regions in the script |

## Example

```
- function sComputeStarLayout(centerName) { var center = sNodeMap[centerName]; ... 60 lines }
+ function sComputeStarLayout(centerName) { RPT.computeStarLayout(sNodes, centerName, sW, sH); }
```
