### PR TITLE
refactor(report): move the endpoint graph build and layout into a real module

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/browser/endpoint-layout.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/endpoint-layout.ts
@@ -1,0 +1,167 @@
+interface DependencyNode {
+	className: string;
+	conditional: boolean;
+	dependencies?: DependencyNode[];
+	expandedElsewhere?: boolean;
+	filePath?: string;
+	line?: number;
+	methodName: string;
+	order: number;
+	totalMethods: number;
+	type: string;
+}
+
+interface EndpointInput {
+	controllerClass: string;
+	dependencies: DependencyNode[];
+	filePath?: string;
+	handlerMethod: string;
+	line?: number;
+}
+
+interface EndpointNode {
+	className: string;
+	conditional: boolean;
+	expandedElsewhere?: boolean;
+	filePath?: string;
+	h: number;
+	id: number;
+	line?: number;
+	methodName: string;
+	order: number;
+	totalMethods: number;
+	type: string;
+	w: number;
+	x: number;
+	y: number;
+}
+
+interface EndpointEdge {
+	conditional: boolean;
+	from: number;
+	to: number;
+}
+
+interface DagreLike {
+	graphlib: {
+		Graph: new () => {
+			node(name: number | string): { x: number; y: number } | undefined;
+			setDefaultEdgeLabel(fn: () => object): void;
+			setEdge(from: number | string, to: number | string): void;
+			setGraph(options: object): void;
+			setNode(
+				name: number | string,
+				size: { height: number; width: number }
+			): void;
+		};
+	};
+	layout(g: object): void;
+}
+
+// Flattens an endpoint's dependency tree into nodes and edges, the controller
+// method as the root.
+export function buildEndpointGraph(ep: EndpointInput): {
+	edges: EndpointEdge[];
+	nodes: EndpointNode[];
+} {
+	const nodes: EndpointNode[] = [];
+	const edges: EndpointEdge[] = [];
+	let nodeId = 0;
+
+	const rootNode: EndpointNode = {
+		id: nodeId++,
+		className: ep.controllerClass,
+		type: "controller",
+		methodName: ep.handlerMethod,
+		conditional: false,
+		order: -1,
+		totalMethods: 1,
+		filePath: ep.filePath,
+		line: ep.line,
+		x: 0,
+		y: 0,
+		w: 180,
+		h: 60,
+	};
+	nodes.push(rootNode);
+
+	function walkDeps(parentNode: EndpointNode, deps: DependencyNode[]): void {
+		for (const dep of deps) {
+			const n: EndpointNode = {
+				id: nodeId++,
+				className: dep.className,
+				type: dep.type,
+				methodName: dep.methodName,
+				conditional: dep.conditional,
+				order: dep.order,
+				totalMethods: dep.totalMethods,
+				filePath: dep.filePath,
+				line: dep.line,
+				expandedElsewhere: dep.expandedElsewhere,
+				x: 0,
+				y: 0,
+				w: 180,
+				h: 60,
+			};
+			nodes.push(n);
+			edges.push({
+				from: parentNode.id,
+				to: n.id,
+				conditional: dep.conditional,
+			});
+			if (dep.dependencies && dep.dependencies.length > 0) {
+				walkDeps(n, dep.dependencies);
+			}
+		}
+	}
+
+	walkDeps(rootNode, ep.dependencies);
+	return { nodes, edges };
+}
+
+// Ranks the graph top-to-bottom with dagre, or stacks it vertically without.
+export function layoutEndpointGraph(
+	nodes: EndpointNode[],
+	edges: EndpointEdge[],
+	dagre: DagreLike | undefined
+): void {
+	if (nodes.length === 0) {
+		return;
+	}
+
+	if (dagre !== undefined) {
+		const g = new dagre.graphlib.Graph();
+		g.setGraph({
+			rankdir: "TB",
+			nodesep: 40,
+			ranksep: 80,
+			marginx: 40,
+			marginy: 40,
+		});
+		g.setDefaultEdgeLabel(() => ({}));
+
+		for (const n of nodes) {
+			g.setNode(n.id, { width: n.w, height: n.h });
+		}
+		for (const e of edges) {
+			g.setEdge(e.from, e.to);
+		}
+
+		dagre.layout(g);
+
+		for (const n of nodes) {
+			const laid = g.node(n.id);
+			if (laid) {
+				n.x = laid.x;
+				n.y = laid.y;
+			}
+		}
+		return;
+	}
+
+	// Fallback: simple vertical layout
+	for (let i = 0; i < nodes.length; i++) {
+		nodes[i].x = 300;
+		nodes[i].y = 60 + i * 100;
+	}
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -4,6 +4,10 @@ export { heading } from "../atoms/heading.js";
 export { icon } from "../atoms/icon.js";
 export { emptyState } from "../molecules/empty-state.js";
 export { badge } from "./badge.js";
+export {
+	buildEndpointGraph,
+	layoutEndpointGraph,
+} from "./endpoint-layout.js";
 export { escapeHtml } from "./escape.js";
 export {
 	blastRadius,

--- a/packages/nestjs-doctor/src/report/ui/scripts/endpoints.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/endpoints.ts
@@ -64,84 +64,13 @@ function epRoundRect(ctx, x, y, w, h, r) {
 }
 
 function epBuildGraph(ep) {
-  epNodes = [];
-  epEdges = [];
-  var nodeId = 0;
-
-  // Root node for the endpoint (controller method)
-  var rootNode = {
-    id: nodeId++,
-    className: ep.controllerClass,
-    type: "controller",
-    methodName: ep.handlerMethod,
-    conditional: false,
-    order: -1,
-    totalMethods: 1,
-    filePath: ep.filePath,
-    line: ep.line,
-    x: 0, y: 0, w: 180, h: 60
-  };
-  epNodes.push(rootNode);
-
-  // Walk dependency tree — each dep is a MethodDependencyNode (one method per node)
-  function walkDeps(parentNode, deps) {
-    for (var i = 0; i < deps.length; i++) {
-      var dep = deps[i];
-      var n = {
-        id: nodeId++,
-        className: dep.className,
-        type: dep.type,
-        methodName: dep.methodName,
-        conditional: dep.conditional,
-        order: dep.order,
-        totalMethods: dep.totalMethods,
-        filePath: dep.filePath,
-        line: dep.line,
-        expandedElsewhere: dep.expandedElsewhere,
-        x: 0, y: 0, w: 180, h: 60
-      };
-      epNodes.push(n);
-      epEdges.push({ from: parentNode.id, to: n.id, conditional: dep.conditional });
-      if (dep.dependencies && dep.dependencies.length > 0) {
-        walkDeps(n, dep.dependencies);
-      }
-    }
-  }
-
-  walkDeps(rootNode, ep.dependencies);
+  var built = RPT.buildEndpointGraph(ep);
+  epNodes = built.nodes;
+  epEdges = built.edges;
 }
 
 function epLayout() {
-  if (epNodes.length === 0) return;
-
-  if (typeof dagre !== "undefined") {
-    var g = new dagre.graphlib.Graph();
-    g.setGraph({ rankdir: "TB", nodesep: 40, ranksep: 80, marginx: 40, marginy: 40 });
-    g.setDefaultEdgeLabel(function() { return {}; });
-
-    for (var i = 0; i < epNodes.length; i++) {
-      g.setNode(epNodes[i].id, { width: epNodes[i].w, height: epNodes[i].h });
-    }
-    for (var i = 0; i < epEdges.length; i++) {
-      g.setEdge(epEdges[i].from, epEdges[i].to);
-    }
-
-    dagre.layout(g);
-
-    for (var i = 0; i < epNodes.length; i++) {
-      var laid = g.node(epNodes[i].id);
-      if (laid) {
-        epNodes[i].x = laid.x;
-        epNodes[i].y = laid.y;
-      }
-    }
-  } else {
-    // Fallback: simple vertical layout
-    for (var i = 0; i < epNodes.length; i++) {
-      epNodes[i].x = 300;
-      epNodes[i].y = 60 + i * 100;
-    }
-  }
+  RPT.layoutEndpointGraph(epNodes, epEdges, typeof dagre === "undefined" ? undefined : dagre);
 }
 
 function epCenterCamera() {


### PR DESCRIPTION
## Context

The endpoints tab's dependency graph was the last dagre layout still living inside a script chunk after #333 moved the module graph's.

## Problem

`epBuildGraph` flattened the dependency tree into two chunk globals and `epLayout` reached the page's `dagre` through a bare global, so neither was testable or typed.

## Possible flows

| Caller | Before | After |
|---|---|---|
| Opening an endpoint | `epBuildGraph(ep)` writing `epNodes`/`epEdges` | wrapper assigns from `RPT.buildEndpointGraph(ep)` |
| Layout | `epLayout()` reading the `dagre` global | `RPT.layoutEndpointGraph(epNodes, epEdges, dagre-or-undefined)` |
| Camera, drawing, tooltips, code panel | untouched | untouched |

## Solution

`browser/endpoint-layout.ts`: `buildEndpointGraph` returns `{ nodes, edges }`, `layoutEndpointGraph` takes dagre as a parameter with the same vertical-stack fallback. Two-line chunk wrappers keep every call site and the evaluation order unchanged.

## Before vs after

| | Before | After |
|---|---|---|
| dagre layouts in chunks | 1 | 0 |
| Static markup | — | unchanged; all 5 emitted-diff regions in the script |

## Example

```
- function epLayout() { ... 30 lines against the dagre global ... }
+ function epLayout() { RPT.layoutEndpointGraph(epNodes, epEdges, typeof dagre === "undefined" ? undefined : dagre); }
```
