### PR TITLE
refactor(report): move the schema column classification into a real module

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/browser/column-kinds.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/column-kinds.ts
@@ -1,0 +1,57 @@
+interface SchemaColumn {
+	hasIndex?: boolean;
+	isPrimary?: boolean;
+	isUnique?: boolean;
+	name: string;
+}
+
+interface SchemaEntity {
+	relations: { propertyName?: string }[];
+}
+
+const NON_ALNUM = /[^a-z0-9]/g;
+
+// Normalises a column or property name for fuzzy matching.
+export function keyName(text: unknown): string {
+	return String(text).toLowerCase().replace(NON_ALNUM, "");
+}
+
+// A relation property's candidate FK column names: itself and with an Id suffix.
+export function fkKeys(propertyName: string): [string, string] {
+	const base = keyName(propertyName);
+	return [base, `${base}id`];
+}
+
+// The normalised names an entity's relations could store their FK under.
+export function foreignKeyColumns(
+	entity: SchemaEntity
+): Record<string, boolean> {
+	const names: Record<string, boolean> = Object.create(null);
+	for (const rel of entity.relations) {
+		const prop = rel.propertyName;
+		if (!prop) {
+			continue;
+		}
+		const keys = fkKeys(prop);
+		names[keys[0]] = true;
+		names[keys[1]] = true;
+	}
+	return names;
+}
+
+// Classifies a column as pk, fk, idx, or nothing.
+export function columnKind(
+	column: SchemaColumn,
+	foreignKeys: Record<string, boolean>
+): string | null {
+	if (column.isPrimary) {
+		return "pk";
+	}
+	if (foreignKeys[keyName(column.name)]) {
+		return "fk";
+	}
+	if (column.isUnique || column.hasIndex) {
+		return "idx";
+	}
+	return null;
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -5,6 +5,12 @@ export { icon } from "../atoms/icon.js";
 export { emptyState } from "../molecules/empty-state.js";
 export { badge } from "./badge.js";
 export {
+	columnKind,
+	fkKeys,
+	foreignKeyColumns,
+	keyName,
+} from "./column-kinds.js";
+export {
 	buildEndpointGraph,
 	layoutEndpointGraph,
 } from "./endpoint-layout.js";

--- a/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/schema.ts
@@ -159,9 +159,9 @@ function sPortRowY(node, colName) {
   var showCols = sColumnsShown(sNodes.length);
   var visible = sVisibleColCount(node, showCols);
   if (colName) {
-    var key = sKeyName(colName);
+    var key = RPT.keyName(colName);
     for (var i = 0; i < node.entity.columns.length && i < visible; i++) {
-      if (sKeyName(node.entity.columns[i].name) === key) return top + 24 + i * 16 + 8;
+      if (RPT.keyName(node.entity.columns[i].name) === key) return top + 24 + i * 16 + 8;
     }
   }
   return top + 12;
@@ -172,9 +172,9 @@ function sRelPortNames(rel) {
   var child = sNodeMap[rel.fromEntity];
   var fkName = null;
   if (child && rel.propertyName) {
-    var keys = sFkKeys(rel.propertyName);
+    var keys = RPT.fkKeys(rel.propertyName);
     for (var i = 0; i < child.entity.columns.length; i++) {
-      var kn = sKeyName(child.entity.columns[i].name);
+      var kn = RPT.keyName(child.entity.columns[i].name);
       if (kn === keys[0] || kn === keys[1]) { fkName = child.entity.columns[i].name; break; }
     }
   }
@@ -249,35 +249,6 @@ var S_DEFAULT_MAX_COLS = RPT.SCHEMA_DEFAULT_MAX_COLS;
 var S_PK_COLOR = "#ea2845";
 var S_FK_COLOR = "#8b5cf6";
 var S_IDX_COLOR = "#f59e0b";
-
-/** Names a relation's property and that property with an Id suffix. */
-function sKeyName(text) {
-  return String(text).toLowerCase().replace(/[^a-z0-9]/g, "");
-}
-
-function sFkKeys(propertyName) {
-  var base = sKeyName(propertyName);
-  return [base, base + "id"];
-}
-
-function sForeignKeyColumns(entity) {
-  var names = Object.create(null);
-  for (var i = 0; i < entity.relations.length; i++) {
-    var prop = entity.relations[i].propertyName;
-    if (!prop) continue;
-    var keys = sFkKeys(prop);
-    names[keys[0]] = true;
-    names[keys[1]] = true;
-  }
-  return names;
-}
-
-function sColumnKind(column, foreignKeys) {
-  if (column.isPrimary) return "pk";
-  if (foreignKeys[sKeyName(column.name)]) return "fk";
-  if (column.isUnique || column.hasIndex) return "idx";
-  return null;
-}
 
 /** Draws the key, link or index glyph that marks what a column is. */
 function sDrawColumnIcon(ctx, kind, cx, cy) {
@@ -372,13 +343,13 @@ function sCacheNodeLabels(nodes) {
     for (var c = 0; c < n.entity.columns.length; c++) {
       n.colTypes.push(clip(n.entity.columns[c].type, 60));
     }
-    var foreignKeys = sForeignKeyColumns(n.entity);
+    var foreignKeys = RPT.foreignKeyColumns(n.entity);
     sCtx.font = "11px " + RPT_FONT;
     n.colNames = [];
     n.colKinds = [];
     for (var k = 0; k < n.entity.columns.length; k++) {
       n.colNames.push(clip(n.entity.columns[k].name, 83));
-      n.colKinds.push(sColumnKind(n.entity.columns[k], foreignKeys));
+      n.colKinds.push(RPT.columnKind(n.entity.columns[k], foreignKeys));
     }
   }
 }
@@ -841,10 +812,10 @@ function renderSchema() {
       var colGroupId = entityId + "-cols";
       sidebarHtml += sBuildTreeRow(2, colGroupId, ICON_FOLDER_CLOSED, '<span class="st-group-name">columns</span>', '<span class="st-count">' + entity.columns.length + '</span>', "", "");
       sidebarHtml += '<div class="st-children" id="st-' + colGroupId + '">';
-      var entityForeignKeys = sForeignKeyColumns(entity);
+      var entityForeignKeys = RPT.foreignKeyColumns(entity);
       for (var c = 0; c < entity.columns.length; c++) {
         var col = entity.columns[c];
-        var colKind = sColumnKind(col, entityForeignKeys);
+        var colKind = RPT.columnKind(col, entityForeignKeys);
         var colIcon = colKind === "pk" ? ICON_KEY
           : colKind === "fk" ? ICON_FK
           : colKind === "idx" ? ICON_INDEX


### PR DESCRIPTION
## Context

The schema tab guesses which column backs a relation: a relation's `propertyName` is normalised and matched against column names directly and with an `Id` suffix. The same guess decides the PK/FK/index icon on every drawn column and which row an edge attaches to.

## Problem

Heuristics this subtle were four chunk functions with no tests and no types, spread across eight call sites in drawing, port lookup, and star-mode rendering.

## Possible flows

| Caller | Uses |
|---|---|
| Node label cache (overview draw) | `foreignKeyColumns` + `columnKind` per column |
| Star-mode focused draw | same pair |
| Edge port row lookup | `keyName` |
| `sRelPortNames` FK guess | `fkKeys` + `keyName` |

All eight sites now call the `RPT` equivalents.

## Solution

`browser/column-kinds.ts`: `keyName`, `fkKeys`, `foreignKeyColumns`, `columnKind`, typed and exported through the bundle. Pure move; the classification rules are unchanged. Tests land in the last PR of this stack.

## Before vs after

| | Before | After |
|---|---|---|
| Column classification testable | no | direct import |
| Static markup | — | unchanged; all 13 emitted-diff regions in the script |

## Example

```
- if (foreignKeys[sKeyName(column.name)]) return "fk";
+ if (foreignKeys[keyName(column.name)]) { return "fk"; }
```
