### PR TITLE
refactor(report): move the score ring, share payload, and module joins into modules

### DIFF
--- a/packages/nestjs-doctor/src/report/ui/browser/entry.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/entry.ts
@@ -15,6 +15,7 @@ export {
 	layoutEndpointGraph,
 } from "./endpoint-layout.js";
 export { escapeHtml } from "./escape.js";
+export { endpointsOf, providersOf, wiringChildren } from "./module-joins.js";
 export {
 	blastRadius,
 	buildClusters,
@@ -44,6 +45,8 @@ export {
 	segmentHitsBox,
 	simplifyPath,
 } from "./schema-routing.js";
+export { getScoreColor, makeScoreRingSvg } from "./score-ring.js";
+export { buildSharedJson, isNotScored, scoredCount } from "./share-payload.js";
 export {
 	card,
 	infoCard,

--- a/packages/nestjs-doctor/src/report/ui/browser/module-joins.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/module-joins.ts
@@ -1,0 +1,68 @@
+interface Provider {
+	module?: string;
+}
+
+interface WiringDep {
+	className: string;
+	dependencies?: WiringDep[];
+	methodName: string;
+	type: string;
+}
+
+interface Endpoint {
+	controllerClass: string;
+}
+
+const WIRING_TYPES: Record<string, number> = {
+	service: 1,
+	repository: 1,
+	guard: 1,
+	interceptor: 1,
+	pipe: 1,
+	filter: 1,
+	gateway: 1,
+};
+
+// The providers registered by one module.
+export function providersOf<P extends Provider>(
+	providers: P[],
+	moduleName: string
+): P[] {
+	return providers.filter((p) => p.module === moduleName);
+}
+
+// Collapses statement nodes so only injected collaborators are left, and
+// drops a class method already listed at this level.
+export function wiringChildren(deps: WiringDep[] | undefined): WiringDep[] {
+	const seen: Record<string, boolean> = {};
+	const out: WiringDep[] = [];
+	for (const d of deps || []) {
+		if (WIRING_TYPES[d.type]) {
+			const key = `${d.className}.${d.methodName}`;
+			if (seen[key]) {
+				continue;
+			}
+			seen[key] = true;
+			out.push(d);
+			continue;
+		}
+		for (const inner of wiringChildren(d.dependencies)) {
+			const k = `${inner.className}.${inner.methodName}`;
+			if (seen[k]) {
+				continue;
+			}
+			seen[k] = true;
+			out.push(inner);
+		}
+	}
+	return out;
+}
+
+// The endpoints handled by one controller class.
+export function endpointsOf<E extends Endpoint>(
+	endpoints: { endpoints?: E[] } | undefined,
+	controllerClass: string
+): E[] {
+	const list = endpoints?.endpoints || [];
+	return list.filter((e) => e.controllerClass === controllerClass);
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/score-ring.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/score-ring.ts
@@ -1,0 +1,30 @@
+// Score → CSS color token, matching the thresholds used across the report.
+export function getScoreColor(v: number): string {
+	if (v >= 75) {
+		return "var(--score-green)";
+	}
+	if (v >= 50) {
+		return "var(--score-yellow)";
+	}
+	return "var(--score-red)";
+}
+
+// The score ring: a faint track, an arc proportional to the score, and the
+// value centred in the score's color.
+export function makeScoreRingSvg(
+	size: number,
+	strokeW: number,
+	value: number
+): string {
+	const r = (size - strokeW) / 2;
+	const c = 2 * Math.PI * r;
+	const offset = c - (value / 100) * c;
+	const color = getScoreColor(value);
+	return (
+		`<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">` +
+		`<circle cx="${size / 2}" cy="${size / 2}" r="${r}" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="1"/>` +
+		`<circle cx="${size / 2}" cy="${size / 2}" r="${r}" fill="none" stroke="${color}" stroke-width="${strokeW}" stroke-linecap="butt" stroke-dasharray="${c}" stroke-dashoffset="${offset}" transform="rotate(-90 ${size / 2} ${size / 2})"/>` +
+		`<text x="${size / 2}" y="${size / 2}" text-anchor="middle" dominant-baseline="central" fill="${color}" font-size="${Math.round(size * 0.32)}" font-weight="700" font-family="var(--font)">${value}</text>` +
+		"</svg>"
+	);
+}

--- a/packages/nestjs-doctor/src/report/ui/browser/share-payload.ts
+++ b/packages/nestjs-doctor/src/report/ui/browser/share-payload.ts
@@ -1,0 +1,137 @@
+interface SharedFinding {
+	category: string;
+	severity: string;
+	surfaces?: string[];
+}
+
+interface CategorySlice {
+	findings: (SharedFinding & { sourceLines?: unknown })[];
+	schemaIssues: SharedFinding[];
+}
+
+interface ShareData {
+	endpoints?: unknown;
+	findingsByCategory: Record<string, CategorySlice>;
+	modules?: unknown;
+	project?: unknown;
+	schema?: unknown;
+	scope?: unknown;
+	score?: unknown;
+	version: unknown;
+}
+
+// A finding reported for information only never enters a shared export's counts.
+export function isNotScored(d: SharedFinding): boolean {
+	return !!(d.surfaces && d.surfaces.indexOf("score") === -1);
+}
+
+// What a section would actually export once not-scored findings are dropped.
+export function scoredCount(share: ShareData, id: string): number | null {
+	if (id.indexOf("findings:") !== 0) {
+		return null;
+	}
+	const slice = share.findingsByCategory[id.slice(9)];
+	if (!slice) {
+		return 0;
+	}
+	let n = 0;
+	for (const f of slice.findings) {
+		if (!isNotScored(f)) {
+			n++;
+		}
+	}
+	for (const s of slice.schemaIssues) {
+		if (!isNotScored(s)) {
+			n++;
+		}
+	}
+	return n;
+}
+
+// Assembles the downloadable JSON from the picked sections, dropping
+// not-scored findings and, unless asked, the code snippets.
+export function buildSharedJson(
+	share: ShareData,
+	generator: unknown,
+	includeCode: boolean,
+	picked: string[]
+): object {
+	const findings: object[] = [];
+	const schemaIssues: object[] = [];
+	const counts = {
+		total: 0,
+		errors: 0,
+		warnings: 0,
+		info: 0,
+		byCategory: {
+			security: 0,
+			performance: 0,
+			correctness: 0,
+			architecture: 0,
+			schema: 0,
+		} as Record<string, number>,
+	};
+	const count = (d: SharedFinding) => {
+		counts.total++;
+		if (d.severity === "error") {
+			counts.errors++;
+		} else if (d.severity === "warning") {
+			counts.warnings++;
+		} else {
+			counts.info++;
+		}
+		counts.byCategory[d.category]++;
+	};
+	for (const id of picked) {
+		if (id.indexOf("findings:") !== 0) {
+			continue;
+		}
+		const slice = share.findingsByCategory[id.slice(9)];
+		if (!slice) {
+			continue;
+		}
+		for (const d of slice.findings) {
+			if (isNotScored(d)) {
+				continue;
+			}
+			if (includeCode) {
+				findings.push(d);
+			} else {
+				const copy: Record<string, unknown> = {};
+				const source = d as unknown as Record<string, unknown>;
+				for (const key of Object.keys(source)) {
+					if (key !== "sourceLines") {
+						copy[key] = source[key];
+					}
+				}
+				findings.push(copy);
+			}
+			count(d);
+		}
+		for (const issue of slice.schemaIssues) {
+			if (isNotScored(issue)) {
+				continue;
+			}
+			schemaIssues.push(issue);
+			count(issue);
+		}
+	}
+	const has = (id: string) => picked.indexOf(id) >= 0;
+	return {
+		version: share.version,
+		generator,
+		generatedAt: new Date().toISOString(),
+		...(has("score") ? { project: share.project, score: share.score } : {}),
+		...(share.scope ? { scope: share.scope } : {}),
+		summary: counts,
+		sections: picked,
+		includeCode: includeCode && findings.length > 0,
+		findings,
+		schemaIssues,
+		...(share.endpoints && has("endpoints")
+			? { endpoints: share.endpoints }
+			: {}),
+		...(share.schema && has("schema") ? { schema: share.schema } : {}),
+		...(share.modules && has("modules") ? { modules: share.modules } : {}),
+	};
+}

--- a/packages/nestjs-doctor/src/report/ui/scripts/chrome.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/chrome.ts
@@ -1,23 +1,4 @@
 export const CHROME = `
-// ── Score helpers ──
-function getScoreColor(v) {
-  if (v >= 75) return "${"var(--score-green)"}";
-  if (v >= 50) return "${"var(--score-yellow)"}";
-  return "${"var(--score-red)"}";
-}
-
-function makeScoreRingSvg(size, strokeW, value) {
-  const r = (size - strokeW) / 2;
-  const c = 2 * Math.PI * r;
-  const offset = c - (value / 100) * c;
-  const color = getScoreColor(value);
-  return '<svg width="' + size + '" height="' + size + '" viewBox="0 0 ' + size + ' ' + size + '">' +
-    '<circle cx="' + size/2 + '" cy="' + size/2 + '" r="' + r + '" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="1"/>' +
-    '<circle cx="' + size/2 + '" cy="' + size/2 + '" r="' + r + '" fill="none" stroke="' + color + '" stroke-width="' + strokeW + '" stroke-linecap="butt" stroke-dasharray="' + c + '" stroke-dashoffset="' + offset + '" transform="rotate(-90 ' + size/2 + ' ' + size/2 + ')"/>' +
-    '<text x="' + size/2 + '" y="' + size/2 + '" text-anchor="middle" dominant-baseline="central" fill="' + color + '" font-size="' + Math.round(size * 0.32) + '" font-weight="700" font-family="var(--font)">' + value + '</text>' +
-    '</svg>';
-}
-
 // ── Header: meta badges ──
 (function() {
   const meta = document.getElementById("header-meta");

--- a/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/modules-graph.ts
@@ -64,52 +64,19 @@ function mgScheduleRedraw() {
 /** Groups modules by owning project, keeping first-seen order. */
 // ── Modules graph: joins into the other payloads ──
 function mgProvidersOf(moduleName) {
-  var out = [];
-  for (var i = 0; i < providers.length; i++) {
-    if (providers[i].module === moduleName) out.push(providers[i]);
-  }
-  return out;
+  return RPT.providersOf(providers, moduleName);
 }
-
-var MG_WIRING_TYPES = {
-  service: 1, repository: 1, guard: 1, interceptor: 1,
-  pipe: 1, filter: 1, gateway: 1
-};
 
 /**
  * Collapses statement nodes so only injected collaborators are left, and
  * drops a class method already listed at this level.
  */
 function mgWiringChildren(deps) {
-  var seen = {}, out = [], i, j;
-  var list = deps || [];
-  for (i = 0; i < list.length; i++) {
-    var d = list[i];
-    if (MG_WIRING_TYPES[d.type]) {
-      var key = d.className + "." + d.methodName;
-      if (seen[key]) continue;
-      seen[key] = true;
-      out.push(d);
-      continue;
-    }
-    var inner = mgWiringChildren(d.dependencies);
-    for (j = 0; j < inner.length; j++) {
-      var k = inner[j].className + "." + inner[j].methodName;
-      if (seen[k]) continue;
-      seen[k] = true;
-      out.push(inner[j]);
-    }
-  }
-  return out;
+  return RPT.wiringChildren(deps);
 }
 
 function mgEndpointsOf(controllerClass) {
-  var list = (endpoints && endpoints.endpoints) || [];
-  var out = [];
-  for (var i = 0; i < list.length; i++) {
-    if (list[i].controllerClass === controllerClass) out.push(list[i]);
-  }
-  return out;
+  return RPT.endpointsOf(endpoints, controllerClass);
 }
 
 // ── Modules graph: build ──

--- a/packages/nestjs-doctor/src/report/ui/scripts/share.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/share.ts
@@ -5,74 +5,15 @@ export const SHARE = `
   if (!btn) return;
   var SHARE = REPORT.share;
 
-  function isNotScored(d) { return !!(d.surfaces && d.surfaces.indexOf("score") === -1); }
+  function isNotScored(d) { return RPT.isNotScored(d); }
 
   /** What a section would actually export once not-scored findings are dropped. */
   function scoredCount(id) {
-    if (id.indexOf("findings:") !== 0) return null;
-    var slice = SHARE.findingsByCategory[id.slice(9)];
-    if (!slice) return 0;
-    var n = 0;
-    for (var i = 0; i < slice.findings.length; i++) {
-      if (!isNotScored(slice.findings[i])) n++;
-    }
-    for (var j = 0; j < slice.schemaIssues.length; j++) {
-      if (!isNotScored(slice.schemaIssues[j])) n++;
-    }
-    return n;
+    return RPT.scoredCount(SHARE, id);
   }
 
   function buildSharedJson(includeCode, picked) {
-    var findings = [];
-    var schemaIssues = [];
-    var counts = {total: 0, errors: 0, warnings: 0, info: 0, byCategory: {security: 0, performance: 0, correctness: 0, architecture: 0, schema: 0}};
-    for (var i = 0; i < picked.length; i++) {
-      if (picked[i].indexOf("findings:") !== 0) continue;
-      var slice = SHARE.findingsByCategory[picked[i].slice(9)];
-      if (!slice) continue;
-      for (var f = 0; f < slice.findings.length; f++) {
-        var d = slice.findings[f];
-        if (isNotScored(d)) continue;
-        if (includeCode) {
-          findings.push(d);
-        } else {
-          var copy = {};
-          for (var key in d) if (key !== "sourceLines") copy[key] = d[key];
-          findings.push(copy);
-        }
-        counts.total++;
-        if (d.severity === "error") counts.errors++;
-        else if (d.severity === "warning") counts.warnings++;
-        else counts.info++;
-        counts.byCategory[d.category]++;
-      }
-      for (var s = 0; s < slice.schemaIssues.length; s++) {
-        var issue = slice.schemaIssues[s];
-        if (isNotScored(issue)) continue;
-        schemaIssues.push(issue);
-        counts.total++;
-        if (issue.severity === "error") counts.errors++;
-        else if (issue.severity === "warning") counts.warnings++;
-        else counts.info++;
-        counts.byCategory[issue.category]++;
-      }
-    }
-    function has(id) { return picked.indexOf(id) >= 0; }
-    return {
-      version: SHARE.version,
-      generator: REPORT.generator,
-      generatedAt: new Date().toISOString(),
-      ...(has("score") ? {project: SHARE.project, score: SHARE.score} : {}),
-      ...(SHARE.scope ? {scope: SHARE.scope} : {}),
-      summary: counts,
-      sections: picked,
-      includeCode: includeCode && findings.length > 0,
-      findings: findings,
-      schemaIssues: schemaIssues,
-      ...(SHARE.endpoints && has("endpoints") ? {endpoints: SHARE.endpoints} : {}),
-      ...(SHARE.schema && has("schema") ? {schema: SHARE.schema} : {}),
-      ...(SHARE.modules && has("modules") ? {modules: SHARE.modules} : {})
-    };
+    return RPT.buildSharedJson(SHARE, REPORT.generator, includeCode, picked);
   }
 
   btn.addEventListener("click", function() {

--- a/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
+++ b/packages/nestjs-doctor/src/report/ui/scripts/summary.ts
@@ -13,7 +13,7 @@ function renderSummary() {
     return d.surfaces && d.surfaces.indexOf('score') === -1;
   }).length;
   var scoreBody = '<div class="ov-score-row">' +
-    '<div class="ov-score-ring">' + makeScoreRingSvg(120, 6, sv) + '</div>' +
+    '<div class="ov-score-ring">' + RPT.makeScoreRingSvg(120, 6, sv) + '</div>' +
     '<div class="ov-score-details">' +
     '<div class="ov-score-label">' + sv + ' / 100</div>' +
     '<div class="ov-score-sublabel">' + escHtml(project.score.label) + '</div>' +


### PR DESCRIPTION
## Context

Three small pure clusters remained in chunks after the layout and routing hoists: the score ring SVG builder, the share dialog's payload assembly, and the modules-graph joins that feed the detail panel.

## Problem

Each was untyped and untestable: `makeScoreRingSvg` renders the header and summary score, `buildSharedJson` decides exactly what leaves the machine when a user shares a report (dropping not-scored findings and code snippets), and `mgWiringChildren` collapses the dependency tree into the wiring view. A bug in the second silently ships wrong data.

## Possible flows

| Caller | Before | After |
|---|---|---|
| Summary score ring | `makeScoreRingSvg` defined in the chrome chunk | `RPT.makeScoreRingSvg`; the chunk copy is deleted |
| Share dialog counts and download | three closures over `SHARE` | wrappers over `RPT.scoredCount` / `RPT.buildSharedJson` passing `SHARE` and `REPORT.generator` |
| Detail panel providers / wiring / endpoints | globals read inside the functions | `RPT.providersOf(providers, ...)`, `RPT.wiringChildren(deps)`, `RPT.endpointsOf(endpoints, ...)` |

## Solution

`browser/score-ring.ts`, `browser/share-payload.ts`, `browser/module-joins.ts` — bodies ported verbatim with the chunk globals as parameters. Tests land in the next PR of this stack.

## Before vs after

| | Before | After |
|---|---|---|
| Pure logic left in chunks | 3 clusters | 0 |
| Static markup | — | unchanged; all 19 emitted-diff regions in the script |

## Example

```
- function buildSharedJson(includeCode, picked) { ... 45 lines over SHARE ... }
+ function buildSharedJson(includeCode, picked) { return RPT.buildSharedJson(SHARE, REPORT.generator, includeCode, picked); }
```
