### PR TITLE
fix(engine): union same-name modules across directories instead of dropping one

### DIFF
--- a/.changeset/module-graph-name-collision.md
+++ b/.changeset/module-graph-name-collision.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Two `@Module()` classes sharing a class name in different directories no longer silently drop one of the declarations from the module graph. The declarations now union their imports, providers, exports, and controllers — the same behaviour same-directory declarations already had — so cycles through either declaration are detected, and providers or exports on the previously dropped module stop producing phantom `no-unused-providers`, `no-unused-module-exports`, and `no-orphan-modules` findings. A scan warns once per duplicated name, listing every declaration file, and a `no-circular-module-deps` report whose cycle head is declared in several files now names all of them in its help text.

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -68,6 +68,20 @@ export type AnalysisProgress = (
 	total?: number
 ) => void;
 
+/** One warning per @Module class name declared in more than one file. */
+function warnDuplicateModuleNames(
+	moduleGraph: ModuleGraph,
+	warnings: string[]
+): void {
+	for (const node of moduleGraph.modules.values()) {
+		if (node.filePaths && node.filePaths.length > 1) {
+			warnings.push(
+				`@Module class ${node.name} is declared in ${node.filePaths.length} files (${node.filePaths.join(", ")}); their imports, providers, and exports are analyzed as one module`
+			);
+		}
+	}
+}
+
 export async function buildAnalysisContext(
 	targetPath: string,
 	scanConfig: ScanConfig,
@@ -93,6 +107,7 @@ export async function buildAnalysisContext(
 		files,
 		pathAliases
 	);
+	warnDuplicateModuleNames(moduleGraph, scanConfig.customRuleWarnings);
 	await yieldToEventLoop();
 	const providers = await resolveProvidersAsync(astProject, files);
 	await yieldToEventLoop();
@@ -212,6 +227,7 @@ async function buildSubProjectContext(
 		files,
 		pathAliases
 	);
+	warnDuplicateModuleNames(moduleGraph, scanConfig.customRuleWarnings);
 	await yieldToEventLoop();
 	const providers = await resolveProvidersAsync(astProject, files);
 	await yieldToEventLoop();

--- a/packages/nestjs-doctor/src/engine/graph/module-graph.ts
+++ b/packages/nestjs-doctor/src/engine/graph/module-graph.ts
@@ -229,24 +229,16 @@ function mergeSameNameModules(a: ModuleNode, b: ModuleNode): ModuleNode {
 	return merged;
 }
 
-function moduleDir(filePath: string): string {
-	return filePath.slice(0, filePath.lastIndexOf("/") + 1);
-}
-
-/**
- * Same-name declarations in one directory union their metadata; elsewhere
- * the latest declaration wins.
- */
+/** Same-name declarations union their metadata, wherever they are declared. */
 function addModuleNode(
 	modules: Map<string, ModuleNode>,
 	node: ModuleNode
 ): void {
 	const existing = modules.get(node.name);
-	if (existing && moduleDir(existing.filePath) === moduleDir(node.filePath)) {
-		modules.set(node.name, mergeSameNameModules(existing, node));
-		return;
-	}
-	modules.set(node.name, node);
+	modules.set(
+		node.name,
+		existing ? mergeSameNameModules(existing, node) : node
+	);
 }
 
 function collectModuleNodes(
@@ -912,12 +904,10 @@ export function updateModuleGraphForFile(
 		}
 	}
 	for (const [name, node] of added) {
-		// A surviving same-name module from another directory keeps its slot.
-		if (graph.modules.has(name)) {
-			continue;
-		}
-		graph.modules.set(name, node);
-		newModules.push(node);
+		const existing = graph.modules.get(name);
+		const next = existing ? mergeSameNameModules(existing, node) : node;
+		graph.modules.set(name, next);
+		newModules.push(next);
 	}
 
 	// 3. Rebuild edges for new modules and update providerToModule

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-circular-module-deps.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-circular-module-deps.ts
@@ -155,7 +155,11 @@ export const noCircularModuleDeps: ProjectRule = {
 
 			const cycleStr = cycle.join(" -> ");
 			const firstModule = context.moduleGraph.modules.get(cycle[0]);
-			const help = buildConcreteHelp(cycle, context);
+			let help = buildConcreteHelp(cycle, context);
+			const declarations = firstModule?.filePaths;
+			if (declarations && declarations.length > 1) {
+				help += `\n${cycle[0]} is declared in ${declarations.length} files (${declarations.join(", ")}); this report is anchored to the first.`;
+			}
 
 			context.report({
 				filePath: firstModule?.filePath ?? "unknown",

--- a/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "duplicate-module-names",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/src/feature-a/a.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/src/feature-a/a.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { SharedModule } from './shared.module';
+
+@Module({ imports: [SharedModule] })
+export class AModule {}

--- a/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/src/feature-a/shared.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/src/feature-a/shared.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { AModule } from './a.module';
+
+@Module({ imports: [AModule] })
+export class SharedModule {}

--- a/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/src/feature-b/shared.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/src/feature-b/shared.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { SharedService } from './shared.service';
+
+@Module({ providers: [SharedService], exports: [SharedService] })
+export class SharedModule {}

--- a/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/src/feature-b/shared.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/duplicate-module-names/src/feature-b/shared.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SharedService {}

--- a/packages/nestjs-doctor/tests/integration/cli.test.ts
+++ b/packages/nestjs-doctor/tests/integration/cli.test.ts
@@ -660,6 +660,50 @@ describe("scanner integration", () => {
 		expect(result.score.value).toBeGreaterThanOrEqual(90);
 	});
 
+	it("unions duplicate @Module class names and keeps their cycle visible", async () => {
+		const targetPath = resolve(FIXTURES, "duplicate-module-names/src");
+		const scanConfig = await resolveScanConfig(targetPath);
+		const context = await buildAnalysisContext(targetPath, scanConfig);
+		const rawOutput = await diagnose(context);
+		const { result } = buildResult(
+			context,
+			rawOutput,
+			scanConfig.customRuleWarnings
+		);
+
+		// SharedModule (declared twice) unions into one node beside AModule
+		expect(result.project.moduleCount).toBe(2);
+		const shared = context.moduleGraph.modules.get("SharedModule");
+		expect(shared?.filePaths).toHaveLength(2);
+		expect(shared?.providers).toContain("SharedService");
+		expect(context.moduleGraph.edges.get("SharedModule")?.has("AModule")).toBe(
+			true
+		);
+
+		// The scan says the name is duplicated and where
+		const warning = scanConfig.customRuleWarnings.find((w) =>
+			w.includes("@Module class SharedModule is declared in 2 files")
+		);
+		expect(warning).toContain("feature-a/shared.module.ts");
+		expect(warning).toContain("feature-b/shared.module.ts");
+
+		// The cycle through feature-a's declaration survives the collision
+		const circular = result.diagnostics.filter(
+			(d) => d.rule === "architecture/no-circular-module-deps"
+		);
+		expect(circular).toHaveLength(1);
+		expect(circular[0].message).toContain("AModule");
+		expect(circular[0].message).toContain("SharedModule");
+
+		// feature-b's provider does not resurface as a phantom finding
+		const phantom = result.diagnostics.filter(
+			(d) =>
+				d.rule === "performance/no-unused-providers" &&
+				d.message.includes("SharedService")
+		);
+		expect(phantom).toHaveLength(0);
+	});
+
 	it("resolves cross-file monorepo-style chained imports in module graph", async () => {
 		const targetPath = resolve(FIXTURES, "cross-file-monorepo/src");
 		const scanConfig = await resolveScanConfig(targetPath);

--- a/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/project-rules.test.ts
@@ -73,6 +73,32 @@ describe("no-circular-module-deps", () => {
 		expect(diags[0].message).toContain("Circular");
 	});
 
+	it("names every declaration file when a cycle head is declared twice", () => {
+		const diags = runProjectRule(noCircularModuleDeps, {
+			"feature-a/shared.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { AModule } from './a.module';
+        @Module({ imports: [AModule] })
+        export class SharedModule {}
+      `,
+			"feature-a/a.module.ts": `
+        import { Module } from '@nestjs/common';
+        import { SharedModule } from './shared.module';
+        @Module({ imports: [SharedModule] })
+        export class AModule {}
+      `,
+			"feature-b/shared.module.ts": `
+        import { Module } from '@nestjs/common';
+        @Module({})
+        export class SharedModule {}
+      `,
+		});
+		expect(diags).toHaveLength(1);
+		expect(diags[0].help).toContain("declared in 2 files");
+		expect(diags[0].help).toContain("feature-a/shared.module.ts");
+		expect(diags[0].help).toContain("feature-b/shared.module.ts");
+	});
+
 	it("does not flag acyclic imports", () => {
 		const diags = runProjectRule(noCircularModuleDeps, {
 			"app.module.ts": `

--- a/packages/nestjs-doctor/tests/unit/wrapper-detection.test.ts
+++ b/packages/nestjs-doctor/tests/unit/wrapper-detection.test.ts
@@ -411,7 +411,7 @@ describe("wrapper overloads and route paths", () => {
 });
 
 describe("same-name scoping and package imports", () => {
-	it("does not union same-name modules from different directories", () => {
+	it("unions same-name modules from different directories instead of dropping one", () => {
 		const { project, paths } = createProject({
 			"feature-a/shared.module.ts": `
 				import { Module } from '@nestjs/common';
@@ -432,8 +432,11 @@ describe("same-name scoping and package imports", () => {
 		});
 		const graph = buildModuleGraph(project, paths);
 		const shared = graph.modules.get("SharedModule");
-		expect(shared?.filePaths).toBeUndefined();
-		expect(shared?.filePath).toBe("feature-b/shared.module.ts");
+		expect(shared?.filePaths).toEqual([
+			"feature-a/shared.module.ts",
+			"feature-b/shared.module.ts",
+		]);
+		expect(graph.edges.get("SharedModule")).toEqual(new Set(["UsersModule"]));
 	});
 
 	it("leaves a package-imported name unresolved instead of binding it cross-project", () => {
@@ -542,26 +545,86 @@ describe("same-name scoping and package imports", () => {
 		expect(graph.modules.has("AppModule")).toBe(true);
 	});
 
-	it("keeps the surviving winner when updating an evicted same-name declaration", () => {
+	it("unions same-name declarations across directories", () => {
 		const { project, paths } = createProject({
 			"feature-a/shared.module.ts": `
 				import { Module } from '@nestjs/common';
+				import { AModule } from './a.module';
+				@Module({ imports: [AModule], providers: [AService] })
+				export class SharedModule {}
+			`,
+			"feature-a/a.module.ts": `
+				import { Module } from '@nestjs/common';
 				@Module({})
+				export class AModule {}
+			`,
+			"feature-b/shared.module.ts": `
+				import { Module } from '@nestjs/common';
+				import { BModule } from './b.module';
+				@Module({ imports: [BModule], providers: [BService] })
+				export class SharedModule {}
+			`,
+			"feature-b/b.module.ts": `
+				import { Module } from '@nestjs/common';
+				@Module({})
+				export class BModule {}
+			`,
+		});
+		const graph = buildModuleGraph(project, paths);
+		const shared = graph.modules.get("SharedModule");
+		expect(shared?.filePaths).toEqual([
+			"feature-a/shared.module.ts",
+			"feature-b/shared.module.ts",
+		]);
+		expect(graph.edges.get("SharedModule")).toEqual(
+			new Set(["AModule", "BModule"])
+		);
+		expect(graph.providerToModule.get("BService")).toBe(shared);
+	});
+
+	it("keeps the union when one declaration file changes", () => {
+		const { project, paths } = createProject({
+			"feature-a/shared.module.ts": `
+				import { Module } from '@nestjs/common';
+				@Module({ providers: [AService] })
 				export class SharedModule {}
 			`,
 			"feature-b/shared.module.ts": `
 				import { Module } from '@nestjs/common';
-				@Module({})
+				@Module({ providers: [BService] })
 				export class SharedModule {}
 			`,
 		});
 		const graph = buildModuleGraph(project, paths);
-		expect(graph.modules.get("SharedModule")?.filePath).toBe(
-			"feature-b/shared.module.ts"
+		updateModuleGraphForFile(graph, project, "feature-a/shared.module.ts");
+		const shared = graph.modules.get("SharedModule");
+		expect(shared?.filePaths?.sort()).toEqual([
+			"feature-a/shared.module.ts",
+			"feature-b/shared.module.ts",
+		]);
+		expect(shared?.providers.sort()).toEqual(["AService", "BService"]);
+	});
+
+	it("unions a same-name module added later on the incremental path", () => {
+		const { project, paths } = createProject({
+			"feature-b/shared.module.ts": `
+				import { Module } from '@nestjs/common';
+				@Module({ providers: [BService] })
+				export class SharedModule {}
+			`,
+		});
+		const graph = buildModuleGraph(project, paths);
+		project.createSourceFile(
+			"feature-a/shared.module.ts",
+			`
+				import { Module } from '@nestjs/common';
+				@Module({ providers: [AService] })
+				export class SharedModule {}
+			`
 		);
 		updateModuleGraphForFile(graph, project, "feature-a/shared.module.ts");
-		expect(graph.modules.get("SharedModule")?.filePath).toBe(
-			"feature-b/shared.module.ts"
-		);
+		const shared = graph.modules.get("SharedModule");
+		expect(shared?.providers.sort()).toEqual(["AService", "BService"]);
+		expect(graph.providerToModule.get("AService")).toBe(shared);
 	});
 });


### PR DESCRIPTION
## Context

Two unrelated NestJS modules can share a class name — Nest wires modules by which class you import, not by name:

```
src/feature-a/shared.module.ts   @Module class SharedModule   (imports AModule)
src/feature-a/a.module.ts        @Module class AModule        (imports SharedModule)  ← a real cycle
src/feature-b/shared.module.ts   @Module class SharedModule   (unrelated)
```

nestjs-doctor stores modules in a map keyed by the name alone: `modules.set("SharedModule", node)`.

## Problem

A map key holds one value, so feature-b's `SharedModule` overwrites feature-a's — that module is erased from the analysis with everything it declared (#119). The rules then get wrong answers in both directions: the real cycle `AModule ↔ SharedModule` is not reported because one member no longer exists, and `AModule` — whose only importer was erased — is reported as an orphan. Nothing warns the user. Measured on 76 real projects: 5 affected, 6 declarations erased.

## Possible flows

| Path | After |
|---|---|
| Full build (`addModuleNode`) | same-name declarations always merge; the one-directory-only guard from #231 is deleted |
| Incremental update (public API + LSP) | merges too; its skip branch silently dropped re-added merges |
| Scan output | one warning per duplicated name, listing every declaration file |
| `no-circular-module-deps` | help names all declaration files of a multi-declared cycle head |
| Unique names, same-directory duplicates | unchanged |

## Solution

Merge instead of overwrite — the union machinery and the `filePaths` node shape already existed for same-directory duplicates (#231); this removes the directory condition and warns, per "degrade wider, never narrower".

Not done: keying the map by `${filePath}::${className}`, which would model the two modules as truly separate. The name is the identity in every published output (report-json, share manifest, report node map, Lab scripting, boot-trace timings from a live process that cannot know file paths), so a re-key changes the wire format for a 5-in-76 problem. Known ceiling of merging: two unrelated same-named modules whose combined imports close a false cycle — the warning makes that case diagnosable. One deliberate test flip: `wrapper-detection.test.ts` pinned the old overwrite with no recorded reason.

## Before vs after

| | Before | After |
|---|---|---|
| Cross-directory name collision | second declaration erased silently | merged, both files in `filePaths`, warned |
| The cycle above | hidden | reported |
| `AModule` | false orphan finding | clean |
| New fixture `duplicate-module-names` | test fails | passes (verified both ways) |

## Example

Running on the layout above:

```
$ nestjs-doctor ./dup-fixture
```

Before — the cycle is hidden and a false orphan appears:

```
  Project: dup-fixture | NestJS 10.0.0 | 2 modules
  ● Module 'AModule' is never imported by any other module.
```

After — the cycle is reported and the duplication is called out:

```
@Module class SharedModule is declared in 2 files (src/feature-a/shared.module.ts, src/feature-b/shared.module.ts); their imports, providers, and exports are analyzed as one module
  Project: dup-fixture | NestJS 10.0.0 | 2 modules
  ✗ Circular module dependency detected: AModule -> SharedModule
```

Closes #119.
