### PR TITLE
feat(report): report-ui export with shared-file adapter

### DIFF
--- a/.changeset/report-ui-export.md
+++ b/.changeset/report-ui-export.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": minor
+---
+
+Add a `nestjs-doctor/report-ui` export with the report's render seams, styles, page skeleton, and an adapter that expands a shared JSON file into the artifact shape, so other hosts can render report files in the browser.

--- a/packages/nestjs-doctor/package.json
+++ b/packages/nestjs-doctor/package.json
@@ -14,6 +14,10 @@
     "./api": {
       "types": "./dist/api/index.d.mts",
       "default": "./dist/api/index.mjs"
+    },
+    "./report-ui": {
+      "types": "./dist/report-ui/index.d.ts",
+      "default": "./dist/report-ui/index.js"
     }
   },
   "files": [

--- a/packages/nestjs-doctor/src/common/share.ts
+++ b/packages/nestjs-doctor/src/common/share.ts
@@ -8,6 +8,9 @@ import type { DiagnoseSummary, ProjectInfo, Score } from "./result.js";
 import type { SchemaRelation, SerializedSchemaEntity } from "./schema.js";
 import type { ScopeInfo } from "./scope.js";
 
+/** Version of the shared payload shape, stamped on every shared file. */
+export const SHARED_REPORT_VERSION = 1;
+
 /** A section the share flow can offer, with the count shown beside it. */
 export interface ShareSection {
 	count: number;

--- a/packages/nestjs-doctor/src/report/report-ui.ts
+++ b/packages/nestjs-doctor/src/report/report-ui.ts
@@ -1,0 +1,16 @@
+/** Browser-only surface for hosting the report UI outside the CLI page. */
+export type { ReportArtifact } from "../common/artifact.js";
+// biome-ignore lint/performance/noBarrelFile: this is the report-ui entry surface
+export { REPORT_ARTIFACT_VERSION } from "../common/artifact.js";
+export type { SharedReport } from "../common/share.js";
+export { SHARED_REPORT_VERSION } from "../common/share.js";
+export type { ParsedReportFile } from "./shared-view.js";
+export {
+	initialTab,
+	parseReportFile,
+	sharedHiddenTabs,
+	sharedReportToArtifact,
+} from "./shared-view.js";
+export * from "./ui/app/entry.js";
+export { getReportHtml } from "./ui/html.js";
+export { getReportStyles } from "./ui/styles.js";

--- a/packages/nestjs-doctor/src/report/share.ts
+++ b/packages/nestjs-doctor/src/report/share.ts
@@ -22,10 +22,10 @@ import type {
 	ShareManifest,
 	ShareSection,
 } from "../common/share.js";
+import { SHARED_REPORT_VERSION } from "../common/share.js";
 import { toRelativePath } from "../engine/fingerprint.js";
 import { buildSummary } from "../engine/result-builder.js";
 
-export const SHARED_REPORT_VERSION = 1;
 const SHARED_FILENAME = "nestjs-doctor-shared.json";
 
 const FINDINGS_PREFIX = "findings:";

--- a/packages/nestjs-doctor/src/report/shared-view.ts
+++ b/packages/nestjs-doctor/src/report/shared-view.ts
@@ -1,0 +1,165 @@
+import type {
+	ReportArtifact,
+	SerializedModuleGraph,
+} from "../common/artifact.js";
+import { REPORT_ARTIFACT_VERSION } from "../common/artifact.js";
+import type { EndpointGraph } from "../common/endpoint.js";
+import type { ProjectInfo, Score } from "../common/result.js";
+import type { SharedReport } from "../common/share.js";
+import { SHARED_REPORT_VERSION } from "../common/share.js";
+
+export type ParsedReportFile =
+	| { kind: "artifact"; artifact: ReportArtifact }
+	| { kind: "shared"; shared: SharedReport }
+	| { kind: "error"; error: string };
+
+const NOT_A_REPORT =
+	"This file is not a nestjs-doctor report. Load a report-json artifact or a shared file from the report's share dialog.";
+const NEWER_FILE =
+	"This file was made by a newer nestjs-doctor than this page understands. Regenerate it, or try again once the site updates.";
+
+/** Classifies a report-json artifact vs a shared file by its version keys. */
+export function parseReportFile(text: string): ParsedReportFile {
+	let data: unknown;
+	try {
+		data = JSON.parse(text);
+	} catch {
+		return { kind: "error", error: NOT_A_REPORT };
+	}
+	if (typeof data !== "object" || data === null || Array.isArray(data)) {
+		return { kind: "error", error: NOT_A_REPORT };
+	}
+	const record = data as Record<string, unknown>;
+	if ("schemaVersion" in record) {
+		if (record.schemaVersion !== REPORT_ARTIFACT_VERSION) {
+			return { kind: "error", error: NEWER_FILE };
+		}
+		return { kind: "artifact", artifact: data as ReportArtifact };
+	}
+	if (typeof record.version === "number" && Array.isArray(record.sections)) {
+		if (record.version !== SHARED_REPORT_VERSION) {
+			return { kind: "error", error: NEWER_FILE };
+		}
+		return { kind: "shared", shared: data as SharedReport };
+	}
+	return { kind: "error", error: NOT_A_REPORT };
+}
+
+const EMPTY_SCORE: Score = { label: "", value: 0 };
+
+function sharedGraph(shared: SharedReport): SerializedModuleGraph {
+	const modules = shared.modules;
+	if (!modules) {
+		return {
+			bootstrapRoots: [],
+			circularDepRecommendations: {},
+			circularDeps: [],
+			edges: [],
+			modules: [],
+			projects: [],
+			timingsAvailable: false,
+			timingsTrace: {},
+		};
+	}
+	return {
+		bootstrapRoots: modules.bootstrapRoots ?? [],
+		circularDepRecommendations: {},
+		circularDeps: modules.circularDeps,
+		edges: modules.edges,
+		modules: modules.modules,
+		projects: modules.projects,
+		timingsAvailable: false,
+		timingsTrace: {},
+	};
+}
+
+function sharedEndpoints(shared: SharedReport): EndpointGraph {
+	return {
+		endpoints: (shared.endpoints ?? []).map((endpoint) => ({
+			...endpoint,
+			dependencies: [],
+			endLine: 0,
+			filePath: "",
+			line: 0,
+			returnType: null,
+			swagger: null,
+		})),
+	};
+}
+
+/** Expands a shared file into the artifact shape the report app renders. */
+export function sharedReportToArtifact(shared: SharedReport): ReportArtifact {
+	const project: ProjectInfo = shared.project ?? {
+		fileCount: 0,
+		framework: null,
+		moduleCount: shared.modules?.modules.length ?? 0,
+		name: "shared report",
+		nestVersion: null,
+		orm: null,
+	};
+	const score = shared.score ?? EMPTY_SCORE;
+	return {
+		diagnostics: [...shared.findings, ...shared.schemaIssues],
+		elapsedMs: 0,
+		endpoints: sharedEndpoints(shared),
+		examples: {},
+		generatedAt: shared.generatedAt,
+		generator: shared.generator,
+		graph: sharedGraph(shared),
+		monorepo: false,
+		project,
+		providers: [],
+		ruleErrors: [],
+		schema: shared.schema ?? { entities: [], orm: "", relations: [] },
+		schemaVersion: REPORT_ARTIFACT_VERSION,
+		scope: shared.scope,
+		score,
+		share: {
+			filename: "nestjs-doctor-shared.json",
+			findingsByCategory: {},
+			project,
+			score,
+			sections: [],
+			version: shared.version,
+		},
+		sources: {},
+		summary: shared.summary,
+	};
+}
+
+/** Tabs a shared file cannot fill; schema and endpoints hide on their own. */
+export function sharedHiddenTabs(shared: SharedReport): string[] {
+	const hidden = ["lab"];
+	if (!shared.sections.includes("score")) {
+		hidden.push("summary");
+	}
+	if (!shared.sections.some((section) => section.startsWith("findings:"))) {
+		hidden.push("diagnosis");
+	}
+	if (!shared.sections.includes("modules")) {
+		hidden.push("modules");
+	}
+	return hidden;
+}
+
+const TAB_ORDER = ["summary", "diagnosis", "modules", "endpoints", "schema"];
+
+/** First tab that has something to show, mirroring the tab bar's hiding. */
+export function initialTab(
+	artifact: ReportArtifact,
+	hiddenTabs: string[]
+): string {
+	for (const tab of TAB_ORDER) {
+		if (hiddenTabs.includes(tab)) {
+			continue;
+		}
+		if (tab === "schema" && artifact.schema.entities.length === 0) {
+			continue;
+		}
+		if (tab === "endpoints" && artifact.endpoints.endpoints.length === 0) {
+			continue;
+		}
+		return tab;
+	}
+	return "summary";
+}

--- a/packages/nestjs-doctor/src/report/ui/app/entry.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/entry.tsx
@@ -25,6 +25,13 @@ import { SummaryTab } from "./templates/summary.js";
 
 const roots = new Map<string, Root>();
 
+/** Host-supplied tweaks for embedding the report outside the CLI page. */
+export interface ChromeOptions {
+	hiddenTabs?: string[];
+	hideShare?: boolean;
+	onLoadAnother?: () => void;
+}
+
 // Renders synchronously so callers can read the DOM right after, like the
 // string renderers they replace.
 function mount(containerId: string, node: ReactNode): void {
@@ -90,9 +97,29 @@ export function labOpened(): void {
 	labOpenedImpl();
 }
 
-export function renderChrome(report: ReportArtifact): void {
-	mount("header-row1", <HeaderRow report={report} />);
-	mount("header-row2", <TabBar report={report} />);
+export function renderChrome(
+	report: ReportArtifact,
+	options: ChromeOptions = {}
+): void {
+	mount(
+		"header-row1",
+		<HeaderRow
+			hideShare={options.hideShare}
+			onLoadAnother={options.onLoadAnother}
+			report={report}
+		/>
+	);
+	mount(
+		"header-row2",
+		<TabBar hiddenTabs={options.hiddenTabs} report={report} />
+	);
+}
+
+export function unmountAll(): void {
+	for (const root of roots.values()) {
+		root.unmount();
+	}
+	roots.clear();
 }
 
 export function setActiveTab(name: string): void {

--- a/packages/nestjs-doctor/src/report/ui/app/organisms/header.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/organisms/header.tsx
@@ -168,7 +168,15 @@ function ShareDialog({
 	);
 }
 
-export function HeaderRow({ report }: { report: ReportArtifact }) {
+export function HeaderRow({
+	hideShare,
+	onLoadAnother,
+	report,
+}: {
+	hideShare?: boolean;
+	onLoadAnother?: () => void;
+	report: ReportArtifact;
+}) {
 	const [shareOpen, setShareOpen] = useState(false);
 	const project = report.project;
 	const boot = bootBadge(report);
@@ -194,9 +202,11 @@ export function HeaderRow({ report }: { report: ReportArtifact }) {
 					<span className="meta-badge">{project.framework}</span>
 				)}
 				{project.orm && <span className="meta-badge">{project.orm}</span>}
-				<span className="meta-badge">
-					{report.graph.modules.length} modules
-				</span>
+				{report.graph.modules.length > 0 && (
+					<span className="meta-badge">
+						{report.graph.modules.length} modules
+					</span>
+				)}
 				{boot && (
 					// biome-ignore lint/a11y/noStaticElementInteractions: the badge is the click target, as in the report's CSS
 					// biome-ignore lint/a11y/noNoninteractiveElementInteractions: the badge is the click target, as in the report's CSS
@@ -218,13 +228,20 @@ export function HeaderRow({ report }: { report: ReportArtifact }) {
 			</div>
 			<div className="spacer" />
 			<div className="nav-actions">
-				<TextButton
-					classes="nav-btn"
-					id="nav-share"
-					onClick={() => setShareOpen((prev) => !prev)}
-				>
-					share
-				</TextButton>
+				{onLoadAnother && (
+					<TextButton classes="nav-btn" id="nav-load" onClick={onLoadAnother}>
+						load file
+					</TextButton>
+				)}
+				{!hideShare && (
+					<TextButton
+						classes="nav-btn"
+						id="nav-share"
+						onClick={() => setShareOpen((prev) => !prev)}
+					>
+						share
+					</TextButton>
+				)}
 				<a
 					className="nav-btn"
 					href="https://nestjs.doctor/docs"

--- a/packages/nestjs-doctor/src/report/ui/app/organisms/tab-bar.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/organisms/tab-bar.tsx
@@ -87,7 +87,13 @@ function switchTab(name: string): void {
 	(globalThis as { switchTab?: (name: string) => void }).switchTab?.(name);
 }
 
-export function TabBar({ report }: { report: ReportArtifact }) {
+export function TabBar({
+	hiddenTabs,
+	report,
+}: {
+	hiddenTabs?: string[];
+	report: ReportArtifact;
+}) {
 	const [active, setActive] = useState("summary");
 	const [withNotScored, setWithNotScored] = useState(false);
 	useLayoutEffect(() => {
@@ -105,6 +111,9 @@ export function TabBar({ report }: { report: ReportArtifact }) {
 	).length;
 
 	const hidden = (def: TabDef): boolean => {
+		if (hiddenTabs?.includes(def.tab)) {
+			return true;
+		}
 		if (def.tab === "schema") {
 			return report.schema.entities.length === 0;
 		}

--- a/packages/nestjs-doctor/tests/unit/report-dom.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-dom.test.ts
@@ -119,3 +119,33 @@ it("renders every tab into a DOM", () => {
 		expect(detail).toContain(variant);
 	}
 });
+
+it("renderChrome host options hide tabs and share and add load file", () => {
+	const dom = new JSDOM(`<body>${getReportHtml()}</body>`, {
+		runScripts: "outside-only",
+		pretendToBeVisual: true,
+	});
+	const win = dom.window as unknown as typeof globalThis & Window;
+	stubCanvas(win);
+	win.eval(getReportScripts(RICH_ARTIFACT_JSON));
+
+	// Baseline: the CLI page keeps its share button and every tab.
+	expect(win.document.getElementById("nav-share")).not.toBeNull();
+	expect(win.document.getElementById("nav-load")).toBeNull();
+	const tabStyle = (tab: string) =>
+		(win.document.querySelector(`[data-tab="${tab}"]`) as HTMLElement).style
+			.display;
+	expect(tabStyle("modules")).not.toBe("none");
+
+	(win as Record<string, unknown>).__report = JSON.parse(RICH_ARTIFACT_JSON);
+	(win as Record<string, unknown>).__onLoad = () => undefined;
+	win.eval(
+		"REPORT_APP.renderChrome(__report," +
+			" {hiddenTabs: ['modules', 'lab'], hideShare: true, onLoadAnother: __onLoad})"
+	);
+	expect(win.document.getElementById("nav-share")).toBeNull();
+	expect(win.document.getElementById("nav-load")).not.toBeNull();
+	expect(tabStyle("modules")).toBe("none");
+	expect(tabStyle("lab")).toBe("none");
+	expect(tabStyle("summary")).not.toBe("none");
+});

--- a/packages/nestjs-doctor/tests/unit/report-share.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-share.test.ts
@@ -7,6 +7,7 @@ import type {
 	Diagnostic,
 } from "../../src/common/diagnostic.js";
 import type { DiagnoseResult } from "../../src/common/result.js";
+import { SHARED_REPORT_VERSION } from "../../src/common/share.js";
 import { buildReportArtifact } from "../../src/report/artifact.js";
 import {
 	buildSharedReport,
@@ -18,7 +19,6 @@ import {
 	parseShareSections,
 	SCHEMA_SECTION,
 	SCORE_SECTION,
-	SHARED_REPORT_VERSION,
 	writeSharedReportFile,
 } from "../../src/report/share.js";
 

--- a/packages/nestjs-doctor/tests/unit/shared-view.test.ts
+++ b/packages/nestjs-doctor/tests/unit/shared-view.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import type {
+	CodeDiagnostic,
+	SchemaDiagnostic,
+} from "../../src/common/diagnostic.js";
+import type { SharedReport } from "../../src/common/share.js";
+import {
+	initialTab,
+	parseReportFile,
+	sharedHiddenTabs,
+	sharedReportToArtifact,
+} from "../../src/report/shared-view.js";
+
+const FINDING = {
+	category: "security",
+	column: 1,
+	filePath: "src/app.service.ts",
+	line: 3,
+	message: "hardcoded secret",
+	ruleId: "security/no-hardcoded-secrets",
+	severity: "error",
+} as CodeDiagnostic;
+
+const SCHEMA_ISSUE = {
+	category: "schema",
+	entity: "User",
+	message: "missing primary key",
+	ruleId: "schema/require-primary-key",
+	severity: "warning",
+} as SchemaDiagnostic;
+
+function shared(overrides: Partial<SharedReport> = {}): SharedReport {
+	return {
+		findings: [],
+		generatedAt: "2026-08-28T00:00:00.000Z",
+		generator: { name: "nestjs-doctor", version: "0.9.1" },
+		includeCode: false,
+		schemaIssues: [],
+		sections: [],
+		summary: {
+			byCategory: {
+				architecture: 0,
+				correctness: 0,
+				performance: 0,
+				schema: 0,
+				security: 0,
+			},
+			errors: 0,
+			info: 0,
+			total: 0,
+			warnings: 0,
+		},
+		version: 1,
+		...overrides,
+	};
+}
+
+describe("parseReportFile", () => {
+	it("classifies a report artifact by schemaVersion", () => {
+		const parsed = parseReportFile('{"schemaVersion":1,"project":{}}');
+		expect(parsed.kind).toBe("artifact");
+	});
+
+	it("classifies a shared file by version and sections", () => {
+		const parsed = parseReportFile(JSON.stringify(shared()));
+		expect(parsed.kind).toBe("shared");
+	});
+
+	it("rejects a newer artifact or shared file", () => {
+		for (const text of [
+			'{"schemaVersion":2}',
+			JSON.stringify(shared({ version: 2 })),
+		]) {
+			const parsed = parseReportFile(text);
+			expect(parsed.kind).toBe("error");
+			expect(parsed.kind === "error" && parsed.error).toContain("newer");
+		}
+	});
+
+	it("rejects non-report JSON and non-JSON text", () => {
+		for (const text of ['{"foo":1}', "[1,2]", "not json", "3"]) {
+			expect(parseReportFile(text).kind).toBe("error");
+		}
+	});
+});
+
+describe("sharedReportToArtifact", () => {
+	it("merges findings and schema issues into diagnostics", () => {
+		const artifact = sharedReportToArtifact(
+			shared({ findings: [FINDING], schemaIssues: [SCHEMA_ISSUE] })
+		);
+		expect(artifact.diagnostics).toEqual([FINDING, SCHEMA_ISSUE]);
+		expect(artifact.sources).toEqual({});
+		expect(artifact.providers).toEqual([]);
+	});
+
+	it("defaults the project and score when the score section was not shared", () => {
+		const artifact = sharedReportToArtifact(shared());
+		expect(artifact.project.name).toBe("shared report");
+		expect(artifact.score).toEqual({ label: "", value: 0 });
+	});
+
+	it("builds a graph from shared modules with timings off", () => {
+		const artifact = sharedReportToArtifact(
+			shared({
+				sections: ["modules"],
+				modules: {
+					circularDeps: [],
+					edges: [{ from: "AppModule", to: "UserModule" }],
+					modules: [
+						{
+							controllers: [],
+							exports: [],
+							filePath: "src/app.module.ts",
+							imports: ["UserModule"],
+							name: "AppModule",
+							providers: [],
+						},
+					],
+					projects: [],
+				},
+			})
+		);
+		expect(artifact.graph.modules).toHaveLength(1);
+		expect(artifact.graph.edges).toHaveLength(1);
+		expect(artifact.graph.timingsAvailable).toBe(false);
+		expect(artifact.project.moduleCount).toBe(1);
+	});
+
+	it("expands flat shared endpoints into endpoint nodes", () => {
+		const artifact = sharedReportToArtifact(
+			shared({
+				sections: ["endpoints"],
+				endpoints: [
+					{
+						controllerClass: "UserController",
+						handlerMethod: "findAll",
+						httpMethod: "GET",
+						routePath: "/users",
+					},
+				],
+			})
+		);
+		expect(artifact.endpoints.endpoints).toHaveLength(1);
+		const endpoint = artifact.endpoints.endpoints[0];
+		expect(endpoint.routePath).toBe("/users");
+		expect(endpoint.dependencies).toEqual([]);
+		expect(endpoint.swagger).toBeNull();
+	});
+});
+
+describe("sharedHiddenTabs", () => {
+	it("hides everything data-less for a score-only share", () => {
+		expect(sharedHiddenTabs(shared({ sections: ["score"] }))).toEqual([
+			"lab",
+			"diagnosis",
+			"modules",
+		]);
+	});
+
+	it("keeps diagnosis for a findings share and summary hidden", () => {
+		expect(
+			sharedHiddenTabs(shared({ sections: ["findings:security"] }))
+		).toEqual(["lab", "summary", "modules"]);
+	});
+
+	it("keeps modules when the modules section was picked", () => {
+		expect(sharedHiddenTabs(shared({ sections: ["modules"] }))).toEqual([
+			"lab",
+			"summary",
+			"diagnosis",
+		]);
+	});
+});
+
+describe("initialTab", () => {
+	it("walks the tab order past hidden and empty tabs", () => {
+		const scoreOnly = sharedReportToArtifact(shared({ sections: ["score"] }));
+		expect(
+			initialTab(scoreOnly, sharedHiddenTabs(shared({ sections: ["score"] })))
+		).toBe("summary");
+
+		const findingsOnly = shared({
+			sections: ["findings:security"],
+			findings: [FINDING],
+		});
+		expect(
+			initialTab(
+				sharedReportToArtifact(findingsOnly),
+				sharedHiddenTabs(findingsOnly)
+			)
+		).toBe("diagnosis");
+
+		const endpointsOnly = shared({
+			sections: ["endpoints"],
+			endpoints: [
+				{
+					controllerClass: "UserController",
+					handlerMethod: "findAll",
+					httpMethod: "GET",
+					routePath: "/users",
+				},
+			],
+		});
+		expect(
+			initialTab(
+				sharedReportToArtifact(endpointsOnly),
+				sharedHiddenTabs(endpointsOnly)
+			)
+		).toBe("endpoints");
+	});
+});

--- a/packages/nestjs-doctor/tsdown.config.ts
+++ b/packages/nestjs-doctor/tsdown.config.ts
@@ -47,4 +47,14 @@ export default defineConfig([
 		clean: false,
 		minify: true,
 	},
+	{
+		entry: { "report-ui/index": "src/report/report-ui.ts" },
+		format: ["esm"],
+		platform: "browser",
+		plugins: [rawText],
+		dts: true,
+		clean: false,
+		sourcemap: false,
+		minify: true,
+	},
 ]);

--- a/packages/nestjs-doctor/tsdown.config.ts
+++ b/packages/nestjs-doctor/tsdown.config.ts
@@ -51,6 +51,7 @@ export default defineConfig([
 		entry: { "report-ui/index": "src/report/report-ui.ts" },
 		format: ["esm"],
 		platform: "browser",
+		external: [/^react(\/|$)/, /^react-dom(\/|$)/, "scheduler"],
 		plugins: [rawText],
 		dts: true,
 		clean: false,


### PR DESCRIPTION
## Context

The report is a React 19 app since #342–#349, but it only ships baked into the self-contained HTML file: the package publishes `dist` with exports `.` and `./api`, and the app source never lands in `dist` as importable modules. The website is getting an online viewer that must render report files with the same components, including the reduced `nestjs-doctor-shared.json` the Share dialog downloads — which has a different schema from the artifact and no renderer anywhere.

## Problem

Nothing outside the CLI page can mount the report UI, and a shared JSON cannot be displayed at all. `SharedReport` lacks most keys the app reads (`sources`, `graph` timings, `EndpointGraph` nodes), and its version constant lived in `src/report/share.ts`, which imports `node:fs` and so cannot be pulled into a browser bundle.

## Possible flows

| Path into the changed code | Affected |
|---|---|
| CLI HTML report: `BOOT` → `REPORT_APP.renderChrome(REPORT)` | No — options default to `{}`; canonical DOM on all six tabs is byte-identical to main |
| jsdom seam tests (`report-dom.test.ts`) | Extended, existing case untouched |
| `--share-sections` / TUI / browser share builders reading `SHARED_REPORT_VERSION` | Constant moved to `src/common/share.ts`; `report/share.ts` consumers updated |
| A host importing `nestjs-doctor/report-ui` | New |

## Solution

A third tsdown entry bundles `src/report/report-ui.ts` (render seams, `getReportStyles`, `getReportHtml`, version constants) into `dist/report-ui/index.js` with react/react-dom external, exported as `"./report-ui"`. New `src/report/shared-view.ts` classifies a file (`parseReportFile`), expands a shared JSON into the artifact shape (`sharedReportToArtifact`), and names the tabs it cannot fill (`sharedHiddenTabs`, `initialTab`). `renderChrome` gains host options (`hiddenTabs`, `hideShare`, `onLoadAnother`) and `unmountAll()` tears the app down for hosts that remount.

Deliberately not done: porting the chrome floating-tooltip glue (its bindings no-op in shipped reports) and any change to the emitted HTML page.

## Before vs after

| | Before | After |
|---|---|---|
| Import the report UI from another package | Unreachable (`dist` has no app modules) | `import { renderChrome } from "nestjs-doctor/report-ui"` |
| Render a shared JSON | No renderer exists | `sharedReportToArtifact` + `sharedHiddenTabs` feed the same UI |
| CLI HTML report DOM | — | Unchanged (canonical diff empty on all six tabs) |
| Published files | `dist` | `dist` plus `dist/report-ui/` (~400 kB, react external) |

## Example

```
$ node -e "import('./packages/nestjs-doctor/dist/report-ui/index.js').then(m => console.log(Object.keys(m).join(' ')))"
```

Before: `Cannot find module '.../dist/report-ui/index.js'`

After:

```
REPORT_ARTIFACT_VERSION SHARED_REPORT_VERSION getReportHtml getReportStyles initialTab jumpToSlowestBoot labOpened openModule parseReportFile renderChrome renderDiagnosis renderEndpoints renderLab renderModules renderSchema renderSummary resizeEndpoints resizeModules setActiveTab setDiagnosisBadge sharedHiddenTabs sharedReportToArtifact unmountAll
```
