### PR TITLE
feat(report): labelled boot timeline in the trace dock

### DIFF
--- a/.changeset/boot-timeline-labels.md
+++ b/.changeset/boot-timeline-labels.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+The boot trace's phase strip becomes a labelled timeline: each segment shows a plain-language label and its duration in place, the technical lifecycle names move into the tooltips, and a note ties the per-class rows to the building-modules segment with the total at the end.

--- a/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
@@ -30,6 +30,7 @@ const HOOK_META: Record<string, { label: string; rgb: string }> = {
 };
 
 interface PhasePart {
+	gloss: string;
 	label: string;
 	ms: number;
 	rgb: string;
@@ -56,6 +57,7 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 	let prev = 0;
 	const push = (
 		label: string,
+		gloss: string,
 		end: number | undefined,
 		rgb: string,
 		tip: string
@@ -63,30 +65,34 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 		if (typeof end !== "number" || end <= prev) {
 			return;
 		}
-		parts.push({ label, ms: end - prev, rgb, tip });
+		parts.push({ gloss, label, ms: end - prev, rgb, tip });
 		prev = end;
 	};
 	push(
 		"create",
+		"building modules",
 		p.createMs,
 		"34,211,238",
-		"create — constructing providers and controllers"
+		"create — NestFactory constructs every module, provider, and controller. The rows below break this segment down per class."
 	);
 	if (typeof p.moduleInitMs === "number") {
 		push(
 			"onModuleInit",
+			"init hooks",
 			p.moduleInitMs,
 			"52,211,153",
-			"onModuleInit — hooks across all classes"
+			"onModuleInit — after construction, Nest calls each class's onModuleInit() hook"
 		);
 		push(
 			"onApplicationBootstrap",
+			"bootstrap hooks",
 			p.initMs,
 			"167,139,250",
-			"onApplicationBootstrap — hooks across all classes"
+			"onApplicationBootstrap — hooks that run once the whole app is wired, right before it listens"
 		);
 	} else {
 		push(
+			"lifecycle hooks",
 			"lifecycle hooks",
 			p.initMs,
 			"52,211,153",
@@ -96,17 +102,23 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 	if (typeof graph.startupMs === "number") {
 		let tail = {
 			label: "hooks + listen",
+			gloss: "hooks + port",
 			tip: "hooks + listen — everything after NestFactory.create",
 		};
 		if (typeof p.initMs === "number") {
-			tail = { label: "listen", tip: "listen — binding the HTTP server" };
+			tail = {
+				label: "listen",
+				gloss: "opening the port",
+				tip: "listen — the HTTP server binds its port; at the end of this segment the app is up",
+			};
 		} else if (typeof p.moduleInitMs === "number") {
 			tail = {
 				label: "bootstrap + listen",
+				gloss: "bootstrap + port",
 				tip: "bootstrap + listen — onApplicationBootstrap hooks and the server bind",
 			};
 		}
-		push(tail.label, graph.startupMs, "107,114,128", tail.tip);
+		push(tail.label, tail.gloss, graph.startupMs, "107,114,128", tail.tip);
 	}
 	return parts;
 }

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -1063,23 +1063,32 @@ function PhasesStrip({ graph }: { graph: SerializedModuleGraph }) {
 				{parts.map((seg) => (
 					<span
 						className="mg-phase-seg"
-						data-tip={seg.tip}
+						data-tip={`${seg.tip}. Took ${formatMs(seg.ms)}`}
 						key={seg.label}
 						style={{
 							width: `${((seg.ms / total) * 100).toFixed(2)}%`,
-							background: `rgba(${seg.rgb},0.4)`,
+							background: `rgba(${seg.rgb},0.35)`,
 						}}
-					/>
-				))}
-			</div>
-			<div className="mg-trace-note">
-				{parts.map((seg, index) => (
-					<span key={seg.label} style={{ display: "contents" }}>
-						{index > 0 ? " · " : ""}
-						<span style={{ color: `rgb(${seg.rgb})` }}>{seg.label}</span>{" "}
-						{formatMs(seg.ms)}
+					>
+						<span
+							className="mg-phase-label"
+							style={{ color: `rgb(${seg.rgb})` }}
+						>
+							{seg.gloss}{" "}
+							<span className="mg-phase-ms">{formatMs(seg.ms)}</span>
+						</span>
 					</span>
 				))}
+			</div>
+			<div className="mg-trace-note mg-phase-note">
+				<span>
+					▴ one timeline from launch to ready — the rows below detail{" "}
+					<span style={{ color: `rgb(${parts[0].rgb})` }}>
+						{parts[0].gloss}
+					</span>
+					, class by class
+				</span>
+				<span className="mg-phase-total">total {formatMs(total)}</span>
 			</div>
 		</div>
 	);
@@ -1789,7 +1798,7 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 							aria-label="How to read the trace"
 							className="mg-trace-info"
 							data-tip={
-								"How to read the trace\n• bars scale to the slowest row\n• yellow segment ≈ the class's own work\n• dimmed hollow bar = reused, built earlier\n• rows are the create phase\n• +ms chips = lifecycle hooks"
+								"How to read the trace\n• bars scale to the slowest row\n• yellow segment ≈ the class's own work\n• dimmed hollow bar = reused, built earlier\n• rows are the building-modules (create) segment\n• +ms chips = lifecycle hooks"
 							}
 							role="img"
 							// biome-ignore lint/a11y/noNoninteractiveTabindex: focusable on purpose so the tooltip opens from the keyboard

--- a/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
@@ -62,8 +62,12 @@
 #mg-trace-phases { display: none; padding: 8px 14px 2px; border-top: 1px solid var(--border); }
 #mg-dock.open[data-active="trace"] #mg-trace-phases:not(:empty) { display: block; }
 #mg-trace-phases .mg-trace-note { padding: 4px 0 0; }
-.mg-phase-strip { display: flex; gap: 2px; height: 10px; margin-bottom: 4px; }
-.mg-phase-seg { border-radius: 2px; min-width: 2px; }
+.mg-phase-strip { display: flex; gap: 2px; height: 20px; margin-bottom: 4px; }
+.mg-phase-seg { border-radius: 3px; min-width: 3px; display: flex; align-items: center; padding: 0 7px; overflow: hidden; }
+.mg-phase-label { font-size: 10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; letter-spacing: 0.02em; }
+.mg-phase-ms { color: var(--text-dim); }
+.mg-phase-note { display: flex; justify-content: space-between; gap: 12px; }
+.mg-phase-total { color: var(--text); white-space: nowrap; }
 #mg-trace-body {
   display: none; overflow-y: auto;
   border-top: 1px solid var(--border); padding: 6px 0;

--- a/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-scripts.test.ts
@@ -75,6 +75,8 @@ describe("report scripts", () => {
 
 	it("renders the lifecycle phase strip from the dump's markers", () => {
 		expect(scripts).toContain("mg-phase-strip");
+		expect(scripts).toContain("building modules");
+		expect(scripts).toContain("one timeline from launch to ready");
 		expect(scripts).toContain("lifecycle hooks");
 	});
 


### PR DESCRIPTION
## Context

The boot trace dock opens with a phase strip: a thin colored bar splitting time-to-start into the Nest lifecycle phases, captioned `create 210ms · onModuleInit 833ms · onApplicationBootstrap 136ms · listen 282ms`. Readers who don't know the Nest lifecycle can't tell what the segments mean, or that the per-class rows underneath belong to the first one.

## Problem

The strip is unlabelled (10px tall, colors only), the caption sits detached below it in lifecycle jargon, and nothing says which segment the rows detail. Builds on #352 (merged), which restored the tooltips this UI leans on.

## Possible flows

| Path | Affected |
|---|---|
| Boot trace dock with full phase markers | The new labelled timeline |
| Dump without markers (no createMs) | Unchanged — no strip, as before |
| Partial markers (merged segments) | Same layout, merged labels get glosses too |
| Header time-to-start badge tooltip | Unchanged — keeps the technical phase names |

## Solution

The strip becomes one labelled timeline: each segment is 20px tall and carries a plain-language label with its duration in place (`building modules 210ms`, `init hooks 833ms`, `bootstrap hooks 136ms`, `opening the port 282ms`); narrow segments clip and their tooltip completes them. The technical lifecycle names move into the tooltips with an explanation and the duration (`onApplicationBootstrap — hooks that run once the whole app is wired, right before it listens. Took 136ms`). The caption becomes a note that ties the rows to the timeline (`▴ one timeline from launch to ready — the rows below detail building modules, class by class`) with `total 1463ms` on the right. `phaseParts` gains a `gloss` field; the wire shape is untouched.

Deliberately not done: changing the per-class rows or the dump format.

## Before vs after

| | Before | After |
|---|---|---|
| Segment meaning | Color only, jargon caption below | Label and duration on the segment, explanation in its tooltip |
| Where the rows fit | Unstated | The note names the building-modules segment |
| Total | Absent from the strip | `total 1463ms` at the note's right edge |
| No-markers dump | No strip | No strip (unchanged) |

## Example

Open the demo monorepo report, click `time to start ≈ 1463ms`.

Before: a 10px color bar over `create 210ms · onModuleInit 833ms · onApplicationBootstrap 136ms · listen 282ms`.

After: `building modules 210ms | init hooks 833ms | bootstrap hooks 136ms | opening the port 282ms` on the bar itself, the note underneath, and hovering a segment explains it in a sentence. Verified in Chrome on the website viewer.
