### PR TITLE
feat(report): time axis and inline durations in the boot trace

### DIFF
--- a/.changeset/trace-axis-inline.md
+++ b/.changeset/trace-axis-inline.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+The boot trace gains a time axis above the rows (round-number cuts from 0 to the slowest class, each projecting a dotted reference line through the bars) and every class row now carries its duration inline at the end of its bar, inside it when the bar nearly fills the track. The right-hand time column is gone.

--- a/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
@@ -179,10 +179,14 @@ function traceBarHtml(
 ): string {
 	const frac = Math.max(0, Math.min(1, initTime / traceMax));
 	const width = (frac * 100).toFixed(2);
+	const inline =
+		`<span class="mg-trace-inline${frac > 0.8 ? " inside" : ""}"` +
+		` style="left:${width}%">${escapeHtml(formatMs(initTime))}</span>`;
 	if (hollowTip) {
 		return (
 			`<span class="mg-trace-track" data-tip="${escapeHtml(`${formatMs(initTime)} total — ${hollowTip}`)}">` +
 			`<span class="mg-trace-bar" style="width:${width}%;background:transparent;box-shadow:inset 0 0 0 1px rgba(${traceColor(type)},0.5)"></span>` +
+			inline +
 			"</span>"
 		);
 	}
@@ -211,8 +215,33 @@ function traceBarHtml(
 		(selfFrac > 0.002
 			? `<span class="mg-trace-self" style="left:${((frac - selfFrac) * 100).toFixed(2)}%;width:${(selfFrac * 100).toFixed(2)}%"></span>`
 			: "") +
+		inline +
 		"</span>"
 	);
+}
+
+// Round tick spacing so axis cuts land on 1/2/5-style values.
+export function axisStep(maxMs: number): number {
+	const raw = maxMs / 4;
+	const pow = 10 ** Math.floor(Math.log10(Math.max(raw, 0.001)));
+	for (const m of [5, 2, 1]) {
+		if (m * pow <= raw) {
+			return m * pow;
+		}
+	}
+	return pow;
+}
+
+export function axisTicks(maxMs: number): number[] {
+	if (maxMs <= 0) {
+		return [];
+	}
+	const step = axisStep(maxMs);
+	const ticks: number[] = [];
+	for (let t = step; t < maxMs * 0.92; t += step) {
+		ticks.push(t);
+	}
+	return ticks;
 }
 
 export function traceRowHtml(
@@ -278,7 +307,6 @@ export function traceRowHtml(
 			node.type,
 			mark ? mark.bar : null
 		) +
-		`<span class="mg-trace-time">${escapeHtml(formatMs(node.initTime))}</span>` +
 		"</div>"
 	);
 }

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -1,4 +1,5 @@
 import {
+	type CSSProperties,
 	type MouseEvent as ReactMouseEvent,
 	type ReactNode,
 	useEffect,
@@ -30,6 +31,8 @@ import {
 	ModulesCanvas,
 } from "../lib/modules-canvas.js";
 import {
+	axisStep,
+	axisTicks,
 	formatMs,
 	hookChipHtml,
 	phaseParts,
@@ -928,6 +931,31 @@ function InfoPop({
 	);
 }
 
+function TraceAxis({ maxMs }: { maxMs: number }) {
+	if (maxMs <= 0) {
+		return <div id="mg-trace-axis" />;
+	}
+	return (
+		<div id="mg-trace-axis">
+			<span className="mg-trace-label">
+				<span className="mg-axis-zero">0</span>
+			</span>
+			<span className="mg-trace-track">
+				{axisTicks(maxMs).map((tick) => (
+					<span
+						className="mg-axis-tick"
+						key={tick}
+						style={{ left: `${((tick / maxMs) * 100).toFixed(2)}%` }}
+					>
+						{formatMs(tick)}
+					</span>
+				))}
+				<span className="mg-axis-end">{formatMs(maxMs)}</span>
+			</span>
+		</div>
+	);
+}
+
 // The trace body keeps the shipped renderer: rows come from traceRowHtml and
 // expansion splices child rows in place, exactly like the script chunk did.
 function TraceBody({
@@ -1281,6 +1309,16 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 	const nodeMap = controller ? controller.nodeMap : {};
 	const importers = controller ? controller.importers : {};
 	const selected = selectedName ? (nodeMap[selectedName] ?? null) : null;
+	const traceMod =
+		selected &&
+		!selected.external &&
+		graph.timingsAvailable &&
+		selected.initTimings?.length
+			? selected
+			: null;
+	const traceMax = traceMod?.initTimings
+		? Math.max((traceMod.initTimings[0] as { initTime: number }).initTime, 0)
+		: 0;
 
 	const byProject: Record<string, MgNode[]> = {};
 	for (const n of nodes) {
@@ -1748,6 +1786,14 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 					className={dockOpen ? "open" : undefined}
 					data-active={dockActive}
 					id="mg-dock"
+					style={
+						{
+							"--mg-tick":
+								traceMax > 0
+									? `${((axisStep(traceMax) / traceMax) * 100).toFixed(3)}%`
+									: "200%",
+						} as CSSProperties
+					}
 				>
 					{/* biome-ignore lint/a11y/noStaticElementInteractions: the whole header is the click target, as in the report's CSS */}
 					{/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: the whole header is the click target, as in the report's CSS */}
@@ -1842,6 +1888,7 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 						)}
 					</div>
 					<PhasesStrip graph={graph} />
+					<TraceAxis maxMs={traceMax} />
 					<TraceBody
 						graph={graph}
 						node={selected}

--- a/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
@@ -82,7 +82,24 @@
 .mg-trace-track { position: relative; flex: 1; height: 12px; background: rgba(255,255,255,0.03); border-radius: 2px; }
 .mg-trace-bar { position: absolute; left: 0; top: 1px; height: 10px; border-radius: 2px; background: rgba(34,211,238,0.35); min-width: 2px; }
 .mg-trace-self { position: absolute; top: 1px; height: 10px; border-radius: 2px; background: #fbbf24; }
-.mg-trace-time { width: 64px; flex-shrink: 0; text-align: right; color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.mg-trace-inline {
+  position: absolute; top: 0; line-height: 12px; font-size: 10px; color: var(--text-dim);
+  padding-left: 6px; white-space: nowrap; font-variant-numeric: tabular-nums; pointer-events: none;
+}
+.mg-trace-inline.inside { transform: translateX(-100%); padding-left: 0; padding-right: 6px; color: #eee; text-shadow: 0 1px 2px rgba(0,0,0,0.9), 0 0 3px rgba(0,0,0,0.7); }
+#mg-trace-axis { display: none; align-items: flex-end; gap: 10px; padding: 6px 14px 2px; font-size: 9px; color: var(--text-dim); }
+#mg-dock.open[data-active="trace"] #mg-trace-axis:not(:empty) { display: flex; }
+#mg-trace-axis .mg-trace-label { width: 300px; flex-shrink: 0; }
+#mg-trace-axis .mg-trace-track { background: none; height: 12px; }
+.mg-axis-zero { margin-left: auto; font-variant-numeric: tabular-nums; }
+.mg-axis-tick {
+  position: absolute; bottom: 0; transform: translateX(-50%);
+  font-variant-numeric: tabular-nums; white-space: nowrap;
+}
+.mg-axis-end { position: absolute; right: 0; bottom: 0; color: var(--text); font-variant-numeric: tabular-nums; }
+.mg-trace-row .mg-trace-track {
+  background-image: repeating-linear-gradient(to right, rgba(255,255,255,0.09) 0 1px, transparent 1px var(--mg-tick, 200%));
+}
 .mg-trace-note { padding: 4px 14px; font-size: 11px; color: var(--text-dim); }
 .mg-trace-caret {
   width: 12px; flex-shrink: 0; display: inline-block;

--- a/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+	axisStep,
+	axisTicks,
 	formatMs,
 	type TraceMap,
 	traceRowHtml,
@@ -32,6 +34,35 @@ describe("traceRowHtml", () => {
 	it("never marks a top-level row as reused", () => {
 		expect(row("ta", 0, "ta")).not.toContain("mg-trace-reused");
 		expect(row("tb", 0, "tb")).not.toContain("mg-trace-reused");
+	});
+
+	it("labels every bar with its time inline", () => {
+		expect(row("ta", 0, "ta")).toContain(
+			`<span class="mg-trace-inline" style="left:0.90%">&lt;1ms</span>`
+		);
+		expect(row("tb", 0, "tb")).toContain("mg-trace-inline");
+	});
+
+	it("moves the label inside the bar when it nearly fills the track", () => {
+		expect(traceRowHtml(trace, 67, "tb", 0, "tb")).toContain(
+			"mg-trace-inline inside"
+		);
+	});
+});
+
+describe("axis ticks", () => {
+	it("cuts at round steps below the maximum", () => {
+		expect(axisStep(463)).toBe(100);
+		expect(axisTicks(463)).toEqual([100, 200, 300, 400]);
+	});
+
+	it("scales down for fast boots", () => {
+		expect(axisStep(1.9)).toBe(0.2);
+		expect(axisTicks(1.9)[0]).toBe(0.2);
+	});
+
+	it("returns nothing without a positive maximum", () => {
+		expect(axisTicks(0)).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
## Context

The boot trace dock shows per-class bars scaled to the slowest class, with each duration in a fixed column at the far right of the row. #353 gave the phase strip above it labels; the rows still had no scale of their own.

## Problem

The bars have no axis, so a bar's length means nothing absolute; the duration sits detached at the row's far edge; and there is no visual reference connecting a bar's end to a time. Stacks on #353.

## Possible flows

| Path | Affected |
|---|---|
| Trace dock with a selected timed module | Axis, gridlines, and inline durations |
| Expanded dependency rows | Same inline durations and gridlines |
| Module without timing data | Unchanged — the note, no axis |
| Phase strip and header badge | Untouched |

## Solution

An axis row renders between the strip and the rows, reusing the row flex layout so it aligns with the bar track by construction: cuts at round 1/2/5-style steps from 0 to the slowest class (`0 · 100ms · 200ms · 300ms · 400ms · 463ms`), the maximum right-aligned. One `--mg-tick` variable on the dock drives a repeating background gradient on every row's track, so each cut projects a dotted vertical reference line through all bars, expanded rows included. Durations move inline to the end of each bar (`54ms` after a short bar), flipping inside the bar with a dark halo when it nearly fills the track (`463ms`); the right-hand time column is removed. `axisStep`/`axisTicks` are unit-tested.

Deliberately not done: changing the row scale (still the slowest class, not time-to-start) or the bar semantics.

## Before vs after

| | Before | After |
|---|---|---|
| Bar scale | Implicit | Axis with round cuts, 0 to the slowest class |
| Reading a bar's end | Eyeball to the far-right number | Dotted gridline to the nearest cut, duration at the bar |
| Duration placement | Fixed 64px right column | Inline at the bar end, inside when it barely fits |
| Module without timings | Note only | Note only (unchanged) |

## Example

Demo monorepo report, boot badge, expand PaymentsService.

Before: bars with `463ms / 231ms / 54ms / 1.9ms` in a right column, no axis.

After: an axis reading `0 100ms 200ms 300ms 400ms 463ms`, dotted lines through the rows at each cut, and each bar labelled at its end. Verified in Chrome on the website viewer.
