### PR TITLE
chore: release the boot trace as 0.9.2

### DIFF
--- a/.changeset/boot-timeline-labels.md
+++ b/.changeset/boot-timeline-labels.md
@@ -1,5 +1,0 @@
----
-"nestjs-doctor": patch
----
-
-The boot trace's phase strip becomes a labelled timeline: each segment shows a plain-language label and its duration in place, the technical lifecycle names move into the tooltips, and a note ties the per-class rows to the building-modules segment with the total at the end.

--- a/.changeset/report-boot-timeline.md
+++ b/.changeset/report-boot-timeline.md
@@ -1,9 +1,21 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
-The report's two boot timelines, the phase strip and the per-module bar list, are replaced by one Boot trace tab in the style of an APM waterfall. It wears the same shell as the Modules graph, Endpoints, and Schema tabs: a sidebar-style label column with the module tree, its count, expand and collapse, and a filter, then lanes with the lifecycle phases carrying the viewport window and the time axis.
+### Highlights
 
-Every class sits at its real offset from boot start, grouped by module and colored by type. The lanes zoom on wheel, pan on axis drag, and frame a phase on click. Dependency cascades open level by level as shadow rows, a hover card follows the pointer over a bar, and the label column drags to resize and hides like the graph's sidebar.
+- **Boot trace tab** — `--timings` gets its own tab: every class at its real offset from boot start on one absolute axis, grouped by module and colored by type, with the lifecycle phases above the rows carrying the viewport window. Scroll to zoom, drag the axis to pan, click a phase to frame it.
+- **Dependency cascades** — a class row opens level by level into what it waited on. A class already costed above reappears as a `deduped` shadow, and selecting the shadow jumps to its own row.
+- **Hover card** — one card follows the pointer over a bar or a hook span, on a diagonal tether, with the class, what it waited on, its module and type, and its time.
+- **Modules graph** — nodes show `build` and hook time on separate lines (`104ms build`, `63ms init`) instead of one raw number. The dock keeps a compact mount of the trace, and selecting a class there selects its module on the graph and back.
 
-The Modules graph dock keeps a compact mount of the same timeline on the same axis, and module nodes show the build of their slowest class plus their hook time. Dumps whose hook timings carry `startMs` render hooks as labelled spans; older dumps keep duration chips. The `report-ui` entry now exports `renderBoot` and `focusBootTrace` for the tab, in place of `jumpToSlowestBoot`.
+### Behavior changes
+
+- The header `time to start` badge and the phase strip are gone; the tab's overview lane carries the phases.
+- Hook timings render as spans at their real offset when the dump carries `startMs`, which the documented `main.ts` snippet now records. Older dumps keep the `+120ms init` chips.
+- `nestjs-doctor/report-ui` exports `renderBoot` and `focusBootTrace` in place of `jumpToSlowestBoot`.
+
+### Fixed
+
+- A module node showed its slowest class's raw `initTime`, which included time spent waiting on dependencies: `DatabaseModule · 142ms` was `104ms build` plus `63ms init` after 38ms waiting on `ConfigService`.
+- Collapsing a module group in the trace dock toggled a class and hid nothing.

--- a/.changeset/report-ui-export.md
+++ b/.changeset/report-ui-export.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Add a `nestjs-doctor/report-ui` export with the report's render seams, styles, page skeleton, and an adapter that expands a shared JSON file into the artifact shape, so other hosts can render report files in the browser.

--- a/.changeset/shareable-reports.md
+++ b/.changeset/shareable-reports.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Shareable reports. Pick which sections to share — the health score, findings per category, the relational schema, the module graph, endpoints — and whether to include code snippets, from the post-scan menu or the report's new share button; both write a `nestjs-doctor-shared.json`. Also available non-interactively via `--share-sections score,findings:security` and `--share-code`.

--- a/.changeset/trace-axis-inline.md
+++ b/.changeset/trace-axis-inline.md
@@ -1,5 +1,0 @@
----
-"nestjs-doctor": patch
----
-
-The boot trace gains a time axis above the rows (round-number cuts from 0 to the slowest class, each projecting a dotted reference line through the bars) and every class row now carries its duration inline at the end of its bar, inside it when the bar nearly fills the track. The right-hand time column is gone.


### PR DESCRIPTION
## Context

Main carries twenty pending changesets, three of them `minor`, so the open Version Packages PR (#312) is cutting 0.10.0. The boot trace landed across three PRs on one branch, each with its own changeset describing a state the next one replaced.

## Problem

The release notes would read as three contradictory entries for one feature: a phase strip becomes a labelled timeline, then gains an inline axis, then is replaced by a tab. And the version would be 0.10.0 for what is a report release.

## Solution

One changeset for the boot trace, written in the grouped style of the 0.9.0 notes, and every pending bump set to `patch` so the next version is 0.9.2. `report-ui-export` and `shareable-reports` were the other two `minor` changesets; only their bump type changed.

## Before vs after

| | Before | After |
|---|---|---|
| Next version | 0.10.0 | 0.9.2 |
| Boot trace changesets | `boot-timeline-labels`, `trace-axis-inline`, `report-boot-timeline` | `report-boot-timeline` |
| Other 17 changesets | unchanged | unchanged |

## Changelog

### Highlights

- **Boot trace tab** — `--timings` gets its own tab: every class at its real offset from boot start on one absolute axis, grouped by module and colored by type, with the lifecycle phases above the rows carrying the viewport window. Scroll to zoom, drag the axis to pan, click a phase to frame it.
- **Dependency cascades** — a class row opens level by level into what it waited on. A class already costed above reappears as a `deduped` shadow, and selecting the shadow jumps to its own row.
- **Hover card** — one card follows the pointer over a bar or a hook span, on a diagonal tether, with the class, what it waited on, its module and type, and its time.
- **Modules graph** — nodes show `build` and hook time on separate lines (`104ms build`, `63ms init`) instead of one raw number. The dock keeps a compact mount of the trace, and selecting a class there selects its module on the graph and back.

### Behavior changes

- The header `time to start` badge and the phase strip are gone; the tab's overview lane carries the phases.
- Hook timings render as spans at their real offset when the dump carries `startMs`, which the documented `main.ts` snippet now records. Older dumps keep the `+120ms init` chips.
- `nestjs-doctor/report-ui` exports `renderBoot` and `focusBootTrace` in place of `jumpToSlowestBoot`.

### Fixed

- A module node showed its slowest class's raw `initTime`, which included time spent waiting on dependencies: `DatabaseModule · 142ms` was `104ms build` plus `63ms init` after 38ms waiting on `ConfigService`.
- Collapsing a module group in the trace dock toggled a class and hid nothing.
