### PR TITLE
fix(report): boot trace groups package classes under their runtime module

### DIFF
--- a/.changeset/boot-trace-external-modules.md
+++ b/.changeset/boot-trace-external-modules.md
@@ -4,9 +4,10 @@
 
 ### Fixed
 
-- **Package classes in the boot trace.** Every timed class now sits under the module that owns it in the dump. Classes from package modules (`TypeOrmCoreModule`, one `TypeOrmModule` per `forFeature`, `BullModule`, `ConfigHostModule`) get their own groups with an `external` tag instead of one `unattributed` list, so the `DataSource` that owns most of a boot is no longer hidden. The hover card names the module that imports a package module when there is exactly one.
+- The boot trace listed every class from a package module (`TypeOrmCoreModule`, `TypeOrmModule`, `BullModule`, `ConfigHostModule`) in one `unattributed` group, which hid the `DataSource` that owns most of a boot. Those classes now group under the module name the dump gives them, with an `external` tag. Instances that share a name, such as one `TypeOrmModule` per `forFeature`, merge into one group. The hover card names the module that imports a non-global package module when exactly one does.
+- A user module whose name repeats, in the dump or across a monorepo's projects, groups under its bare name with an `ambiguous` tag instead of `unattributed`.
 
 ### Behavior changes
 
-- The `--timings` warning about module names that appear more than once in the dump is gone; those classes are no longer dropped.
+- The `--timings` warning about module names that appear more than once is gone. Those classes group under that name in the trace and still do not attach to a graph module node.
 - `--format report-json` trace nodes carry `module` and, when known, `via`.

--- a/.changeset/boot-trace-external-modules.md
+++ b/.changeset/boot-trace-external-modules.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- The boot trace listed every class from a package module (`TypeOrmCoreModule`, `TypeOrmModule`, `BullModule`, `ConfigHostModule`) in one `unattributed` group, which hid the `DataSource` that owns most of a boot. Those classes now group under the module name the dump gives them, with an `external` tag. Instances that share a name, such as one `TypeOrmModule` per `forFeature`, merge into one group. The hover card names the module that imports a non-global package module when exactly one does.
+- The boot trace listed every class from a package module (`TypeOrmCoreModule`, `TypeOrmModule`, `BullModule`, `ConfigHostModule`) in one `unattributed` group, which hid the `DataSource` that owns most of a boot. Those classes now group under the module name the dump gives them, with an `external` tag. Instances that share a name, such as one `TypeOrmModule` per `forFeature`, merge into one group. The hover card names the module that imported a non-global package module instance, when exactly one did.
 - A user module whose name repeats, in the dump or across a monorepo's projects, groups under its bare name with an `ambiguous` tag instead of `unattributed`.
 
 ### Behavior changes

--- a/.changeset/boot-trace-external-modules.md
+++ b/.changeset/boot-trace-external-modules.md
@@ -1,0 +1,12 @@
+---
+"nestjs-doctor": patch
+---
+
+### Fixed
+
+- **Package classes in the boot trace.** Every timed class now sits under the module that owns it in the dump. Classes from package modules (`TypeOrmCoreModule`, one `TypeOrmModule` per `forFeature`, `BullModule`, `ConfigHostModule`) get their own groups with an `external` tag instead of one `unattributed` list, so the `DataSource` that owns most of a boot is no longer hidden. The hover card names the module that imports a package module when there is exactly one.
+
+### Behavior changes
+
+- The `--timings` warning about module names that appear more than once in the dump is gone; those classes are no longer dropped.
+- `--format report-json` trace nodes carry `module` and, when known, `via`.

--- a/packages/nestjs-doctor/skills/nestjs-boot-trace/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-boot-trace/SKILL.md
@@ -99,11 +99,12 @@ classes. Its hook time is the total across the module's classes, for example
 `104ms build · 63ms init`.
 
 Classes from package modules (`TypeOrmCoreModule`, `BullModule`,
-`ConfigHostModule`) sit in their own groups with an `external` tag. A slow boot
-often lives there: `DataSource` in `TypeOrmCoreModule` is the database
-connection, and every repository waits on it. When a package module has
-exactly one importer the hover card names it, which is where `forFeature` or
-`registerQueue` was called.
+`ConfigHostModule`) sit in their own groups with an `external` tag. The slow
+part of a boot is often there: `DataSource` in `TypeOrmCoreModule` is the
+database connection, and every repository waits on it. When a non-global
+package module has exactly one importer the hover card names it, which is
+where `forFeature` or `registerQueue` was called. Global ones such as
+`TypeOrmCoreModule` and `ConfigHostModule` never name an importer.
 
 ## 5. Put main.ts back
 

--- a/packages/nestjs-doctor/skills/nestjs-boot-trace/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-boot-trace/SKILL.md
@@ -96,15 +96,16 @@ time. If `UsersService` reads 120ms and the `SlowService` it injects reads 119ms
 
 A module node shows the build of its slowest class, never a sum across
 classes. Its hook time is the total across the module's classes, for example
-`104ms build · 63ms init`.
+`104ms build · 63ms init`. A package node keeps its `package` line and shows
+its time in the tooltip.
 
 Classes from package modules (`TypeOrmCoreModule`, `BullModule`,
 `ConfigHostModule`) sit in their own groups with an `external` tag. The slow
 part of a boot is often there: `DataSource` in `TypeOrmCoreModule` is the
-database connection, and every repository waits on it. When a non-global
-package module has exactly one importer the hover card names it, which is
-where `forFeature` or `registerQueue` was called. Global ones such as
-`TypeOrmCoreModule` and `ConfigHostModule` never name an importer.
+database connection, and every repository waits on it. When exactly one
+module imports a non-global package module instance, the hover card names
+it, which is where `forFeature` or `registerQueue` was called. Global ones
+such as `TypeOrmCoreModule` and `ConfigHostModule` never name an importer.
 
 ## 5. Put main.ts back
 

--- a/packages/nestjs-doctor/skills/nestjs-boot-trace/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-boot-trace/SKILL.md
@@ -98,6 +98,13 @@ A module node shows the build of its slowest class, never a sum across
 classes. Its hook time is the total across the module's classes, for example
 `104ms build · 63ms init`.
 
+Classes from package modules (`TypeOrmCoreModule`, `BullModule`,
+`ConfigHostModule`) sit in their own groups with an `external` tag. A slow boot
+often lives there: `DataSource` in `TypeOrmCoreModule` is the database
+connection, and every repository waits on it. When a package module has
+exactly one importer the hover card names it, which is where `forFeature` or
+`registerQueue` was called.
+
 ## 5. Put main.ts back
 
 Revert the instrumentation unless the user asked to keep it behind a flag.

--- a/packages/nestjs-doctor/src/common/timings.ts
+++ b/packages/nestjs-doctor/src/common/timings.ts
@@ -27,8 +27,12 @@ export interface TraceNode {
 	deps: string[];
 	hooks?: HookTiming[];
 	initTime: number;
+	/** Label of the dump module that owns the class; absent in older artifacts. */
+	module?: string;
 	name: string;
 	type: string;
+	/** Label of the one module importing the owning module, when it is not global. */
+	via?: string;
 }
 
 export interface BootstrapTimings {

--- a/packages/nestjs-doctor/src/report/timings.ts
+++ b/packages/nestjs-doctor/src/report/timings.ts
@@ -32,6 +32,7 @@ function asPositiveMs(value: unknown): number | undefined {
 interface DumpNode {
 	label?: unknown;
 	metadata?: {
+		global?: unknown;
 		initTime?: unknown;
 		internal?: unknown;
 		type?: unknown;
@@ -76,6 +77,7 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 	const dumpNodes = nodes as Record<string, DumpNode>;
 	const moduleLabels = new Map<string, string>();
 	const moduleLabelCounts = new Map<string, number>();
+	const globalModules = new Set<string>();
 	// Counts class-node labels; hook entries only join to a unique label.
 	// Module nodes are excluded: a module class also appears as a class node.
 	const labelCounts = new Map<string, number>();
@@ -94,6 +96,9 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 			typeof node.label === "string"
 		) {
 			moduleLabels.set(id, node.label);
+			if (meta.global === true) {
+				globalModules.add(id);
+			}
 			moduleLabelCounts.set(
 				node.label,
 				(moduleLabelCounts.get(node.label) ?? 0) + 1
@@ -101,8 +106,40 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 		}
 	}
 
+	const rawEdges = (data as { edges?: unknown }).edges;
+	const edges =
+		typeof rawEdges === "object" && rawEdges !== null
+			? Object.values(rawEdges as Record<string, DumpEdge>)
+			: [];
+	// Distinct importing module ids per module id; only module nodes count.
+	const importersByModule = new Map<string, Set<string>>();
+	for (const edge of edges) {
+		if (edge?.metadata?.type !== "module-to-module") {
+			continue;
+		}
+		const { source, target } = edge;
+		if (
+			typeof source !== "string" ||
+			typeof target !== "string" ||
+			source === target ||
+			!moduleLabels.has(source)
+		) {
+			continue;
+		}
+		const importers = importersByModule.get(target) ?? new Set<string>();
+		importers.add(source);
+		importersByModule.set(target, importers);
+	}
+	// A global module is reachable from everywhere, so its importer says nothing.
+	const viaOf = (moduleId: string): string | undefined => {
+		const importers = importersByModule.get(moduleId);
+		if (globalModules.has(moduleId) || importers?.size !== 1) {
+			return undefined;
+		}
+		return moduleLabels.get([...importers][0] as string);
+	};
+
 	const modules = new Map<string, ClassTiming[]>();
-	let ambiguousModuleClasses = 0;
 	// Ids get a "t" prefix so an id like "__proto__" stays a plain object key.
 	const trace: Record<string, TraceNode> = {};
 	for (const [rawId, node] of Object.entries(dumpNodes)) {
@@ -127,10 +164,17 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 		}
 		const type = typeof meta.type === "string" ? meta.type : "provider";
 		const id = `t${rawId}`;
-		trace[id] = { name: node.label, type, initTime, deps: [] };
+		const via = viaOf(node.parent);
+		trace[id] = {
+			name: node.label,
+			type,
+			initTime,
+			deps: [],
+			module: moduleName,
+			...(via ? { via } : {}),
+		};
 		// Two dump modules sharing a name would merge their class lists; skip both.
 		if (moduleLabelCounts.get(moduleName) !== 1) {
-			ambiguousModuleClasses++;
 			continue;
 		}
 		const list = modules.get(moduleName) ?? [];
@@ -138,23 +182,20 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 		modules.set(moduleName, list);
 	}
 
-	const edges = (data as { edges?: unknown }).edges;
-	if (typeof edges === "object" && edges !== null) {
-		for (const edge of Object.values(edges as Record<string, DumpEdge>)) {
-			if (edge?.metadata?.type !== "class-to-class") {
-				continue;
-			}
-			const { source, target } = edge;
-			if (typeof source !== "string" || typeof target !== "string") {
-				continue;
-			}
-			const from = Object.hasOwn(trace, `t${source}`)
-				? trace[`t${source}`]
-				: undefined;
-			const to = `t${target}`;
-			if (from && Object.hasOwn(trace, to) && !from.deps.includes(to)) {
-				from.deps.push(to);
-			}
+	for (const edge of edges) {
+		if (edge?.metadata?.type !== "class-to-class") {
+			continue;
+		}
+		const { source, target } = edge;
+		if (typeof source !== "string" || typeof target !== "string") {
+			continue;
+		}
+		const from = Object.hasOwn(trace, `t${source}`)
+			? trace[`t${source}`]
+			: undefined;
+		const to = `t${target}`;
+		if (from && Object.hasOwn(trace, to) && !from.deps.includes(to)) {
+			from.deps.push(to);
 		}
 	}
 
@@ -166,14 +207,9 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 	}
 
 	const warnings: string[] = [];
-	if (modules.size === 0) {
+	if (Object.keys(trace).length === 0) {
 		warnings.push(
 			"--timings: no class init times found in the dump — was it produced with NestFactory.create(AppModule, { snapshot: true })?"
-		);
-	}
-	if (ambiguousModuleClasses > 0) {
-		warnings.push(
-			`--timings: ${ambiguousModuleClasses} class timings belong to module names that appear more than once in the dump; they are not attached to a module`
 		);
 	}
 
@@ -286,7 +322,9 @@ export function loadBootstrapTimings(
 	}
 	const { hooksByClass, modules, phases, startupMs, trace, warnings } =
 		parseBootstrapTimings(raw);
-	return modules.size > 0 || startupMs !== undefined || phases !== undefined
+	return Object.keys(trace).length > 0 ||
+		startupMs !== undefined ||
+		phases !== undefined
 		? {
 				timings: { byModule: modules, hooksByClass, phases, startupMs, trace },
 				warnings,

--- a/packages/nestjs-doctor/src/report/timings.ts
+++ b/packages/nestjs-doctor/src/report/timings.ts
@@ -130,7 +130,7 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 		importers.add(source);
 		importersByModule.set(target, importers);
 	}
-	// A global module is reachable from everywhere, so its importer says nothing.
+	// Only a non-global module with exactly one importer gets a via label.
 	const viaOf = (moduleId: string): string | undefined => {
 		const importers = importersByModule.get(moduleId);
 		if (globalModules.has(moduleId) || importers?.size !== 1) {

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-hover.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-hover.ts
@@ -11,16 +11,23 @@ function share(ms: number, maxMs: number): string {
 	return `${((ms / maxMs) * 100).toFixed(1)}% of boot`;
 }
 
+function contextOf(span: BootSpan): string {
+	if (span.module === UNATTRIBUTED_MODULE) {
+		return `module not identified · ${span.type}`;
+	}
+	if (span.external && span.via) {
+		return `in ${span.module} · imported by ${span.via} · ${span.type}`;
+	}
+	return `in ${span.module} · ${span.type}`;
+}
+
 /** What the hover card says for a class bar, or for one of its hook spans. */
 export function hoverCardData(
 	t: BootTimeline,
 	span: BootSpan,
 	hookIndex: number | null
 ): HoverCardData {
-	const context =
-		span.module === UNATTRIBUTED_MODULE
-			? `module not identified · ${span.type}`
-			: `in ${span.module} · ${span.type}`;
+	const context = contextOf(span);
 	const from = { color: `rgb(${spanColor(span.type)})`, label: span.name };
 	const hook = hookIndex === null ? undefined : span.hooks?.[hookIndex];
 	if (hook) {

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-hover.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-hover.ts
@@ -18,6 +18,9 @@ function contextOf(span: BootSpan): string {
 	if (span.external && span.via) {
 		return `in ${span.module} · imported by ${span.via} · ${span.type}`;
 	}
+	if (span.ambiguous) {
+		return `in ${span.module} (ambiguous name) · ${span.type}`;
+	}
 	return `in ${span.module} · ${span.type}`;
 }
 

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -41,7 +41,7 @@ export interface BootSpan {
 	name: string;
 	start: number;
 	type: string;
-	/** The importer of the class's module, when that module is not global and has one. */
+	/** The importer of the class's module, when it is not global and has exactly one. */
 	via?: string;
 	/** Id of the dependency whose finish set this class's start, if any. */
 	waitedOn?: string;

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -28,6 +28,8 @@ export function spanColor(type: string): string {
 }
 
 export interface BootSpan {
+	/** The class's module name repeats, so it joined no single graph module. */
+	ambiguous?: boolean;
 	deps: string[];
 	/** Offset from boot start when construction finished (the dump's initTime). */
 	end: number;
@@ -39,13 +41,14 @@ export interface BootSpan {
 	name: string;
 	start: number;
 	type: string;
-	/** The one module importing the class's module, for external spans. */
+	/** The one non-global module importing the class's module, when exactly one does. */
 	via?: string;
 	/** Id of the dependency whose finish set this class's start, if any. */
 	waitedOn?: string;
 }
 
 interface BootGroup {
+	ambiguous?: boolean;
 	end: number;
 	external?: boolean;
 	module: string;
@@ -74,7 +77,7 @@ export interface BootWindow {
 	to: number;
 }
 
-// Same rule as displayName in modules-canvas, which imports this file.
+// Drops the "<project>/" prefix from a module name.
 function bareName(m: { name: string; project?: string }): string {
 	return m.project && m.name.startsWith(`${m.project}/`)
 		? m.name.slice(m.project.length + 1)
@@ -114,12 +117,13 @@ export function buildBootTimeline(
 			}
 		}
 		const attributed = moduleOfId.get(id);
-		// A dump module with no node in the scanned graph is a package module.
-		const external =
-			attributed === undefined &&
-			node.module !== undefined &&
-			!graphNames.has(node.module);
+		// An unattributed label matching no scanned module's bare name is a
+		// package module; one that matches is a name the graph could not join.
+		const unattributed = attributed === undefined && node.module !== undefined;
+		const external = unattributed && !graphNames.has(node.module as string);
+		const ambiguous = unattributed && !external;
 		byId.set(id, {
+			...(ambiguous ? { ambiguous: true } : {}),
 			deps: node.deps,
 			end: node.initTime,
 			...(external ? { external: true } : {}),
@@ -155,6 +159,7 @@ export function buildBootTimeline(
 			}
 		}
 		groups.push({
+			...(spans.every((s) => s.ambiguous) ? { ambiguous: true } : {}),
 			end,
 			...(spans.every((s) => s.external) ? { external: true } : {}),
 			module,
@@ -483,6 +488,16 @@ export function cascadeChildrenHtml(
 	return html;
 }
 
+function groupTagHtml(g: BootGroup): string {
+	if (g.external) {
+		return '<span class="boot-reused-tag">external</span>';
+	}
+	if (g.ambiguous) {
+		return '<span class="boot-reused-tag">ambiguous</span>';
+	}
+	return "";
+}
+
 export function rowsHtml(t: BootTimeline, o: BootRowOptions): string {
 	let html = guidesHtml(t, o.win);
 	for (const g of t.groups) {
@@ -493,7 +508,7 @@ export function rowsHtml(t: BootTimeline, o: BootRowOptions): string {
 			'<span class="boot-label">' +
 			caretHtml(true) +
 			`<span class="boot-name">${escapeHtml(g.module)}</span>` +
-			(g.external ? '<span class="boot-reused-tag">external</span>' : "") +
+			groupTagHtml(g) +
 			`<span class="boot-count">${g.spans.length}</span>` +
 			"</span>" +
 			'<span class="boot-track">' +

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -11,7 +11,7 @@ import {
 	phaseParts,
 } from "./trace.js";
 
-/** Group for trace classes whose module name repeated across projects. */
+/** Group for trace nodes written before the dump's module label was kept. */
 export const UNATTRIBUTED_MODULE = "unattributed";
 
 const SPAN_COLORS: Record<string, string> = {
@@ -31,18 +31,23 @@ export interface BootSpan {
 	deps: string[];
 	/** Offset from boot start when construction finished (the dump's initTime). */
 	end: number;
+	/** The class lives in a package module, one the scanned graph never saw. */
+	external?: boolean;
 	hooks?: HookTiming[];
 	id: string;
 	module: string;
 	name: string;
 	start: number;
 	type: string;
+	/** The one module importing the class's module, for external spans. */
+	via?: string;
 	/** Id of the dependency whose finish set this class's start, if any. */
 	waitedOn?: string;
 }
 
 interface BootGroup {
 	end: number;
+	external?: boolean;
 	module: string;
 	spans: BootSpan[];
 	start: number;
@@ -69,6 +74,13 @@ export interface BootWindow {
 	to: number;
 }
 
+// Same rule as displayName in modules-canvas, which imports this file.
+function bareName(m: { name: string; project?: string }): string {
+	return m.project && m.name.startsWith(`${m.project}/`)
+		? m.name.slice(m.project.length + 1)
+		: m.name;
+}
+
 export function buildBootTimeline(
 	graph: SerializedModuleGraph
 ): BootTimeline | null {
@@ -77,7 +89,9 @@ export function buildBootTimeline(
 		return null;
 	}
 	const moduleOfId = new Map<string, string>();
+	const graphNames = new Set<string>();
 	for (const m of graph.modules) {
+		graphNames.add(bareName(m));
 		for (const t of m.initTimings ?? []) {
 			moduleOfId.set(t.id, m.name);
 		}
@@ -99,15 +113,23 @@ export function buildBootTimeline(
 				break;
 			}
 		}
+		const attributed = moduleOfId.get(id);
+		// A dump module with no node in the scanned graph is a package module.
+		const external =
+			attributed === undefined &&
+			node.module !== undefined &&
+			!graphNames.has(node.module);
 		byId.set(id, {
 			deps: node.deps,
 			end: node.initTime,
+			...(external ? { external: true } : {}),
 			hooks: node.hooks,
 			id,
-			module: moduleOfId.get(id) ?? UNATTRIBUTED_MODULE,
+			module: attributed ?? node.module ?? UNATTRIBUTED_MODULE,
 			name: node.name,
 			start,
 			type: node.type,
+			...(node.via ? { via: node.via } : {}),
 			...(waitedOn ? { waitedOn } : {}),
 		});
 	}
@@ -132,7 +154,13 @@ export function buildBootTimeline(
 				}
 			}
 		}
-		groups.push({ end, module, spans, start });
+		groups.push({
+			end,
+			...(spans.every((s) => s.external) ? { external: true } : {}),
+			module,
+			spans,
+			start,
+		});
 	}
 	// Groups run in the order their first class finished.
 	const firstEnd = (g: BootGroup) => (g.spans[0] as BootSpan).end;
@@ -465,6 +493,7 @@ export function rowsHtml(t: BootTimeline, o: BootRowOptions): string {
 			'<span class="boot-label">' +
 			caretHtml(true) +
 			`<span class="boot-name">${escapeHtml(g.module)}</span>` +
+			(g.external ? '<span class="boot-reused-tag">external</span>' : "") +
 			`<span class="boot-count">${g.spans.length}</span>` +
 			"</span>" +
 			'<span class="boot-track">' +

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -41,7 +41,7 @@ export interface BootSpan {
 	name: string;
 	start: number;
 	type: string;
-	/** The one non-global module importing the class's module, when exactly one does. */
+	/** The importer of the class's module, when that module is not global and has one. */
 	via?: string;
 	/** Id of the dependency whose finish set this class's start, if any. */
 	waitedOn?: string;
@@ -119,9 +119,9 @@ export function buildBootTimeline(
 		const attributed = moduleOfId.get(id);
 		// An unattributed label matching no scanned module's bare name is a
 		// package module; one that matches is a name the graph could not join.
-		const unattributed = attributed === undefined && node.module !== undefined;
-		const external = unattributed && !graphNames.has(node.module as string);
-		const ambiguous = unattributed && !external;
+		const label = attributed === undefined ? node.module : undefined;
+		const external = label !== undefined && !graphNames.has(label);
+		const ambiguous = label !== undefined && !external;
 		byId.set(id, {
 			...(ambiguous ? { ambiguous: true } : {}),
 			deps: node.deps,

--- a/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
@@ -398,7 +398,8 @@ export class ModulesCanvas {
 		}
 		const label = displayName(n);
 		const subLines = [`${n.providers.length}p · ${n.controllers.length}c`];
-		const timing = this.moduleTimings.get(n.name);
+		// A package node shows only its "package" line; its timing stays in the tooltip.
+		const timing = n.external ? undefined : this.moduleTimings.get(n.name);
 		if (timing) {
 			subLines.push(...moduleTimingLines(timing));
 		}

--- a/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
@@ -398,7 +398,7 @@ export class ModulesCanvas {
 		}
 		const label = displayName(n);
 		const subLines = [`${n.providers.length}p · ${n.controllers.length}c`];
-		// A package node shows only its "package" line; its timing stays in the tooltip.
+		// Skips the timing lines for a package node; the tooltip still shows its timing.
 		const timing = n.external ? undefined : this.moduleTimings.get(n.name);
 		if (timing) {
 			subLines.push(...moduleTimingLines(timing));

--- a/packages/nestjs-doctor/tests/unit/report-boot-app.test.tsx
+++ b/packages/nestjs-doctor/tests/unit/report-boot-app.test.tsx
@@ -63,6 +63,25 @@ const TIMED_ARTIFACT: ReportArtifact = {
 	},
 };
 
+// One class from a third-party module the graph has no node for.
+const EXTERNAL_ARTIFACT: ReportArtifact = {
+	...TIMED_ARTIFACT,
+	graph: {
+		...TIMED_ARTIFACT.graph,
+		modules: [],
+		timingsTrace: {
+			ta: {
+				deps: [],
+				initTime: 154,
+				module: "TypeOrmModule",
+				name: "UserRepository",
+				type: "provider",
+				via: "UsersModule",
+			},
+		},
+	},
+};
+
 describe("BootTab", () => {
 	let container: HTMLDivElement;
 	let root: Root;
@@ -496,6 +515,48 @@ describe("BootTab", () => {
 				);
 		});
 		expect(picked).toEqual(["CatsModule"]);
+	});
+
+	it("names a third-party module group instead of the unattributed bucket", () => {
+		mount(EXTERNAL_ARTIFACT);
+		const rows = container.querySelector(".boot-rows");
+		expect(rows?.innerHTML).toContain('data-group="TypeOrmModule"');
+		expect(rows?.innerHTML).not.toContain("unattributed");
+		expect(container.querySelector(".boot-rows .boot-count")?.textContent).toBe(
+			"1"
+		);
+	});
+
+	it("selects an external row and names its module on hover", () => {
+		mount(EXTERNAL_ARTIFACT);
+		act(() => {
+			container
+				.querySelector<HTMLElement>('.boot-rows [data-id="ta"]')
+				?.dispatchEvent(
+					new MouseEvent("click", { bubbles: true, composed: true })
+				);
+		});
+		expect(
+			container
+				.querySelector('.boot-rows [data-id="ta"]')
+				?.classList.contains("boot-selected")
+		).toBe(true);
+		act(() => {
+			container
+				.querySelector<HTMLElement>('.boot-rows [data-id="ta"] .boot-bar')
+				?.dispatchEvent(
+					new MouseEvent("mousemove", {
+						bubbles: true,
+						clientX: 40,
+						clientY: 30,
+					})
+				);
+		});
+		const card = container.querySelector<HTMLElement>(".hover-card");
+		expect(card?.hidden).toBe(false);
+		expect(card?.textContent).toContain(
+			"TypeOrmModule · imported by UsersModule"
+		);
 	});
 
 	it("shows a crosshair with a time chip while the mouse moves", () => {

--- a/packages/nestjs-doctor/tests/unit/report-boot-hover.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-hover.test.ts
@@ -60,7 +60,43 @@ const EXTERNAL = buildBootTimeline({
 	},
 } as SerializedModuleGraph);
 
+// A user module name the graph could not join to one node.
+const AMBIGUOUS = buildBootTimeline({
+	...EMPTY_ARTIFACT.graph,
+	modules: [
+		{
+			controllers: [],
+			exports: [],
+			filePath: "config.module.ts",
+			imports: [],
+			isGlobal: false,
+			line: 1,
+			name: "ConfigModule",
+			providerTokens: [],
+			providers: [],
+		},
+	],
+	startupMs: 400,
+	timingsAvailable: true,
+	timingsTrace: {
+		ta: {
+			deps: [],
+			initTime: 1.3,
+			module: "ConfigModule",
+			name: "ConfigService",
+			type: "provider",
+		},
+	},
+} as SerializedModuleGraph);
+
 describe("hoverCardData", () => {
+	it("marks a module name the graph could not join as ambiguous", () => {
+		const t = AMBIGUOUS as NonNullable<typeof AMBIGUOUS>;
+		expect(hoverCardData(t, t.byId.get("ta") as never, null).context).toBe(
+			"in ConfigModule (ambiguous name) · provider"
+		);
+	});
+
 	it("names an external module and the one module importing it", () => {
 		const t = EXTERNAL as NonNullable<typeof EXTERNAL>;
 		expect(hoverCardData(t, t.byId.get("ta") as never, null).context).toBe(

--- a/packages/nestjs-doctor/tests/unit/report-boot-hover.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-hover.test.ts
@@ -36,7 +36,41 @@ const TIMELINE = buildBootTimeline({
 	},
 } as SerializedModuleGraph);
 
+// Classes from third-party modules the graph does not know about.
+const EXTERNAL = buildBootTimeline({
+	...EMPTY_ARTIFACT.graph,
+	startupMs: 400,
+	timingsAvailable: true,
+	timingsTrace: {
+		ta: {
+			deps: [],
+			initTime: 154,
+			module: "TypeOrmModule",
+			name: "UserRepository",
+			type: "provider",
+			via: "UsersModule",
+		},
+		tb: {
+			deps: [],
+			initTime: 33,
+			module: "BullModule",
+			name: "BullQueue_notifications",
+			type: "provider",
+		},
+	},
+} as SerializedModuleGraph);
+
 describe("hoverCardData", () => {
+	it("names an external module and the one module importing it", () => {
+		const t = EXTERNAL as NonNullable<typeof EXTERNAL>;
+		expect(hoverCardData(t, t.byId.get("ta") as never, null).context).toBe(
+			"in TypeOrmModule · imported by UsersModule · provider"
+		);
+		expect(hoverCardData(t, t.byId.get("tb") as never, null).context).toBe(
+			"in BullModule · provider"
+		);
+	});
+
 	it("names the class and the dependency it waited on, with its own time", () => {
 		const t = TIMELINE as NonNullable<typeof TIMELINE>;
 		const data = hoverCardData(t, t.byId.get("ta") as never, null);

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -49,7 +49,7 @@ function traceNode(
 	return { deps, hooks, initTime, name: "", type: "provider", ...extra };
 }
 
-// A trace node the dump labelled with its module; no deps, no hooks.
+/** A trace node the dump labelled with its module. */
 function inModule(module: string, name: string, initTime: number) {
 	return traceNode(initTime, [], undefined, { module, name });
 }
@@ -203,7 +203,6 @@ describe("buildBootTimeline", () => {
 	});
 
 	it("merges two dump instances of a user module name into one ambiguous group", () => {
-		// The serializer attaches nothing to ConfigModule: its label repeats.
 		const t = buildBootTimeline(
 			graph({
 				modules: [mod("ConfigModule")],

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -49,6 +49,11 @@ function traceNode(
 	return { deps, hooks, initTime, name: "", type: "provider", ...extra };
 }
 
+// A trace node the dump labelled with its module; no deps, no hooks.
+function inModule(module: string, name: string, initTime: number) {
+	return traceNode(initTime, [], undefined, { module, name });
+}
+
 /** A graph module; a `project/Name` name also carries its project. */
 function mod(
 	name: string,
@@ -170,14 +175,8 @@ describe("buildBootTimeline", () => {
 				],
 				timingsAvailable: true,
 				timingsTrace: {
-					ta: traceNode(154.3, [], undefined, {
-						module: "UsersModule",
-						name: "UsersService",
-					}),
-					tb: traceNode(154.1, [], undefined, {
-						module: "TypeOrmModule",
-						name: "UserRepository",
-					}),
+					ta: inModule("UsersModule", "UsersService", 154.3),
+					tb: inModule("TypeOrmModule", "UserRepository", 154.1),
 				},
 			})
 		);
@@ -193,10 +192,7 @@ describe("buildBootTimeline", () => {
 				modules: [mod("api/UsersModule"), mod("worker/UsersModule")],
 				timingsAvailable: true,
 				timingsTrace: {
-					ta: traceNode(154.3, [], undefined, {
-						module: "UsersModule",
-						name: "UsersService",
-					}),
+					ta: inModule("UsersModule", "UsersService", 154.3),
 				},
 			})
 		);
@@ -213,14 +209,8 @@ describe("buildBootTimeline", () => {
 				modules: [mod("ConfigModule")],
 				timingsAvailable: true,
 				timingsTrace: {
-					ta: traceNode(1.3, [], undefined, {
-						module: "ConfigModule",
-						name: "ConfigService",
-					}),
-					tb: traceNode(2.1, [], undefined, {
-						module: "ConfigModule",
-						name: "ConfigService",
-					}),
+					ta: inModule("ConfigModule", "ConfigService", 1.3),
+					tb: inModule("ConfigModule", "ConfigService", 2.1),
 				},
 			})
 		);
@@ -235,16 +225,14 @@ describe("buildBootTimeline", () => {
 			graph({
 				timingsAvailable: true,
 				timingsTrace: {
-					ta: traceNode(154.15, [], undefined, {
-						module: "TypeOrmModule",
-						name: "UserRepository",
+					ta: {
+						...inModule("TypeOrmModule", "UserRepository", 154.15),
 						via: "UsersModule",
-					}),
-					tb: traceNode(154.12, [], undefined, {
-						module: "TypeOrmModule",
-						name: "CategoryRepository",
+					},
+					tb: {
+						...inModule("TypeOrmModule", "CategoryRepository", 154.12),
 						via: "CatalogModule",
-					}),
+					},
 				},
 			})
 		);
@@ -261,10 +249,7 @@ describe("buildBootTimeline", () => {
 			graph({
 				timingsAvailable: true,
 				timingsTrace: {
-					ta: traceNode(154.1, [], undefined, {
-						module: "TypeOrmModule",
-						name: "UserRepository",
-					}),
+					ta: inModule("TypeOrmModule", "UserRepository", 154.1),
 				},
 			})
 		);
@@ -424,10 +409,7 @@ describe("moduleTimings", () => {
 			graph({
 				timingsAvailable: true,
 				timingsTrace: {
-					topt: traceNode(1.6, [], undefined, {
-						module: "TypeOrmCoreModule",
-						name: "TypeOrmModuleOptions",
-					}),
+					topt: inModule("TypeOrmCoreModule", "TypeOrmModuleOptions", 1.6),
 					tds: traceNode(154.1, ["topt"], [{ hook: "onModuleInit", ms: 2 }], {
 						module: "TypeOrmCoreModule",
 						name: "DataSource",
@@ -805,10 +787,7 @@ describe("external groups in rowsHtml", () => {
 			timingsAvailable: true,
 			timingsTrace: {
 				tc: traceNode(200, [], undefined, { name: "CatsService" }),
-				ta: traceNode(154.1, [], undefined, {
-					module: "TypeOrmModule",
-					name: "UserRepository",
-				}),
+				ta: inModule("TypeOrmModule", "UserRepository", 154.1),
 			},
 		})
 	)!;
@@ -844,10 +823,7 @@ describe("external groups in rowsHtml", () => {
 				modules: [mod("ConfigModule")],
 				timingsAvailable: true,
 				timingsTrace: {
-					ta: traceNode(1.3, [], undefined, {
-						module: "ConfigModule",
-						name: "ConfigService",
-					}),
+					ta: inModule("ConfigModule", "ConfigService", 1.3),
 				},
 			})
 		) as NonNullable<ReturnType<typeof buildBootTimeline>>;

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { SerializedModuleGraph } from "../../src/common/artifact.js";
+import type {
+	SerializedModuleGraph,
+	SerializedModuleNode,
+} from "../../src/common/artifact.js";
+import type { ClassTiming } from "../../src/common/timings.js";
+import { parseBootstrapTimings } from "../../src/report/timings.js";
 import {
 	axisHtml,
 	type BootWindow,
@@ -38,9 +43,28 @@ function graph(
 function traceNode(
 	initTime: number,
 	deps: string[] = [],
-	hooks?: { hook: string; ms: number; startMs?: number }[]
+	hooks?: { hook: string; ms: number; startMs?: number }[],
+	extra: { module?: string; name?: string; via?: string } = {}
 ) {
-	return { deps, hooks, initTime, name: "", type: "provider" };
+	return { deps, hooks, initTime, name: "", type: "provider", ...extra };
+}
+
+/** A graph module; a `project/Name` name also carries its project. */
+function mod(
+	name: string,
+	initTimings: ClassTiming[] = []
+): SerializedModuleNode {
+	const slash = name.indexOf("/");
+	return {
+		controllers: [],
+		exports: [],
+		filePath: `${name}.ts`,
+		imports: [],
+		initTimings,
+		name,
+		...(slash > 0 ? { project: name.slice(0, slash) } : {}),
+		providers: [],
+	};
 }
 
 const WIN: BootWindow = { from: 0, to: 100 };
@@ -117,7 +141,7 @@ describe("buildBootTimeline", () => {
 		expect(t?.groups[0]?.spans[0]?.id).toBe("td");
 	});
 
-	it("collects classes from repeated module names into an unattributed group", () => {
+	it("falls back to an unattributed group for nodes without a module", () => {
 		const t = buildBootTimeline(
 			graph({
 				timingsAvailable: true,
@@ -128,6 +152,99 @@ describe("buildBootTimeline", () => {
 		);
 		expect(t?.groups).toHaveLength(1);
 		expect(t?.groups[0]?.module).toBe(UNATTRIBUTED_MODULE);
+		expect(t?.groups[0]?.external).toBeUndefined();
+	});
+
+	it("groups by the graph module when it claims a span, by the dump label when it does not", () => {
+		const t = buildBootTimeline(
+			graph({
+				modules: [
+					mod("api/UsersModule", [
+						{
+							id: "ta",
+							initTime: 154.3,
+							name: "UsersService",
+							type: "provider",
+						},
+					]),
+				],
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(154.3, [], undefined, {
+						module: "UsersModule",
+						name: "UsersService",
+					}),
+					tb: traceNode(154.1, [], undefined, {
+						module: "TypeOrmModule",
+						name: "UserRepository",
+					}),
+				},
+			})
+		);
+		expect(t?.groups.map((g) => [g.module, g.external ?? false])).toEqual([
+			["TypeOrmModule", true],
+			["api/UsersModule", false],
+		]);
+	});
+
+	it("keeps a repeated user module under its bare name without the external tag", () => {
+		const t = buildBootTimeline(
+			graph({
+				modules: [mod("api/UsersModule"), mod("worker/UsersModule")],
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(154.3, [], undefined, {
+						module: "UsersModule",
+						name: "UsersService",
+					}),
+				},
+			})
+		);
+		expect(t?.groups.map((g) => g.module)).toEqual(["UsersModule"]);
+		expect(t?.groups[0]?.external).toBeUndefined();
+	});
+
+	it("merges two dump modules with the same label into one external group", () => {
+		const t = buildBootTimeline(
+			graph({
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(154.15, [], undefined, {
+						module: "TypeOrmModule",
+						name: "UserRepository",
+						via: "UsersModule",
+					}),
+					tb: traceNode(154.12, [], undefined, {
+						module: "TypeOrmModule",
+						name: "CategoryRepository",
+						via: "CatalogModule",
+					}),
+				},
+			})
+		);
+		expect(t?.groups).toHaveLength(1);
+		expect(t?.groups[0]?.module).toBe("TypeOrmModule");
+		expect(t?.groups[0]?.external).toBe(true);
+		expect(t?.groups[0]?.spans.map((s) => s.id)).toEqual(["tb", "ta"]);
+		expect(t?.byId.get("ta")?.via).toBe("UsersModule");
+		expect(t?.byId.get("tb")?.via).toBe("CatalogModule");
+	});
+
+	it("finds an external span by its third-party module label", () => {
+		const t = buildBootTimeline(
+			graph({
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(154.1, [], undefined, {
+						module: "TypeOrmModule",
+						name: "UserRepository",
+					}),
+				},
+			})
+		);
+		const span = t?.byId.get("ta");
+		expect(span).toBeDefined();
+		expect(spanMatches(span as NonNullable<typeof span>, "typeorm")).toBe(true);
 	});
 
 	it("extends maxMs to startupMs and to hook ends", () => {
@@ -274,6 +391,157 @@ describe("moduleTimings", () => {
 
 	it("is empty without timings", () => {
 		expect(moduleTimings(graph()).size).toBe(0);
+	});
+
+	it("reports an external group's own build time and its hooks", () => {
+		const timings = moduleTimings(
+			graph({
+				timingsAvailable: true,
+				timingsTrace: {
+					topt: traceNode(1.6, [], undefined, {
+						module: "TypeOrmCoreModule",
+						name: "TypeOrmModuleOptions",
+					}),
+					tds: traceNode(154.1, ["topt"], [{ hook: "onModuleInit", ms: 2 }], {
+						module: "TypeOrmCoreModule",
+						name: "DataSource",
+					}),
+				},
+			})
+		);
+		const core = timings.get("TypeOrmCoreModule");
+		expect(core?.buildMs).toBeCloseTo(152.5, 6);
+		expect(core?.hooks).toEqual([{ label: "init", ms: 2 }]);
+	});
+});
+
+describe("external modules from a real dump", () => {
+	// A NestJS SerializedGraph dump for a shop API: user modules plus the
+	// TypeORM and Bull modules they pull in, one of which is internal.
+	function shopDump(): string {
+		const module = (label: string, extra: Record<string, unknown> = {}) => ({
+			label,
+			metadata: { type: "module", ...extra },
+		});
+		const klass = (label: string, parent: string, initTime: number) => ({
+			label,
+			metadata: { initTime, type: "provider" },
+			parent,
+		});
+		const m2m = (source: string, target: string) => ({
+			metadata: { type: "module-to-module" },
+			source,
+			target,
+		});
+		const c2c = (source: string, target: string) => ({
+			metadata: { type: "class-to-class" },
+			source,
+			target,
+		});
+		return JSON.stringify({
+			createMs: 246.9,
+			edges: {
+				e01: m2m("mApp", "mUsers"),
+				e02: m2m("mApp", "mCatalog"),
+				e03: m2m("mApp", "mNotifications"),
+				e04: m2m("mUsers", "mTypeOrm1"),
+				e05: m2m("mCatalog", "mTypeOrm2"),
+				e06: m2m("mUsers", "mTypeOrmCore"),
+				e07: m2m("mCatalog", "mTypeOrmCore"),
+				e08: m2m("mApp", "mBullGlobal"),
+				e09: m2m("mUsers", "mBullGlobal"),
+				e10: m2m("mNotifications", "mBullQueue"),
+				e11: m2m("mUsers", "mInternal"),
+				e12: c2c("cUsersService", "cUserRepository"),
+				e13: c2c("cUserRepository", "cDataSource"),
+				e14: c2c("cCategoryRepository", "cDataSource"),
+				e15: c2c("cDataSource", "cTypeOrmModuleOptions"),
+			},
+			entrypoints: {},
+			hookTimings: [
+				{
+					className: "BullRegistrar",
+					hook: "onModuleInit",
+					ms: 0.48,
+					startMs: 250.7,
+				},
+			],
+			initMs: 277.8,
+			nodes: {
+				mApp: module("AppModule"),
+				mUsers: module("UsersModule"),
+				mCatalog: module("CatalogModule"),
+				mNotifications: module("NotificationsModule"),
+				mTypeOrm1: module("TypeOrmModule", { dynamic: "forFeature" }),
+				mTypeOrm2: module("TypeOrmModule", { dynamic: "forFeature" }),
+				mTypeOrmCore: module("TypeOrmCoreModule", {
+					dynamic: "forRoot",
+					global: true,
+				}),
+				mBullGlobal: module("BullModule", {
+					dynamic: "forRoot",
+					global: true,
+				}),
+				mBullQueue: module("BullModule", { dynamic: "registerQueue" }),
+				mInternal: module("InternalCoreModule", { internal: true }),
+				cUsersService: klass("UsersService", "mUsers", 154.261_584),
+				cUserRepository: klass("UserRepository", "mTypeOrm1", 154.147_917),
+				cCategoryRepository: klass(
+					"CategoryRepository",
+					"mTypeOrm2",
+					154.125_166
+				),
+				cDataSource: klass("DataSource", "mTypeOrmCore", 154.115_708),
+				cTypeOrmModuleOptions: klass(
+					"TypeOrmModuleOptions",
+					"mTypeOrmCore",
+					1.585_834
+				),
+				cBullRegistrar: klass("BullRegistrar", "mBullGlobal", 1.363_375),
+				cBullQueue_notifications: klass(
+					"BullQueue_notifications",
+					"mBullQueue",
+					33.928_042
+				),
+				cModuleRef: klass("ModuleRef", "mInternal", 0.2),
+			},
+			startupMs: 278.5,
+		});
+	}
+
+	it("splits a real dump into the user module and the third-party modules behind it", () => {
+		const parsed = parseBootstrapTimings(shopDump());
+		expect(parsed.warnings).toEqual([]);
+
+		const g = graph({
+			modules: [
+				mod("api/UsersModule", parsed.modules.get("UsersModule") ?? []),
+			],
+			phases: parsed.phases,
+			projects: ["api"],
+			startupMs: parsed.startupMs,
+			timingsAvailable: true,
+			timingsTrace: parsed.trace,
+		});
+		const t = buildBootTimeline(g);
+		expect(t).not.toBeNull();
+		expect(
+			t?.groups.map((x) => [x.module, x.spans.length, x.external ?? false])
+		).toEqual([
+			["BullModule", 2, true],
+			["TypeOrmCoreModule", 2, true],
+			["TypeOrmModule", 2, true],
+			["api/UsersModule", 1, false],
+		]);
+		expect(t?.byId.get("tcUserRepository")?.via).toBe("UsersModule");
+		expect(t?.byId.get("tcDataSource")?.via).toBeUndefined();
+		expect(t?.byId.get("tcModuleRef")).toBeUndefined();
+
+		const timings = moduleTimings(g);
+		expect(timings.get("TypeOrmCoreModule")?.buildMs).toBeCloseTo(152.53, 2);
+		expect(timings.get("BullModule")?.hooks).toEqual([
+			{ label: "init", ms: 0.48 },
+		]);
 	});
 });
 
@@ -497,6 +765,51 @@ describe("rowsHtml", () => {
 		expect(html2).toContain('<span class="boot-hook-span" data-hook="0"');
 		expect(html2).toContain("+5.0ms init</span>");
 		expect(html2).not.toContain("boot-hook-chip");
+	});
+});
+
+describe("external groups in rowsHtml", () => {
+	const t = buildBootTimeline(
+		graph({
+			modules: [
+				mod("CatsModule", [
+					{ id: "tc", initTime: 200, name: "CatsService", type: "provider" },
+				]),
+			],
+			timingsAvailable: true,
+			timingsTrace: {
+				tc: traceNode(200, [], undefined, { name: "CatsService" }),
+				ta: traceNode(154.1, [], undefined, {
+					module: "TypeOrmModule",
+					name: "UserRepository",
+				}),
+			},
+		})
+	)!;
+	const base = {
+		expandedModules: new Set(["CatsModule", "TypeOrmModule"]),
+		query: "",
+		selectedId: null,
+		win: { from: 0, to: 300 },
+	};
+
+	it("tags an external group right after its name and leaves user modules untagged", () => {
+		const html = rowsHtml(t, base);
+		const external = html.indexOf('data-group="TypeOrmModule"');
+		const cats = html.indexOf('data-group="CatsModule"');
+		expect(external).toBeGreaterThanOrEqual(0);
+		expect(cats).toBeGreaterThan(external);
+		expect(html.slice(external, cats)).toContain(
+			'<span class="boot-name">TypeOrmModule</span><span class="boot-reused-tag">external</span>'
+		);
+		expect(html.slice(cats)).not.toContain("boot-reused-tag");
+	});
+
+	it("highlights an external group picked from the graph", () => {
+		const html = rowsHtml(t, { ...base, selectedModule: "TypeOrmModule" });
+		expect(html).toContain(
+			'data-group="TypeOrmModule"><div class="boot-row boot-group-row boot-group-selected">'
+		);
 	});
 });
 

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -187,7 +187,7 @@ describe("buildBootTimeline", () => {
 		]);
 	});
 
-	it("keeps a repeated user module under its bare name without the external tag", () => {
+	it("tags a user module name repeated across projects as ambiguous, not external", () => {
 		const t = buildBootTimeline(
 			graph({
 				modules: [mod("api/UsersModule"), mod("worker/UsersModule")],
@@ -201,6 +201,32 @@ describe("buildBootTimeline", () => {
 			})
 		);
 		expect(t?.groups.map((g) => g.module)).toEqual(["UsersModule"]);
+		expect(t?.groups[0]?.external).toBeUndefined();
+		expect(t?.groups[0]?.ambiguous).toBe(true);
+		expect(t?.byId.get("ta")?.ambiguous).toBe(true);
+	});
+
+	it("merges two dump instances of a user module name into one ambiguous group", () => {
+		// The serializer attaches nothing to ConfigModule: its label repeats.
+		const t = buildBootTimeline(
+			graph({
+				modules: [mod("ConfigModule")],
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(1.3, [], undefined, {
+						module: "ConfigModule",
+						name: "ConfigService",
+					}),
+					tb: traceNode(2.1, [], undefined, {
+						module: "ConfigModule",
+						name: "ConfigService",
+					}),
+				},
+			})
+		);
+		expect(
+			t?.groups.map((g) => [g.module, g.spans.length, g.ambiguous ?? false])
+		).toEqual([["ConfigModule", 2, true]]);
 		expect(t?.groups[0]?.external).toBeUndefined();
 	});
 
@@ -810,6 +836,28 @@ describe("external groups in rowsHtml", () => {
 		expect(html).toContain(
 			'data-group="TypeOrmModule"><div class="boot-row boot-group-row boot-group-selected">'
 		);
+	});
+
+	it("tags an ambiguous group when its name matches a graph module it could not join", () => {
+		const a = buildBootTimeline(
+			graph({
+				modules: [mod("ConfigModule")],
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(1.3, [], undefined, {
+						module: "ConfigModule",
+						name: "ConfigService",
+					}),
+				},
+			})
+		) as NonNullable<ReturnType<typeof buildBootTimeline>>;
+		const html = rowsHtml(a, {
+			...base,
+			expandedModules: new Set(["ConfigModule"]),
+		});
+		expect(html).toContain('data-group="ConfigModule"');
+		expect(html).toContain('boot-reused-tag">ambiguous</span>');
+		expect(html).not.toContain(">external<");
 	});
 });
 

--- a/packages/nestjs-doctor/tests/unit/timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/timings.test.ts
@@ -7,8 +7,8 @@ import {
 	parseBootstrapTimings,
 } from "../../src/report/timings.js";
 
-function moduleNode(label: string, internal = false) {
-	return { id: label, label, metadata: { type: "module", internal } };
+function moduleNode(label: string, internal = false, global = false) {
+	return { id: label, label, metadata: { type: "module", internal, global } };
 }
 
 function classNode(
@@ -23,6 +23,9 @@ function classNode(
 function edge(source: string, target: string, type = "class-to-class") {
 	return { source, target, metadata: { type } };
 }
+
+const imports = (importer: string, imported: string) =>
+	edge(importer, imported, "module-to-module");
 
 function dump(
 	nodes: Record<string, unknown>,
@@ -75,6 +78,7 @@ describe("parseBootstrapTimings", () => {
 			type: "controller",
 			initTime: 210,
 			deps: ["tc2"],
+			module: "CatsModule",
 		});
 		expect(trace.tc2.deps).toEqual(["tc3"]);
 		expect(trace.tc3.deps).toEqual([]);
@@ -116,12 +120,13 @@ describe("parseBootstrapTimings", () => {
 			type: "provider",
 			initTime: 5,
 			deps: [],
+			module: "CatsModule",
 		});
 		expect(trace.tc2.deps).toEqual(["t__proto__"]);
 	});
 
 	it("ignores nodes whose metadata.internal is true", () => {
-		const { modules } = parseBootstrapTimings(
+		const { modules, trace } = parseBootstrapTimings(
 			dump({
 				m1: moduleNode("InternalCoreModule", true),
 				c1: classNode("ModuleRef", "m1", 1.2),
@@ -134,6 +139,7 @@ describe("parseBootstrapTimings", () => {
 		);
 
 		expect(modules.size).toBe(0);
+		expect(trace).toEqual({});
 	});
 
 	it("skips a class node with no numeric initTime rather than recording 0", () => {
@@ -150,7 +156,7 @@ describe("parseBootstrapTimings", () => {
 		]);
 	});
 
-	it("attaches no classes to a module name that appears more than once in the dump", () => {
+	it("keeps classes of a repeated module name in the trace but attaches them to no module", () => {
 		const { modules, trace, warnings } = parseBootstrapTimings(
 			dump({
 				m1: moduleNode("SharedModule"),
@@ -166,9 +172,125 @@ describe("parseBootstrapTimings", () => {
 		expect(modules.get("CatsModule")).toHaveLength(1);
 		// The classes keep their own trace entries; only the module join is refused.
 		expect(trace.tc1.name).toBe("BillingService");
-		expect(warnings.join(" ")).toContain(
-			"2 class timings belong to module names that appear more than once"
+		expect(trace.tc1.module).toBe("SharedModule");
+		expect(trace.tc2.module).toBe("SharedModule");
+		expect(warnings).toEqual([]);
+	});
+
+	it("records the parent module's label on every trace node", () => {
+		const { trace } = parseBootstrapTimings(
+			dump({
+				m1: moduleNode("CatsModule"),
+				c1: classNode("CatsService", "m1", 4.5),
+			})
 		);
+
+		expect(trace.tc1).toEqual({
+			deps: [],
+			initTime: 4.5,
+			module: "CatsModule",
+			name: "CatsService",
+			type: "provider",
+		});
+	});
+
+	it("drops a class whose parent module is missing from the dump", () => {
+		const { modules, trace } = parseBootstrapTimings(
+			dump({
+				m1: moduleNode("CatsModule"),
+				c1: classNode("Orphan", "gone", 4.5),
+			})
+		);
+
+		expect(trace).toEqual({});
+		expect(modules.size).toBe(0);
+	});
+
+	it("names the one module that imports a class's module as via", () => {
+		const { trace } = parseBootstrapTimings(
+			dump(
+				{
+					mUsers: moduleNode("UsersModule"),
+					mTypeOrm: moduleNode("TypeOrmModule"),
+					c1: classNode("UserRepository", "mTypeOrm", 154.1),
+				},
+				{ e1: imports("mUsers", "mTypeOrm") }
+			)
+		);
+
+		expect(trace.tc1.module).toBe("TypeOrmModule");
+		expect(trace.tc1.via).toBe("UsersModule");
+	});
+
+	it("leaves via unset for a global module, even with one importer", () => {
+		const { trace } = parseBootstrapTimings(
+			dump(
+				{
+					mApp: moduleNode("AppModule"),
+					mConfig: moduleNode("ConfigModule", false, true),
+					c1: classNode("ConfigService", "mConfig", 2),
+				},
+				{ e1: imports("mApp", "mConfig") }
+			)
+		);
+
+		expect(trace.tc1.module).toBe("ConfigModule");
+		expect(trace.tc1.via).toBeUndefined();
+	});
+
+	it("leaves via unset for a module more than one module imports", () => {
+		const { trace } = parseBootstrapTimings(
+			dump(
+				{
+					mApp: moduleNode("AppModule"),
+					mAdmin: moduleNode("AdminModule"),
+					mCatalog: moduleNode("CatalogModule"),
+					mUsers: moduleNode("UsersModule"),
+					mCore: moduleNode("TypeOrmCoreModule"),
+					c1: classNode("DataSource", "mCore", 154),
+					c2: classNode("UsersService", "mUsers", 150),
+				},
+				{
+					e1: imports("mUsers", "mCore"),
+					e2: imports("mCatalog", "mCore"),
+					e3: imports("mAdmin", "mCore"),
+					e4: imports("mApp", "mUsers"),
+					e5: imports("mAdmin", "mUsers"),
+				}
+			)
+		);
+
+		expect(trace.tc1.via).toBeUndefined();
+		expect(trace.tc2.via).toBeUndefined();
+	});
+
+	it("counts only module nodes as importers, ignoring malformed and self edges", () => {
+		const { trace } = parseBootstrapTimings(
+			dump(
+				{
+					mUsers: moduleNode("UsersModule"),
+					mInternal: moduleNode("InternalCoreModule", true),
+					mTypeOrm: moduleNode("TypeOrmModule"),
+					c1: classNode("UserRepository", "mTypeOrm", 154.1),
+					c2: classNode("UsersService", "mUsers", 155),
+				},
+				{
+					e1: imports("mUsers", "mTypeOrm"),
+					e2: imports("mInternal", "mTypeOrm"),
+					e3: imports("c2", "mTypeOrm"),
+					e4: imports("missing", "mTypeOrm"),
+					e5: { metadata: { type: "module-to-module" } },
+					e6: {
+						source: 7,
+						target: "mTypeOrm",
+						metadata: { type: "module-to-module" },
+					},
+					e7: imports("mTypeOrm", "mTypeOrm"),
+				}
+			)
+		);
+
+		expect(trace.tc1.via).toBe("UsersModule");
 	});
 
 	it("returns an empty map and a warning for JSON that does not parse", () => {
@@ -384,5 +506,24 @@ describe("loadBootstrapTimings", () => {
 		expect(timings?.startupMs).toBe(4200);
 		expect(timings?.byModule.size).toBe(0);
 		expect(warnings.join(" ")).toContain("no class init times");
+	});
+
+	it("returns timings when every module label repeats", () => {
+		writeFileSync(
+			join(dir, "repeated.json"),
+			dump({
+				m1: moduleNode("SharedModule"),
+				m2: moduleNode("SharedModule"),
+				c1: classNode("BillingService", "m1", 5),
+				c2: classNode("AuthService", "m2", 3),
+			})
+		);
+
+		const { timings, warnings } = loadBootstrapTimings(dir, "repeated.json");
+
+		expect(warnings).toEqual([]);
+		expect(timings?.byModule.size).toBe(0);
+		expect(timings?.trace.tc1.module).toBe("SharedModule");
+		expect(timings?.trace.tc2.module).toBe("SharedModule");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/timings.test.ts
@@ -24,8 +24,9 @@ function edge(source: string, target: string, type = "class-to-class") {
 	return { source, target, metadata: { type } };
 }
 
-const imports = (importer: string, imported: string) =>
-	edge(importer, imported, "module-to-module");
+function imports(importer: string, imported: string) {
+	return edge(importer, imported, "module-to-module");
+}
 
 function dump(
 	nodes: Record<string, unknown>,

--- a/packages/website/src/app/docs/report/boot-trace/page.mdx
+++ b/packages/website/src/app/docs/report/boot-trace/page.mdx
@@ -157,15 +157,15 @@ its real offset from boot start.
 |---|---|---|
 | Overview lane | Top of the lanes | `building modules · lifecycle hooks · opening the port`, from the `createMs`, `initMs`, and `startupMs` markers; with `moduleInitMs` the hooks split into `init hooks · bootstrap hooks`. The window on top is the view: drag it to pan, drag its edges to resize, scroll to zoom, click a phase to frame it |
 | Dotted line | Down the rows | Where one phase hands over to the next |
-| Class bar | Per row, under the module that owns it in the dump; a package module wears an `external` tag | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |
+| Class bar | Per row, under the module that owns it in the dump; a package module shows an `external` tag | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |
 | Hook span | On a row, after the bar | An `onModuleInit` or `onApplicationBootstrap` at its real offset, time inside, when the dump carries `startMs`. Older dumps show a `+120ms init` chip instead |
 | Cascade row | Under an opened chevron, solid black | A shadow of the dependency's own row in its module group, where its cost is drawn once. `deduped` says so, as `npm ls` would. `shared` means it was built earlier for another consumer, `circular` closes a loop to an ancestor |
 
 The chevron before a class opens its dependencies in place; expand all in the
 header opens every level at once. Hovering a bar or a hook span shows a card
 with the class, what it waited on, its module and type, and its time. For a
-package module it also names the one module that imports it, when there is
-exactly one.
+package module that is not global it also names the importing module, when
+exactly one module imports it.
 
 The label column drags to resize and hides like the graph's sidebar. The
 Modules graph keeps a compact mount of the same timeline in its dock. The
@@ -181,5 +181,6 @@ class.
 - Out-of-order phase markers drop the lifecycle strip, also with a warning.
 - A class joins a graph module only when that module's class name is unique,
   inside the dump and across a monorepo's projects. Otherwise it sits under
-  the name the dump gives it: a package module such as `TypeOrmModule` gets an
-  `external` tag, a user module whose name repeats does not.
+  the name the dump gives it. A package module such as `TypeOrmModule` shows
+  an `external` tag; a user module whose name repeats shows an `ambiguous`
+  tag. Every instance with the same name lands in one group.

--- a/packages/website/src/app/docs/report/boot-trace/page.mdx
+++ b/packages/website/src/app/docs/report/boot-trace/page.mdx
@@ -158,7 +158,7 @@ its real offset from boot start.
 |---|---|---|
 | Overview lane | Top of the lanes | `building modules · lifecycle hooks · opening the port`, from the `createMs`, `initMs`, and `startupMs` markers; with `moduleInitMs` the hooks split into `init hooks · bootstrap hooks`. The window on top is the view: drag it to pan, drag its edges to resize, scroll to zoom, click a phase to frame it |
 | Dotted line | Down the rows | Where one phase hands over to the next |
-| Group header | Above its classes | The module that owns them in the dump and their count. A package module shows an `external` tag; a user module whose name repeats shows an `ambiguous` tag |
+| Group header | Above its classes | The module that owns them in the dump, their count, and an `external` or `ambiguous` tag when the graph has no single node for it |
 | Class bar | Per row, under its module's header | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |
 | Hook span | On a row, after the bar | An `onModuleInit` or `onApplicationBootstrap` at its real offset, time inside, when the dump carries `startMs`. Older dumps show a `+120ms init` chip instead |
 | Cascade row | Under an opened chevron, solid black | A shadow of the dependency's own row in its module group, where its cost is drawn once. `deduped` says so, as `npm ls` would. `shared` means it was built earlier for another consumer, `circular` closes a loop to an ancestor |

--- a/packages/website/src/app/docs/report/boot-trace/page.mdx
+++ b/packages/website/src/app/docs/report/boot-trace/page.mdx
@@ -144,7 +144,8 @@ time. If `UsersService` reads 120ms and the `SlowService` it injects reads
 A module node shows two numbers. The build is the own construction of its
 slowest class, after that class's dependencies, never a sum across classes.
 The hook time is the total its classes spent in lifecycle hooks, for example
-`104ms build · 63ms init`.
+`104ms build · 63ms init`. A package node keeps its `package` line and shows
+its time in the tooltip.
 
 ## What the report shows
 
@@ -157,7 +158,8 @@ its real offset from boot start.
 |---|---|---|
 | Overview lane | Top of the lanes | `building modules · lifecycle hooks · opening the port`, from the `createMs`, `initMs`, and `startupMs` markers; with `moduleInitMs` the hooks split into `init hooks · bootstrap hooks`. The window on top is the view: drag it to pan, drag its edges to resize, scroll to zoom, click a phase to frame it |
 | Dotted line | Down the rows | Where one phase hands over to the next |
-| Class bar | Per row, under the module that owns it in the dump; a package module shows an `external` tag | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |
+| Group header | Above its classes | The module that owns them in the dump and their count. A package module shows an `external` tag; a user module whose name repeats shows an `ambiguous` tag |
+| Class bar | Per row, under its module's header | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |
 | Hook span | On a row, after the bar | An `onModuleInit` or `onApplicationBootstrap` at its real offset, time inside, when the dump carries `startMs`. Older dumps show a `+120ms init` chip instead |
 | Cascade row | Under an opened chevron, solid black | A shadow of the dependency's own row in its module group, where its cost is drawn once. `deduped` says so, as `npm ls` would. `shared` means it was built earlier for another consumer, `circular` closes a loop to an ancestor |
 
@@ -165,7 +167,7 @@ The chevron before a class opens its dependencies in place; expand all in the
 header opens every level at once. Hovering a bar or a hook span shows a card
 with the class, what it waited on, its module and type, and its time. For a
 package module that is not global it also names the importing module, when
-exactly one module imports it.
+exactly one module imports that instance.
 
 The label column drags to resize and hides like the graph's sidebar. The
 Modules graph keeps a compact mount of the same timeline in its dock. The

--- a/packages/website/src/app/docs/report/boot-trace/page.mdx
+++ b/packages/website/src/app/docs/report/boot-trace/page.mdx
@@ -157,13 +157,15 @@ its real offset from boot start.
 |---|---|---|
 | Overview lane | Top of the lanes | `building modules · lifecycle hooks · opening the port`, from the `createMs`, `initMs`, and `startupMs` markers; with `moduleInitMs` the hooks split into `init hooks · bootstrap hooks`. The window on top is the view: drag it to pan, drag its edges to resize, scroll to zoom, click a phase to frame it |
 | Dotted line | Down the rows | Where one phase hands over to the next |
-| Class bar | Per row, grouped by module | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |
+| Class bar | Per row, under the module that owns it in the dump; a package module wears an `external` tag | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |
 | Hook span | On a row, after the bar | An `onModuleInit` or `onApplicationBootstrap` at its real offset, time inside, when the dump carries `startMs`. Older dumps show a `+120ms init` chip instead |
 | Cascade row | Under an opened chevron, solid black | A shadow of the dependency's own row in its module group, where its cost is drawn once. `deduped` says so, as `npm ls` would. `shared` means it was built earlier for another consumer, `circular` closes a loop to an ancestor |
 
 The chevron before a class opens its dependencies in place; expand all in the
 header opens every level at once. Hovering a bar or a hook span shows a card
-with the class, what it waited on, its module and type, and its time.
+with the class, what it waited on, its module and type, and its time. For a
+package module it also names the one module that imports it, when there is
+exactly one.
 
 The label column drags to resize and hides like the graph's sidebar. The
 Modules graph keeps a compact mount of the same timeline in its dock. The
@@ -177,5 +179,7 @@ class.
 - An unreadable, malformed, or unrecognized dump degrades to a stderr warning,
   and the report renders without timings.
 - Out-of-order phase markers drop the lifecycle strip, also with a warning.
-- A timing attaches to a module only when that module's class name is unique,
-  inside the dump and across a monorepo's projects.
+- A class joins a graph module only when that module's class name is unique,
+  inside the dump and across a monorepo's projects. Otherwise it sits under
+  the name the dump gives it: a package module such as `TypeOrmModule` gets an
+  `external` tag, a user module whose name repeats does not.

--- a/packages/website/src/app/docs/report/module-graph/page.mdx
+++ b/packages/website/src/app/docs/report/module-graph/page.mdx
@@ -116,7 +116,7 @@ meant it.
 
 `--timings` overlays how long each class took to construct during one real boot.
 Node subtitles gain the slowest class's build time and the module's hook
-time; a package node keeps its `package` line and shows its time in the
+time. A package node keeps its `package` line and shows its time in the
 tooltip. A Boot trace tab appears, with a compact mount in the bottom dock.
 
 That needs one change to `main.ts`, because a scan never runs your application.

--- a/packages/website/src/app/docs/report/module-graph/page.mdx
+++ b/packages/website/src/app/docs/report/module-graph/page.mdx
@@ -116,7 +116,8 @@ meant it.
 
 `--timings` overlays how long each class took to construct during one real boot.
 Node subtitles gain the slowest class's build time and the module's hook
-time. A Boot trace tab appears, with a compact mount in the bottom dock.
+time; a package node keeps its `package` line and shows its time in the
+tooltip. A Boot trace tab appears, with a compact mount in the bottom dock.
 
 That needs one change to `main.ts`, because a scan never runs your application.
 [Boot trace](/docs/report/boot-trace) covers the change and how to read the


### PR DESCRIPTION
## Context

`--timings` overlays a NestJS `SerializedGraph` dump on the report. The Boot trace tab groups every timed class by module: the parser (`src/report/timings.ts`) reads each class's `parent` module only to fill `byModule`, the serializer attaches `byModule` to graph modules (the user's own `@Module` classes, parsed from source), and the timeline (`lib/boot-timeline.ts`) puts every class no graph module claims into one group named `unattributed`.

## Problem

On a real app the scanner's graph never contains the runtime modules that own most of the boot. Booting the `nest-shop` monorepo (NestJS 12, TypeORM, BullMQ, `@nestjs/config`) gives 38 timed classes; 25 land in `unattributed`, among them `DataSource` in `TypeOrmCoreModule`, which owns 153 of the 247ms build phase. Every graph node then reads `<1ms build`, because the class that owns the time sits in the one group the UI hides. The CLI also warned `--timings: 18 class timings belong to module names that appear more than once in the dump; they are not attached to a module`, which fires on every TypeORM app (`TypeOrmModule` appears once per `forFeature`).

Verified against `@nestjs/core` 12.0.1 source: class nodes always carry `parent`; module nodes carry `label`, `metadata.global`, `dynamic`, `internal`; `module-to-module` edges run importer → imported and a global module gets one from every module (`bindGlobalsToImports`). All of that exists since 9.3.0; `initTime` since 9.3.9. On Nest 11+ every `forFeature()` call site is its own module node with the same label; Nest ≤10 collapses identical dynamic metadata into one. Merging by label is right on both.

## Possible flows

| Flow | Affected |
|---|---|
| Class in a user module with a unique name | No: still attributed to the graph module, no tag |
| Class in a package module (`TypeOrmCoreModule`, `TypeOrmModule`, `BullModule`, `ConfigHostModule`, `DiscoveryModule`) | Yes: own group named by the dump label, `external` tag, hover names the importer when there is one |
| Class in a user module whose label repeats in the dump, or whose bare name repeats across projects | Yes: shown under its bare name with an `ambiguous` tag (was `unattributed`); every instance with that name lands in one group; still not joined to a graph node |
| Dump whose every module label repeats | Yes: kept (was dropped by the `byModule.size` guard) |
| Artifact written before this change (no `module` on trace nodes) | No: legacy `unattributed` fallback |
| Shared report (`timingsTrace: {}`), modules dock selection guard, keyboard walk | No |

## Solution

- `TraceNode` gains `module` (parent module label) and `via` (label of the single importer of the class's module instance, never for a global module).
- `parseBootstrapTimings` collects `global` module ids and an importers-by-module map from `module-to-module` edges (string ids, no self edges, only non-internal module sources), sets `module`/`via` on every node, and keeps the duplicate-label skip for graph attachment. The ambiguity warning is gone; the empty check and the `loadBootstrapTimings` guard read the trace instead of `byModule`.
- `buildBootTimeline` groups an unattributed node under its `module` label and marks the span and group `external` when that label is not the bare name of any graph module, or `ambiguous` when it is (a name the graph could not join to one node). `rowsHtml` adds the existing `boot-reused-tag` reading `external` or `ambiguous` to the group row. `moduleTimings` now carries package-module labels, so `measureNode` in `modules-canvas.ts` skips the timing lookup for external nodes: their box keeps its single `package` line and the tooltip still shows the time.
- `hoverCardData` context: `in TypeOrmModule · imported by UsersModule · provider` for a non-global package module with exactly one importer; `in ConfigModule (ambiguous name) · provider` for a repeated user module name.
- Docs: boot trace page table row, hover sentence, and Limits bullet; skill §4.

Deliberately not done: folding `forFeature` repositories into the importing user module (would misstate Nest's tree), mapping `TypeOrmCoreModule` onto the graph's `TypeOrmModule` node (package-specific knowledge), collapsing external groups by default (would hide `DataSource`), and relabelling `mixin()` classes such as `63aa65c815a883daaa862` (random per boot, shown as-is).

## Before vs after

| | Before | After |
|---|---|---|
| Groups on `nest-shop` | 8 user modules + `unattributed 25` | 8 user modules + `TypeOrmModule external 8`, `BullModule external 8`, `TypeOrmCoreModule external 3`, `ConfigHostModule external 2`, `ConfigModule external 2`, `DiscoveryModule external 2` |
| `DataSource` 153ms | Inside `unattributed` | `TypeOrmCoreModule` group, `153ms` bar |
| Hover on `UserRepository` | `module not identified · provider` | `in TypeOrmModule · imported by UsersModule · provider` |
| Hover on a class of a user module whose name repeats | `module not identified · provider` | `in ConfigModule (ambiguous name) · provider` |
| stderr | `--timings: 18 class timings belong to module names that appear more than once…` | nothing |
| `--format report-json` trace node | `{name,type,initTime,deps}` | `+ module`, `+ via` when known |
| User module with a unique name | attributed, no tag | Unchanged |
| Legacy artifact without `module` | `unattributed` | Unchanged |

## Example

```
$ node dist/cli/index.mjs . --format report-json --timings nestjs-doctor-timings.json --output nestjs-doctor-report.json
```

Old stderr: `--timings: 18 class timings belong to module names that appear more than once in the dump; they are not attached to a module`
New stderr: empty.

Old `graph.timingsTrace["t-1488832441"]`: `{"name":"UserRepository","type":"provider","initTime":154.147917,"deps":["t…DataSource"]}`
New: `{"name":"UserRepository","type":"provider","initTime":154.147917,"deps":["t…DataSource"],"module":"TypeOrmModule","via":"UsersModule"}`; `DataSource` reads `"module":"TypeOrmCoreModule"` with no `via`.

Screenshot of the real report is in the review thread. Tests: 26 parser, 46 timeline, 6 hover, 21 app cases (red first, then green); 1723 total.

The website demo (`demo-report.json`) was exported before this change and is re-exported in a separate website PR after this merges (#358 closed for that reason).
