### PR TITLE
fix(report): name every boot phase on hover and keep narrow ones visible

### DIFF
--- a/.changeset/boot-phase-tips.md
+++ b/.changeset/boot-phase-tips.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Fixed
+
+- A phase in the boot trace's overview lane shorter than its label had no name: a 0.7ms `opening the port` drew as a 2px sliver, so the lane read as ending with the hooks. Every phase now carries a hover tip with its time and meaning, and no phase draws narrower than 0.6% of the lane.

--- a/.changeset/boot-phase-tips.md
+++ b/.changeset/boot-phase-tips.md
@@ -4,4 +4,4 @@
 
 ### Fixed
 
-- A phase in the boot trace's overview lane shorter than its label had no name: a 0.7ms `opening the port` drew as a 2px sliver, so the lane read as ending with the hooks. Every phase now carries a hover tip with its time and meaning, and no phase draws narrower than 0.6% of the lane.
+- A phase in the boot trace's overview lane shorter than its label had no name: a 0.7ms `opening the port` drew as a 2px sliver, so the lane read as ending with the hooks. Every phase now carries a hover tip with its time and meaning, and no phase draws narrower than 0.6% of the lane. A phase nothing ran inside draws as a black weave, at least 1.5% wide, so an empty `bootstrap hooks` or a sub-millisecond `listen` still reads as a section.

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -57,6 +57,8 @@ interface BootGroup {
 }
 
 interface BootPhase {
+	/** No class or hook span falls inside the phase. */
+	empty: boolean;
 	end: number;
 	gloss: string;
 	label: string;
@@ -177,6 +179,7 @@ export function buildBootTimeline(
 	let prev = 0;
 	for (const p of phaseParts(graph)) {
 		phases.push({
+			empty: false,
 			end: prev + p.ms,
 			gloss: p.gloss,
 			label: p.label,
@@ -185,6 +188,10 @@ export function buildBootTimeline(
 			tip: p.tip,
 		});
 		prev += p.ms;
+	}
+	const spans = [...byId.values()];
+	for (const ph of phases) {
+		ph.empty = !spans.some((s) => spanTouches(s, ph));
 	}
 
 	const maxMs = Math.max(
@@ -196,6 +203,29 @@ export function buildBootTimeline(
 		return null;
 	}
 	return { byId, groups, maxMs, phases };
+}
+
+// A chip has no offset, so it counts toward the phase named for its hook.
+function chipBelongs(hook: string, phaseLabel: string): boolean {
+	if (
+		phaseLabel === "onModuleInit" ||
+		phaseLabel === "onApplicationBootstrap"
+	) {
+		return hook === phaseLabel;
+	}
+	return phaseLabel !== "create" && phaseLabel !== "listen";
+}
+
+function spanTouches(s: BootSpan, ph: BootPhase): boolean {
+	const inside = (from: number, to: number) => from < ph.end && to > ph.start;
+	if (inside(s.start, s.end)) {
+		return true;
+	}
+	return (s.hooks ?? []).some((h) =>
+		typeof h.startMs === "number"
+			? inside(h.startMs, h.startMs + h.ms)
+			: chipBelongs(h.hook, ph.label)
+	);
 }
 
 /** Ids of every class whose dependencies can be cascaded open. */
@@ -543,8 +573,10 @@ export function axisHtml(win: BootWindow): string {
 	return html;
 }
 
-// Narrowest a phase segment draws, as a share of the lane.
+// Narrowest a phase segment draws, as a share of the lane; an empty one
+// gets more room so its weave shows.
 const PHASE_MIN_PCT = 0.6;
+const EMPTY_PHASE_MIN_PCT = 1.5;
 
 // The phase lane: tinted segments over the whole boot with their names and
 // durations; each carries its range so a click can zoom to it, and a tip so
@@ -555,15 +587,20 @@ export function phaseLaneHtml(t: BootTimeline): string {
 	for (const p of t.phases) {
 		const width = Math.max(
 			pct(p.end, full) - pct(p.start, full),
-			PHASE_MIN_PCT
+			p.empty ? EMPTY_PHASE_MIN_PCT : PHASE_MIN_PCT
 		);
 		const left = Math.min(pct(p.start, full), 100 - width);
 		const ms = formatMs(p.end - p.start);
+		const tip = p.empty
+			? `${ms} · ${p.tip} · nothing ran inside`
+			: `${ms} · ${p.tip}`;
+		const fill = p.empty ? "" : `;background:rgba(${p.rgb},0.3)`;
+		const ink = p.empty ? "rgba(255,255,255,0.45)" : `rgb(${p.rgb})`;
 		html +=
-			`<span class="boot-phase" data-from="${p.start}" data-to="${p.end}"` +
-			` data-tip="${escapeHtml(`${ms} · ${p.tip}`)}"` +
-			` style="left:${left.toFixed(3)}%;width:${width.toFixed(3)}%;background:rgba(${p.rgb},0.3)">` +
-			`<span class="boot-phase-label" style="color:rgb(${p.rgb})">${escapeHtml(p.gloss)} ` +
+			`<span class="boot-phase${p.empty ? " boot-phase-empty" : ""}" data-from="${p.start}" data-to="${p.end}"` +
+			` data-tip="${escapeHtml(tip)}"` +
+			` style="left:${left.toFixed(3)}%;width:${width.toFixed(3)}%${fill}">` +
+			`<span class="boot-phase-label" style="color:${ink}">${escapeHtml(p.gloss)} ` +
 			`<span class="boot-phase-ms">${escapeHtml(ms)}</span></span></span>`;
 	}
 	return html;

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -543,17 +543,28 @@ export function axisHtml(win: BootWindow): string {
 	return html;
 }
 
+// Narrowest a phase segment draws, as a share of the lane.
+const PHASE_MIN_PCT = 0.6;
+
 // The phase lane: tinted segments over the whole boot with their names and
-// durations; each carries its range so a click can zoom to it.
+// durations; each carries its range so a click can zoom to it, and a tip so
+// a segment too narrow for its label still names itself.
 export function phaseLaneHtml(t: BootTimeline): string {
 	const full: BootWindow = { from: 0, to: t.maxMs };
 	let html = "";
 	for (const p of t.phases) {
+		const width = Math.max(
+			pct(p.end, full) - pct(p.start, full),
+			PHASE_MIN_PCT
+		);
+		const left = Math.min(pct(p.start, full), 100 - width);
+		const ms = formatMs(p.end - p.start);
 		html +=
 			`<span class="boot-phase" data-from="${p.start}" data-to="${p.end}"` +
-			` style="${barStyle(p.start, p.end, full, 0.1)};background:rgba(${p.rgb},0.3)">` +
+			` data-tip="${escapeHtml(`${ms} · ${p.tip}`)}"` +
+			` style="left:${left.toFixed(3)}%;width:${width.toFixed(3)}%;background:rgba(${p.rgb},0.3)">` +
 			`<span class="boot-phase-label" style="color:rgb(${p.rgb})">${escapeHtml(p.gloss)} ` +
-			`<span class="boot-phase-ms">${escapeHtml(formatMs(p.end - p.start))}</span></span></span>`;
+			`<span class="boot-phase-ms">${escapeHtml(ms)}</span></span></span>`;
 	}
 	return html;
 }

--- a/packages/nestjs-doctor/src/report/ui/app/lib/float-tip.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/float-tip.ts
@@ -1,4 +1,4 @@
-const ROOT_IDS = ["mg-dock", "header-meta", "detail-badges"];
+const ROOTS = ["#mg-dock", "#header-meta", "#detail-badges", ".boot-overview"];
 
 let installed = false;
 let shown: Element | null = null;
@@ -44,7 +44,7 @@ function onMouseOver(ev: Event): void {
 	}
 	const tip = tipElement();
 	const el = target.closest("[data-tip]");
-	if (!(el && ROOT_IDS.some((id) => el.closest(`#${id}`)))) {
+	if (!(el && ROOTS.some((root) => el.closest(root)))) {
 		if (shown) {
 			hide(tip);
 		}

--- a/packages/nestjs-doctor/src/report/ui/styles/boot.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/boot.css
@@ -60,6 +60,13 @@
   overflow: hidden; display: flex; align-items: flex-start;
   padding: 5px 6px 0; cursor: pointer; box-sizing: border-box;
 }
+/* A phase nothing ran inside: black carbon weave instead of a tint. */
+.boot-phase-empty {
+  background-color: #0a0a0a;
+  background-image:
+    repeating-linear-gradient(45deg, rgba(255,255,255,0.06) 0 2px, transparent 2px 6px),
+    repeating-linear-gradient(-45deg, rgba(255,255,255,0.06) 0 2px, transparent 2px 6px);
+}
 .boot-phase-label {
   font-size: 10px; white-space: nowrap; overflow: hidden;
   text-overflow: ellipsis; letter-spacing: 0.02em;

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -27,6 +27,11 @@ import {
 	zoomWindow,
 } from "../../src/report/ui/app/lib/boot-timeline.js";
 
+const PHASE_POSITION_RE = /left:([\d.]+)%;width:([\d.]+)%/g;
+const PHASE_TAG_RE =
+	/<span class="boot-phase([^"]*)" data-from="[^"]*" data-to="[^"]*" data-tip="([^"]*)" style="([^"]*)"/g;
+const PHASE_WIDTH_RE = /width:([\d.]+)%/;
+
 function graph(
 	overrides: Partial<SerializedModuleGraph> = {}
 ): SerializedModuleGraph {
@@ -315,6 +320,52 @@ describe("buildBootTimeline", () => {
 			["onModuleInit", 100, 250],
 			["onApplicationBootstrap", 250, 300],
 			["listen", 300, 400],
+		]);
+	});
+
+	it("marks a phase empty when no class or hook span falls inside it", () => {
+		const t = buildBootTimeline(
+			graph({
+				phases: { createMs: 100, initMs: 300, moduleInitMs: 250 },
+				startupMs: 400,
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(
+						50,
+						[],
+						[{ hook: "onModuleInit", ms: 20, startMs: 150 }]
+					),
+				},
+			})
+		);
+		expect(t?.phases.map((p) => [p.label, p.empty])).toEqual([
+			["create", false],
+			["onModuleInit", false],
+			["onApplicationBootstrap", true],
+			["listen", true],
+		]);
+	});
+
+	it("counts a hook chip without an offset toward its own phase", () => {
+		const t = buildBootTimeline(
+			graph({
+				phases: { createMs: 100, initMs: 300, moduleInitMs: 250 },
+				startupMs: 400,
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(
+						50,
+						[],
+						[{ count: 2, hook: "onApplicationBootstrap", ms: 20 }]
+					),
+				},
+			})
+		);
+		expect(t?.phases.map((p) => [p.label, p.empty])).toEqual([
+			["create", false],
+			["onModuleInit", true],
+			["onApplicationBootstrap", false],
+			["listen", true],
 		]);
 	});
 
@@ -933,14 +984,41 @@ describe("lanes and axis", () => {
 			})
 		)!;
 		const html = phaseLaneHtml(t);
-		const styles = [...html.matchAll(/left:([\d.]+)%;width:([\d.]+)%/g)].map(
-			(m) => [Number(m[1]), Number(m[2])]
-		);
+		const styles = [...html.matchAll(PHASE_POSITION_RE)].map((m) => [
+			Number(m[1]),
+			Number(m[2]),
+		]);
 		expect(styles).toHaveLength(3);
 		const [left, width] = styles[2] as [number, number];
 		expect(width).toBeGreaterThanOrEqual(0.6);
 		expect(left + width).toBeLessThanOrEqual(100.0001);
 		expect(html).toContain('data-tip="&lt;1ms · listen — ');
+	});
+
+	it("draws an empty phase as a wider woven segment with a plain tip", () => {
+		const t = buildBootTimeline(
+			graph({
+				phases: { createMs: 246.9, initMs: 277.8 },
+				startupMs: 278.5,
+				timingsAvailable: true,
+				timingsTrace: { ta: traceNode(50) },
+			})
+		)!;
+		const html = phaseLaneHtml(t);
+		const tags = [...html.matchAll(PHASE_TAG_RE)].map((m) => ({
+			classes: m[1],
+			style: m[3],
+			tip: m[2],
+		}));
+		expect(tags).toHaveLength(3);
+		expect(tags[0]?.classes).toBe("");
+		expect(tags[0]?.style).toContain("background:rgba");
+		expect(tags[1]?.classes).toBe(" boot-phase-empty");
+		expect(tags[1]?.tip).toContain("nothing ran inside");
+		expect(tags[1]?.style).not.toContain("background:rgba");
+		expect(tags[2]?.classes).toBe(" boot-phase-empty");
+		const width = Number(PHASE_WIDTH_RE.exec(tags[2]?.style ?? "")?.[1]);
+		expect(width).toBeGreaterThanOrEqual(1.5);
 	});
 
 	it("renders the windowed axis with edge labels", () => {

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -917,7 +917,30 @@ describe("lanes and axis", () => {
 		expect(html).toContain("boot-phase");
 		expect(html).toContain('data-from="0" data-to="100"');
 		expect(html).toContain("building modules");
-		expect(html).not.toContain("data-tip");
+		expect(html).toContain(
+			'data-tip="100ms · create — NestFactory constructs every module, provider, and controller."'
+		);
+		expect(html).toContain('data-tip="100ms · listen — ');
+	});
+
+	it("keeps a sub-millisecond phase wide enough to hover, inside the lane", () => {
+		const t = buildBootTimeline(
+			graph({
+				phases: { createMs: 246.9, initMs: 277.8 },
+				startupMs: 278.5,
+				timingsAvailable: true,
+				timingsTrace: { ta: traceNode(50) },
+			})
+		)!;
+		const html = phaseLaneHtml(t);
+		const styles = [...html.matchAll(/left:([\d.]+)%;width:([\d.]+)%/g)].map(
+			(m) => [Number(m[1]), Number(m[2])]
+		);
+		expect(styles).toHaveLength(3);
+		const [left, width] = styles[2] as [number, number];
+		expect(width).toBeGreaterThanOrEqual(0.6);
+		expect(left + width).toBeLessThanOrEqual(100.0001);
+		expect(html).toContain('data-tip="&lt;1ms · listen — ');
 	});
 
 	it("renders the windowed axis with edge labels", () => {

--- a/packages/nestjs-doctor/tests/unit/report-dom.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-dom.test.ts
@@ -175,3 +175,24 @@ it("shows the floating tooltip for data-tip elements in the header", () => {
 	);
 	expect(tip?.style.display).toBe("none");
 });
+
+it("shows the floating tooltip for a phase in the boot overview lane", () => {
+	const dom = new JSDOM(`<body>${getReportHtml()}</body>`, {
+		runScripts: "outside-only",
+		pretendToBeVisual: true,
+	});
+	const win = dom.window as unknown as typeof globalThis & Window;
+	stubCanvas(win);
+	win.eval(getReportScripts(RICH_ARTIFACT_JSON));
+
+	const lane = win.document.createElement("div");
+	lane.className = "boot-lane boot-overview";
+	lane.innerHTML =
+		'<span class="boot-phases"><span class="boot-phase" data-tip="<1ms · listen"></span></span>';
+	win.document.body.appendChild(lane);
+	const phase = lane.querySelector(".boot-phase");
+	phase?.dispatchEvent(new win.MouseEvent("mouseover", { bubbles: true }));
+	const tip = win.document.getElementById("mg-float-tip");
+	expect(tip?.style.display).toBe("block");
+	expect(tip?.textContent).toBe("<1ms · listen");
+});

--- a/packages/nestjs-doctor/tests/unit/report-styles.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-styles.test.ts
@@ -9,6 +9,11 @@ describe("report styles", () => {
 		expect(css).not.toContain("REPORT_FONT_STACK");
 	});
 
+	it("weaves the empty boot phase", () => {
+		expect(css).toContain(".boot-phase-empty {");
+		expect(css).toContain("repeating-linear-gradient(45deg");
+	});
+
 	it("concatenates every sheet", () => {
 		for (const marker of [
 			":root {",

--- a/packages/website/src/app/docs/report/boot-trace/page.mdx
+++ b/packages/website/src/app/docs/report/boot-trace/page.mdx
@@ -156,7 +156,7 @@ its real offset from boot start.
 
 | Element | Where | Means |
 |---|---|---|
-| Overview lane | Top of the lanes | `building modules · lifecycle hooks · opening the port`, from the `createMs`, `initMs`, and `startupMs` markers; with `moduleInitMs` the hooks split into `init hooks · bootstrap hooks`. The window on top is the view: drag it to pan, drag its edges to resize, scroll to zoom, click a phase to frame it |
+| Overview lane | Top of the lanes | `building modules · lifecycle hooks · opening the port`, from the `createMs`, `initMs`, and `startupMs` markers; with `moduleInitMs` the hooks split into `init hooks · bootstrap hooks`. The window on top is the view: drag it to pan, drag its edges to resize, scroll to zoom, click a phase to frame it, hover one for its name and time |
 | Dotted line | Down the rows | Where one phase hands over to the next |
 | Group header | Above its classes | The module that owns them in the dump, their count, and an `external` or `ambiguous` tag when the graph has no single node for it |
 | Class bar | Per row, under its module's header | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |

--- a/packages/website/src/app/docs/report/boot-trace/page.mdx
+++ b/packages/website/src/app/docs/report/boot-trace/page.mdx
@@ -156,7 +156,7 @@ its real offset from boot start.
 
 | Element | Where | Means |
 |---|---|---|
-| Overview lane | Top of the lanes | `building modules · lifecycle hooks · opening the port`, from the `createMs`, `initMs`, and `startupMs` markers; with `moduleInitMs` the hooks split into `init hooks · bootstrap hooks`. The window on top is the view: drag it to pan, drag its edges to resize, scroll to zoom, click a phase to frame it, hover one for its name and time |
+| Overview lane | Top of the lanes | `building modules · lifecycle hooks · opening the port`, from the `createMs`, `initMs`, and `startupMs` markers; with `moduleInitMs` the hooks split into `init hooks · bootstrap hooks`. The window on top is the view: drag it to pan, drag its edges to resize, scroll to zoom, click a phase to frame it, hover one for its name and time. A phase nothing ran inside draws as a black weave |
 | Dotted line | Down the rows | Where one phase hands over to the next |
 | Group header | Above its classes | The module that owns them in the dump, their count, and an `external` or `ambiguous` tag when the graph has no single node for it |
 | Class bar | Per row, under its module's header | From its slowest dependency's finish to its own, or from boot start when nothing traced came before; colored by type. The time it took sits inside the bar |


### PR DESCRIPTION
## Context

The Boot trace tab's overview lane draws the lifecycle phases from the dump's markers: `building modules` up to `createMs`, `lifecycle hooks` up to `initMs`, `opening the port` up to `startupMs`. Each segment carries its name and duration as text inside it, and a click frames it. `phaseParts` in `lib/trace.ts` also builds a one-line explanation per phase (`tip`) that nothing rendered.

## Problem

On the real `nest-shop` boot the listen phase is 0.7ms of 278ms. `phaseLaneHtml` gave it `width:0.251%` and CSS `min-width: 2px`, so it drew as a 2px grey sliver at the right edge with its label clipped. The lane read as ending with `lifecycle hooks 31ms`, and nothing on the page could tell a reader that the boot ends at the listening step, or what the sliver was. The report's floating tooltip (`lib/float-tip.ts`) only served `#mg-dock`, `#header-meta`, and `#detail-badges`, so a `data-tip` on a phase would have been inert on the Boot tab.

## Possible flows

| Flow | Affected |
|---|---|
| Phase wide enough for its label | Tip added on hover; drawing unchanged |
| Phase narrower than 0.6% of the lane (a sub-millisecond `listen`) | Drawn at 0.6% (about 12px), shifted left to stay inside the lane; hover names it |
| Dock's compact trace under `#mg-dock` | Already served by the float tip; now carries the same `data-tip` |
| Click to frame a phase, drag, zoom | Unchanged |

## Solution

- `phaseLaneHtml` sets `data-tip="<duration> · <tip>"` on every `.boot-phase` (`<1ms · listen — the HTTP server binds its port; at the end of this segment the app is up`) and enforces a 0.6% minimum width, clamping `left` so the last segment ends at the lane's edge.
- `float-tip.ts` matches roots by selector and adds `.boot-overview`, so the tab's own lane gets the floating tip the dock already had.
- A phase nothing ran inside (no class span, no positioned hook span, no chip of its kind) draws as a black carbon weave at least 4.5% of the lane wide, without the tint, with `· nothing ran inside` on its tip: an empty `bootstrap hooks` section or the port bind reads as a section rather than a sliver.
- Docs: the Overview lane row says hover names a phase and what the weave means. Changeset, patch.

Not done: labels inside narrow segments (no room), and the 2px CSS minimum stays as the floor for windows the 0.6% rule cannot reach.

## Before vs after

| | Before | After |
|---|---|---|
| `opening the port` at 0.7ms of 278ms | 2px sliver, no label, no tip | 12px segment, hover reads `<1ms · listen — the HTTP server binds its port; at the end of this segment the app is up` |
| `building modules 247ms` | Label inside | Unchanged, plus the same hover tip with the phase's meaning |
| Float tip on the Boot tab | Inert outside the dock | Serves `.boot-overview` |
| Empty `bootstrap hooks` (no `onApplicationBootstrap` ran) | Tinted violet like a busy one | Black weave, `nothing ran inside` on hover |
| Click, drag, zoom on the lane | Unchanged | Unchanged |

## Example

`nest-shop` dump: `createMs 246.9`, `initMs 277.8`, `startupMs 278.5`.

Old third segment: `style="left:99.749%;width:0.251%"`, no `data-tip`.
New: `style="left:99.400%;width:0.600%"`, `data-tip="&lt;1ms · listen — the HTTP server binds its port; at the end of this segment the app is up"`; hovering it shows that text (screenshot in the thread).

Tests: the lane test asserts the tips; cases pin the 0.6% floor and the in-lane clamp, the empty flag per phase (overlap and chip rules), the woven segment's class, tip, width, and missing tint, and the CSS rule; a DOM test hovers a phase inside `.boot-overview` and reads the float tip. 1729 total.
