### PR TITLE
feat(report): one boot trace per entry point

### DIFF
--- a/.changeset/boot-multi-trace.md
+++ b/.changeset/boot-multi-trace.md
@@ -5,3 +5,7 @@
 ### Added
 
 - **One boot trace per entry point.** `--timings` takes a comma list of SerializedGraph dumps, each optionally labelled (`--timings api.json,worker=worker.json`). Every dump becomes its own trace on the Boot tab with a picker, keeping its own clock; the report attributes each dump to a monorepo project by its label, its root module against the bootstrap roots, or the modules only one project owns. The artifact gains an additive `graph.traces` array while the old singular fields keep mirroring the primary trace, so existing consumers read unchanged. In the modules graph, the trace dock is pinned to the selected module's own app and says so instead of showing another app's boot when none covers it; per-module timings attach per project, so two projects sharing a module class name no longer lose their timings.
+
+### Behavior changes
+
+- Node API: `buildReportArtifact` takes `traces` (`LoadedBootTrace[]`, exported from the api barrel) instead of the old `timings` input.

--- a/.changeset/boot-multi-trace.md
+++ b/.changeset/boot-multi-trace.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Added
+
+- **One boot trace per entry point.** `--timings` takes a comma list of SerializedGraph dumps, each optionally labelled (`--timings api.json,worker=worker.json`). Every dump becomes its own trace on the Boot tab with a picker, keeping its own clock; the report attributes each dump to a monorepo project by its label, its root module against the bootstrap roots, or the modules only one project owns. The artifact gains an additive `graph.traces` array while the old singular fields keep mirroring the primary trace, so existing consumers read unchanged. In the modules graph, the trace dock is pinned to the selected module's own app and says so instead of showing another app's boot when none covers it; per-module timings attach per project, so two projects sharing a module class name no longer lose their timings.

--- a/.changeset/boot-stray-hooks.md
+++ b/.changeset/boot-stray-hooks.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Fixed
+
+- A lifecycle hook whose recorded offset falls outside the phase its kind names kept blending in as if nothing were wrong. It keeps its measured position and the range sums it sits in, and now wears a striped marker with `past its phase` on its hover card. A framework-driven boot cannot produce this ordering (`app.init()` awaits every hook before resolving); it appears when user code re-invokes a hook after init.

--- a/packages/nestjs-doctor/skills/nestjs-boot-trace/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-boot-trace/SKILL.md
@@ -80,6 +80,8 @@ environment check or a separate entry point rather than shipping it.
 npx nestjs-doctor@latest . --report --timings nestjs-doctor-timings.json
 ```
 
+A monorepo boots once per entry point. Instrument each `main.ts`, keep one dump per app, and pass them together, labelled when a name helps: `--timings nestjs-doctor-timings.json,worker=worker-timings.json`. Each dump becomes its own trace in the report.
+
 Relative paths resolve against the scanned directory. Without `--report` the
 flag is ignored, with a warning. A missing file, invalid JSON, or a dump
 without `initTime` each warn on stderr and still render the report, so check

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -139,6 +139,7 @@ export {
 export type { SarifLog } from "../formatters/sarif-report.js";
 export { buildSarifLog } from "../formatters/sarif-report.js";
 export { buildReportArtifact } from "../report/artifact.js";
+export type { LoadedBootTrace } from "../report/timings.js";
 
 function validatePath(path: string): string {
 	if (!path || path.trim() === "") {
@@ -225,4 +226,3 @@ export async function diagnoseMonorepo(
 	const { result } = await scanMonorepo(targetPath, scanConfig, monorepo);
 	return result;
 }
-export type { LoadedBootTrace } from "../report/timings.js";

--- a/packages/nestjs-doctor/src/api/index.ts
+++ b/packages/nestjs-doctor/src/api/index.ts
@@ -225,3 +225,4 @@ export async function diagnoseMonorepo(
 	const { result } = await scanMonorepo(targetPath, scanConfig, monorepo);
 	return result;
 }
+export type { LoadedBootTrace } from "../report/timings.js";

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -82,7 +82,7 @@ export const flags = {
 	timings: {
 		type: "string",
 		description:
-			"Path to a SerializedGraph JSON dump (from app.get(SerializedGraph)) to overlay bootstrap init times on the report's module graph; relative paths resolve against the scanned directory",
+			"Comma list of SerializedGraph JSON dumps (from app.get(SerializedGraph)), one per entry point, each optionally labelled as name=path; relative paths resolve against the scanned directory",
 	},
 	sources: {
 		type: "string",

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -394,7 +394,7 @@ export class MonorepoPipeline extends ScanPipeline {
 				bootstrapRoots: this.bootstrapRoots,
 				monorepo: true,
 				sources: this.options.sources,
-				timings: this.options.timings,
+				traces: this.options.traces,
 				version: getCliVersion(),
 			});
 		}
@@ -608,7 +608,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 				providers: this.reportProviders,
 				bootstrapRoots: this.bootstrapRoots,
 				sources: this.options.sources,
-				timings: this.options.timings,
+				traces: this.options.traces,
 				version: getCliVersion(),
 			});
 		}

--- a/packages/nestjs-doctor/src/cli/scan-worker.ts
+++ b/packages/nestjs-doctor/src/cli/scan-worker.ts
@@ -31,7 +31,7 @@ const options: PipelineOptions = {
 	shareSections: undefined,
 	skipOutput: true,
 	sources: "none",
-	timings: undefined,
+	traces: undefined,
 	verbose: false,
 };
 

--- a/packages/nestjs-doctor/src/cli/setup.ts
+++ b/packages/nestjs-doctor/src/cli/setup.ts
@@ -1,8 +1,8 @@
 import { resolve } from "node:path";
 import type { SourceInclusion } from "../common/artifact.js";
 import { isScopeMode, type ScopeMode } from "../common/scope.js";
-import type { BootstrapTimings } from "../common/timings.js";
 import { parseShareSections, type ShareSectionId } from "../report/share.js";
+import type { LoadedBootTrace } from "../report/timings.js";
 import { logger } from "../ui/logger.js";
 import {
 	type BlockingLevel,
@@ -48,7 +48,7 @@ export interface PipelineOptions extends ScanOptions {
 	/** How much source text the report artifact embeds. */
 	sources: SourceInclusion;
 	/** Parsed bootstrap dump, for the artifact's module-graph overlay. */
-	timings?: BootstrapTimings;
+	traces?: LoadedBootTrace[];
 	verbose: boolean;
 }
 
@@ -323,12 +323,12 @@ export class CliSetup {
 		}
 
 		const format = resolveFormat(this.args);
-		let timings: BootstrapTimings | undefined;
+		let traces: LoadedBootTrace[] | undefined;
 		if (this.args.timings) {
 			if (format === "report-json") {
-				const { loadBootstrapTimings } = await import("../report/timings.js");
-				const loaded = loadBootstrapTimings(this.targetPath, this.args.timings);
-				timings = loaded.timings;
+				const { loadBootstrapTraces } = await import("../report/timings.js");
+				const loaded = loadBootstrapTraces(this.targetPath, this.args.timings);
+				traces = loaded.traces;
 				for (const warning of loaded.warnings) {
 					logger.warn(warning);
 				}
@@ -360,7 +360,7 @@ export class CliSetup {
 				sources: resolveSources(this.args),
 				staged: this.args.staged ?? false,
 				telemetry: this.args.telemetry ?? true,
-				timings,
+				traces,
 				verbose: this.args.verbose ?? false,
 			},
 		};

--- a/packages/nestjs-doctor/src/common/artifact.ts
+++ b/packages/nestjs-doctor/src/common/artifact.ts
@@ -57,6 +57,15 @@ export interface SerializedModuleNode {
 	providerTokens?: string[];
 }
 
+/** One boot trace: a dump's classes and phases, attributed to a project when known. */
+export interface SerializedBootTrace {
+	label: string;
+	phases?: BootPhases;
+	project?: string;
+	startupMs?: number;
+	trace: Record<string, TraceNode>;
+}
+
 export interface SerializedModuleGraph {
 	bootstrapRoots?: string[];
 	circularDepRecommendations: Record<string, string>;
@@ -68,6 +77,7 @@ export interface SerializedModuleGraph {
 	startupMs?: number;
 	timingsAvailable?: boolean;
 	timingsTrace?: Record<string, TraceNode>;
+	traces?: SerializedBootTrace[];
 }
 
 /**

--- a/packages/nestjs-doctor/src/common/artifact.ts
+++ b/packages/nestjs-doctor/src/common/artifact.ts
@@ -108,3 +108,10 @@ export interface ReportArtifact {
 	sources: Record<string, string>;
 	summary: DiagnoseSummary;
 }
+
+/** Strips the monorepo project prefix from a module name. */
+export function bareModuleName(m: { name: string; project?: string }): string {
+	return m.project && m.name.startsWith(`${m.project}/`)
+		? m.name.slice(m.project.length + 1)
+		: m.name;
+}

--- a/packages/nestjs-doctor/src/common/timings.ts
+++ b/packages/nestjs-doctor/src/common/timings.ts
@@ -40,6 +40,7 @@ export interface BootstrapTimings {
 	byModule: Map<string, ClassTiming[]>;
 	hooksByClass: Map<string, HookTiming[]>;
 	phases?: BootPhases;
+	rootModule?: string;
 	startupMs?: number;
 	trace: Record<string, TraceNode>;
 }

--- a/packages/nestjs-doctor/src/report/artifact.ts
+++ b/packages/nestjs-doctor/src/report/artifact.ts
@@ -15,7 +15,7 @@ import type { ProviderInfo } from "../engine/graph/type-resolver.js";
 import { getRuleExamples } from "./data/examples.js";
 import { serializeModuleGraph } from "./formatters/module-serializer.js";
 import { buildShareManifest } from "./share.js";
-import type { BootstrapTimings } from "./timings.js";
+import type { LoadedBootTrace } from "./timings.js";
 
 const EMPTY_SCHEMA: SerializedSchemaGraph = {
 	entities: [],
@@ -93,7 +93,7 @@ interface ReportArtifactInput {
 	sources?: SourceInclusion;
 	/** Where the scan ran; share slices relativize their paths against it. */
 	targetPath?: string;
-	timings?: BootstrapTimings;
+	traces?: LoadedBootTrace[];
 	version: string;
 }
 
@@ -107,7 +107,7 @@ export function buildReportArtifact(
 		input.result,
 		input.projects,
 		input.bootstrapRoots,
-		input.timings
+		input.traces
 	);
 	const share = buildShareManifest(input.result, {
 		graph,

--- a/packages/nestjs-doctor/src/report/formatters/module-serializer.ts
+++ b/packages/nestjs-doctor/src/report/formatters/module-serializer.ts
@@ -7,7 +7,12 @@ import {
 	findCircularDeps,
 	type ModuleGraph,
 } from "../../engine/graph/module-graph.js";
-import type { BootstrapTimings, ClassTiming, HookTiming } from "../timings.js";
+import type {
+	BootstrapTimings,
+	ClassTiming,
+	HookTiming,
+	LoadedBootTrace,
+} from "../timings.js";
 
 /** Strips the monorepo project prefix, matching getDisplayName in the report UI. */
 function bareModuleName(node: { name: string; project?: string }): string {
@@ -21,26 +26,112 @@ export function serializeModuleGraph(
 	result: DiagnoseResult,
 	projects?: string[],
 	bootstrapRoots?: string[],
-	timings?: BootstrapTimings
+	traces?: LoadedBootTrace[]
 ): SerializedModuleGraph {
-	// A timing entry only knows the bare class name; attach it only when unique.
+	const rootSet = new Set(bootstrapRoots ?? []);
+	const projectsByBare = new Map<string, Set<string | undefined>>();
+	const rootProjectsByBare = new Map<string, Set<string | undefined>>();
+	const rootedProjects = new Set<string>();
+	// A timing entry only knows the bare name; a project-scoped trace needs
+	// it unique inside the project, a shared one unique across the graph.
 	const bareNameCounts = new Map<string, number>();
-	if (timings) {
-		for (const node of graph.modules.values()) {
-			const bare = bareModuleName(node);
-			bareNameCounts.set(bare, (bareNameCounts.get(bare) ?? 0) + 1);
+	const globalNameCounts = new Map<string, number>();
+	for (const node of graph.modules.values()) {
+		const bare = bareModuleName(node);
+		const key = `${node.project ?? ""}\u0000${bare}`;
+		bareNameCounts.set(key, (bareNameCounts.get(key) ?? 0) + 1);
+		globalNameCounts.set(bare, (globalNameCounts.get(bare) ?? 0) + 1);
+		const owners = projectsByBare.get(bare) ?? new Set();
+		owners.add(node.project);
+		projectsByBare.set(bare, owners);
+		if (rootSet.has(node.name)) {
+			const rootOwners = rootProjectsByBare.get(bare) ?? new Set();
+			rootOwners.add(node.project);
+			rootProjectsByBare.set(bare, rootOwners);
+			if (node.project) {
+				rootedProjects.add(node.project);
+			}
 		}
 	}
+
+	const only = (set: Set<string | undefined> | undefined) =>
+		set && set.size === 1 ? [...set][0] : undefined;
+
+	// A dump names no project; its label, its root module, or the modules
+	// only one project owns decide where it belongs.
+	const attributeProject = (t: LoadedBootTrace): string | undefined => {
+		if (!projects?.length) {
+			return undefined;
+		}
+		if (t.label && projects.includes(t.label)) {
+			return t.label;
+		}
+		if (t.timings.rootModule) {
+			const owner = only(rootProjectsByBare.get(t.timings.rootModule));
+			if (owner) {
+				return owner;
+			}
+		}
+		const votes = new Map<string, number>();
+		for (const bare of t.timings.byModule.keys()) {
+			const owner = only(projectsByBare.get(bare));
+			if (owner) {
+				votes.set(owner, (votes.get(owner) ?? 0) + 1);
+			}
+		}
+		const ranked = [...votes.entries()].sort((a, b) => b[1] - a[1]);
+		if (
+			ranked.length > 0 &&
+			(ranked.length === 1 || (ranked[0]?.[1] ?? 0) > (ranked[1]?.[1] ?? 0))
+		) {
+			return ranked[0]?.[0];
+		}
+		return undefined;
+	};
+
+	const attributed = (traces ?? []).map(attributeProject);
+	const traceByProject = new Map<string, BootstrapTimings>();
+	(traces ?? []).forEach((t, i) => {
+		const p = attributed[i];
+		if (p && !traceByProject.has(p)) {
+			traceByProject.set(p, t.timings);
+		}
+	});
+	const primaryIdx = Math.max(
+		attributed.findIndex((p) => p !== undefined),
+		0
+	);
+	const primary = traces?.[primaryIdx]?.timings;
+	// A project with its own entry point but no dump attaches nothing;
+	// projects without one fall back to the primary trace.
+	const timingsFor = (node: {
+		project?: string;
+	}): { scoped: boolean; timings: BootstrapTimings } | undefined => {
+		if (node.project) {
+			const own = traceByProject.get(node.project);
+			if (own) {
+				return { scoped: true, timings: own };
+			}
+			if (traceByProject.size > 0 && rootedProjects.has(node.project)) {
+				return undefined;
+			}
+		}
+		return primary ? { scoped: false, timings: primary } : undefined;
+	};
 
 	const modules: SerializedModuleNode[] = [];
 	for (const node of graph.modules.values()) {
 		let initTimings: ClassTiming[] | undefined;
 		let hookTimings: HookTiming[] | undefined;
-		if (timings) {
+		const source = timingsFor(node);
+		if (source) {
 			const bare = bareModuleName(node);
-			if (bareNameCounts.get(bare) === 1) {
-				initTimings = timings.byModule.get(bare);
-				hookTimings = timings.hooksByClass.get(bare);
+			const unique = source.scoped
+				? bareNameCounts.get(`${node.project ?? ""}\u0000${bare}`) === 1
+				: globalNameCounts.get(bare) === 1;
+			if (unique) {
+				initTimings = source.timings.byModule.get(bare);
+				hookTimings = source.timings.hooksByClass.get(bare);
 			}
 		}
 		modules.push({
@@ -90,9 +181,18 @@ export function serializeModuleGraph(
 		circularDepRecommendations,
 		projects: projects ?? [],
 		bootstrapRoots,
-		phases: timings?.phases,
-		startupMs: timings?.startupMs,
-		timingsAvailable: timings ? true : undefined,
-		timingsTrace: timings?.trace,
+		phases: primary?.phases,
+		startupMs: primary?.startupMs,
+		timingsAvailable: traces?.length ? true : undefined,
+		timingsTrace: primary?.trace,
+		traces: traces?.length
+			? traces.map((t, i) => ({
+					label: t.label ?? attributed[i] ?? t.name,
+					phases: t.timings.phases,
+					project: attributed[i],
+					startupMs: t.timings.startupMs,
+					trace: t.timings.trace,
+				}))
+			: undefined,
 	};
 }

--- a/packages/nestjs-doctor/src/report/formatters/module-serializer.ts
+++ b/packages/nestjs-doctor/src/report/formatters/module-serializer.ts
@@ -1,6 +1,7 @@
-import type {
-	SerializedModuleGraph,
-	SerializedModuleNode,
+import {
+	bareModuleName,
+	type SerializedModuleGraph,
+	type SerializedModuleNode,
 } from "../../common/artifact.js";
 import type { DiagnoseResult } from "../../common/result.js";
 import {
@@ -13,13 +14,7 @@ import type {
 	HookTiming,
 	LoadedBootTrace,
 } from "../timings.js";
-
-/** Strips the monorepo project prefix, matching getDisplayName in the report UI. */
-function bareModuleName(node: { name: string; project?: string }): string {
-	return node.project && node.name.startsWith(`${node.project}/`)
-		? node.name.slice(node.project.length + 1)
-		: node.name;
-}
+import { attributeTraces } from "./trace-attribution.js";
 
 export function serializeModuleGraph(
 	graph: ModuleGraph,
@@ -28,10 +23,6 @@ export function serializeModuleGraph(
 	bootstrapRoots?: string[],
 	traces?: LoadedBootTrace[]
 ): SerializedModuleGraph {
-	const rootSet = new Set(bootstrapRoots ?? []);
-	const projectsByBare = new Map<string, Set<string | undefined>>();
-	const rootProjectsByBare = new Map<string, Set<string | undefined>>();
-	const rootedProjects = new Set<string>();
 	// A timing entry only knows the bare name; a project-scoped trace needs
 	// it unique inside the project, a shared one unique across the graph.
 	const bareNameCounts = new Map<string, number>();
@@ -41,55 +32,14 @@ export function serializeModuleGraph(
 		const key = `${node.project ?? ""}\u0000${bare}`;
 		bareNameCounts.set(key, (bareNameCounts.get(key) ?? 0) + 1);
 		globalNameCounts.set(bare, (globalNameCounts.get(bare) ?? 0) + 1);
-		const owners = projectsByBare.get(bare) ?? new Set();
-		owners.add(node.project);
-		projectsByBare.set(bare, owners);
-		if (rootSet.has(node.name)) {
-			const rootOwners = rootProjectsByBare.get(bare) ?? new Set();
-			rootOwners.add(node.project);
-			rootProjectsByBare.set(bare, rootOwners);
-			if (node.project) {
-				rootedProjects.add(node.project);
-			}
-		}
 	}
 
-	const only = (set: Set<string | undefined> | undefined) =>
-		set && set.size === 1 ? [...set][0] : undefined;
-
-	// A dump names no project; its label, its root module, or the modules
-	// only one project owns decide where it belongs.
-	const attributeProject = (t: LoadedBootTrace): string | undefined => {
-		if (!projects?.length) {
-			return undefined;
-		}
-		if (t.label && projects.includes(t.label)) {
-			return t.label;
-		}
-		if (t.timings.rootModule) {
-			const owner = only(rootProjectsByBare.get(t.timings.rootModule));
-			if (owner) {
-				return owner;
-			}
-		}
-		const votes = new Map<string, number>();
-		for (const bare of t.timings.byModule.keys()) {
-			const owner = only(projectsByBare.get(bare));
-			if (owner) {
-				votes.set(owner, (votes.get(owner) ?? 0) + 1);
-			}
-		}
-		const ranked = [...votes.entries()].sort((a, b) => b[1] - a[1]);
-		if (
-			ranked.length > 0 &&
-			(ranked.length === 1 || (ranked[0]?.[1] ?? 0) > (ranked[1]?.[1] ?? 0))
-		) {
-			return ranked[0]?.[0];
-		}
-		return undefined;
-	};
-
-	const attributed = (traces ?? []).map(attributeProject);
+	const { projects: attributed, rootedProjects } = attributeTraces(
+		traces ?? [],
+		graph.modules.values(),
+		projects,
+		bootstrapRoots
+	);
 	const traceByProject = new Map<string, BootstrapTimings>();
 	(traces ?? []).forEach((t, i) => {
 		const p = attributed[i];

--- a/packages/nestjs-doctor/src/report/formatters/module-serializer.ts
+++ b/packages/nestjs-doctor/src/report/formatters/module-serializer.ts
@@ -102,8 +102,8 @@ export function serializeModuleGraph(
 		0
 	);
 	const primary = traces?.[primaryIdx]?.timings;
-	// A project with its own entry point but no dump attaches nothing;
-	// projects without one fall back to the primary trace.
+	// Once any dump is attributed, a project with its own entry point but
+	// no dump attaches nothing; otherwise every node uses the primary trace.
 	const timingsFor = (node: {
 		project?: string;
 	}): { scoped: boolean; timings: BootstrapTimings } | undefined => {

--- a/packages/nestjs-doctor/src/report/formatters/trace-attribution.ts
+++ b/packages/nestjs-doctor/src/report/formatters/trace-attribution.ts
@@ -1,0 +1,65 @@
+import { bareModuleName } from "../../common/artifact.js";
+import type { LoadedBootTrace } from "../timings.js";
+
+const only = (set: Set<string | undefined> | undefined) =>
+	set && set.size === 1 ? [...set][0] : undefined;
+
+/** Decides each dump's project: its label, its root module, or the modules only one project owns. */
+export function attributeTraces(
+	traces: LoadedBootTrace[],
+	modules: Iterable<{ name: string; project?: string }>,
+	projects: string[] | undefined,
+	bootstrapRoots: string[] | undefined
+): {
+	projects: (string | undefined)[];
+	rootedProjects: Set<string>;
+} {
+	const rootSet = new Set(bootstrapRoots ?? []);
+	const projectsByBare = new Map<string, Set<string | undefined>>();
+	const rootProjectsByBare = new Map<string, Set<string | undefined>>();
+	const rootedProjects = new Set<string>();
+	for (const node of modules) {
+		const bare = bareModuleName(node);
+		const owners = projectsByBare.get(bare) ?? new Set();
+		owners.add(node.project);
+		projectsByBare.set(bare, owners);
+		if (rootSet.has(node.name)) {
+			const rootOwners = rootProjectsByBare.get(bare) ?? new Set();
+			rootOwners.add(node.project);
+			rootProjectsByBare.set(bare, rootOwners);
+			if (node.project) {
+				rootedProjects.add(node.project);
+			}
+		}
+	}
+	const attributeProject = (t: LoadedBootTrace): string | undefined => {
+		if (!projects?.length) {
+			return undefined;
+		}
+		if (t.label && projects.includes(t.label)) {
+			return t.label;
+		}
+		if (t.timings.rootModule) {
+			const owner = only(rootProjectsByBare.get(t.timings.rootModule));
+			if (owner) {
+				return owner;
+			}
+		}
+		const votes = new Map<string, number>();
+		for (const bare of t.timings.byModule.keys()) {
+			const owner = only(projectsByBare.get(bare));
+			if (owner) {
+				votes.set(owner, (votes.get(owner) ?? 0) + 1);
+			}
+		}
+		const ranked = [...votes.entries()].sort((a, b) => b[1] - a[1]);
+		if (
+			ranked.length > 0 &&
+			(ranked.length === 1 || (ranked[0]?.[1] ?? 0) > (ranked[1]?.[1] ?? 0))
+		) {
+			return ranked[0]?.[0];
+		}
+		return undefined;
+	};
+	return { projects: traces.map(attributeProject), rootedProjects };
+}

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -24,7 +24,7 @@ import { scanTelemetryEnabled } from "../telemetry/send.js";
 import { spinner } from "../ui/spinner.js";
 import { buildReportArtifact, collectScanFacts } from "./artifact.js";
 import { buildHtmlReport } from "./html-report.js";
-import type { BootstrapTimings } from "./timings.js";
+import type { LoadedBootTrace } from "./timings.js";
 
 type PipelineStep = () => void | Promise<void>;
 
@@ -36,7 +36,7 @@ abstract class ReportPipeline {
 	protected readonly steps: PipelineStep[] = [];
 	protected readonly targetPath: string;
 	protected readonly telemetry: boolean;
-	protected readonly timings: BootstrapTimings | undefined;
+	protected readonly traces: LoadedBootTrace[] | undefined;
 	protected readonly version: string;
 
 	private readonly configPath: string | undefined;
@@ -45,14 +45,14 @@ abstract class ReportPipeline {
 		targetPath: string,
 		configPath: string | undefined,
 		version: string,
-		timings?: BootstrapTimings,
+		traces?: LoadedBootTrace[],
 		telemetry = true,
 		sources: SourceInclusion = "all"
 	) {
 		this.targetPath = targetPath;
 		this.configPath = configPath;
 		this.version = version;
-		this.timings = timings;
+		this.traces = traces;
 		this.telemetry = telemetry;
 		this.sources = sources;
 	}
@@ -160,7 +160,7 @@ export class SingleProjectReportPipeline extends ReportPipeline {
 					bootstrapRoots: facts.bootstrapRoots,
 					providers: facts.providers,
 					sources: this.sources,
-					timings: this.timings,
+					traces: this.traces,
 					version: this.version,
 				}),
 				{ telemetry: this.telemetryEnabled }
@@ -186,11 +186,11 @@ export class MonorepoReportPipeline extends ReportPipeline {
 		configPath: string | undefined,
 		monorepo: MonorepoInfo,
 		version: string,
-		timings?: BootstrapTimings,
+		traces?: LoadedBootTrace[],
 		telemetry = true,
 		sources: SourceInclusion = "all"
 	) {
-		super(targetPath, configPath, version, timings, telemetry, sources);
+		super(targetPath, configPath, version, traces, telemetry, sources);
 		this.monorepo = monorepo;
 	}
 
@@ -265,7 +265,7 @@ export class MonorepoReportPipeline extends ReportPipeline {
 					bootstrapRoots: this.bootstrapRoots,
 					monorepo: true,
 					sources: this.sources,
-					timings: this.timings,
+					traces: this.traces,
 					version: this.version,
 				}),
 				{ telemetry: this.telemetryEnabled }

--- a/packages/nestjs-doctor/src/report/setup.ts
+++ b/packages/nestjs-doctor/src/report/setup.ts
@@ -12,7 +12,8 @@ import {
 	MonorepoReportPipeline,
 	SingleProjectReportPipeline,
 } from "./pipeline.js";
-import { type BootstrapTimings, loadBootstrapTimings } from "./timings.js";
+import type { LoadedBootTrace } from "./timings.js";
+import { loadBootstrapTraces } from "./timings.js";
 
 /** Detect monorepo vs single project and run the appropriate report pipeline */
 export const runReport = async (
@@ -32,10 +33,10 @@ export const runReport = async (
 		openReportInBrowser(outPath);
 	};
 
-	let bootTimings: BootstrapTimings | undefined;
+	let bootTraces: LoadedBootTrace[] | undefined;
 	if (timingsPath) {
-		const { timings, warnings } = loadBootstrapTimings(targetPath, timingsPath);
-		bootTimings = timings;
+		const { traces, warnings } = loadBootstrapTraces(targetPath, timingsPath);
+		bootTraces = traces;
 		for (const warning of warnings) {
 			logger.warn(warning);
 		}
@@ -47,7 +48,7 @@ export const runReport = async (
 			configPath,
 			monorepo,
 			version,
-			bootTimings,
+			bootTraces,
 			telemetry ?? true,
 			sources
 		);
@@ -67,7 +68,7 @@ export const runReport = async (
 		targetPath,
 		configPath,
 		version,
-		bootTimings,
+		bootTraces,
 		telemetry ?? true,
 		sources
 	);

--- a/packages/nestjs-doctor/src/report/timings.ts
+++ b/packages/nestjs-doctor/src/report/timings.ts
@@ -226,6 +226,7 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 
 	const hooksByClass = new Map<string, HookTiming[]>();
 	let firstBootstrapStart: number | undefined;
+	let firstHookStart: number | undefined;
 	let lastInitEnd: number | undefined;
 	const rawHooks = (data as { hookTimings?: unknown }).hookTimings;
 	if (Array.isArray(rawHooks)) {
@@ -254,6 +255,10 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 				Number.isFinite(startMs) &&
 				startMs >= 0
 			) {
+				firstHookStart = Math.min(
+					firstHookStart ?? Number.POSITIVE_INFINITY,
+					startMs
+				);
 				if (hook === "onApplicationBootstrap") {
 					firstBootstrapStart = Math.min(
 						firstBootstrapStart ?? Number.POSITIVE_INFINITY,
@@ -299,11 +304,11 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 	}
 
 	const startupMs = asPositiveMs((data as { startupMs?: unknown }).startupMs);
-	const createMs = asPositiveMs((data as { createMs?: unknown }).createMs);
+	let createMs = asPositiveMs((data as { createMs?: unknown }).createMs);
 	let moduleInitMs = asPositiveMs(
 		(data as { moduleInitMs?: unknown }).moduleInitMs
 	);
-	const initMs = asPositiveMs((data as { initMs?: unknown }).initMs);
+	let initMs = asPositiveMs((data as { initMs?: unknown }).initMs);
 	if (
 		moduleInitMs === undefined &&
 		(createMs ?? initMs ?? startupMs) !== undefined
@@ -322,6 +327,32 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 				break;
 			}
 		}
+	}
+	// The earliest positioned hook start stands in for an absent create marker,
+	// only when a measured marker anchors the dump.
+	if (
+		createMs === undefined &&
+		(moduleInitMs ?? initMs ?? startupMs) !== undefined &&
+		firstHookStart !== undefined &&
+		firstHookStart > 0 &&
+		(moduleInitMs === undefined || firstHookStart <= moduleInitMs) &&
+		(initMs === undefined || firstHookStart <= initMs) &&
+		(startupMs === undefined || firstHookStart <= startupMs)
+	) {
+		createMs = firstHookStart;
+	}
+	// An empty entrypoints object is a context app: init ends when creation
+	// returns, there is no listen.
+	const entrypoints = (data as { entrypoints?: unknown }).entrypoints;
+	if (
+		initMs === undefined &&
+		startupMs !== undefined &&
+		typeof entrypoints === "object" &&
+		entrypoints !== null &&
+		!Array.isArray(entrypoints) &&
+		Object.keys(entrypoints).length === 0
+	) {
+		initMs = startupMs;
 	}
 	const markers = [createMs, moduleInitMs, initMs, startupMs].filter(
 		(m): m is number => m !== undefined

--- a/packages/nestjs-doctor/src/report/timings.ts
+++ b/packages/nestjs-doctor/src/report/timings.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { basename } from "node:path";
 import type {
 	BootPhases,
 	BootstrapTimings,
@@ -18,6 +19,7 @@ interface ParsedTimings {
 	hooksByClass: Map<string, HookTiming[]>;
 	modules: Map<string, ClassTiming[]>;
 	phases?: BootPhases;
+	rootModule?: string;
 	startupMs?: number;
 	trace: Record<string, TraceNode>;
 	warnings: string[];
@@ -138,6 +140,11 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 		}
 		return moduleLabels.get([...importers][0] as string);
 	};
+	const rootIds = [...moduleLabels.keys()].filter(
+		(id) => !importersByModule.has(id)
+	);
+	const rootModule =
+		rootIds.length === 1 ? moduleLabels.get(rootIds[0] as string) : undefined;
 
 	const modules = new Map<string, ClassTiming[]>();
 	// Ids get a "t" prefix so an id like "__proto__" stays a plain object key.
@@ -330,7 +337,15 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 	) {
 		phases = { createMs, initMs, moduleInitMs };
 	}
-	return { hooksByClass, modules, phases, startupMs, trace, warnings };
+	return {
+		hooksByClass,
+		modules,
+		phases,
+		rootModule,
+		startupMs,
+		trace,
+		warnings,
+	};
 }
 
 /** Reads and parses a timings dump; any failure degrades to a warning, never a crash. */
@@ -349,14 +364,64 @@ export function loadBootstrapTimings(
 			],
 		};
 	}
-	const { hooksByClass, modules, phases, startupMs, trace, warnings } =
-		parseBootstrapTimings(raw);
+	const {
+		hooksByClass,
+		modules,
+		phases,
+		rootModule,
+		startupMs,
+		trace,
+		warnings,
+	} = parseBootstrapTimings(raw);
 	return Object.keys(trace).length > 0 ||
 		startupMs !== undefined ||
 		phases !== undefined
 		? {
-				timings: { byModule: modules, hooksByClass, phases, startupMs, trace },
+				timings: {
+					byModule: modules,
+					hooksByClass,
+					phases,
+					rootModule,
+					startupMs,
+					trace,
+				},
 				warnings,
 			}
 		: { warnings };
+}
+
+export interface LoadedBootTrace {
+	label?: string;
+	name: string;
+	timings: BootstrapTimings;
+}
+
+const EXT_RE = /\.[^.]*$/;
+
+/** Loads a comma list of dumps; `label=path` names one explicitly. */
+export function loadBootstrapTraces(
+	targetPath: string,
+	spec: string
+): { traces: LoadedBootTrace[]; warnings: string[] } {
+	const traces: LoadedBootTrace[] = [];
+	const warnings: string[] = [];
+	for (const part of spec.split(",")) {
+		const item = part.trim();
+		if (!item) {
+			continue;
+		}
+		const eq = item.indexOf("=");
+		const label = eq > 0 ? item.slice(0, eq).trim() : undefined;
+		const path = eq > 0 ? item.slice(eq + 1).trim() : item;
+		const loaded = loadBootstrapTimings(targetPath, path);
+		warnings.push(...loaded.warnings);
+		if (loaded.timings) {
+			traces.push({
+				label,
+				name: basename(path).replace(EXT_RE, ""),
+				timings: loaded.timings,
+			});
+		}
+	}
+	return { traces, warnings };
 }

--- a/packages/nestjs-doctor/src/report/timings.ts
+++ b/packages/nestjs-doctor/src/report/timings.ts
@@ -430,6 +430,7 @@ export interface LoadedBootTrace {
 }
 
 const EXT_RE = /\.[^.]*$/;
+const SEP_RE = /[\\/]/;
 
 /** Loads a comma list of dumps; `label=path` names one explicitly. */
 export function loadBootstrapTraces(
@@ -444,8 +445,10 @@ export function loadBootstrapTraces(
 			continue;
 		}
 		const eq = item.indexOf("=");
-		const label = eq > 0 ? item.slice(0, eq).trim() : undefined;
-		const path = eq > 0 ? item.slice(eq + 1).trim() : item;
+		// A prefix with a path separator is part of the path, not a label.
+		const labelled = eq > 0 && !SEP_RE.test(item.slice(0, eq));
+		const label = labelled ? item.slice(0, eq).trim() : undefined;
+		const path = labelled ? item.slice(eq + 1).trim() : item;
 		const loaded = loadBootstrapTimings(targetPath, path);
 		warnings.push(...loaded.warnings);
 		if (loaded.timings) {

--- a/packages/nestjs-doctor/src/report/timings.ts
+++ b/packages/nestjs-doctor/src/report/timings.ts
@@ -308,17 +308,19 @@ export function parseBootstrapTimings(jsonText: string): ParsedTimings {
 		moduleInitMs === undefined &&
 		(createMs ?? initMs ?? startupMs) !== undefined
 	) {
-		// The boundary sits where the first bootstrap hook starts, else where
-		// the last init hook ends.
-		const derived = firstBootstrapStart ?? lastInitEnd;
-		if (
-			derived !== undefined &&
-			derived > 0 &&
-			(createMs === undefined || derived >= createMs) &&
-			(initMs === undefined || derived <= initMs) &&
-			(startupMs === undefined || derived <= startupMs)
-		) {
-			moduleInitMs = derived;
+		// The boundary is the first bootstrap start, else the last init end;
+		// the first candidate that fits between the markers wins.
+		for (const derived of [firstBootstrapStart, lastInitEnd]) {
+			if (
+				derived !== undefined &&
+				derived > 0 &&
+				(createMs === undefined || derived >= createMs) &&
+				(initMs === undefined || derived <= initMs) &&
+				(startupMs === undefined || derived <= startupMs)
+			) {
+				moduleInitMs = derived;
+				break;
+			}
 		}
 	}
 	const markers = [createMs, moduleInitMs, initMs, startupMs].filter(

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-hover.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-hover.ts
@@ -37,10 +37,11 @@ export function hoverCardData(
 		const meta = hookMeta(hook.hook);
 		const at =
 			typeof hook.startMs === "number" ? ` · at ${formatMs(hook.startMs)}` : "";
+		const stray = hook.stray ? " · past its phase" : "";
 		return {
 			context,
 			detail: {
-				dim: `(${share(hook.ms, t.maxMs)})${at}`,
+				dim: `(${share(hook.ms, t.maxMs)})${at}${stray}`,
 				main: formatMs(hook.ms),
 			},
 			from,

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -88,7 +88,6 @@ export interface BootWindow {
 	to: number;
 }
 
-// Drops the "<project>/" prefix from a module name.
 export function buildBootTimeline(
 	graph: SerializedModuleGraph
 ): BootTimeline | null {

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -889,7 +889,7 @@ export function traceViews(graph: SerializedModuleGraph): BootTraceView[] {
 	return [{ graph, label: "boot" }];
 }
 
-/** The view a module may show: its project's, else the only one naming it. */
+/** The view a module may show: its project's, else the first one naming it. */
 export function traceIndexForModule(
 	views: BootTraceView[],
 	m: { name: string; project?: string }
@@ -908,7 +908,7 @@ export function traceIndexForModule(
 				(n) => n.module === bare
 			)
 		);
-	if (holders.length === 1) {
+	if (holders.length > 0) {
 		return holders[0] ?? -1;
 	}
 	if (

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -1,4 +1,7 @@
-import type { SerializedModuleGraph } from "../../../../common/artifact.js";
+import {
+	bareModuleName,
+	type SerializedModuleGraph,
+} from "../../../../common/artifact.js";
 import type { HookTiming } from "../../../../common/timings.js";
 import { ICONS } from "../atoms/icons.js";
 import { escapeHtml } from "./escape.js";
@@ -65,6 +68,8 @@ interface BootPhase {
 	end: number;
 	gloss: string;
 	label: string;
+	/** The lifecycle hook kinds this phase owns. */
+	owns: readonly string[];
 	rgb: string;
 	start: number;
 	tip: string;
@@ -84,12 +89,6 @@ export interface BootWindow {
 }
 
 // Drops the "<project>/" prefix from a module name.
-function bareName(m: { name: string; project?: string }): string {
-	return m.project && m.name.startsWith(`${m.project}/`)
-		? m.name.slice(m.project.length + 1)
-		: m.name;
-}
-
 export function buildBootTimeline(
 	graph: SerializedModuleGraph
 ): BootTimeline | null {
@@ -100,7 +99,7 @@ export function buildBootTimeline(
 	const moduleOfId = new Map<string, string>();
 	const graphNames = new Set<string>();
 	for (const m of graph.modules) {
-		graphNames.add(bareName(m));
+		graphNames.add(bareModuleName(m));
 		for (const t of m.initTimings ?? []) {
 			moduleOfId.set(t.id, m.name);
 		}
@@ -211,6 +210,7 @@ export function buildBootTimeline(
 			end: prev + p.ms,
 			gloss: p.gloss,
 			label: p.label,
+			owns: p.owns,
 			rgb: p.rgb,
 			start: prev,
 			tip: p.tip,
@@ -224,7 +224,7 @@ export function buildBootTimeline(
 			if (typeof h.startMs !== "number") {
 				return h;
 			}
-			const own = phases.find((p) => hookBelongs(h.hook, p.label));
+			const own = phases.find((p) => p.owns.includes(h.hook));
 			if (!own || own.end <= own.start) {
 				return h;
 			}
@@ -248,20 +248,6 @@ export function buildBootTimeline(
 	return { byId, groups, maxMs, phases, scale: buildTimeScale(phases, maxMs) };
 }
 
-// A hook without an offset counts toward the phase named for its kind.
-function hookBelongs(hook: string, phaseLabel: string): boolean {
-	if (
-		phaseLabel === "onModuleInit" ||
-		phaseLabel === "onApplicationBootstrap"
-	) {
-		return hook === phaseLabel;
-	}
-	if (phaseLabel === "create + onModuleInit") {
-		return hook === "onModuleInit";
-	}
-	return phaseLabel !== "create" && phaseLabel !== "listen";
-}
-
 function spanTouches(s: BootSpan, ph: BootPhase): boolean {
 	const inside = (from: number, to: number) => from < ph.end && to > ph.start;
 	if (inside(s.start, s.end)) {
@@ -270,7 +256,8 @@ function spanTouches(s: BootSpan, ph: BootPhase): boolean {
 	return (s.hooks ?? []).some((h) =>
 		typeof h.startMs === "number"
 			? inside(h.startMs, h.startMs + h.ms)
-			: hookBelongs(h.hook, ph.label)
+			: // A hook without an offset counts toward the phase owning its kind.
+				ph.owns.includes(h.hook)
 	);
 }
 
@@ -305,37 +292,42 @@ export function moduleTimings(
 	graph: SerializedModuleGraph
 ): Map<string, ModuleTiming> {
 	const out = new Map<string, ModuleTiming>();
-	const t = buildBootTimeline(graph);
-	if (!t) {
-		return out;
-	}
-	for (const g of t.groups) {
-		let buildMs = 0;
-		// Overlapping runs count once; hooks without an offset add their ms.
-		const hooks = new Map<
-			string,
-			{ loose: number; runs: [number, number][] }
-		>();
-		for (const s of g.spans) {
-			buildMs = Math.max(buildMs, s.end - s.start);
-			for (const h of s.hooks ?? []) {
-				const label = hookMeta(h.hook).label;
-				const entry = hooks.get(label) ?? { loose: 0, runs: [] };
-				if (typeof h.startMs === "number") {
-					entry.runs.push([h.startMs, h.startMs + h.ms]);
-				} else {
-					entry.loose += h.ms;
-				}
-				hooks.set(label, entry);
-			}
+	for (const view of traceViews(graph)) {
+		const t = buildBootTimeline(view.graph);
+		if (!t) {
+			continue;
 		}
-		out.set(g.module, {
-			buildMs,
-			hooks: [...hooks].map(([label, e]) => ({
-				label,
-				ms: e.loose + unionMs(e.runs),
-			})),
-		});
+		for (const g of t.groups) {
+			if (out.has(g.module)) {
+				continue;
+			}
+			let buildMs = 0;
+			// Overlapping runs count once; hooks without an offset add their ms.
+			const hooks = new Map<
+				string,
+				{ loose: number; runs: [number, number][] }
+			>();
+			for (const s of g.spans) {
+				buildMs = Math.max(buildMs, s.end - s.start);
+				for (const h of s.hooks ?? []) {
+					const label = hookMeta(h.hook).label;
+					const entry = hooks.get(label) ?? { loose: 0, runs: [] };
+					if (typeof h.startMs === "number") {
+						entry.runs.push([h.startMs, h.startMs + h.ms]);
+					} else {
+						entry.loose += h.ms;
+					}
+					hooks.set(label, entry);
+				}
+			}
+			out.set(g.module, {
+				buildMs,
+				hooks: [...hooks].map(([label, e]) => ({
+					label,
+					ms: e.loose + unionMs(e.runs),
+				})),
+			});
+		}
 	}
 	return out;
 }
@@ -918,7 +910,7 @@ export function traceIndexForModule(
 	if (byProject !== -1) {
 		return byProject;
 	}
-	const bare = bareName(m);
+	const bare = bareModuleName(m);
 	const holders = views
 		.map((_, i) => i)
 		.filter((i) =>

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -864,3 +864,59 @@ export function phaseLaneHtml(t: BootTimeline): string {
 	});
 	return html;
 }
+
+export interface BootTraceView {
+	graph: SerializedModuleGraph;
+	label: string;
+	project?: string;
+}
+
+/** One renderable view per boot trace; a legacy graph is its own single view. */
+export function traceViews(graph: SerializedModuleGraph): BootTraceView[] {
+	if (graph.traces?.length) {
+		return graph.traces.map((t) => ({
+			graph: {
+				...graph,
+				phases: t.phases,
+				startupMs: t.startupMs,
+				timingsAvailable: true,
+				timingsTrace: t.trace,
+			},
+			label: t.label,
+			project: t.project,
+		}));
+	}
+	return [{ graph, label: "boot" }];
+}
+
+/** The view a module may show: its project's, else the only one naming it. */
+export function traceIndexForModule(
+	views: BootTraceView[],
+	m: { name: string; project?: string }
+): number {
+	const byProject = views.findIndex(
+		(v) => v.project !== undefined && v.project === m.project
+	);
+	if (byProject !== -1) {
+		return byProject;
+	}
+	const bare = bareName(m);
+	const holders = views
+		.map((_, i) => i)
+		.filter((i) =>
+			Object.values(views[i]?.graph.timingsTrace ?? {}).some(
+				(n) => n.module === bare
+			)
+		);
+	if (holders.length === 1) {
+		return holders[0] ?? -1;
+	}
+	if (
+		views.length === 1 &&
+		views[0]?.project === undefined &&
+		m.project === undefined
+	) {
+		return 0;
+	}
+	return -1;
+}

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -256,6 +256,9 @@ function hookBelongs(hook: string, phaseLabel: string): boolean {
 	) {
 		return hook === phaseLabel;
 	}
+	if (phaseLabel === "create + onModuleInit") {
+		return hook === "onModuleInit";
+	}
 	return phaseLabel !== "create" && phaseLabel !== "listen";
 }
 
@@ -908,8 +911,9 @@ export function traceIndexForModule(
 	views: BootTraceView[],
 	m: { name: string; project?: string }
 ): number {
+	const proj = m.project || undefined;
 	const byProject = views.findIndex(
-		(v) => v.project !== undefined && v.project === m.project
+		(v) => v.project !== undefined && v.project === proj
 	);
 	if (byProject !== -1) {
 		return byProject;
@@ -925,11 +929,7 @@ export function traceIndexForModule(
 	if (holders.length > 0) {
 		return holders[0] ?? -1;
 	}
-	if (
-		views.length === 1 &&
-		views[0]?.project === undefined &&
-		m.project === undefined
-	) {
+	if (views.length === 1 && views[0]?.project === undefined) {
 		return 0;
 	}
 	return -1;

--- a/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/boot-timeline.ts
@@ -38,7 +38,7 @@ export interface BootSpan {
 	end: number;
 	/** The class lives in a package module, one the scanned graph never saw. */
 	external?: boolean;
-	hooks?: HookTiming[];
+	hooks?: (HookTiming & { stray?: boolean })[];
 	id: string;
 	module: string;
 	name: string;
@@ -218,6 +218,20 @@ export function buildBootTimeline(
 		prev += p.ms;
 	}
 	const spans = [...byId.values()];
+	// A positioned hook outside the phase its kind names wears a marker.
+	for (const s of spans) {
+		s.hooks = s.hooks?.map((h) => {
+			if (typeof h.startMs !== "number") {
+				return h;
+			}
+			const own = phases.find((p) => hookBelongs(h.hook, p.label));
+			if (!own || own.end <= own.start) {
+				return h;
+			}
+			const stray = h.startMs >= own.end || h.startMs + h.ms <= own.start;
+			return stray ? { ...h, stray: true } : h;
+		});
+	}
 	for (const ph of phases) {
 		// A zero-width phase is empty even when an offsetless hook names it.
 		ph.empty = ph.end <= ph.start || !spans.some((s) => spanTouches(s, ph));
@@ -459,7 +473,7 @@ function classBarHtml(span: BootSpan, win: BootWindow, sc: TimeScale): string {
 		segs.push([from, to]);
 		const meta = hookMeta(h.hook);
 		hookHtml +=
-			`<span class="boot-hook-span" data-hook="${index}"` +
+			`<span class="boot-hook-span${h.stray ? " boot-hook-stray" : ""}" data-hook="${index}"` +
 			` style="${barStyle(from, to, win, 0.12)};background:rgb(${fillOf(meta.rgb)})">` +
 			`${escapeHtml(`+${formatMs(h.ms)} ${meta.label}`)}</span>`;
 	});

--- a/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
@@ -3,6 +3,7 @@ import type {
 	SerializedModuleGraph,
 	SerializedModuleNode,
 } from "../../../../common/artifact.js";
+import { bareModuleName } from "../../../../common/artifact.js";
 import { REPORT_FONT_STACK } from "../../font.js";
 import {
 	type ModuleTiming,
@@ -54,10 +55,7 @@ interface MgEdge {
 }
 
 export function displayName(n: { name: string; project?: string }): string {
-	if (n.project && n.name.indexOf(`${n.project}/`) === 0) {
-		return n.name.slice(n.project.length + 1);
-	}
-	return n.name;
+	return bareModuleName(n);
 }
 
 function buildProjectColorMap(

--- a/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
@@ -173,7 +173,7 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 			tail = {
 				label: "bootstrap + listen",
 				gloss: "bootstrap + port",
-				owns: BOOTSTRAP_HOOKS,
+				owns: ALL_HOOKS,
 				tip: "bootstrap + listen — onApplicationBootstrap hooks and the server bind",
 			};
 		}

--- a/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
@@ -49,13 +49,10 @@ interface PhasedGraph {
 	startupMs?: number;
 }
 
-// Splits the captured boot into labelled segments. Without createMs the
-// earlier boundaries are unknown, so segments would mislabel.
+// Splits the captured boot into labelled segments. Missing markers fold
+// into merged neighbours; startupMs alone yields one whole-boot segment.
 export function phaseParts(graph: PhasedGraph): PhasePart[] {
-	const p = graph.phases;
-	if (!p || typeof p.createMs !== "number") {
-		return [];
-	}
+	const p = graph.phases ?? {};
 	const parts: PhasePart[] = [];
 	let prev = 0;
 	const push = (
@@ -73,20 +70,21 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 		parts.push({ gloss, label, ms: end - prev, rgb, tip });
 		prev = end;
 	};
-	push(
-		"create",
-		"building modules",
-		p.createMs,
-		PALETTE.blue,
-		"create — NestFactory constructs every module, provider, and controller."
-	);
-	if (typeof p.moduleInitMs === "number") {
+	if (typeof p.createMs === "number") {
 		push(
-			"onModuleInit",
-			"init hooks",
+			"create",
+			"building modules",
+			p.createMs,
+			PALETTE.blue,
+			"create — NestFactory constructs every module, provider, and controller."
+		);
+	} else if (typeof p.moduleInitMs === "number") {
+		push(
+			"create + onModuleInit",
+			"build + init hooks",
 			p.moduleInitMs,
 			PALETTE.green,
-			"onModuleInit — after construction, Nest calls each class's onModuleInit() hook"
+			"create + onModuleInit — construction and init hooks together; the trace carried no create marker to split them"
 		);
 		push(
 			"onApplicationBootstrap",
@@ -95,14 +93,51 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 			PALETTE.violet,
 			"onApplicationBootstrap — hooks that run once the whole app is wired, right before it listens"
 		);
-	} else {
+	} else if (typeof p.initMs === "number") {
 		push(
-			"lifecycle hooks",
-			"lifecycle hooks",
+			"create + hooks",
+			"build + hooks",
 			p.initMs,
 			PALETTE.green,
-			"lifecycle hooks — onModuleInit and onApplicationBootstrap"
+			"create + hooks — construction and lifecycle hooks together; the trace carried no create marker to split them"
 		);
+	} else if (typeof graph.startupMs === "number") {
+		push(
+			"boot",
+			"whole boot",
+			graph.startupMs,
+			PALETTE.grey,
+			"boot — the whole startup; the trace carried no phase markers"
+		);
+		return parts;
+	} else {
+		return parts;
+	}
+	if (typeof p.createMs === "number") {
+		if (typeof p.moduleInitMs === "number") {
+			push(
+				"onModuleInit",
+				"init hooks",
+				p.moduleInitMs,
+				PALETTE.green,
+				"onModuleInit — after construction, Nest calls each class's onModuleInit() hook"
+			);
+			push(
+				"onApplicationBootstrap",
+				"bootstrap hooks",
+				p.initMs,
+				PALETTE.violet,
+				"onApplicationBootstrap — hooks that run once the whole app is wired, right before it listens"
+			);
+		} else {
+			push(
+				"lifecycle hooks",
+				"lifecycle hooks",
+				p.initMs,
+				PALETTE.green,
+				"lifecycle hooks — onModuleInit and onApplicationBootstrap"
+			);
+		}
 	}
 	if (typeof graph.startupMs === "number") {
 		let tail = {

--- a/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/trace.ts
@@ -36,9 +36,16 @@ interface PhasePart {
 	gloss: string;
 	label: string;
 	ms: number;
+	/** The lifecycle hook kinds this phase owns. */
+	owns: readonly string[];
 	rgb: string;
 	tip: string;
 }
+
+const NO_HOOKS: readonly string[] = [];
+const INIT_HOOKS: readonly string[] = ["onModuleInit"];
+const BOOTSTRAP_HOOKS: readonly string[] = ["onApplicationBootstrap"];
+const ALL_HOOKS: readonly string[] = ["onModuleInit", "onApplicationBootstrap"];
 
 interface PhasedGraph {
 	phases?: {
@@ -60,14 +67,15 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 		gloss: string,
 		end: number | undefined,
 		rgb: string,
-		tip: string
+		tip: string,
+		owns: readonly string[]
 	) => {
 		// Markers are validated monotonic upstream; only coincident markers
 		// reach here, and they are a real 0ms phase.
 		if (typeof end !== "number" || end < prev) {
 			return;
 		}
-		parts.push({ gloss, label, ms: end - prev, rgb, tip });
+		parts.push({ gloss, label, ms: end - prev, owns, rgb, tip });
 		prev = end;
 	};
 	if (typeof p.createMs === "number") {
@@ -76,7 +84,8 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 			"building modules",
 			p.createMs,
 			PALETTE.blue,
-			"create — NestFactory constructs every module, provider, and controller."
+			"create — NestFactory constructs every module, provider, and controller.",
+			NO_HOOKS
 		);
 	} else if (typeof p.moduleInitMs === "number") {
 		push(
@@ -84,14 +93,16 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 			"build + init hooks",
 			p.moduleInitMs,
 			PALETTE.green,
-			"create + onModuleInit — construction and init hooks together; the trace carried no create marker to split them"
+			"create + onModuleInit — construction and init hooks together; the trace carried no create marker to split them",
+			INIT_HOOKS
 		);
 		push(
 			"onApplicationBootstrap",
 			"bootstrap hooks",
 			p.initMs,
 			PALETTE.violet,
-			"onApplicationBootstrap — hooks that run once the whole app is wired, right before it listens"
+			"onApplicationBootstrap — hooks that run once the whole app is wired, right before it listens",
+			BOOTSTRAP_HOOKS
 		);
 	} else if (typeof p.initMs === "number") {
 		push(
@@ -99,7 +110,8 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 			"build + hooks",
 			p.initMs,
 			PALETTE.green,
-			"create + hooks — construction and lifecycle hooks together; the trace carried no create marker to split them"
+			"create + hooks — construction and lifecycle hooks together; the trace carried no create marker to split them",
+			ALL_HOOKS
 		);
 	} else if (typeof graph.startupMs === "number") {
 		push(
@@ -107,7 +119,8 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 			"whole boot",
 			graph.startupMs,
 			PALETTE.grey,
-			"boot — the whole startup; the trace carried no phase markers"
+			"boot — the whole startup; the trace carried no phase markers",
+			ALL_HOOKS
 		);
 		return parts;
 	} else {
@@ -120,14 +133,16 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 				"init hooks",
 				p.moduleInitMs,
 				PALETTE.green,
-				"onModuleInit — after construction, Nest calls each class's onModuleInit() hook"
+				"onModuleInit — after construction, Nest calls each class's onModuleInit() hook",
+				INIT_HOOKS
 			);
 			push(
 				"onApplicationBootstrap",
 				"bootstrap hooks",
 				p.initMs,
 				PALETTE.violet,
-				"onApplicationBootstrap — hooks that run once the whole app is wired, right before it listens"
+				"onApplicationBootstrap — hooks that run once the whole app is wired, right before it listens",
+				BOOTSTRAP_HOOKS
 			);
 		} else {
 			push(
@@ -135,7 +150,8 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 				"lifecycle hooks",
 				p.initMs,
 				PALETTE.green,
-				"lifecycle hooks — onModuleInit and onApplicationBootstrap"
+				"lifecycle hooks — onModuleInit and onApplicationBootstrap",
+				ALL_HOOKS
 			);
 		}
 	}
@@ -143,22 +159,32 @@ export function phaseParts(graph: PhasedGraph): PhasePart[] {
 		let tail = {
 			label: "hooks + listen",
 			gloss: "hooks + port",
+			owns: ALL_HOOKS,
 			tip: "hooks + listen — everything after NestFactory.create",
 		};
 		if (typeof p.initMs === "number") {
 			tail = {
 				label: "listen",
 				gloss: "opening the port",
+				owns: NO_HOOKS,
 				tip: "listen — the HTTP server binds its port; at the end of this segment the app is up",
 			};
 		} else if (typeof p.moduleInitMs === "number") {
 			tail = {
 				label: "bootstrap + listen",
 				gloss: "bootstrap + port",
+				owns: BOOTSTRAP_HOOKS,
 				tip: "bootstrap + listen — onApplicationBootstrap hooks and the server bind",
 			};
 		}
-		push(tail.label, tail.gloss, graph.startupMs, PALETTE.grey, tail.tip);
+		push(
+			tail.label,
+			tail.gloss,
+			graph.startupMs,
+			PALETTE.grey,
+			tail.tip,
+			tail.owns
+		);
 	}
 	return parts;
 }

--- a/packages/nestjs-doctor/src/report/ui/app/templates/boot.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/boot.tsx
@@ -488,7 +488,7 @@ export function BootView({
 		<div className={viewClasses} ref={viewRef}>
 			{!compact && <BootResizer viewRef={viewRef} />}
 			<div className="boot-main" ref={mainRef}>
-				{!compact && views.length > 1 && (
+				{!compact && traceIndex === undefined && views.length > 1 && (
 					<div className="boot-trace-picker">
 						{views.map((v, i) => {
 							const cls = i === activeIdx ? "active" : undefined;

--- a/packages/nestjs-doctor/src/report/ui/app/templates/boot.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/boot.tsx
@@ -8,11 +8,13 @@ import { hoverCardData } from "../lib/boot-hover.js";
 import { hoverAnchor, placeHoverCard, timeAt } from "../lib/boot-pointer.js";
 import {
 	type BootSpan,
+	type BootTraceView,
 	type BootWindow,
 	buildBootTimeline,
 	expandableIds,
 	rowsHtml,
 	slowestSpanId,
+	traceViews,
 	u,
 	windowAround,
 } from "../lib/boot-timeline.js";
@@ -37,6 +39,8 @@ interface BootViewProps {
 	graph: SerializedModuleGraph;
 	/** Fires with the span whenever a class row is selected. */
 	onSelectSpan?: (span: BootSpan) => void;
+	/** Pins the view to one trace and hides the picker. */
+	traceIndex?: number;
 }
 
 function toggled(set: ReadonlySet<string>, key: string): Set<string> {
@@ -78,8 +82,16 @@ export function BootView({
 	focusModule,
 	graph,
 	onSelectSpan,
+	traceIndex,
 }: BootViewProps) {
-	const timeline = useMemo(() => buildBootTimeline(graph), [graph]);
+	const views = useMemo<BootTraceView[]>(() => traceViews(graph), [graph]);
+	const [ownIdx, setOwnIdx] = useState(0);
+	const activeIdx = Math.min(traceIndex ?? ownIdx, views.length - 1);
+	const view = views[activeIdx];
+	const timeline = useMemo(
+		() => (view ? buildBootTimeline(view.graph) : null),
+		[view]
+	);
 	const [win, setWin] = useState<BootWindow>({
 		from: 0,
 		to: timeline?.maxMs ?? 1,
@@ -110,6 +122,7 @@ export function BootView({
 		y: number;
 	} | null>(null);
 	const pendingScrollRef = useRef<string | null>(null);
+	const pendingFocusRef = useRef<string | null>(null);
 
 	const timelineRef = useLatest(timeline);
 	const selectedIdRef = useLatest(selectedId);
@@ -125,6 +138,20 @@ export function BootView({
 		const named = className
 			? [...t.byId.values()].find((s) => s.name === className)
 			: undefined;
+		if (className && !named && traceIndex === undefined) {
+			const other = views.findIndex(
+				(v, i) =>
+					i !== activeIdx &&
+					Object.values(v.graph.timingsTrace ?? {}).some(
+						(n) => n.name === className
+					)
+			);
+			if (other !== -1) {
+				pendingFocusRef.current = className;
+				setOwnIdx(other);
+				return;
+			}
+		}
 		const hit = named ?? t.byId.get(slowestSpanId(t) ?? "");
 		if (!hit) {
 			return;
@@ -151,6 +178,19 @@ export function BootView({
 			registry.focus = undefined;
 		};
 	}, [compact]);
+
+	// A view switch gets a fresh window, selection, and open groups.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: focusRef is a stable useLatest ref
+	useEffect(() => {
+		setWin({ from: 0, to: timeline?.maxMs ?? 1 });
+		setSelectedId(null);
+		setExpandedModules(new Set(timeline?.groups.map((g) => g.module) ?? []));
+		const pending = pendingFocusRef.current;
+		if (pending) {
+			pendingFocusRef.current = null;
+			focusRef.current(pending);
+		}
+	}, [timeline]);
 
 	// The dock's compact view follows the module selected in the graph.
 	useEffect(() => {
@@ -448,6 +488,23 @@ export function BootView({
 		<div className={viewClasses} ref={viewRef}>
 			{!compact && <BootResizer viewRef={viewRef} />}
 			<div className="boot-main" ref={mainRef}>
+				{!compact && views.length > 1 && (
+					<div className="boot-trace-picker">
+						{views.map((v, i) => {
+							const cls = i === activeIdx ? "active" : undefined;
+							return (
+								<button
+									className={cls}
+									key={`${v.project ?? ""}:${v.label}`}
+									onClick={() => setOwnIdx(i)}
+									type="button"
+								>
+									{v.label}
+								</button>
+							);
+						})}
+					</div>
+				)}
 				<div className="boot-head">
 					<BootSideHead
 						classCount={timeline.byId.size}

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -1620,7 +1620,7 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 					<div className="boot-dock-body" data-active={dockActive}>
 						{dockTraceIdx === -1 ? (
 							<div className="boot-dock-empty">
-								No boot timings cover {selected?.project ?? "this module"}
+								No boot timings cover {selected?.project || "this module"}
 							</div>
 						) : (
 							<BootView

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -16,7 +16,12 @@ import { Badge } from "../atoms/badge.js";
 import { IconButton, TextButton } from "../atoms/button.js";
 import { Heading } from "../atoms/heading.js";
 import { Icon } from "../atoms/icon.js";
-import { moduleTimingLabel, moduleTimings } from "../lib/boot-timeline.js";
+import {
+	moduleTimingLabel,
+	moduleTimings,
+	traceIndexForModule,
+	traceViews,
+} from "../lib/boot-timeline.js";
 import { installFloatTip } from "../lib/float-tip.js";
 import {
 	endpointsOf,
@@ -926,6 +931,7 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 	const graph = report.graph;
 	const [selectedName, setSelectedName] = useState<string | null>(null);
 	const modTimings = useMemo(() => moduleTimings(graph), [graph]);
+	const bootViews = useMemo(() => traceViews(graph), [graph]);
 	const timingLabelOf = (name: string): string => {
 		const timing = modTimings.get(name);
 		return timing ? moduleTimingLabel(timing) : "";
@@ -1075,6 +1081,7 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 	const nodeMap = controller ? controller.nodeMap : {};
 	const importers = controller ? controller.importers : {};
 	const selected = selectedName ? (nodeMap[selectedName] ?? null) : null;
+	const dockTraceIdx = selected ? traceIndexForModule(bootViews, selected) : 0;
 
 	const byProject: Record<string, MgNode[]> = {};
 	for (const n of nodes) {
@@ -1611,16 +1618,23 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 						)}
 					</div>
 					<div className="boot-dock-body" data-active={dockActive}>
-						<BootView
-							compact
-							focusModule={selectedName}
-							graph={graph}
-							onSelectSpan={(span) => {
-								if (graph.modules.some((m) => m.name === span.module)) {
-									selectRef.current(span.module, true);
-								}
-							}}
-						/>
+						{dockTraceIdx === -1 ? (
+							<div className="boot-dock-empty">
+								No boot timings cover {selected?.project ?? "this module"}
+							</div>
+						) : (
+							<BootView
+								compact
+								focusModule={selectedName}
+								graph={graph}
+								onSelectSpan={(span) => {
+									if (graph.modules.some((m) => m.name === span.module)) {
+										selectRef.current(span.module, true);
+									}
+								}}
+								traceIndex={dockTraceIdx}
+							/>
+						)}
 					</div>
 				</div>
 				<div

--- a/packages/nestjs-doctor/src/report/ui/styles/boot.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/boot.css
@@ -204,3 +204,14 @@
 .boot-compact .boot-row { font-size: 11px; line-height: 22px; }
 .boot-compact .boot-track { height: 16px; }
 .boot-compact .boot-bar, .boot-compact .boot-hook-span { height: 12px; line-height: 12px; font-size: 9px; }
+
+.boot-trace-picker { display: flex; gap: 6px; padding: 8px 14px 0; }
+.boot-trace-picker button {
+  background: none; border: 1px solid rgba(255,255,255,0.18); border-radius: 4px;
+  color: var(--text-dim); font: inherit; font-size: 11px; padding: 2px 10px; cursor: pointer;
+}
+.boot-trace-picker button.active { color: var(--text); border-color: rgba(255,255,255,0.45); }
+.boot-dock-empty {
+  flex: 1; display: flex; align-items: center; justify-content: center;
+  color: var(--text-dim); font-size: 12px;
+}

--- a/packages/nestjs-doctor/src/report/ui/styles/boot.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/boot.css
@@ -215,3 +215,8 @@
   flex: 1; display: flex; align-items: center; justify-content: center;
   color: var(--text-dim); font-size: 12px;
 }
+
+/* A hook whose recorded offset lies outside the phase its kind names. */
+.boot-hook-stray {
+  background-image: repeating-linear-gradient(135deg, rgba(0,0,0,0.4) 0 3px, transparent 3px 6px);
+}

--- a/packages/nestjs-doctor/tests/unit/module-serializer.test.ts
+++ b/packages/nestjs-doctor/tests/unit/module-serializer.test.ts
@@ -6,6 +6,7 @@ import {
 	mergeModuleGraphs,
 } from "../../src/engine/graph/module-graph.js";
 import { serializeModuleGraph } from "../../src/report/formatters/module-serializer.js";
+import { attributeTraces } from "../../src/report/formatters/trace-attribution.js";
 
 function createProject(files: Record<string, string>) {
 	const project = new Project({ useInMemoryFileSystem: true });
@@ -411,5 +412,43 @@ describe("module-serializer traces", () => {
 		);
 		expect(serialized.traces?.[0]?.label).toBe("mystery");
 		expect(serialized.traces?.[0]?.project).toBeUndefined();
+	});
+});
+
+describe("attributeTraces", () => {
+	const mods = [
+		{ name: "api/AppModule", project: "api" },
+		{ name: "worker/WorkerModule", project: "worker" },
+	];
+
+	it("prefers the explicit label over inference", () => {
+		const { projects } = attributeTraces(
+			[
+				{
+					label: "worker",
+					name: "d",
+					timings: timingsOf("AppModule", "A", 1, "AppModule"),
+				},
+			],
+			mods,
+			["api", "worker"],
+			["api/AppModule"]
+		);
+		expect(projects).toEqual(["worker"]);
+	});
+
+	it("leaves a tied vote unattributed", () => {
+		const shared = [
+			{ name: "api/SharedModule", project: "api" },
+			{ name: "worker/SharedModule", project: "worker" },
+		];
+		const { projects, rootedProjects } = attributeTraces(
+			[{ name: "d", timings: timingsOf("SharedModule", "S", 1) }],
+			shared,
+			["api", "worker"],
+			["api/SharedModule"]
+		);
+		expect(projects).toEqual([undefined]);
+		expect(rootedProjects).toEqual(new Set(["api"]));
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/module-serializer.test.ts
+++ b/packages/nestjs-doctor/tests/unit/module-serializer.test.ts
@@ -134,7 +134,7 @@ describe("module-serializer", () => {
 			emptyResult,
 			undefined,
 			undefined,
-			timings
+			[{ name: "boot", timings }]
 		);
 
 		expect(serialized.timingsAvailable).toBe(true);
@@ -205,7 +205,7 @@ describe("module-serializer", () => {
 			emptyResult,
 			["api", "shared"],
 			undefined,
-			timings
+			[{ name: "boot", timings }]
 		);
 
 		const cats = serialized.modules.find(
@@ -254,7 +254,7 @@ describe("module-serializer", () => {
 			emptyResult,
 			["api", "worker"],
 			undefined,
-			timings
+			[{ name: "boot", timings }]
 		);
 
 		expect(serialized.timingsAvailable).toBe(true);
@@ -280,5 +280,136 @@ describe("module-serializer", () => {
 		expect(serialized.modules[0].name).toBe("AppModule");
 		expect(serialized.modules[0].project).toBeUndefined();
 		expect(serialized.bootstrapRoots).toBeUndefined();
+	});
+});
+
+function nestModule(name: string): string {
+	return [
+		"import { Module } from '@nestjs/common';",
+		"@Module({})",
+		`export class ${name} {}`,
+	].join("\n");
+}
+
+function timingsOf(
+	moduleName: string,
+	className: string,
+	initTime: number,
+	rootModule?: string
+) {
+	return {
+		byModule: new Map([
+			[moduleName, [{ id: "c1", initTime, name: className, type: "provider" }]],
+		]),
+		hooksByClass: new Map(),
+		rootModule,
+		trace: {
+			c1: { deps: [], initTime, name: className, type: "provider" },
+		},
+	};
+}
+
+describe("module-serializer traces", () => {
+	function twoProjects(workerHasAppModule = false) {
+		const { project: api, paths: apiPaths } = createProject({
+			"app.module.ts": nestModule("AppModule"),
+		});
+		const workerFiles: Record<string, string> = {
+			"worker.module.ts": nestModule("WorkerModule"),
+		};
+		if (workerHasAppModule) {
+			workerFiles["app.module.ts"] = nestModule("AppModule");
+		}
+		const { project: worker, paths: workerPaths } = createProject(workerFiles);
+		return mergeModuleGraphs(
+			new Map([
+				["api", buildModuleGraph(api, apiPaths)],
+				["worker", buildModuleGraph(worker, workerPaths)],
+			])
+		);
+	}
+
+	it("emits one trace per dump, attributed by root module, mirroring the first", () => {
+		const apiTimings = {
+			...timingsOf("AppModule", "AppService", 42, "AppModule"),
+			startupMs: 300,
+		};
+		const workerTimings = {
+			...timingsOf("WorkerModule", "JobsService", 7, "WorkerModule"),
+			startupMs: 120,
+		};
+		const serialized = serializeModuleGraph(
+			twoProjects(),
+			emptyResult,
+			["api", "worker"],
+			["api/AppModule", "worker/WorkerModule"],
+			[
+				{ name: "api-dump", timings: apiTimings },
+				{ name: "worker-dump", timings: workerTimings },
+			]
+		);
+		expect(serialized.traces?.map((t) => [t.label, t.project])).toEqual([
+			["api", "api"],
+			["worker", "worker"],
+		]);
+		expect(serialized.timingsTrace).toEqual(apiTimings.trace);
+		expect(serialized.startupMs).toBe(300);
+		const app = serialized.modules.find((m) => m.name === "api/AppModule");
+		expect(app?.initTimings?.[0]?.name).toBe("AppService");
+		const wm = serialized.modules.find((m) => m.name === "worker/WorkerModule");
+		expect(wm?.initTimings?.[0]?.name).toBe("JobsService");
+	});
+
+	it("attaches same-named modules from each project's own trace", () => {
+		const apiTimings = timingsOf("AppModule", "AppService", 42, "AppModule");
+		const workerTimings = timingsOf(
+			"AppModule",
+			"WorkerBoot",
+			9,
+			"WorkerModule"
+		);
+		const serialized = serializeModuleGraph(
+			twoProjects(true),
+			emptyResult,
+			["api", "worker"],
+			["api/AppModule", "worker/WorkerModule"],
+			[
+				{ name: "api-dump", timings: apiTimings },
+				{ name: "worker-dump", timings: workerTimings },
+			]
+		);
+		const app = serialized.modules.find((m) => m.name === "api/AppModule");
+		expect(app?.initTimings?.[0]?.name).toBe("AppService");
+		const wapp = serialized.modules.find((m) => m.name === "worker/AppModule");
+		expect(wapp?.initTimings?.[0]?.name).toBe("WorkerBoot");
+	});
+
+	it("attributes a dump by its explicit label before inference", () => {
+		const workerTimings = timingsOf("AppModule", "WorkerBoot", 9, "AppModule");
+		const serialized = serializeModuleGraph(
+			twoProjects(true),
+			emptyResult,
+			["api", "worker"],
+			["api/AppModule", "worker/WorkerModule"],
+			[{ label: "worker", name: "dump", timings: workerTimings }]
+		);
+		expect(serialized.traces?.[0]?.project).toBe("worker");
+		const app = serialized.modules.find((m) => m.name === "api/AppModule");
+		expect(app?.initTimings).toBeUndefined();
+		const wapp = serialized.modules.find((m) => m.name === "worker/AppModule");
+		expect(wapp?.initTimings?.[0]?.name).toBe("WorkerBoot");
+	});
+
+	it("keeps an unattributable dump as a trace without a project and warns", () => {
+		const timings = timingsOf("ShopModule", "ShopService", 4);
+		const serialized = serializeModuleGraph(
+			twoProjects(),
+			emptyResult,
+			["api", "worker"],
+			["api/AppModule", "worker/WorkerModule"],
+			[{ name: "mystery", timings }]
+		);
+		expect(serialized.traces?.[0]?.label).toBe("mystery");
+		expect(serialized.traces?.[0]?.project).toBeUndefined();
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-boot-app.test.tsx
+++ b/packages/nestjs-doctor/tests/unit/report-boot-app.test.tsx
@@ -599,3 +599,85 @@ describe("BootTab", () => {
 		expect(cursor?.style.display).toBe("none");
 	});
 });
+
+const TWO_TRACE_ARTIFACT: ReportArtifact = {
+	...EMPTY_ARTIFACT,
+	graph: {
+		...EMPTY_ARTIFACT.graph,
+		startupMs: 300,
+		timingsAvailable: true,
+		timingsTrace: {
+			ta: { deps: [], initTime: 50, name: "ApiService", type: "provider" },
+		},
+		traces: [
+			{
+				label: "api",
+				project: "api",
+				startupMs: 300,
+				trace: {
+					ta: { deps: [], initTime: 50, name: "ApiService", type: "provider" },
+				},
+			},
+			{
+				label: "worker",
+				project: "worker",
+				startupMs: 120,
+				trace: {
+					tb: { deps: [], initTime: 20, name: "JobsService", type: "provider" },
+				},
+			},
+		],
+	},
+};
+
+describe("BootTab traces", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	const mount = (artifact: ReportArtifact) => {
+		act(() => {
+			root.render(<BootTab report={artifact} />);
+		});
+	};
+
+	it("shows a picker for two traces and switches between them", () => {
+		mount(TWO_TRACE_ARTIFACT);
+		const picker = container.querySelector(".boot-trace-picker");
+		expect(picker?.textContent).toContain("api");
+		expect(picker?.textContent).toContain("worker");
+		expect(container.querySelector('.boot-rows [data-id="ta"]')).not.toBeNull();
+		const workerBtn = [
+			...container.querySelectorAll<HTMLElement>(".boot-trace-picker button"),
+		].find((b) => b.textContent === "worker");
+		act(() => workerBtn?.click());
+		expect(container.querySelector('.boot-rows [data-id="tb"]')).not.toBeNull();
+		expect(container.querySelector('.boot-rows [data-id="ta"]')).toBeNull();
+	});
+
+	it("locks the compact view to the given trace with no picker", () => {
+		act(() => {
+			root.render(
+				<BootView
+					compact
+					focusModule={null}
+					graph={TWO_TRACE_ARTIFACT.graph}
+					traceIndex={1}
+				/>
+			);
+		});
+		expect(container.querySelector(".boot-trace-picker")).toBeNull();
+		expect(container.querySelector('.boot-rows [data-id="tb"]')).not.toBeNull();
+		expect(container.querySelector('.boot-rows [data-id="ta"]')).toBeNull();
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/report-boot-app.test.tsx
+++ b/packages/nestjs-doctor/tests/unit/report-boot-app.test.tsx
@@ -678,6 +678,10 @@ describe("BootTab traces", () => {
 		});
 		expect(container.querySelector(".boot-trace-picker")).toBeNull();
 		expect(container.querySelector('.boot-rows [data-id="tb"]')).not.toBeNull();
+		act(() => {
+			root.render(<BootView graph={TWO_TRACE_ARTIFACT.graph} traceIndex={1} />);
+		});
+		expect(container.querySelector(".boot-trace-picker")).toBeNull();
 		expect(container.querySelector('.boot-rows [data-id="ta"]')).toBeNull();
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -1156,6 +1156,26 @@ describe("lanes and axis", () => {
 		expect(html).toContain('data-tip="100ms · listen — ');
 	});
 
+	it("renders four sections for a context app's derived markers", () => {
+		const t = buildBootTimeline(
+			graph({
+				phases: { createMs: 139.9, initMs: 170.8, moduleInitMs: 170.1 },
+				startupMs: 170.8,
+				timingsAvailable: true,
+				timingsTrace: { ta: traceNode(50) },
+			})
+		) as NonNullable<ReturnType<typeof buildBootTimeline>>;
+		const html = phaseLaneHtml(t);
+		expect(html).toContain("building modules");
+		expect(html).toContain("init hooks");
+		expect(html).toContain("bootstrap hooks");
+		expect(html).toContain("opening the port");
+		const tags = [...html.matchAll(PHASE_TAG_RE)].map((m) => m[1]);
+		expect(tags).toHaveLength(4);
+		expect(tags[3]).toContain("boot-phase-empty");
+		expect(html).toContain('boot-phase-ms">0ms</span>');
+	});
+
 	it("keeps a sub-millisecond phase wide enough to hover, inside the lane", () => {
 		const t = buildBootTimeline(
 			graph({

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -376,6 +376,38 @@ describe("buildBootTimeline", () => {
 		]);
 	});
 
+	it("tiles the phases over the whole boot for every marker subset", () => {
+		const subsets = [
+			{},
+			{ createMs: 100 },
+			{ moduleInitMs: 250 },
+			{ initMs: 300 },
+			{ createMs: 100, moduleInitMs: 250 },
+			{ createMs: 100, initMs: 300 },
+			{ initMs: 300, moduleInitMs: 250 },
+			{ createMs: 100, initMs: 300, moduleInitMs: 250 },
+		];
+		for (const phases of subsets) {
+			const label = JSON.stringify(phases);
+			const t = buildBootTimeline(
+				graph({
+					phases,
+					startupMs: 400,
+					timingsAvailable: true,
+					timingsTrace: { ta: traceNode(50) },
+				})
+			);
+			expect(t, label).not.toBeNull();
+			const ph = t?.phases ?? [];
+			expect(ph.length, label).toBeGreaterThanOrEqual(1);
+			expect(ph[0]?.start, label).toBe(0);
+			for (let i = 1; i < ph.length; i++) {
+				expect(ph[i]?.start, label).toBe(ph[i - 1]?.end);
+			}
+			expect(ph.at(-1)?.end, label).toBe(t?.maxMs);
+		}
+	});
+
 	it("marks a phase empty when no class or hook span falls inside it", () => {
 		const t = buildBootTimeline(
 			graph({

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../src/common/artifact.js";
 import type { ClassTiming } from "../../src/common/timings.js";
 import { parseBootstrapTimings } from "../../src/report/timings.js";
+import { hoverCardData } from "../../src/report/ui/app/lib/boot-hover.js";
 import {
 	axisHtml,
 	type BootWindow,
@@ -818,6 +819,31 @@ describe("rowsHtml", () => {
 		expect(html).toMatch(GUIDE_MS_100_RE);
 		expect(html).toMatch(GUIDE_MS_250_RE);
 		expect(html).toMatch(GUIDE_MS_300_RE);
+	});
+
+	it("stripes a hook that ran outside the phase its kind names", () => {
+		const t = buildBootTimeline(
+			graph({
+				phases: { createMs: 60.4, initMs: 84.2, moduleInitMs: 79.3 },
+				startupMs: 92.7,
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(
+						5,
+						[],
+						[{ hook: "onApplicationBootstrap", ms: 6.8, startMs: 85 }]
+					),
+					tb: traceNode(4, [], [{ hook: "onModuleInit", ms: 3, startMs: 62 }]),
+				},
+			})
+		)!;
+		const html = rowsHtml(t, { ...base, win: { from: 0, to: 92.7 } });
+		expect(html.split("boot-hook-stray").length - 1).toBe(1);
+		expect(html).toContain("boot-hook-span boot-hook-stray");
+		const card = hoverCardData(t, t.byId.get("ta") as never, 0);
+		expect(card.detail.dim).toContain("past its phase");
+		const tame = hoverCardData(t, t.byId.get("tb") as never, 0);
+		expect(tame.detail.dim).not.toContain("past its phase");
 	});
 
 	it("marks offscreen content on both sides of the window", () => {

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -22,6 +22,8 @@ import {
 	slowestSpanId,
 	spanMatches,
 	tOf,
+	traceIndexForModule,
+	traceViews,
 	UNATTRIBUTED_MODULE,
 	windowAround,
 	windowTicks,
@@ -1520,5 +1522,87 @@ describe("lanes and axis", () => {
 		expect(html).toContain("boot-axis-zero");
 		expect(html).toContain("boot-axis-tick");
 		expect(html).toContain("boot-axis-end");
+	});
+});
+
+describe("trace views", () => {
+	it("normalizes a legacy graph into one view", () => {
+		const g = graph({
+			startupMs: 100,
+			timingsAvailable: true,
+			timingsTrace: { ta: traceNode(50) },
+		});
+		const views = traceViews(g);
+		expect(views).toHaveLength(1);
+		expect(views[0]?.label).toBe("boot");
+		expect(views[0]?.graph.timingsTrace).toBe(g.timingsTrace);
+	});
+
+	it("builds one view per serialized trace with its own clock", () => {
+		const g = graph({
+			startupMs: 300,
+			timingsAvailable: true,
+			timingsTrace: { ta: traceNode(50) },
+			traces: [
+				{
+					label: "api",
+					project: "api",
+					startupMs: 300,
+					trace: { ta: traceNode(50) },
+				},
+				{
+					label: "worker",
+					project: "worker",
+					startupMs: 120,
+					trace: { tb: traceNode(20) },
+				},
+			],
+		});
+		const views = traceViews(g);
+		expect(views.map((v) => [v.label, v.project])).toEqual([
+			["api", "api"],
+			["worker", "worker"],
+		]);
+		expect(views[1]?.graph.startupMs).toBe(120);
+		expect(buildBootTimeline(views[1]?.graph ?? g)?.maxMs).toBe(120);
+	});
+
+	it("locks a module to its own project's view and to none when absent", () => {
+		const g = graph({
+			timingsAvailable: true,
+			traces: [
+				{
+					label: "api",
+					project: "api",
+					startupMs: 300,
+					trace: { ta: traceNode(50) },
+				},
+				{
+					label: "worker",
+					project: "worker",
+					startupMs: 120,
+					trace: {
+						tb: traceNode(20, [], undefined, { module: "SharedModule" }),
+					},
+				},
+			],
+		});
+		const views = traceViews(g);
+		expect(traceIndexForModule(views, mod("worker/JobsModule"))).toBe(1);
+		expect(traceIndexForModule(views, mod("api/AppModule"))).toBe(0);
+		expect(traceIndexForModule(views, mod("shared/SharedModule"))).toBe(1);
+		expect(traceIndexForModule(views, mod("ghost/GhostModule"))).toBe(-1);
+	});
+
+	it("keeps a legacy single view for its own single project only", () => {
+		const g = graph({
+			timingsAvailable: true,
+			timingsTrace: {
+				ta: traceNode(50, [], undefined, { module: "AppModule" }),
+			},
+		});
+		const views = traceViews(g);
+		expect(traceIndexForModule(views, mod("AppModule"))).toBe(0);
+		expect(traceIndexForModule(views, mod("worker/JobsModule"))).toBe(-1);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -1753,6 +1753,54 @@ describe("trace views", () => {
 		);
 	});
 
+	it("labels every project's modules from its own trace", () => {
+		const g = graph({
+			modules: [
+				mod("api/AppModule", [
+					{ id: "ta", initTime: 50, name: "ApiService", type: "provider" },
+				]),
+				mod("worker/JobsModule", [
+					{ id: "tb", initTime: 20, name: "JobsService", type: "provider" },
+				]),
+			],
+			startupMs: 300,
+			timingsAvailable: true,
+			timingsTrace: {
+				ta: traceNode(50, [], undefined, {
+					module: "AppModule",
+					name: "ApiService",
+				}),
+			},
+			traces: [
+				{
+					label: "api",
+					project: "api",
+					startupMs: 300,
+					trace: {
+						ta: traceNode(50, [], undefined, {
+							module: "AppModule",
+							name: "ApiService",
+						}),
+					},
+				},
+				{
+					label: "worker",
+					project: "worker",
+					startupMs: 120,
+					trace: {
+						tb: traceNode(20, [], undefined, {
+							module: "JobsModule",
+							name: "JobsService",
+						}),
+					},
+				},
+			],
+		});
+		const timings = moduleTimings(g);
+		expect(timings.get("api/AppModule")?.buildMs).toBeGreaterThan(0);
+		expect(timings.get("worker/JobsModule")?.buildMs).toBeGreaterThan(0);
+	});
+
 	it("serves every module from a lone unattributed view", () => {
 		const g = graph({
 			timingsAvailable: true,

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -1591,6 +1591,28 @@ describe("trace views", () => {
 		expect(traceIndexForModule(views, mod("worker/JobsModule"))).toBe(1);
 		expect(traceIndexForModule(views, mod("api/AppModule"))).toBe(0);
 		expect(traceIndexForModule(views, mod("shared/SharedModule"))).toBe(1);
+		const both = traceViews(
+			graph({
+				timingsAvailable: true,
+				traces: [
+					{
+						label: "api",
+						project: "api",
+						trace: {
+							ta: traceNode(5, [], undefined, { module: "SharedModule" }),
+						},
+					},
+					{
+						label: "worker",
+						project: "worker",
+						trace: {
+							tb: traceNode(3, [], undefined, { module: "SharedModule" }),
+						},
+					},
+				],
+			})
+		);
+		expect(traceIndexForModule(both, mod("shared/SharedModule"))).toBe(0);
 		expect(traceIndexForModule(views, mod("ghost/GhostModule"))).toBe(-1);
 	});
 

--- a/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-boot-timeline.test.ts
@@ -853,6 +853,26 @@ describe("rowsHtml", () => {
 		expect(html).toMatch(GUIDE_MS_300_RE);
 	});
 
+	it("keeps a bootstrap hook inside its own phase unstriped under a merged label", () => {
+		const t = buildBootTimeline(
+			graph({
+				phases: { initMs: 90, moduleInitMs: 50 },
+				startupMs: 100,
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(
+						5,
+						[],
+						[{ hook: "onApplicationBootstrap", ms: 20, startMs: 60 }]
+					),
+				},
+			})
+		)!;
+		const html = rowsHtml(t, { ...base, win: { from: 0, to: 100 } });
+		expect(html).not.toContain("boot-hook-stray");
+		expect(t.phases[1]?.empty).toBe(false);
+	});
+
 	it("stripes a hook that ran outside the phase its kind names", () => {
 		const t = buildBootTimeline(
 			graph({
@@ -1694,7 +1714,46 @@ describe("trace views", () => {
 		expect(traceIndexForModule(views, mod("ghost/GhostModule"))).toBe(-1);
 	});
 
-	it("keeps a legacy single view for its own single project only", () => {
+	it("treats a canvas empty-string project like no project at all", () => {
+		const legacy = traceViews(
+			graph({
+				timingsAvailable: true,
+				timingsTrace: {
+					ta: traceNode(50, [], undefined, { module: "AppModule" }),
+				},
+			})
+		);
+		expect(
+			traceIndexForModule(legacy, { name: "CoreModule", project: "" })
+		).toBe(0);
+		expect(
+			traceIndexForModule(legacy, { name: "api/AppModule", project: "api" })
+		).toBe(0);
+		const two = traceViews(
+			graph({
+				timingsAvailable: true,
+				traces: [
+					{
+						label: "api",
+						project: "api",
+						startupMs: 300,
+						trace: { ta: traceNode(5) },
+					},
+					{
+						label: "worker",
+						project: "worker",
+						startupMs: 120,
+						trace: { tb: traceNode(3) },
+					},
+				],
+			})
+		);
+		expect(traceIndexForModule(two, { name: "GhostModule", project: "" })).toBe(
+			-1
+		);
+	});
+
+	it("serves every module from a lone unattributed view", () => {
 		const g = graph({
 			timingsAvailable: true,
 			timingsTrace: {
@@ -1703,6 +1762,6 @@ describe("trace views", () => {
 		});
 		const views = traceViews(g);
 		expect(traceIndexForModule(views, mod("AppModule"))).toBe(0);
-		expect(traceIndexForModule(views, mod("worker/JobsModule"))).toBe(-1);
+		expect(traceIndexForModule(views, mod("worker/JobsModule"))).toBe(0);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-module-timings.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatMs } from "../../src/report/ui/app/lib/trace.js";
+import {
+	formatMs,
+	PALETTE,
+	phaseParts,
+} from "../../src/report/ui/app/lib/trace.js";
 
 describe("formatMs", () => {
 	it("rounds to the nearest millisecond at 10ms and above", () => {
@@ -22,5 +26,41 @@ describe("formatMs", () => {
 
 	it("rounds 9.96ms up cleanly rather than printing 10.0ms", () => {
 		expect(formatMs(9.96)).toBe("10ms");
+	});
+});
+
+describe("phaseParts without a create marker", () => {
+	it("merges construction into the init segment when only moduleInitMs is marked", () => {
+		const parts = phaseParts({
+			phases: { moduleInitMs: 170.1 },
+			startupMs: 170.8,
+		});
+		expect(parts.length).toBeGreaterThanOrEqual(2);
+		expect(parts.reduce((sum, p) => sum + p.ms, 0)).toBeCloseTo(170.8, 6);
+		const head = parts[0];
+		expect(head?.ms).toBeCloseTo(170.1, 6);
+		expect(head?.label).not.toBe("create");
+		expect(head?.gloss).toBe("build + init hooks");
+		expect(parts.at(-1)?.label).toBe("bootstrap + listen");
+	});
+
+	it("renders one grey whole-boot segment when only startupMs is known", () => {
+		for (const phases of [{}, undefined]) {
+			const parts = phaseParts({ phases, startupMs: 170.8 });
+			expect(parts).toHaveLength(1);
+			expect(parts[0]).toMatchObject({
+				gloss: "whole boot",
+				ms: 170.8,
+				rgb: PALETTE.grey,
+			});
+		}
+	});
+
+	it("merges everything before initMs when the earlier markers are missing", () => {
+		const parts = phaseParts({ phases: { initMs: 84 }, startupMs: 92 });
+		expect(parts.map((p) => [p.label, p.ms])).toEqual([
+			["create + hooks", 84],
+			["listen", 8],
+		]);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/report-styles.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-styles.test.ts
@@ -30,6 +30,11 @@ describe("report styles", () => {
 		);
 	});
 
+	it("styles the trace picker and the dock's empty note", () => {
+		expect(css).toContain(".boot-trace-picker {");
+		expect(css).toContain(".boot-dock-empty {");
+	});
+
 	it("aligns the lanes with the scrolled rows and labels the guides", () => {
 		expect(css).toContain(
 			".boot-scroll { flex: 1; overflow: auto; min-height: 0; outline: none; scrollbar-gutter: stable; }"

--- a/packages/nestjs-doctor/tests/unit/report-styles.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-styles.test.ts
@@ -33,6 +33,7 @@ describe("report styles", () => {
 	it("styles the trace picker and the dock's empty note", () => {
 		expect(css).toContain(".boot-trace-picker {");
 		expect(css).toContain(".boot-dock-empty {");
+		expect(css).toContain(".boot-hook-stray {");
 	});
 
 	it("aligns the lanes with the scrolled rows and labels the guides", () => {

--- a/packages/nestjs-doctor/tests/unit/timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/timings.test.ts
@@ -566,6 +566,118 @@ describe("parseBootstrapTimings", () => {
 		expect(warnings).toEqual([]);
 	});
 
+	it("derives all three markers for a context app dump", () => {
+		const { phases, warnings } = parseBootstrapTimings(
+			JSON.stringify({
+				edges: {},
+				entrypoints: {},
+				hookTimings: [
+					{
+						className: "QueueService",
+						hook: "onModuleInit",
+						ms: 30.2,
+						startMs: 139.9,
+					},
+					{
+						className: "JobsService",
+						hook: "onModuleInit",
+						ms: 19.8,
+						startMs: 150.3,
+					},
+				],
+				nodes: {
+					c1: classNode("QueueService", "m1", 5),
+					c2: classNode("JobsService", "m1", 3),
+					m1: moduleNode("WorkerModule"),
+				},
+				startupMs: 170.8,
+			})
+		);
+		expect(warnings).toEqual([]);
+		expect(phases?.createMs).toBeCloseTo(139.9, 5);
+		expect(phases?.moduleInitMs).toBeCloseTo(170.1, 5);
+		expect(phases?.initMs).toBeCloseTo(170.8, 5);
+	});
+
+	it("keeps initMs unset when the dump has entrypoints", () => {
+		const { phases, warnings } = parseBootstrapTimings(
+			JSON.stringify({
+				edges: {},
+				entrypoints: { e1: { id: "e1" } },
+				hookTimings: [
+					{
+						className: "QueueService",
+						hook: "onModuleInit",
+						ms: 30.2,
+						startMs: 139.9,
+					},
+				],
+				nodes: {
+					c1: classNode("QueueService", "m1", 5),
+					m1: moduleNode("WorkerModule"),
+				},
+				startupMs: 170.8,
+			})
+		);
+		expect(warnings).toEqual([]);
+		expect(phases?.createMs).toBeCloseTo(139.9, 5);
+		expect(phases?.moduleInitMs).toBeCloseTo(170.1, 5);
+		expect(phases?.initMs).toBeUndefined();
+	});
+
+	it("skips the derived createMs when the earliest hook starts past moduleInitMs", () => {
+		const { phases, warnings } = parseBootstrapTimings(
+			JSON.stringify({
+				edges: {},
+				entrypoints: {},
+				hookTimings: [
+					{
+						className: "QueueService",
+						hook: "onModuleInit",
+						ms: 10,
+						startMs: 150,
+					},
+				],
+				moduleInitMs: 100,
+				nodes: {
+					c1: classNode("QueueService", "m1", 5),
+					m1: moduleNode("WorkerModule"),
+				},
+				startupMs: 200,
+			})
+		);
+		expect(warnings).toEqual([]);
+		expect(phases?.createMs).toBeUndefined();
+		expect(phases?.moduleInitMs).toBe(100);
+		expect(phases?.initMs).toBe(200);
+	});
+
+	it("keeps an explicit createMs over a smaller hook start", () => {
+		const { phases, warnings } = parseBootstrapTimings(
+			JSON.stringify({
+				createMs: 100,
+				edges: {},
+				entrypoints: {},
+				hookTimings: [
+					{
+						className: "QueueService",
+						hook: "onModuleInit",
+						ms: 10,
+						startMs: 50,
+					},
+				],
+				nodes: {
+					c1: classNode("QueueService", "m1", 5),
+					m1: moduleNode("WorkerModule"),
+				},
+				startupMs: 200,
+			})
+		);
+		expect(warnings).toEqual([]);
+		expect(phases?.createMs).toBe(100);
+		expect(phases?.initMs).toBe(200);
+	});
+
 	it("leaves middleware out of the trace", () => {
 		const { modules, trace } = parseBootstrapTimings(
 			dump({

--- a/packages/nestjs-doctor/tests/unit/timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/timings.test.ts
@@ -83,6 +83,39 @@ describe("parseBootstrapTimings", () => {
 		expect(rootModule).toBeUndefined();
 	});
 
+	it("derives the boundary from the last init end when the first bootstrap start is past initMs", () => {
+		const { phases, warnings } = parseBootstrapTimings(
+			JSON.stringify({
+				createMs: 60.4,
+				edges: {},
+				entrypoints: {},
+				hookTimings: [
+					{
+						className: "JobsService",
+						hook: "onModuleInit",
+						ms: 18.2,
+						startMs: 61.1,
+					},
+					{
+						className: "SyncService",
+						hook: "onApplicationBootstrap",
+						ms: 6.8,
+						startMs: 85,
+					},
+				],
+				initMs: 84.2,
+				nodes: {
+					c1: classNode("JobsService", "m1", 5),
+					c2: classNode("SyncService", "m1", 3),
+					m1: moduleNode("WorkerModule"),
+				},
+				startupMs: 92.7,
+			})
+		);
+		expect(warnings).toEqual([]);
+		expect(phases?.moduleInitMs).toBeCloseTo(79.3, 5);
+	});
+
 	it("keeps a hooks-only dump without a phase breakdown", () => {
 		const { phases, warnings } = parseBootstrapTimings(
 			JSON.stringify({

--- a/packages/nestjs-doctor/tests/unit/timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/timings.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
 	loadBootstrapTimings,
+	loadBootstrapTraces,
 	parseBootstrapTimings,
 } from "../../src/report/timings.js";
 
@@ -55,6 +56,31 @@ describe("parseBootstrapTimings", () => {
 			},
 			{ id: "tc1", name: "CatsService", type: "provider", initTime: 4.5 },
 		]);
+	});
+
+	it("names the dump's root module when exactly one has no importer", () => {
+		const { rootModule } = parseBootstrapTimings(
+			dump(
+				{
+					c1: classNode("CatsService", "m1", 5),
+					m1: moduleNode("CatsModule"),
+					m2: moduleNode("DogsModule"),
+				},
+				{ e1: imports("m1", "m2") }
+			)
+		);
+		expect(rootModule).toBe("CatsModule");
+	});
+
+	it("leaves the root module unset when two modules have no importer", () => {
+		const { rootModule } = parseBootstrapTimings(
+			dump({
+				c1: classNode("CatsService", "m1", 5),
+				m1: moduleNode("CatsModule"),
+				m2: moduleNode("DogsModule"),
+			})
+		);
+		expect(rootModule).toBeUndefined();
 	});
 
 	it("keeps a hooks-only dump without a phase breakdown", () => {
@@ -672,5 +698,55 @@ describe("loadBootstrapTimings", () => {
 		expect(timings?.byModule.size).toBe(0);
 		expect(timings?.trace.tc1.module).toBe("SharedModule");
 		expect(timings?.trace.tc2.module).toBe("SharedModule");
+	});
+});
+
+describe("loadBootstrapTraces", () => {
+	it("loads a comma list, keeping labels and naming unlabeled dumps by file", () => {
+		const dir = mkdtempSync(join(tmpdir(), "nd-traces-"));
+		writeFileSync(
+			join(dir, "api.json"),
+			dump({
+				c1: classNode("AppService", "m1", 5),
+				m1: moduleNode("AppModule"),
+			})
+		);
+		writeFileSync(
+			join(dir, "w.json"),
+			dump({
+				c1: classNode("JobsService", "m1", 3),
+				m1: moduleNode("WorkerModule"),
+			})
+		);
+		const { traces, warnings } = loadBootstrapTraces(
+			dir,
+			"api.json,worker=w.json"
+		);
+		expect(warnings).toEqual([]);
+		expect(traces.map((t) => [t.label, t.name])).toEqual([
+			[undefined, "api"],
+			["worker", "w"],
+		]);
+		expect(Object.keys(traces[1]?.timings.trace ?? {})).toContain("tc1");
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("keeps loading past a bad path and says which one failed", () => {
+		const dir = mkdtempSync(join(tmpdir(), "nd-traces-"));
+		writeFileSync(
+			join(dir, "api.json"),
+			dump({
+				c1: classNode("AppService", "m1", 5),
+				m1: moduleNode("AppModule"),
+			})
+		);
+		const { traces, warnings } = loadBootstrapTraces(
+			dir,
+			"missing.json,api.json"
+		);
+		expect(traces).toHaveLength(1);
+		expect(traces[0]?.name).toBe("api");
+		expect(warnings.some((w) => w.includes("missing.json"))).toBe(true);
+		rmSync(dir, { recursive: true, force: true });
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/timings.test.ts
+++ b/packages/nestjs-doctor/tests/unit/timings.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
@@ -873,6 +873,22 @@ describe("loadBootstrapTraces", () => {
 			["worker", "w"],
 		]);
 		expect(Object.keys(traces[1]?.timings.trace ?? {})).toContain("tc1");
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("keeps an equals sign inside a path when the prefix looks like a directory", () => {
+		const dir = mkdtempSync(join(tmpdir(), "nd-traces-"));
+		mkdirSync(join(dir, "out=v2"));
+		writeFileSync(
+			join(dir, "out=v2", "dump.json"),
+			dump({
+				c1: classNode("AppService", "m1", 5),
+				m1: moduleNode("AppModule"),
+			})
+		);
+		const { traces, warnings } = loadBootstrapTraces(dir, "./out=v2/dump.json");
+		expect(warnings).toEqual([]);
+		expect(traces.map((t) => [t.label, t.name])).toEqual([[undefined, "dump"]]);
 		rmSync(dir, { recursive: true, force: true });
 	});
 

--- a/packages/website/src/app/docs/report/boot-trace/page.mdx
+++ b/packages/website/src/app/docs/report/boot-trace/page.mdx
@@ -174,6 +174,16 @@ Modules graph keeps a compact mount of the same timeline in its dock. The
 trace button in a module's detail panel opens the tab on that module's slowest
 class.
 
+## Multiple entry points
+
+A monorepo boots more than once. Pass one dump per entry point, each optionally labelled:
+
+```bash
+npx nestjs-doctor@latest . --report --timings api.json,worker=apps/worker/dump.json
+```
+
+Every dump becomes its own trace with a picker on the Boot tab, and the report matches each one to a project by its label, its root module, or the modules only that project owns. In the modules graph, the dock shows the selected module's own trace; a module whose app was never booted says so instead of borrowing another trace.
+
 ## Limits
 
 - Timings are display-only. They never affect the score, the diagnostics, or


### PR DESCRIPTION
## Context

A `--timings` dump is one process's `SerializedGraph`. A monorepo boots once per entry point — nest-shop's api and worker are separate processes with separate clocks — but the report accepted exactly one dump, and everything on the Boot tab and in the modules-graph trace dock derived from it.

## Problem

Selecting a worker module in the modules graph showed the api's boot in the bottom dock: a 359ms api timeline under `worker/JobsModule`, which never ran in that process. And a monorepo where two projects both own an `AppModule` silently lost all per-module timings to the serializer's global unique-name guard — the same root as #119.

## Possible flows

| Flow | Before | Affected |
|---|---|---|
| `--timings one.json` → HTML report | one trace | unchanged (mirrored) |
| `--timings one.json` → `--format report-json` | one trace | unchanged (mirrored) |
| `--timings a.json,worker=b.json` | rejected as one path | new: one trace per dump |
| Dock for a module whose app has a trace | primary trace always | its own trace |
| Dock for a module no trace covers | primary trace | honest empty note |
| Old artifact without `traces` | — | renders as before |

## Solution

`--timings` takes a comma list, each entry optionally `label=path` (matching the repo's `--share-sections` CSV precedent). The parser names each dump's root module (the one no module imports); the serializer attributes every dump to a project by explicit label, root module against the bootstrap roots, then modules only one project owns — ambiguity stays unattributed and visibly labelled by file name, never guessed. The artifact gains an additive `graph.traces` array (no version bump; the v1 contract says additive fields don't) while the old singular fields mirror the primary trace for old viewers and report-json consumers. Per-module timings attach from each project's own trace with per-project name uniqueness; a project with its own entry point but no dump attaches nothing rather than borrowing.

The Boot tab renders one view per trace behind a picker; each keeps its own clock, TimeScale, window, and open groups — traces are never merged. The dock is pinned: the selected module's project's trace first, else the first trace naming the module, else "No boot timings cover worker". Deliberately not done: merging timelines (separate clocks make that a lie), dump auto-discovery, and the demo re-export (that rides the #361 follow-up).

## Before vs after

| Case | Before | After |
|---|---|---|
| One dump, single project | one trace | identical |
| `worker/JobsModule` selected, worker dump given | api's 359ms boot in the dock | worker's 93ms boot, no picker |
| api and worker both own `AppModule` | no timings on either | each from its own boot |
| Boot tab with two dumps | impossible | `api · worker` picker |
| `shared/SharedModule` (boots in both) | api trace | api trace (first covering) |

## Example

```
node dist/cli/index.mjs . --report \
  --timings nestjs-doctor-timings.json,worker=worker-timings.json
```

Old: the second path made the whole argument an unreadable file, one 359ms trace. New: Boot tab shows `api | worker`; api keeps the 359ms timeline, worker gets its own 93ms clock (60ms building modules, 24ms lifecycle hooks, 19ms `JobsService` with an 18ms `onModuleInit` span); clicking `worker/JobsModule` in the modules graph docks the worker trace, and `shared/SharedModule` docks the api one.

