### PR TITLE
feat(website): demo report carries both real boot traces

### DIFF
--- a/packages/website/public/demo-report.json
+++ b/packages/website/public/demo-report.json
@@ -1,1 +1,9400 @@
-{"schemaVersion":1,"generator":{"name":"nestjs-doctor","version":"0.9.3"},"generatedAt":"2026-08-29T22:47:47.707Z","monorepo":true,"project":{"name":"monorepo","nestVersion":"12.0.1","orm":"typeorm","framework":"express","fileCount":58,"moduleCount":12},"score":{"value":93,"label":"Excellent"},"summary":{"total":25,"errors":4,"warnings":14,"info":7,"byCategory":{"security":6,"performance":5,"correctness":5,"architecture":5,"schema":4}},"diagnostics":[{"filePath":"/demo/nest-shop/apps/api/src/app.module.ts","message":"TypeORM 'synchronize: true' can auto-drop columns and tables in production.","help":"Set synchronize: false and use migrations for production schema changes.","line":27,"column":1,"rule":"security/no-synchronize-in-production","category":"security","scope":"file","severity":"error","sourceLines":[{"line":22,"text":"        port: Number(config.getOrThrow<string>('DATABASE_PORT')),"},{"line":23,"text":"        username: config.getOrThrow<string>('DATABASE_USER'),"},{"line":24,"text":"        password: config.getOrThrow<string>('DATABASE_PASSWORD'),"},{"line":25,"text":"        database: config.getOrThrow<string>('DATABASE_NAME'),"},{"line":26,"text":"        autoLoadEntities: true,"},{"line":27,"text":"        synchronize: true,"},{"line":28,"text":"      }),"},{"line":29,"text":"    }),"},{"line":30,"text":"    BullModule.forRootAsync({"},{"line":31,"text":"      inject: [ConfigService],"},{"line":32,"text":"      useFactory: (config: ConfigService) => ({"}]},{"filePath":"/demo/nest-shop/apps/api/src/audit/audit.service.ts","message":"Constructor parameter 'logs' should be readonly.","help":"Add the 'readonly' modifier to the constructor parameter.","line":15,"column":13,"rule":"correctness/prefer-readonly-injection","category":"correctness","scope":"file","severity":"warning","surfaces":["cli"],"sourceLines":[{"line":10,"text":""},{"line":11,"text":"@Injectable()"},{"line":12,"text":"export class AuditService {"},{"line":13,"text":"  constructor("},{"line":14,"text":"    @Inject(AUDIT_OPTIONS) private readonly options: AuditOptions,"},{"line":15,"text":"    private logs: AuditRepository,"},{"line":16,"text":"  ) {}"},{"line":17,"text":""},{"line":18,"text":"  record(action: string, actor: string, payload: Record<string, unknown> = {}): Promise<AuditLog> {"},{"line":19,"text":"    return this.logs.insert(action, actor, payload);"},{"line":20,"text":"  }"}]},{"filePath":"/demo/nest-shop/apps/api/src/main.ts","message":"Synchronous I/O call 'writeFileSync()' blocks the event loop.","help":"Use the async variant (e.g., readFile instead of readFileSync) with await.","line":59,"column":1,"rule":"performance/no-sync-io","category":"performance","scope":"file","severity":"warning","sourceLines":[{"line":54,"text":"  Logger.log(`API listening on http://localhost:${port}`, 'Bootstrap');"},{"line":55,"text":""},{"line":56,"text":"  if (traceEnabled) {"},{"line":57,"text":"    const graph = JSON.parse(app.get(SerializedGraph).toString());"},{"line":58,"text":"    Object.assign(graph, { createMs, initMs, moduleInitMs, startupMs, hookTimings });"},{"line":59,"text":"    writeFileSync('nestjs-doctor-timings.json', JSON.stringify(graph));"},{"line":60,"text":"    Logger.log(`Boot trace written to nestjs-doctor-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');"},{"line":61,"text":"    await app.close();"},{"line":62,"text":"    process.exit(0);"},{"line":63,"text":"  }"},{"line":64,"text":"}"}]},{"filePath":"/demo/nest-shop/apps/api/src/notifications/notifications.service.ts","message":"Direct 'process.env.NOTIFICATIONS_FROM' access in 'NotificationsService'. Use ConfigService instead.","help":"Inject ConfigService and use configService.get('VAR_NAME') instead of process.env.VAR_NAME.","line":12,"column":1,"rule":"security/no-exposed-env-vars","category":"security","scope":"file","severity":"warning","sourceLines":[{"line":7,"text":"export type NotificationKind = 'receipt' | 'refund' | 'welcome' | 'payment-reminder';"},{"line":8,"text":""},{"line":9,"text":"@Injectable()"},{"line":10,"text":"export class NotificationsService implements OnApplicationBootstrap {"},{"line":11,"text":"  private readonly logger = new Logger(NotificationsService.name);"},{"line":12,"text":"  private readonly from = process.env.NOTIFICATIONS_FROM ?? 'shop@example.com';"},{"line":13,"text":""},{"line":14,"text":"  constructor("},{"line":15,"text":"    @InjectQueue('notifications') private readonly queue: Queue,"},{"line":16,"text":"    @Inject(forwardRef(() => OrdersService))"},{"line":17,"text":"    private readonly ordersService: OrdersService,"}]},{"filePath":"/demo/nest-shop/apps/api/src/orders/orders.controller.ts","message":"Controller method 'pay' contains business logic (0 if, 0 loops, 1 switch). Move to a service.","help":"Extract branches, loops, and complex calculations into a service method.","line":22,"column":1,"rule":"architecture/no-business-logic-in-controllers","category":"architecture","scope":"file","severity":"error","sourceLines":[{"line":17,"text":"  @Post()"},{"line":18,"text":"  create(@Body(new ValidationPipe({ whitelist: true, transform: true })) dto: CreateOrderDto) {"},{"line":19,"text":"    return this.ordersService.create(dto);"},{"line":20,"text":"  }"},{"line":21,"text":""},{"line":22,"text":"  @Post(':id/pay')"},{"line":23,"text":"  pay(@Param('id') id: string, @Body() body: { provider?: string }) {"},{"line":24,"text":"    let surchargeCents: number;"},{"line":25,"text":"    switch (body.provider) {"},{"line":26,"text":"      case 'card':"},{"line":27,"text":"        surchargeCents = 30;"}]},{"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","message":"Service uses @InjectRepository() directly. Consider wrapping in a repository class.","help":"Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.","line":30,"column":1,"rule":"architecture/no-orm-in-services","category":"architecture","scope":"file","severity":"info","sourceLines":[{"line":25,"text":"@Injectable()"},{"line":26,"text":"export class OrdersService implements OnModuleInit, OnApplicationBootstrap {"},{"line":27,"text":"  private readonly logger = new Logger(OrdersService.name);"},{"line":28,"text":""},{"line":29,"text":"  constructor("},{"line":30,"text":"    @InjectRepository(Order) private readonly orders: Repository<Order>,"},{"line":31,"text":"    @InjectRepository(OrderItem) private readonly items: Repository<OrderItem>,"},{"line":32,"text":"    private readonly usersService: UsersService,"},{"line":33,"text":"    private readonly catalogService: CatalogService,"},{"line":34,"text":"    private readonly audit: AuditService,"},{"line":35,"text":"    private readonly metrics: MetricsService,"}]},{"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","message":"Async call 'record()' is not awaited — unhandled rejections will crash the process.","help":"Add await before the async call, or use void with explicit error handling if fire-and-forget is intentional.","line":135,"column":1,"rule":"correctness/no-fire-and-forget-async","category":"correctness","scope":"file","severity":"warning","sourceLines":[{"line":130,"text":"  }"},{"line":131,"text":""},{"line":132,"text":"  async markRefunded(id: string): Promise<void> {"},{"line":133,"text":"    const order = await this.findOne(id);"},{"line":134,"text":"    await this.orders.update({ id }, { status: OrderStatus.Refunded });"},{"line":135,"text":"    this.audit.record('order.refunded', order.user.email, { orderId: id });"},{"line":136,"text":"  }"},{"line":137,"text":""},{"line":138,"text":"  // Demo orders for the system user, one payment each, spread over the last 30 days."},{"line":139,"text":"  private async seedDemoOrders(): Promise<number> {"},{"line":140,"text":"    if ((await this.orders.count()) > 0) {"}]},{"filePath":"/demo/nest-shop/apps/api/src/payments/payments.controller.ts","message":"Endpoint 'list' has no @UseGuards() at class or method level.","help":"Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.","line":8,"column":1,"rule":"security/require-guards-on-endpoints","category":"security","scope":"file","severity":"warning","sourceLines":[{"line":3,"text":""},{"line":4,"text":"@Controller('payments')"},{"line":5,"text":"export class PaymentsController {"},{"line":6,"text":"  constructor(private readonly paymentsService: PaymentsService) {}"},{"line":7,"text":""},{"line":8,"text":"  @Get()"},{"line":9,"text":"  list() {"},{"line":10,"text":"    return this.paymentsService.findAll();"},{"line":11,"text":"  }"},{"line":12,"text":""},{"line":13,"text":"  @Post(':id/refund')"}]},{"filePath":"/demo/nest-shop/apps/api/src/payments/payments.controller.ts","message":"Endpoint 'refund' has no @UseGuards() at class or method level.","help":"Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.","line":13,"column":1,"rule":"security/require-guards-on-endpoints","category":"security","scope":"file","severity":"warning","sourceLines":[{"line":8,"text":"  @Get()"},{"line":9,"text":"  list() {"},{"line":10,"text":"    return this.paymentsService.findAll();"},{"line":11,"text":"  }"},{"line":12,"text":""},{"line":13,"text":"  @Post(':id/refund')"},{"line":14,"text":"  refund(@Param('id') id: string) {"},{"line":15,"text":"    return this.paymentsService.refund(id);"},{"line":16,"text":"  }"},{"line":17,"text":"}"},{"line":18,"text":""}]},{"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","message":"Service uses @InjectRepository() directly. Consider wrapping in a repository class.","help":"Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.","line":31,"column":1,"rule":"architecture/no-orm-in-services","category":"architecture","scope":"file","severity":"info","sourceLines":[{"line":26,"text":"  // Pending amount per order id, warmed at boot so refunds can check quickly."},{"line":27,"text":"  private readonly pendingByOrder = new Map<string, number>();"},{"line":28,"text":"  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';"},{"line":29,"text":""},{"line":30,"text":"  constructor("},{"line":31,"text":"    @InjectRepository(Payment) private readonly payments: Repository<Payment>,"},{"line":32,"text":"    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,"},{"line":33,"text":"    private readonly cardGateway: CardGateway,"},{"line":34,"text":"    private readonly sepaGateway: SepaGateway,"},{"line":35,"text":"    private readonly metrics: MetricsService,"},{"line":36,"text":"    private readonly audit: AuditService,"}]},{"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","message":"Property 'webhookSecret' appears to contain a hardcoded secret.","help":"Move secrets to environment variables and access them via ConfigService.","line":28,"column":1,"rule":"security/no-hardcoded-secrets","category":"security","scope":"file","severity":"error","sourceLines":[{"line":23,"text":"@Injectable()"},{"line":24,"text":"export class PaymentsService implements OnModuleInit, OnApplicationBootstrap {"},{"line":25,"text":"  private readonly logger = new Logger(PaymentsService.name);"},{"line":26,"text":"  // Pending amount per order id, warmed at boot so refunds can check quickly."},{"line":27,"text":"  private readonly pendingByOrder = new Map<string, number>();"},{"line":28,"text":"  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';"},{"line":29,"text":""},{"line":30,"text":"  constructor("},{"line":31,"text":"    @InjectRepository(Payment) private readonly payments: Repository<Payment>,"},{"line":32,"text":"    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,"},{"line":33,"text":"    private readonly cardGateway: CardGateway,"}]},{"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","message":"Weak hashing algorithm 'md5' used in createHash().","help":"Use a stronger algorithm like SHA-256 or bcrypt for password hashing.","line":144,"column":1,"rule":"security/no-weak-crypto","category":"security","scope":"file","severity":"warning","sourceLines":[{"line":139,"text":"    return expected.length === signature.length && timingSafeEqual(Buffer.from(expected), Buffer.from(signature));"},{"line":140,"text":"  }"},{"line":141,"text":""},{"line":142,"text":"  private nextInvoiceNumber(order: Order): string {"},{"line":143,"text":"    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');"},{"line":144,"text":"    const suffix = createHash('md5').update(order.id).digest('hex').slice(0, 8);"},{"line":145,"text":"    return `INV-${stamp}-${suffix.toUpperCase()}`;"},{"line":146,"text":"  }"},{"line":147,"text":"}"},{"line":148,"text":""}]},{"filePath":"/demo/nest-shop/apps/api/src/users/dto/update-user.dto.ts","message":"Property 'addresses' is an array with @ValidateNested() but missing { each: true }.","help":"Change @ValidateNested() to @ValidateNested({ each: true }) for array properties.","line":23,"column":1,"rule":"correctness/validate-nested-array-each","category":"correctness","scope":"file","severity":"warning","sourceLines":[{"line":18,"text":"  @IsString()"},{"line":19,"text":"  @MinLength(2)"},{"line":20,"text":"  name?: string;"},{"line":21,"text":""},{"line":22,"text":"  @IsOptional()"},{"line":23,"text":"  @ValidateNested()"},{"line":24,"text":"  @Type(() => AddressDto)"},{"line":25,"text":"  addresses: AddressDto[];"},{"line":26,"text":"}"},{"line":27,"text":""}]},{"filePath":"/demo/nest-shop/apps/api/src/orders/orders.module.ts","message":"Circular module dependency detected: OrdersModule -> PaymentsModule -> NotificationsModule","help":"OrdersModule -> PaymentsModule: OrdersService (in OrdersModule) injects PaymentsService (from PaymentsModule)\nPaymentsModule -> NotificationsModule: PaymentsService (in PaymentsModule) injects NotificationsService (from NotificationsModule)\nNotificationsModule -> OrdersModule: NotificationsService (in NotificationsModule) injects OrdersService (from OrdersModule)\nConsider extracting PaymentsService into a shared module — it would break the OrdersModule -> PaymentsModule edge (1 dependency).","line":12,"column":1,"rule":"architecture/no-circular-module-deps","category":"architecture","scope":"project","severity":"error","tags":["module-graph"]},{"filePath":"/demo/nest-shop/apps/api/src/audit/audit-archiver.service.ts","message":"Provider 'AuditArchiverService' is never injected by any other provider or controller.","help":"Remove the unused provider, inject it where needed, or verify the framework activates it, through a decorator such as @Cron or @OnEvent or a contract such as OnModuleInit or CanActivate.","line":4,"column":1,"rule":"performance/no-unused-providers","category":"performance","scope":"project","severity":"warning","tags":["module-graph"]},{"filePath":"/demo/nest-shop/apps/api/src/reports/reports.module.ts","message":"Module 'ReportsModule' is never imported by any other module.","help":"Import this module in another module or remove it if it is unused.","line":5,"column":1,"rule":"performance/no-orphan-modules","category":"performance","scope":"project","severity":"info","tags":["module-graph"]},{"filePath":"/demo/nest-shop/apps/api/src/catalog/category.entity.ts","entity":"Category","message":"Entity 'Category' has no timestamp columns (createdAt/updatedAt).","help":"Add createdAt/updatedAt columns to track when records are created and modified.","rule":"schema/require-timestamps","category":"schema","scope":"schema","severity":"warning"},{"filePath":"/demo/nest-shop/apps/api/src/payments/invoice.entity.ts","entity":"Invoice","message":"Entity 'Invoice' has no timestamp columns (createdAt/updatedAt).","help":"Add createdAt/updatedAt columns to track when records are created and modified.","rule":"schema/require-timestamps","category":"schema","scope":"schema","severity":"warning"},{"filePath":"/demo/nest-shop/apps/api/src/catalog/product.entity.ts","entity":"Product","message":"Relation 'category' on 'Product' has no explicit onDelete behavior.","help":"Add an explicit onDelete option (e.g. CASCADE, SET NULL) to avoid relying on database defaults.","rule":"schema/require-cascade-rule","category":"schema","scope":"schema","severity":"info"},{"filePath":"/demo/nest-shop/apps/api/src/orders/order.entity.ts","entity":"Order","message":"Relation 'user' on 'Order' has no explicit onDelete behavior.","help":"Add an explicit onDelete option (e.g. CASCADE, SET NULL) to avoid relying on database defaults.","rule":"schema/require-cascade-rule","category":"schema","scope":"schema","severity":"info"},{"filePath":"/demo/nest-shop/apps/worker/src/jobs/notifications.processor.ts","message":"Async method 'process()' has no await expression.","help":"Either add an await expression or remove the async keyword. Framework entry points are exempted, since Nest awaits what they return: route handlers, GraphQL resolvers, WebSocket, microservice, ts-rest and gRPC handlers.","line":14,"column":1,"rule":"correctness/no-async-without-await","category":"correctness","scope":"file","severity":"warning","surfaces":["cli"],"sourceLines":[{"line":9,"text":""},{"line":10,"text":"  constructor(private readonly metrics: MetricsService) {"},{"line":11,"text":"    super();"},{"line":12,"text":"  }"},{"line":13,"text":""},{"line":14,"text":"  async process(job: Job<{ message?: string; orderId?: string }>): Promise<void> {"},{"line":15,"text":"    this.logger.log(`[${job.name}] #${job.id} ${job.data.message ?? ''}`);"},{"line":16,"text":"    this.metrics.increment(`notifications.${job.name}`);"},{"line":17,"text":"  }"},{"line":18,"text":"}"},{"line":19,"text":""}]},{"filePath":"/demo/nest-shop/apps/worker/src/jobs/jobs.module.ts","message":"Module 'JobsModule' exports 'JobsService' but no importing module uses it.","help":"Remove the unused export or use the provider in an importing module.","line":6,"column":1,"rule":"performance/no-unused-module-exports","category":"performance","scope":"project","severity":"info","tags":["module-graph"]},{"filePath":"/demo/nest-shop/libs/shared/src/index.ts","message":"Barrel file re-exports internal module './redis.strategy'.","help":"Only export the module's public API (services, DTOs, interfaces) from the index.ts beside its module file.","line":5,"column":1,"rule":"architecture/no-barrel-export-internals","category":"architecture","scope":"file","severity":"info","sourceLines":[{"line":1,"text":"export * from './shared.module';"},{"line":2,"text":"export * from './metrics.service';"},{"line":3,"text":"export * from './app-config.service';"},{"line":4,"text":"export * from './request-context.service';"},{"line":5,"text":"export * from './redis.strategy';"},{"line":6,"text":""}]},{"filePath":"/demo/nest-shop/libs/shared/src/metrics.service.ts","message":"Class 'MetricsService' has 'onModuleInit()' but does not implement 'OnModuleInit'.","help":"Add 'implements OnModuleInit' (or the appropriate interface) to the class declaration.","line":9,"column":1,"rule":"correctness/require-lifecycle-interface","category":"correctness","scope":"file","severity":"warning","sourceLines":[{"line":4,"text":""},{"line":5,"text":"@Injectable({ scope: Scope.TRANSIENT })"},{"line":6,"text":"export class MetricsService {"},{"line":7,"text":"  private readonly counters = new Map<string, number>();"},{"line":8,"text":""},{"line":9,"text":"  async onModuleInit(): Promise<void> {"},{"line":10,"text":"    await new Promise((resolve) => setTimeout(resolve, 5));"},{"line":11,"text":"    for (const name of SEED_COUNTERS) {"},{"line":12,"text":"      this.counters.set(name, 0);"},{"line":13,"text":"    }"},{"line":14,"text":"  }"}]},{"filePath":"/demo/nest-shop/libs/shared/src/request-context.service.ts","message":"Scope.REQUEST creates a new instance per request, which impacts performance and propagates request scope to all dependents.","help":"Remove Scope.REQUEST unless the provider genuinely needs per-request state (e.g., request-scoped context). Consider Scope.DEFAULT or Scope.TRANSIENT instead.","line":4,"column":1,"rule":"performance/no-request-scope-abuse","category":"performance","scope":"file","severity":"warning","tags":["module-graph"],"sourceLines":[{"line":1,"text":"import { Injectable, Scope } from '@nestjs/common';"},{"line":2,"text":"import { randomUUID } from 'node:crypto';"},{"line":3,"text":""},{"line":4,"text":"@Injectable({ scope: Scope.REQUEST })"},{"line":5,"text":"export class RequestContextService {"},{"line":6,"text":"  readonly requestId = randomUUID();"},{"line":7,"text":"  readonly startedAt = new Date();"},{"line":8,"text":"}"},{"line":9,"text":""}]}],"ruleErrors":[],"elapsedMs":1698.288,"graph":{"modules":[{"name":"api/AppModule","filePath":"/demo/nest-shop/apps/api/src/app.module.ts","imports":["ConfigModule","TypeOrmModule","BullModule","shared/SharedModule","api/UsersModule","api/CatalogModule","api/OrdersModule","api/PaymentsModule","api/NotificationsModule","api/AuditModule"],"exports":[],"providers":[],"providerTokens":[],"controllers":["AppController"],"project":"api","isGlobal":false,"line":14,"dynamicImports":{"ConfigModule":"forRoot","TypeOrmModule":"forRootAsync","BullModule":"forRootAsync","api/AuditModule":"register"}},{"name":"api/AuditModule","filePath":"/demo/nest-shop/apps/api/src/audit/audit.module.ts","imports":["TypeOrmModule"],"exports":["AuditService"],"providers":["AuditService","AuditRepository","AuditArchiverService"],"providerTokens":[],"controllers":[],"project":"api","isGlobal":false,"line":8,"dynamicImports":{"TypeOrmModule":"forFeature"}},{"name":"api/CatalogModule","filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.module.ts","imports":["TypeOrmModule"],"exports":["CatalogService"],"providers":["CatalogService","CatalogRepository"],"providerTokens":[],"controllers":["CatalogController"],"project":"api","isGlobal":false,"line":10,"dynamicImports":{"TypeOrmModule":"forFeature"},"initTimings":[{"id":"t-427628343","name":"CatalogService","type":"provider","initTime":78.51129100000003},{"id":"t-588828542","name":"CatalogRepository","type":"provider","initTime":78.30662500000005},{"id":"t-1460465701","name":"ParseIntPipe","type":"injectable","initTime":0.28158299999995506},{"id":"t414662000","name":"CatalogController","type":"controller","initTime":0.0544999999999618}]},{"name":"api/NotificationsModule","filePath":"/demo/nest-shop/apps/api/src/notifications/notifications.module.ts","imports":["BullModule","api/OrdersModule"],"exports":["NotificationsService"],"providers":["NotificationsService"],"providerTokens":[],"controllers":[],"project":"api","isGlobal":false,"line":6,"initTimings":[{"id":"t1223435111","name":"NotificationsService","type":"provider","initTime":19.59483399999999}]},{"name":"api/OrdersModule","filePath":"/demo/nest-shop/apps/api/src/orders/orders.module.ts","imports":["TypeOrmModule","api/UsersModule","api/CatalogModule","api/AuditModule","api/PaymentsModule"],"exports":["OrdersService"],"providers":["OrdersService"],"providerTokens":[],"controllers":["OrdersController"],"project":"api","isGlobal":false,"line":12,"dynamicImports":{"TypeOrmModule":"forFeature","api/AuditModule":"register"},"initTimings":[{"id":"t1382773185","name":"OrdersService","type":"provider","initTime":78.58699999999999},{"id":"t-1209639726","name":"OrdersController","type":"controller","initTime":0.06204200000001947},{"id":"t-772216377","name":"JwtAuthGuard","type":"injectable","initTime":0.01479200000005676}]},{"name":"api/PaymentsModule","filePath":"/demo/nest-shop/apps/api/src/payments/payments.module.ts","imports":["TypeOrmModule","api/AuditModule","api/NotificationsModule"],"exports":["PaymentsService"],"providers":["PaymentsService","CardGateway","SepaGateway"],"providerTokens":[],"controllers":["PaymentsController"],"project":"api","isGlobal":false,"line":12,"dynamicImports":{"TypeOrmModule":"forFeature","api/AuditModule":"register"},"initTimings":[{"id":"t1716640961","name":"PaymentsService","type":"provider","initTime":78.51408300000003},{"id":"t-1882040819","name":"CardGateway","type":"provider","initTime":0.586208000000056},{"id":"t-1696006342","name":"SepaGateway","type":"provider","initTime":0.5845420000000559},{"id":"t-1622328542","name":"PaymentsController","type":"controller","initTime":0.05608400000005531}]},{"name":"api/ReportsModule","filePath":"/demo/nest-shop/apps/api/src/reports/reports.module.ts","imports":[],"exports":["SalesReportService"],"providers":["SalesReportRepository","SalesReportService"],"providerTokens":[],"controllers":[],"project":"api","isGlobal":false,"line":5},{"name":"api/UsersModule","filePath":"/demo/nest-shop/apps/api/src/users/users.module.ts","imports":["TypeOrmModule"],"exports":["UsersService"],"providers":["UsersService","UsersRepository"],"providerTokens":[],"controllers":["UsersController"],"project":"api","isGlobal":false,"line":8,"dynamicImports":{"TypeOrmModule":"forFeature"},"initTimings":[{"id":"t603011239","name":"UsersService","type":"provider","initTime":78.534583},{"id":"t27207650","name":"UsersRepository","type":"provider","initTime":78.32904199999996},{"id":"t-21681218","name":"JwtAuthGuard","type":"injectable","initTime":0.0724999999999909},{"id":"t-1102473136","name":"UsersController","type":"controller","initTime":0.06079099999999471}]},{"name":"worker/JobsModule","filePath":"/demo/nest-shop/apps/worker/src/jobs/jobs.module.ts","imports":["BullModule"],"exports":["JobsService"],"providers":["NotificationsProcessor","JobsService"],"providerTokens":[],"controllers":[],"project":"worker","isGlobal":false,"line":6},{"name":"worker/SyncModule","filePath":"/demo/nest-shop/apps/worker/src/sync/sync.module.ts","imports":[],"exports":[],"providers":["SyncService","SyncRepository"],"providerTokens":[],"controllers":[],"project":"worker","isGlobal":false,"line":5},{"name":"worker/WorkerModule","filePath":"/demo/nest-shop/apps/worker/src/worker.module.ts","imports":["ConfigModule","BullModule","TypeOrmModule","shared/SharedModule","worker/JobsModule","worker/SyncModule"],"exports":[],"providers":[],"providerTokens":[],"controllers":[],"project":"worker","isGlobal":false,"line":9,"dynamicImports":{"ConfigModule":"forRoot","BullModule":"forRootAsync","TypeOrmModule":"forRootAsync"}},{"name":"shared/SharedModule","filePath":"/demo/nest-shop/libs/shared/src/shared.module.ts","imports":["ConfigModule"],"exports":["MetricsService","AppConfigService","RequestContextService","RedisStrategy"],"providers":["MetricsService","AppConfigService","RequestContextService","RedisStrategy"],"providerTokens":[],"controllers":[],"project":"shared","isGlobal":true,"line":8,"initTimings":[{"id":"t2027583","name":"RedisStrategy","type":"provider","initTime":10.92954199999997},{"id":"t-339153693","name":"AppConfigService","type":"provider","initTime":1.6259169999999585},{"id":"t961691875","name":"MetricsService","type":"provider","initTime":0.04025000000001455}]}],"edges":[{"from":"api/AppModule","to":"shared/SharedModule"},{"from":"api/AppModule","to":"api/UsersModule"},{"from":"api/AppModule","to":"api/CatalogModule"},{"from":"api/AppModule","to":"api/OrdersModule"},{"from":"api/AppModule","to":"api/PaymentsModule"},{"from":"api/AppModule","to":"api/NotificationsModule"},{"from":"api/AppModule","to":"api/AuditModule"},{"from":"api/NotificationsModule","to":"api/OrdersModule"},{"from":"api/OrdersModule","to":"api/UsersModule"},{"from":"api/OrdersModule","to":"api/CatalogModule"},{"from":"api/OrdersModule","to":"api/AuditModule"},{"from":"api/OrdersModule","to":"api/PaymentsModule"},{"from":"api/PaymentsModule","to":"api/AuditModule"},{"from":"api/PaymentsModule","to":"api/NotificationsModule"},{"from":"worker/WorkerModule","to":"shared/SharedModule"},{"from":"worker/WorkerModule","to":"worker/JobsModule"},{"from":"worker/WorkerModule","to":"worker/SyncModule"}],"circularDeps":[["api/OrdersModule","api/PaymentsModule","api/NotificationsModule"]],"circularDepRecommendations":{},"projects":["api","worker","shared"],"bootstrapRoots":["api/AppModule","worker/WorkerModule"],"phases":{"createMs":126.09837500000003,"initMs":384.16770899999995,"moduleInitMs":293.9494169999999},"startupMs":384.772834,"timingsAvailable":true,"timingsTrace":{"t2027583":{"name":"RedisStrategy","type":"provider","initTime":10.92954199999997,"deps":["t-339153693"],"module":"SharedModule"},"t27207650":{"name":"UsersRepository","type":"provider","initTime":78.32904199999996,"deps":["t-1488832441"],"module":"UsersModule"},"t266839889":{"name":"EntityManager","type":"provider","initTime":78.309125,"deps":["t-2103415210"],"module":"TypeOrmCoreModule"},"t339160962":{"name":"AuditRepository","type":"provider","initTime":78.21045800000002,"deps":["t750781673"],"module":"AuditModule","via":"OrdersModule"},"t400681591":{"name":"DiscoveryService","type":"provider","initTime":0.7806249999999864,"deps":[],"module":"DiscoveryModule","via":"BullModule"},"t414662000":{"name":"CatalogController","type":"controller","initTime":0.0544999999999618,"deps":["t-427628343","t-1460465701"],"module":"CatalogModule"},"t603011239":{"name":"UsersService","type":"provider","initTime":78.534583,"deps":["t27207650"],"module":"UsersModule","hooks":[{"hook":"onModuleInit","ms":2.3217919999999594,"startMs":148.49812500000007}]},"t750781673":{"name":"AuditLogRepository","type":"provider","initTime":78.10854200000006,"deps":["t-2103415210"],"module":"TypeOrmModule"},"t820073489":{"name":"OrderItemRepository","type":"provider","initTime":78.13687499999992,"deps":["t-2103415210"],"module":"TypeOrmModule","via":"OrdersModule"},"t873810013":{"name":"AuditArchiverService","type":"provider","initTime":78.40641599999992,"deps":["t339160962"],"module":"AuditModule","via":"OrdersModule"},"t930519593":{"name":"ConfigService","type":"provider","initTime":1.1250409999998965,"deps":["t1063746662"],"module":"ConfigHostModule"},"t945124753":{"name":"BullExplorer","type":"provider","initTime":1.067792000000054,"deps":["t-2122099672","t400681591","t2129637643","t-438112115"],"module":"BullModule"},"t961691875":{"name":"MetricsService","type":"provider","initTime":0.04025000000001455,"deps":[],"module":"SharedModule","hooks":[{"hook":"onModuleInit","ms":12.735332999999969,"count":2}]},"t985056236":{"name":"PaymentRepository","type":"provider","initTime":78.0754169999999,"deps":["t-2103415210"],"module":"TypeOrmModule","via":"PaymentsModule"},"t1063746662":{"name":"CONFIGURATION_TOKEN","type":"provider","initTime":0.8379159999999501,"deps":[],"module":"ConfigHostModule"},"t1105836877":{"name":"AuditService","type":"provider","initTime":78.41750000000002,"deps":["t339160962"],"module":"AuditModule","via":"OrdersModule"},"t1223435111":{"name":"NotificationsService","type":"provider","initTime":19.59483399999999,"deps":["t1382773185","t-1737543994"],"module":"NotificationsModule","hooks":[{"hook":"onApplicationBootstrap","ms":35.84004199999981,"startMs":294.29979200000014}]},"t1382773185":{"name":"OrdersService","type":"provider","initTime":78.58699999999999,"deps":["t603011239","t1716640961","t-427628343","t1105836877","t1513522596","t820073489","t961691875"],"module":"OrdersModule","hooks":[{"hook":"onModuleInit","ms":69.33779199999981,"startMs":224.61162500000012},{"hook":"onApplicationBootstrap","ms":2.1415830000000824,"startMs":381.978209}]},"t1513522596":{"name":"OrderRepository","type":"provider","initTime":78.13941699999998,"deps":["t-2103415210"],"module":"TypeOrmModule","via":"OrdersModule"},"t1716640961":{"name":"PaymentsService","type":"provider","initTime":78.51408300000003,"deps":["t1852319679","t985056236","t-2072619291","t1223435111","t-1882040819","t-1696006342","t961691875"],"module":"PaymentsModule","hooks":[{"hook":"onModuleInit","ms":12.436666999999943,"startMs":136.03325000000007},{"hook":"onApplicationBootstrap","ms":51.72745899999995,"startMs":330.20625000000007}]},"t1852319679":{"name":"AuditService","type":"provider","initTime":78.35699999999997,"deps":["t-483827020"],"module":"AuditModule","via":"PaymentsModule"},"t1852319680":{"name":"AuditService","type":"provider","initTime":78.27841699999999,"deps":["t-483827019"],"module":"AuditModule","via":"AppModule"},"t2075644217":{"name":"TypeOrmModuleOptions","type":"provider","initTime":1.6674170000000004,"deps":["t-503631789"],"module":"TypeOrmCoreModule"},"t2129637643":{"name":"ProcessorDecoratorService","type":"provider","initTime":0.5123340000000098,"deps":[],"module":"BullModule"},"t-503631789":{"name":"ConfigService","type":"provider","initTime":1.3960839999999735,"deps":["t930519593"],"module":"ConfigModule"},"t-2103415210":{"name":"DataSource","type":"provider","initTime":78.20712500000002,"deps":["t2075644217"],"module":"TypeOrmCoreModule"},"t-1579533083":{"name":"BULLMQ_CONFIG(default)","type":"provider","initTime":1.6395840000000135,"deps":["t-503631789"],"module":"BullModule"},"t-339153693":{"name":"AppConfigService","type":"provider","initTime":1.6259169999999585,"deps":["t-503631788"],"module":"SharedModule"},"t-503631788":{"name":"ConfigService","type":"provider","initTime":1.2405410000000074,"deps":["t930519593"],"module":"ConfigModule","via":"SharedModule"},"t-21681218":{"name":"JwtAuthGuard","type":"injectable","initTime":0.0724999999999909,"deps":[],"module":"UsersModule"},"t-1102473136":{"name":"UsersController","type":"controller","initTime":0.06079099999999471,"deps":["t603011239","t-21681218"],"module":"UsersModule"},"t-1488832441":{"name":"UserRepository","type":"provider","initTime":78.22662500000001,"deps":["t-2103415210"],"module":"TypeOrmModule","via":"UsersModule"},"t-427628343":{"name":"CatalogService","type":"provider","initTime":78.51129100000003,"deps":["t-588828542"],"module":"CatalogModule","hooks":[{"hook":"onModuleInit","ms":73.73995900000011,"startMs":150.83500000000004}]},"t-588828542":{"name":"CatalogRepository","type":"provider","initTime":78.30662500000005,"deps":["t-1223438924","t-58527005","t-2127282216"],"module":"CatalogModule"},"t-1460465701":{"name":"ParseIntPipe","type":"injectable","initTime":0.28158299999995506,"deps":[],"module":"CatalogModule"},"t-1223438924":{"name":"CategoryRepository","type":"provider","initTime":78.18683299999998,"deps":["t-2103415210"],"module":"TypeOrmModule","via":"CatalogModule"},"t-58527005":{"name":"ProductRepository","type":"provider","initTime":78.18220900000006,"deps":["t-2103415210"],"module":"TypeOrmModule","via":"CatalogModule"},"t-2127282216":{"name":"TagRepository","type":"provider","initTime":78.1792079999999,"deps":["t-2103415210"],"module":"TypeOrmModule","via":"CatalogModule"},"t-772216377":{"name":"JwtAuthGuard","type":"injectable","initTime":0.01479200000005676,"deps":[],"module":"OrdersModule"},"t-1209639726":{"name":"OrdersController","type":"controller","initTime":0.06204200000001947,"deps":["t1382773185","t-772216377"],"module":"OrdersModule"},"t-1882040819":{"name":"CardGateway","type":"provider","initTime":0.586208000000056,"deps":[],"module":"PaymentsModule"},"t-1696006342":{"name":"SepaGateway","type":"provider","initTime":0.5845420000000559,"deps":[],"module":"PaymentsModule"},"t-1622328542":{"name":"PaymentsController","type":"controller","initTime":0.05608400000005531,"deps":["t1716640961"],"module":"PaymentsModule"},"t-2072619291":{"name":"InvoiceRepository","type":"provider","initTime":78.07287500000007,"deps":["t-2103415210"],"module":"TypeOrmModule","via":"PaymentsModule"},"t-483827020":{"name":"AuditRepository","type":"provider","initTime":78.15162499999997,"deps":["t750781673"],"module":"AuditModule","via":"PaymentsModule"},"t-2082164529":{"name":"AuditArchiverService","type":"provider","initTime":78.34883300000001,"deps":["t-483827020"],"module":"AuditModule","via":"PaymentsModule"},"t-1040989142":{"name":"910c12f3ab3961b893523","type":"provider","initTime":10.69487499999991,"deps":["t-1579533083"],"module":"BullModule","via":"NotificationsModule"},"t-1315419860":{"name":"BullMQQueueOptions_notifications","type":"provider","initTime":10.812332999999967,"deps":["t-1040989142"],"module":"BullModule","via":"NotificationsModule"},"t-1737543994":{"name":"BullQueue_notifications","type":"provider","initTime":19.535999999999945,"deps":["t-1315419860"],"module":"BullModule","via":"NotificationsModule"},"t-2122099672":{"name":"BullMetadataAccessor","type":"provider","initTime":0.8622910000000275,"deps":[],"module":"BullModule"},"t-1667609095":{"name":"BullRegistrar","type":"provider","initTime":1.401207999999997,"deps":["t945124753"],"module":"BullModule","hooks":[{"hook":"onModuleInit","ms":0.35695800000007694,"startMs":135.616084}]},"t-438112115":{"name":"MetadataScanner","type":"provider","initTime":0.5086250000000518,"deps":[],"module":"DiscoveryModule","via":"BullModule"},"t-483827019":{"name":"AuditRepository","type":"provider","initTime":78.073083,"deps":["t750781673"],"module":"AuditModule","via":"AppModule"},"t-2082164528":{"name":"AuditArchiverService","type":"provider","initTime":78.26745900000003,"deps":["t-483827019"],"module":"AuditModule","via":"AppModule"}}},"providers":[{"dependencies":["AuditRepository"],"filePath":"/demo/nest-shop/apps/api/src/audit/audit-archiver.service.ts","name":"AuditArchiverService","publicMethodCount":1,"module":"api/AuditModule","project":"api"},{"dependencies":["Repository"],"filePath":"/demo/nest-shop/apps/api/src/audit/audit.repository.ts","name":"AuditRepository","publicMethodCount":3,"module":"api/AuditModule","project":"api"},{"dependencies":["AuditOptions","AuditRepository"],"filePath":"/demo/nest-shop/apps/api/src/audit/audit.service.ts","name":"AuditService","publicMethodCount":2,"module":"api/AuditModule","project":"api"},{"dependencies":[],"filePath":"/demo/nest-shop/apps/api/src/auth/jwt-auth.guard.ts","name":"JwtAuthGuard","publicMethodCount":1,"project":"api"},{"dependencies":["Repository","Repository","Repository"],"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts","name":"CatalogRepository","publicMethodCount":11,"module":"api/CatalogModule","project":"api"},{"dependencies":["CatalogRepository"],"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.service.ts","name":"CatalogService","publicMethodCount":5,"module":"api/CatalogModule","project":"api"},{"dependencies":["Queue","OrdersService"],"filePath":"/demo/nest-shop/apps/api/src/notifications/notifications.service.ts","name":"NotificationsService","publicMethodCount":2,"module":"api/NotificationsModule","project":"api"},{"dependencies":["Repository","Repository","UsersService","CatalogService","AuditService","MetricsService","PaymentsService"],"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","name":"OrdersService","publicMethodCount":8,"module":"api/OrdersModule","project":"api"},{"dependencies":[],"filePath":"/demo/nest-shop/apps/api/src/payments/gateways/card.gateway.ts","name":"CardGateway","publicMethodCount":1,"module":"api/PaymentsModule","project":"api"},{"dependencies":[],"filePath":"/demo/nest-shop/apps/api/src/payments/gateways/sepa.gateway.ts","name":"SepaGateway","publicMethodCount":1,"module":"api/PaymentsModule","project":"api"},{"dependencies":["Repository","Repository","CardGateway","SepaGateway","MetricsService","AuditService","NotificationsService"],"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","name":"PaymentsService","publicMethodCount":7,"module":"api/PaymentsModule","project":"api"},{"dependencies":["DataSource"],"filePath":"/demo/nest-shop/apps/api/src/reports/reports.repository.ts","name":"SalesReportRepository","publicMethodCount":1,"module":"api/ReportsModule","project":"api"},{"dependencies":["SalesReportRepository"],"filePath":"/demo/nest-shop/apps/api/src/reports/reports.service.ts","name":"SalesReportService","publicMethodCount":1,"module":"api/ReportsModule","project":"api"},{"dependencies":["Repository"],"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","name":"UsersRepository","publicMethodCount":6,"module":"api/UsersModule","project":"api"},{"dependencies":["UsersRepository"],"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","name":"UsersService","publicMethodCount":7,"module":"api/UsersModule","project":"api"},{"dependencies":["Queue","MetricsService"],"filePath":"/demo/nest-shop/apps/worker/src/jobs/jobs.service.ts","name":"JobsService","publicMethodCount":1,"module":"worker/JobsModule","project":"worker"},{"dependencies":["DataSource"],"filePath":"/demo/nest-shop/apps/worker/src/sync/sync.repository.ts","name":"SyncRepository","publicMethodCount":1,"module":"worker/SyncModule","project":"worker"},{"dependencies":["SyncRepository","MetricsService"],"filePath":"/demo/nest-shop/apps/worker/src/sync/sync.service.ts","name":"SyncService","publicMethodCount":1,"module":"worker/SyncModule","project":"worker"},{"dependencies":["ConfigService"],"filePath":"/demo/nest-shop/libs/shared/src/app-config.service.ts","name":"AppConfigService","publicMethodCount":2,"module":"shared/SharedModule","project":"shared"},{"dependencies":[],"filePath":"/demo/nest-shop/libs/shared/src/metrics.service.ts","name":"MetricsService","publicMethodCount":3,"scope":"transient","module":"shared/SharedModule","project":"shared"},{"dependencies":["AppConfigService"],"filePath":"/demo/nest-shop/libs/shared/src/redis.strategy.ts","name":"RedisStrategy","publicMethodCount":1,"module":"shared/SharedModule","project":"shared"},{"dependencies":[],"filePath":"/demo/nest-shop/libs/shared/src/request-context.service.ts","name":"RequestContextService","publicMethodCount":0,"scope":"request","module":"shared/SharedModule","project":"shared"}],"endpoints":{"endpoints":[{"controllerClass":"AppController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":19,"className":"MetricsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"snapshot","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"service"}],"endLine":21,"filePath":"/demo/nest-shop/apps/api/src/app.controller.ts","handlerMethod":"health","httpMethod":"GET","line":12,"returnType":null,"routePath":"/health","swagger":null},{"controllerClass":"CatalogController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":12,"className":"CatalogService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":48,"className":"CatalogRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":45,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"find","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":46,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":44,"methodName":"findAll","order":0,"parameters":[],"returnType":"Product[]","stepStatements":[],"throwMessage":null,"totalMethods":11,"type":"repository"}],"endLine":49,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":47,"methodName":"findAll","order":0,"parameters":[],"returnType":"Product[]","stepStatements":[],"throwMessage":null,"totalMethods":5,"type":"service"}],"endLine":13,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.controller.ts","handlerMethod":"list","httpMethod":"GET","line":9,"returnType":null,"routePath":"/products","swagger":null},{"controllerClass":"CatalogController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":18,"className":"CatalogService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"product","branchGroupId":null,"branchKind":null,"callSiteLine":52,"className":"CatalogRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":49,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"findOne","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":50,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts","guardThrow":{"branchKind":"if","callSiteLine":54,"className":"NotFoundException","conditionText":"!product","message":"Product ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":48,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"Product | null","stepStatements":[],"throwMessage":null,"totalMethods":11,"type":"repository"}],"endLine":57,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":51,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"Product","stepStatements":[],"throwMessage":null,"totalMethods":5,"type":"service"}],"endLine":19,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.controller.ts","handlerMethod":"get","httpMethod":"GET","line":15,"returnType":null,"routePath":"/products/:id","swagger":null},{"controllerClass":"CatalogController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":24,"className":"CatalogService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":65,"className":"CatalogRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":57,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"update","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":58,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":56,"methodName":"updatePrice","order":0,"parameters":[{"name":"id","type":"string"},{"name":"priceCents","type":"number"}],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":11,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":64,"className":"CatalogService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"product","branchGroupId":null,"branchKind":null,"callSiteLine":52,"className":"CatalogRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":50,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts","guardThrow":{"branchKind":"if","callSiteLine":54,"className":"NotFoundException","conditionText":"!product","message":"Product ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":48,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"Product | null","stepStatements":[],"throwMessage":null,"totalMethods":11,"type":"repository","expandedElsewhere":true}],"endLine":57,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":51,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"Product","stepStatements":[],"throwMessage":null,"totalMethods":5,"type":"service"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":66,"className":"CatalogService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"product","branchGroupId":null,"branchKind":null,"callSiteLine":52,"className":"CatalogRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":50,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts","guardThrow":{"branchKind":"if","callSiteLine":54,"className":"NotFoundException","conditionText":"!product","message":"Product ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":48,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"Product | null","stepStatements":[],"throwMessage":null,"totalMethods":11,"type":"repository","expandedElsewhere":true}],"endLine":57,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":51,"methodName":"findOne","order":2,"parameters":[{"name":"id","type":"string"}],"returnType":"Product","stepStatements":[],"throwMessage":null,"totalMethods":5,"type":"service"}],"endLine":67,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":63,"methodName":"updatePrice","order":0,"parameters":[{"name":"id","type":"string"},{"name":"priceCents","type":"number"}],"returnType":"Product","stepStatements":[],"throwMessage":null,"totalMethods":5,"type":"service"}],"endLine":25,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.controller.ts","handlerMethod":"update","httpMethod":"PUT","line":21,"returnType":null,"routePath":"/products/:id","swagger":{"body":{"description":null,"type":"number"},"description":null,"params":[],"queryParams":[],"responses":[],"summary":null}},{"controllerClass":"OrdersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":14,"className":"OrdersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":69,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"find","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":73,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":68,"methodName":"findAll","order":0,"parameters":[],"returnType":"Order[]","stepStatements":[],"throwMessage":null,"totalMethods":8,"type":"service"}],"endLine":15,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.controller.ts","handlerMethod":"list","httpMethod":"GET","line":12,"returnType":null,"routePath":"/orders","swagger":null},{"controllerClass":"OrdersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":19,"className":"OrdersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"user","branchGroupId":null,"branchKind":null,"callSiteLine":87,"className":"UsersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"user","branchGroupId":null,"branchKind":null,"callSiteLine":29,"className":"UsersRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":15,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"findOne","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":16,"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","guardThrow":{"branchKind":"if","callSiteLine":31,"className":"NotFoundException","conditionText":"!user","message":"User ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":14,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"User | null","stepStatements":[],"throwMessage":null,"totalMethods":6,"type":"repository"}],"endLine":34,"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":28,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"User","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"},{"assignedTo":"products","branchGroupId":null,"branchKind":null,"callSiteLine":88,"className":"CatalogService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":60,"className":"CatalogRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":53,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"find","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":54,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":52,"methodName":"findByIds","order":0,"parameters":[{"name":"ids","type":"string[]"}],"returnType":"Product[]","stepStatements":[],"throwMessage":null,"totalMethods":11,"type":"repository"}],"endLine":61,"filePath":"/demo/nest-shop/apps/api/src/catalog/catalog.service.ts","guardThrow":{"branchKind":"if","callSiteLine":90,"className":"BadRequestException","conditionText":"products.length !== dto.lines.length","message":"One or more products do not exist"},"iterationKind":null,"iterationLabel":null,"line":59,"methodName":"findByIds","order":1,"parameters":[{"name":"ids","type":"string[]"}],"returnType":"Product[]","stepStatements":[],"throwMessage":null,"totalMethods":5,"type":"service"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":95,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":"callback","iterationLabel":"map","line":0,"methodName":"create","order":2,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":"order","branchGroupId":null,"branchKind":null,"callSiteLine":102,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":3,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":102,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"create","order":4,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":103,"className":"AuditService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":19,"className":"AuditRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":11,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":11,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"create","order":1,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":12,"filePath":"/demo/nest-shop/apps/api/src/audit/audit.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":10,"methodName":"insert","order":0,"parameters":[{"name":"action","type":"string"},{"name":"actor","type":"string"},{"name":"payload","type":"Record<string, unknown>"}],"returnType":"AuditLog","stepStatements":[],"throwMessage":null,"totalMethods":3,"type":"repository"}],"endLine":20,"filePath":"/demo/nest-shop/apps/api/src/audit/audit.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":18,"methodName":"record","order":5,"parameters":[{"name":"action","type":"string"},{"name":"actor","type":"string"},{"name":"payload","type":"Record<string, unknown>"}],"returnType":"AuditLog","stepStatements":[],"throwMessage":null,"totalMethods":2,"type":"service"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":104,"className":"MetricsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"increment","order":6,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"service"}],"endLine":107,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":86,"methodName":"create","order":0,"parameters":[{"name":"dto","type":"CreateOrderDto"}],"returnType":"Order","stepStatements":[],"throwMessage":null,"totalMethods":8,"type":"service"}],"endLine":20,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.controller.ts","handlerMethod":"create","httpMethod":"POST","line":17,"returnType":null,"routePath":"/orders","swagger":{"body":{"description":null,"type":"CreateOrderDto"},"description":null,"params":[],"queryParams":[],"responses":[],"summary":null}},{"controllerClass":"OrdersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":35,"className":"OrdersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"order","branchGroupId":null,"branchKind":null,"callSiteLine":110,"className":"OrdersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"order","branchGroupId":null,"branchKind":null,"callSiteLine":76,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":{"branchKind":"if","callSiteLine":81,"className":"NotFoundException","conditionText":"!order","message":"Order ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"findOne","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":84,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":75,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"Order","stepStatements":[],"throwMessage":null,"totalMethods":8,"type":"service"},{"assignedTo":null,"branchGroupId":"L111","branchKind":"if","callSiteLine":112,"className":"BadRequestException","comment":null,"conditional":true,"conditionText":"order.status !== OrderStatus.Pending","dependencies":[],"endLine":112,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":112,"methodName":null,"order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":"Order ${id} is ${order.status}, cannot pay","totalMethods":0,"type":"throw"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":115,"className":"PaymentsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"payment","branchGroupId":null,"branchKind":null,"callSiteLine":84,"className":"Repository","comment":"TODO: run the charge through the provider gateway instead of capturing directly.","conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":85,"className":"Repository","comment":"TODO: run the charge through the provider gateway instead of capturing directly.","conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"create","order":1,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":"invoice","branchGroupId":null,"branchKind":null,"callSiteLine":92,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":2,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":93,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"create","order":3,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":96,"className":"NotificationsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"job","branchGroupId":null,"branchKind":null,"callSiteLine":46,"className":"Queue","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"add","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"service"},{"assignedTo":"message","branchGroupId":null,"branchKind":null,"callSiteLine":45,"className":"NotificationsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":66,"filePath":"/demo/nest-shop/apps/api/src/notifications/notifications.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":51,"methodName":"buildMessage","order":0,"parameters":[{"name":"kind","type":"NotificationKind"},{"name":"payload","type":"Record<string, unknown>"}],"returnType":"string","stepStatements":[],"throwMessage":null,"totalMethods":2,"type":"service"}],"endLine":49,"filePath":"/demo/nest-shop/apps/api/src/notifications/notifications.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":44,"methodName":"enqueue","order":4,"parameters":[{"name":"kind","type":"NotificationKind"},{"name":"payload","type":"Record<string, unknown>"}],"returnType":"string","stepStatements":[],"throwMessage":null,"totalMethods":2,"type":"service"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":93,"className":"PaymentsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":143,"className":"local","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":143,"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":143,"methodName":null,"order":0,"parameters":[],"returnType":null,"stepStatements":[{"assignedTo":"stamp","text":"stamp = new Date().toISOString().slice(0, 10).replace(/…"},{"assignedTo":"suffix","text":"suffix = createHash('md5').update(order.id).digest('hex'…"}],"throwMessage":null,"totalMethods":0,"type":"step"}],"endLine":146,"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":142,"methodName":"nextInvoiceNumber","order":4,"parameters":[{"name":"order","type":"Order"}],"returnType":"string","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":102,"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":82,"methodName":"charge","order":1,"parameters":[{"name":"order","type":"Order"},{"name":"provider","type":"string"}],"returnType":"Payment","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":117,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":2,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":118,"className":"AuditService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":19,"className":"AuditRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":11,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":11,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"create","order":1,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":12,"filePath":"/demo/nest-shop/apps/api/src/audit/audit.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":10,"methodName":"insert","order":0,"parameters":[{"name":"action","type":"string"},{"name":"actor","type":"string"},{"name":"payload","type":"Record<string, unknown>"}],"returnType":"AuditLog","stepStatements":[],"throwMessage":null,"totalMethods":3,"type":"repository"}],"endLine":20,"filePath":"/demo/nest-shop/apps/api/src/audit/audit.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":18,"methodName":"record","order":3,"parameters":[{"name":"action","type":"string"},{"name":"actor","type":"string"},{"name":"payload","type":"Record<string, unknown>"}],"returnType":"AuditLog","stepStatements":[],"throwMessage":null,"totalMethods":2,"type":"service"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":119,"className":"MetricsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"increment","order":4,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"service"}],"endLine":121,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":109,"methodName":"pay","order":0,"parameters":[{"name":"id","type":"string"},{"name":"provider","type":"string"},{"name":"surchargeCents","type":null}],"returnType":"Order","stepStatements":[],"throwMessage":null,"totalMethods":8,"type":"service"}],"endLine":36,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.controller.ts","handlerMethod":"pay","httpMethod":"POST","line":22,"returnType":null,"routePath":"/orders/:id/pay","swagger":{"body":{"description":null,"type":"{ provider?: string }"},"description":null,"params":[],"queryParams":[],"responses":[],"summary":null}},{"controllerClass":"OrdersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":40,"className":"OrdersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"order","branchGroupId":null,"branchKind":null,"callSiteLine":124,"className":"OrdersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"order","branchGroupId":null,"branchKind":null,"callSiteLine":76,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":{"branchKind":"if","callSiteLine":81,"className":"NotFoundException","conditionText":"!order","message":"Order ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"findOne","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":84,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":75,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"Order","stepStatements":[],"throwMessage":null,"totalMethods":8,"type":"service"},{"assignedTo":null,"branchGroupId":"L125","branchKind":"if","callSiteLine":126,"className":"BadRequestException","comment":null,"conditional":true,"conditionText":"!Object.values(OrderStatus).includes(status)","dependencies":[],"endLine":126,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":126,"methodName":null,"order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":"Unknown status ${status}","totalMethods":0,"type":"throw"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":129,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":1,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":130,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":123,"methodName":"updateStatus","order":0,"parameters":[{"name":"id","type":"string"},{"name":"status","type":"OrderStatus"}],"returnType":"Order","stepStatements":[],"throwMessage":null,"totalMethods":8,"type":"service"}],"endLine":41,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.controller.ts","handlerMethod":"updateStatus","httpMethod":"PATCH","line":38,"returnType":null,"routePath":"/orders/:id/status","swagger":{"body":{"description":null,"type":"OrderStatus"},"description":null,"params":[],"queryParams":[],"responses":[],"summary":null}},{"controllerClass":"PaymentsController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":10,"className":"PaymentsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":79,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"find","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":80,"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":78,"methodName":"findAll","order":0,"parameters":[],"returnType":"Payment[]","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":11,"filePath":"/demo/nest-shop/apps/api/src/payments/payments.controller.ts","handlerMethod":"list","httpMethod":"GET","line":8,"returnType":null,"routePath":"/payments","swagger":null},{"controllerClass":"PaymentsController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":15,"className":"PaymentsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"payment","branchGroupId":null,"branchKind":null,"callSiteLine":117,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":{"branchKind":"if","callSiteLine":122,"className":"BadRequestException","conditionText":"payment.status !== PaymentStatus.Captured","message":"Payment ${paymentId} is ${payment.status}, cannot refund"},"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"findOne","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":"L124","branchKind":"if","callSiteLine":125,"className":"CardGateway","comment":null,"conditional":true,"conditionText":"payment.provider === 'card'","dependencies":[],"endLine":10,"filePath":"/demo/nest-shop/apps/api/src/payments/gateways/card.gateway.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":7,"methodName":"refund","order":2,"parameters":[{"name":"paymentId","type":"string"},{"name":"amountCents","type":"number"}],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":1,"type":"gateway"},{"assignedTo":null,"branchGroupId":"L124","branchKind":"else","callSiteLine":127,"className":"SepaGateway","comment":null,"conditional":true,"conditionText":"payment.provider === 'card'","dependencies":[],"endLine":10,"filePath":"/demo/nest-shop/apps/api/src/payments/gateways/sepa.gateway.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":7,"methodName":"refund","order":3,"parameters":[{"name":"paymentId","type":"string"},{"name":"amountCents","type":"number"}],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":1,"type":"gateway"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":130,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":4,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":131,"className":"MetricsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"increment","order":5,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"service"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":133,"className":"NotificationsService","comment":"FIXME: the order stays \"paid\" until the notification job runs.","conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"job","branchGroupId":null,"branchKind":null,"callSiteLine":46,"className":"Queue","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"add","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"service"},{"assignedTo":"message","branchGroupId":null,"branchKind":null,"callSiteLine":45,"className":"NotificationsService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"order","branchGroupId":null,"branchKind":null,"callSiteLine":56,"className":"OrdersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"order","branchGroupId":null,"branchKind":null,"callSiteLine":76,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":{"branchKind":"if","callSiteLine":81,"className":"NotFoundException","conditionText":"!order","message":"Order ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"findOne","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":84,"filePath":"/demo/nest-shop/apps/api/src/orders/orders.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":75,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"Order","stepStatements":[],"throwMessage":null,"totalMethods":8,"type":"service"}],"endLine":66,"filePath":"/demo/nest-shop/apps/api/src/notifications/notifications.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":51,"methodName":"buildMessage","order":0,"parameters":[{"name":"kind","type":"NotificationKind"},{"name":"payload","type":"Record<string, unknown>"}],"returnType":"string","stepStatements":[],"throwMessage":null,"totalMethods":2,"type":"service"}],"endLine":49,"filePath":"/demo/nest-shop/apps/api/src/notifications/notifications.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":44,"methodName":"enqueue","order":6,"parameters":[{"name":"kind","type":"NotificationKind"},{"name":"payload","type":"Record<string, unknown>"}],"returnType":"string","stepStatements":[],"throwMessage":null,"totalMethods":2,"type":"service"}],"endLine":135,"filePath":"/demo/nest-shop/apps/api/src/payments/payments.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":116,"methodName":"refund","order":0,"parameters":[{"name":"paymentId","type":"string"}],"returnType":"Payment","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":16,"filePath":"/demo/nest-shop/apps/api/src/payments/payments.controller.ts","handlerMethod":"refund","httpMethod":"POST","line":13,"returnType":null,"routePath":"/payments/:id/refund","swagger":null},{"controllerClass":"UsersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":14,"className":"UsersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":25,"className":"UsersRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":11,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"find","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":12,"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":10,"methodName":"findAll","order":0,"parameters":[],"returnType":"User[]","stepStatements":[],"throwMessage":null,"totalMethods":6,"type":"repository"}],"endLine":26,"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":24,"methodName":"findAll","order":0,"parameters":[],"returnType":"User[]","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":15,"filePath":"/demo/nest-shop/apps/api/src/users/users.controller.ts","handlerMethod":"list","httpMethod":"GET","line":12,"returnType":null,"routePath":"/users","swagger":null},{"controllerClass":"UsersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":19,"className":"UsersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"user","branchGroupId":null,"branchKind":null,"callSiteLine":29,"className":"UsersRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":15,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"findOne","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":16,"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","guardThrow":{"branchKind":"if","callSiteLine":31,"className":"NotFoundException","conditionText":"!user","message":"User ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":14,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"User | null","stepStatements":[],"throwMessage":null,"totalMethods":6,"type":"repository"}],"endLine":34,"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":28,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"User","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":20,"filePath":"/demo/nest-shop/apps/api/src/users/users.controller.ts","handlerMethod":"get","httpMethod":"GET","line":17,"returnType":null,"routePath":"/users/:id","swagger":null},{"controllerClass":"UsersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":24,"className":"UsersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":41,"className":"UsersRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":23,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":23,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"create","order":1,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":24,"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":22,"methodName":"save","order":0,"parameters":[{"name":"row","type":"Partial<User>"}],"returnType":"User","stepStatements":[],"throwMessage":null,"totalMethods":6,"type":"repository"}],"endLine":42,"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":40,"methodName":"create","order":0,"parameters":[{"name":"dto","type":"CreateUserDto"}],"returnType":"User","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":25,"filePath":"/demo/nest-shop/apps/api/src/users/users.controller.ts","handlerMethod":"create","httpMethod":"POST","line":22,"returnType":null,"routePath":"/users","swagger":{"body":{"description":null,"type":"CreateUserDto"},"description":null,"params":[],"queryParams":[],"responses":[],"summary":null}},{"controllerClass":"UsersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":32,"className":"UsersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":46,"className":"UsersRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":23,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"save","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":23,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"create","order":1,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":24,"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":22,"methodName":"save","order":0,"parameters":[{"name":"row","type":"Partial<User>"}],"returnType":"User","stepStatements":[],"throwMessage":null,"totalMethods":6,"type":"repository"},{"assignedTo":"user","branchGroupId":null,"branchKind":null,"callSiteLine":45,"className":"UsersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"user","branchGroupId":null,"branchKind":null,"callSiteLine":29,"className":"UsersRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":16,"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","guardThrow":{"branchKind":"if","callSiteLine":31,"className":"NotFoundException","conditionText":"!user","message":"User ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":14,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"User | null","stepStatements":[],"throwMessage":null,"totalMethods":6,"type":"repository","expandedElsewhere":true}],"endLine":34,"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":28,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"User","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":47,"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":44,"methodName":"update","order":0,"parameters":[{"name":"id","type":"string"},{"name":"dto","type":"UpdateUserDto"}],"returnType":"User","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":33,"filePath":"/demo/nest-shop/apps/api/src/users/users.controller.ts","handlerMethod":"update","httpMethod":"PATCH","line":27,"returnType":null,"routePath":"/users/:id","swagger":{"body":{"description":null,"type":"UpdateUserDto"},"description":null,"params":[],"queryParams":[],"responses":[],"summary":null}},{"controllerClass":"UsersController","dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":37,"className":"UsersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":51,"className":"UsersRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":31,"className":"Repository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":0,"filePath":"","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":0,"methodName":"delete","order":0,"parameters":[],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":0,"type":"repository"}],"endLine":32,"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":30,"methodName":"remove","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":6,"type":"repository"},{"assignedTo":null,"branchGroupId":null,"branchKind":null,"callSiteLine":50,"className":"UsersService","comment":null,"conditional":false,"conditionText":null,"dependencies":[{"assignedTo":"user","branchGroupId":null,"branchKind":null,"callSiteLine":29,"className":"UsersRepository","comment":null,"conditional":false,"conditionText":null,"dependencies":[],"endLine":16,"filePath":"/demo/nest-shop/apps/api/src/users/users.repository.ts","guardThrow":{"branchKind":"if","callSiteLine":31,"className":"NotFoundException","conditionText":"!user","message":"User ${id} not found"},"iterationKind":null,"iterationLabel":null,"line":14,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"User | null","stepStatements":[],"throwMessage":null,"totalMethods":6,"type":"repository","expandedElsewhere":true}],"endLine":34,"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":28,"methodName":"findOne","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":"User","stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":52,"filePath":"/demo/nest-shop/apps/api/src/users/users.service.ts","guardThrow":null,"iterationKind":null,"iterationLabel":null,"line":49,"methodName":"remove","order":0,"parameters":[{"name":"id","type":"string"}],"returnType":null,"stepStatements":[],"throwMessage":null,"totalMethods":7,"type":"service"}],"endLine":38,"filePath":"/demo/nest-shop/apps/api/src/users/users.controller.ts","handlerMethod":"remove","httpMethod":"DELETE","line":35,"returnType":null,"routePath":"/users/:id","swagger":null}]},"schema":{"entities":[{"name":"AuditLog","tableName":"audit_logs","filePath":"/demo/nest-shop/apps/api/src/audit/audit-log.entity.ts","columns":[{"name":"action","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"actor","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"payload","type":"jsonb","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"{}"},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[],"indexes":[]},{"name":"Category","tableName":"categories","filePath":"/demo/nest-shop/apps/api/src/catalog/category.entity.ts","columns":[{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"slug","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"name","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false}],"relations":[{"type":"one-to-many","fromEntity":"Category","toEntity":"Product","propertyName":"products","isNullable":false}],"indexes":[]},{"name":"Product","tableName":"products","filePath":"/demo/nest-shop/apps/api/src/catalog/product.entity.ts","columns":[{"name":"sku","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"name","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"priceCents","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"many-to-one","fromEntity":"Product","toEntity":"Category","propertyName":"category","isNullable":false},{"type":"many-to-many","fromEntity":"Product","toEntity":"Tag","propertyName":"tags","isNullable":false},{"type":"one-to-many","fromEntity":"Product","toEntity":"OrderItem","propertyName":"orderItems","isNullable":false}],"indexes":[]},{"name":"Tag","tableName":"tags","filePath":"/demo/nest-shop/apps/api/src/catalog/tag.entity.ts","columns":[{"name":"slug","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"name","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[],"indexes":[]},{"name":"OrderItem","tableName":"order_items","filePath":"/demo/nest-shop/apps/api/src/orders/order-item.entity.ts","columns":[{"name":"quantity","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"unitPriceCents","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"many-to-one","fromEntity":"OrderItem","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"},{"type":"many-to-one","fromEntity":"OrderItem","toEntity":"Product","propertyName":"product","isNullable":false,"onDelete":"RESTRICT"}],"indexes":[]},{"name":"Order","tableName":"orders","filePath":"/demo/nest-shop/apps/api/src/orders/order.entity.ts","columns":[{"name":"status","type":"enum","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"OrderStatus.Pending","hasIndex":true},{"name":"totalCents","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"0"},{"name":"note","type":"text","isPrimary":false,"isNullable":true,"isGenerated":false,"isUnique":false},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false,"hasIndex":true},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"many-to-one","fromEntity":"Order","toEntity":"User","propertyName":"user","isNullable":false},{"type":"one-to-many","fromEntity":"Order","toEntity":"OrderItem","propertyName":"items","isNullable":false}],"indexes":[{"columns":["status","createdAt"],"isUnique":false}]},{"name":"Invoice","tableName":"invoices","filePath":"/demo/nest-shop/apps/api/src/payments/invoice.entity.ts","columns":[{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"number","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"issuedAt","type":"timestamptz","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false}],"relations":[{"type":"one-to-one","fromEntity":"Invoice","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"}],"indexes":[]},{"name":"Payment","tableName":"payments","filePath":"/demo/nest-shop/apps/api/src/payments/payment.entity.ts","columns":[{"name":"provider","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"hasIndex":true},{"name":"amountCents","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"status","type":"enum","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"PaymentStatus.Pending"},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"many-to-one","fromEntity":"Payment","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"}],"indexes":[{"columns":["provider"],"isUnique":false}]},{"name":"User","tableName":"users","filePath":"/demo/nest-shop/apps/api/src/users/user.entity.ts","columns":[{"name":"email","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"name","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"addresses","type":"jsonb","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"[]"},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"one-to-many","fromEntity":"User","toEntity":"Order","propertyName":"orders","isNullable":false}],"indexes":[]}],"relations":[{"type":"one-to-many","fromEntity":"Category","toEntity":"Product","propertyName":"products","isNullable":false},{"type":"many-to-one","fromEntity":"Product","toEntity":"Category","propertyName":"category","isNullable":false},{"type":"many-to-many","fromEntity":"Product","toEntity":"Tag","propertyName":"tags","isNullable":false},{"type":"one-to-many","fromEntity":"Product","toEntity":"OrderItem","propertyName":"orderItems","isNullable":false},{"type":"many-to-one","fromEntity":"OrderItem","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"},{"type":"many-to-one","fromEntity":"OrderItem","toEntity":"Product","propertyName":"product","isNullable":false,"onDelete":"RESTRICT"},{"type":"many-to-one","fromEntity":"Order","toEntity":"User","propertyName":"user","isNullable":false},{"type":"one-to-many","fromEntity":"Order","toEntity":"OrderItem","propertyName":"items","isNullable":false},{"type":"one-to-one","fromEntity":"Invoice","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"},{"type":"many-to-one","fromEntity":"Payment","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"},{"type":"one-to-many","fromEntity":"User","toEntity":"Order","propertyName":"orders","isNullable":false}],"orm":"typeorm"},"examples":{"security/no-hardcoded-secrets":{"bad":"@Injectable()\nexport class AuthService {\n  private readonly apiKey = 'sk-1234567890abcdef';\n  private readonly dbPassword = 'super_secret_password';\n}","good":"@Injectable()\nexport class AuthService {\n  constructor(private readonly config: ConfigService) {}\n\n  getApiKey() {\n    return this.config.get('API_KEY');\n  }\n}"},"security/no-eval":{"bad":"@Injectable()\nexport class CalcService {\n  evaluate(expression: string) {\n    return eval(expression);\n  }\n}","good":"@Injectable()\nexport class CalcService {\n  evaluate(expression: string) {\n    return JSON.parse(expression);\n  }\n}"},"security/no-csrf-disabled":{"bad":"app.use(csurf({ cookie: false }));\n// or\nconst csrfOptions = { csrf: false };","good":"app.use(csurf({ cookie: true }));"},"security/no-dangerous-redirects":{"bad":"@Controller('go')\nexport class GoController {\n  @Get('redirect')\n  redirect(@Query('url') url: string, @Res() res: Response) {\n    res.redirect(url);\n  }\n}","good":"@Controller('go')\nexport class GoController {\n  @Get('redirect')\n  redirect(@Query('to') to: string, @Res() res: Response) {\n    const targets: Record<string, string> = { home: '/', docs: '/docs' };\n    res.redirect(targets[to] ?? '/');\n  }\n}"},"security/no-synchronize-in-production":{"bad":"TypeOrmModule.forRoot({\n  type: 'postgres',\n  synchronize: true,\n})","good":"TypeOrmModule.forRoot({\n  type: 'postgres',\n  synchronize: false,\n  // Use migrations instead\n})"},"security/no-weak-crypto":{"bad":"import { createHash } from 'crypto';\nconst hash = createHash('md5').update(data).digest('hex');","good":"import { createHash } from 'crypto';\nconst hash = createHash('sha256').update(data).digest('hex');"},"security/no-exposed-env-vars":{"bad":"@Injectable()\nexport class MailService {\n  private readonly apiKey = process.env.MAIL_API_KEY;\n}","good":"@Injectable()\nexport class MailService {\n  constructor(private readonly config: ConfigService) {}\n\n  getApiKey() {\n    return this.config.get('MAIL_API_KEY');\n  }\n}"},"security/no-exposed-stack-trace":{"bad":"@Catch()\nexport class AllExceptionsFilter implements ExceptionFilter {\n  catch(exception: Error, host: ArgumentsHost) {\n    response.json({ message: exception.message, stack: exception.stack });\n  }\n}","good":"@Catch()\nexport class AllExceptionsFilter implements ExceptionFilter {\n  catch(exception: Error, host: ArgumentsHost) {\n    this.logger.error(exception.stack);\n    response.json({ message: 'Internal server error' });\n  }\n}"},"security/no-raw-entity-in-response":{"bad":"@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string): Promise<UserEntity> {\n    return this.userRepo.findOne(id); // Every column ships\n  }\n}","good":"@Controller('users')\nexport class UserController {\n  @Get(':id')\n  async findOne(@Param('id') id: string): Promise<UserResponseDto> {\n    const user = await this.userService.findOne(id);\n    return new UserResponseDto(user); // Controlled shape\n  }\n}"},"security/require-guards-on-endpoints":{"bad":"@Controller('orders')\nexport class OrderController {\n  @Get()\n  findAll() {\n    return this.orderService.findAll(); // No guard, no @Public()\n  }\n}","good":"@UseGuards(AuthGuard)\n@Controller('orders')\nexport class OrderController {\n  @Get()\n  findAll() {\n    return this.orderService.findAll();\n  }\n}"},"correctness/no-missing-injectable":{"bad":"// user.service.ts\nexport class UserService {  // Missing @Injectable()\n  constructor(private readonly db: DatabaseService) {}\n}\n\n// user.module.ts\n@Module({ providers: [UserService] })\nexport class UserModule {}","good":"@Injectable()\nexport class UserService {\n  constructor(private readonly db: DatabaseService) {}\n}"},"correctness/no-duplicate-routes":{"bad":"@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string) { /* ... */ }\n\n  @Get(':id')  // Duplicate!\n  getUser(@Param('id') id: string) { /* ... */ }\n}","good":"@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string) { /* ... */ }\n\n  @Get(':id/profile')\n  getProfile(@Param('id') id: string) { /* ... */ }\n}"},"correctness/no-missing-guard-method":{"bad":"@Injectable()\nexport class AuthGuard implements CanActivate {\n  // Missing canActivate()!\n}","good":"@Injectable()\nexport class AuthGuard implements CanActivate {\n  canActivate(context: ExecutionContext): boolean {\n    return this.validateRequest(context);\n  }\n}"},"correctness/no-missing-pipe-method":{"bad":"@Injectable()\nexport class ParseIntPipe implements PipeTransform {\n  // Missing transform()!\n}","good":"@Injectable()\nexport class ParseIntPipe implements PipeTransform {\n  transform(value: string): number {\n    return parseInt(value, 10);\n  }\n}"},"correctness/no-missing-filter-catch":{"bad":"@Catch(HttpException)\nexport class HttpFilter implements ExceptionFilter {\n  // Missing catch()!\n}","good":"@Catch(HttpException)\nexport class HttpFilter implements ExceptionFilter {\n  catch(exception: HttpException, host: ArgumentsHost) {\n    const response = host.switchToHttp().getResponse();\n    response.status(exception.getStatus()).json({ error: exception.message });\n  }\n}"},"correctness/no-missing-interceptor-method":{"bad":"@Injectable()\nexport class LoggingInterceptor implements NestInterceptor {\n  // Missing intercept()!\n}","good":"@Injectable()\nexport class LoggingInterceptor implements NestInterceptor {\n  intercept(context: ExecutionContext, next: CallHandler) {\n    console.log('Before...');\n    return next.handle();\n  }\n}"},"correctness/require-inject-decorator":{"bad":"@Injectable()\nexport class UserService {\n  constructor(private readonly connection) {} // No type, no @Inject()\n}","good":"@Injectable()\nexport class UserService {\n  constructor(\n    @Inject('DATABASE_CONNECTION')\n    private readonly connection: Connection,\n  ) {}\n}"},"correctness/prefer-readonly-injection":{"bad":"@Injectable()\nexport class UserService {\n  constructor(private db: DatabaseService) {}\n}","good":"@Injectable()\nexport class UserService {\n  constructor(private readonly db: DatabaseService) {}\n}"},"correctness/require-lifecycle-interface":{"bad":"@Injectable()\nexport class AppService {\n  onModuleInit() {  // No OnModuleInit interface\n    // ...\n  }\n}","good":"@Injectable()\nexport class AppService implements OnModuleInit {\n  onModuleInit() {\n    // ...\n  }\n}"},"correctness/no-empty-handlers":{"bad":"@Controller('users')\nexport class UserController {\n  @Get()\n  findAll() {}  // Empty body\n}","good":"@Controller('users')\nexport class UserController {\n  @Get()\n  findAll() {\n    return this.userService.findAll();\n  }\n}"},"correctness/no-async-without-await":{"bad":"@Injectable()\nexport class UserService {\n  async findAll() {\n    return this.users;  // No await needed\n  }\n}","good":"@Injectable()\nexport class UserService {\n  findAll() {\n    return this.users;\n  }\n\n  // Or, if async is needed:\n  async findById(id: string) {\n    return await this.db.user.findUnique({ where: { id } });\n  }\n}"},"correctness/no-duplicate-module-metadata":{"bad":"@Module({\n  providers: [UserService, AuthService, UserService],  // Duplicate!\n})\nexport class UserModule {}","good":"@Module({\n  providers: [UserService, AuthService],\n})\nexport class UserModule {}"},"correctness/no-missing-module-decorator":{"bad":"export class UserModule {  // Missing @Module()\n  // ...\n}","good":"@Module({\n  controllers: [UserController],\n  providers: [UserService],\n})\nexport class UserModule {}"},"correctness/no-fire-and-forget-async":{"bad":"@Injectable()\nexport class OrderService {\n  complete(orderId: string) {\n    this.notificationService.sendEmail(orderId);  // No await!\n    this.analyticsService.track('order_completed');  // No await!\n  }\n}","good":"@Injectable()\nexport class OrderService {\n  async complete(orderId: string) {\n    await this.notificationService.sendEmail(orderId);\n    await this.analyticsService.track('order_completed');\n  }\n}"},"correctness/factory-inject-matches-params":{"bad":"@Module({\n  providers: [{\n    provide: 'DATA_SOURCE',\n    useFactory: (config: ConfigService) => createDataSource(config),\n    inject: [ConfigService, Logger],  // 2 tokens but 1 param!\n  }],\n})\nexport class AppModule {}","good":"@Module({\n  providers: [{\n    provide: 'DATA_SOURCE',\n    useFactory: (config: ConfigService, logger: Logger) =>\n      createDataSource(config, logger),\n    inject: [ConfigService, Logger],  // 2 tokens, 2 params\n  }],\n})\nexport class AppModule {}"},"correctness/injectable-must-be-provided":{"bad":"@Injectable()\nexport class CacheService {  // Not in any module's providers\n  get(key: string) { /* ... */ }\n}","good":"@Injectable()\nexport class CacheService {\n  get(key: string) { /* ... */ }\n}\n\n@Module({ providers: [CacheService] })\nexport class CacheModule {}"},"correctness/no-duplicate-decorators":{"bad":"@Controller('users')\nexport class UserController {\n  @Get(':id')\n  @Get(':id')  // Duplicate decorator!\n  findOne(@Param('id') id: string) { /* ... */ }\n}","good":"@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string) { /* ... */ }\n}"},"correctness/param-decorator-matches-route":{"bad":"@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('userId') userId: string) {  // 'userId' not in route\n    return this.userService.findOne(userId);\n  }\n}","good":"@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string) {  // 'id' matches :id in route\n    return this.userService.findOne(id);\n  }\n}"},"correctness/validate-nested-array-each":{"bad":"export class CreateOrderDto {\n  @ValidateNested()  // Missing { each: true } for array\n  @Type(() => OrderItemDto)\n  items: OrderItemDto[];\n}","good":"export class CreateOrderDto {\n  @ValidateNested({ each: true })  // Validates each item in the array\n  @Type(() => OrderItemDto)\n  items: OrderItemDto[];\n}"},"correctness/validated-non-primitive-needs-type":{"bad":"export class CreateUserDto {\n  @ValidateNested()\n  address: AddressDto;  // Missing @Type() — validator can't instantiate\n}","good":"export class CreateUserDto {\n  @ValidateNested()\n  @Type(() => AddressDto)\n  address: AddressDto;\n}"},"architecture/no-business-logic-in-controllers":{"bad":"@Controller('orders')\nexport class OrderController {\n  @Post()\n  create(@Body() dto: CreateOrderDto) {\n    const items = [];\n    for (const item of dto.items) {  // Logic in controller\n      if (item.quantity > 0) {\n        items.push({ ...item, total: item.price * item.quantity });\n      }\n    }\n    return this.orderRepo.save({ items });\n  }\n}","good":"@Controller('orders')\nexport class OrderController {\n  @Post()\n  create(@Body() dto: CreateOrderDto) {\n    return this.orderService.create(dto);\n  }\n}"},"architecture/no-repository-in-controllers":{"bad":"@Controller('users')\nexport class UserController {\n  constructor(\n    @InjectRepository(User)\n    private readonly userRepo: Repository<User>,\n  ) {}\n}","good":"@Controller('users')\nexport class UserController {\n  constructor(private readonly userService: UserService) {}\n}"},"architecture/no-orm-in-controllers":{"bad":"@Controller('users')\nexport class UserController {\n  constructor(private readonly prisma: PrismaService) {}\n\n  @Get()\n  findAll() {\n    return this.prisma.user.findMany();\n  }\n}","good":"@Controller('users')\nexport class UserController {\n  constructor(private readonly userService: UserService) {}\n\n  @Get()\n  findAll() {\n    return this.userService.findAll();\n  }\n}"},"architecture/no-circular-module-deps":{"bad":"// user.module.ts\n@Module({ imports: [OrderModule] })\nexport class UserModule {}\n\n// order.module.ts\n@Module({ imports: [UserModule] })  // Circular!\nexport class OrderModule {}","good":"// shared.module.ts — extract shared logic\n@Module({ providers: [SharedService], exports: [SharedService] })\nexport class SharedModule {}\n\n// user.module.ts\n@Module({ imports: [SharedModule] })\nexport class UserModule {}\n\n// order.module.ts\n@Module({ imports: [SharedModule] })\nexport class OrderModule {}"},"architecture/no-manual-instantiation":{"bad":"@Injectable()\nexport class OrderService {\n  processOrder(order: Order) {\n    const pricing = new PricingService();  // Bypasses the injector\n    return pricing.total(order);\n  }\n}","good":"@Injectable()\nexport class OrderService {\n  constructor(private readonly pricing: PricingService) {}\n\n  processOrder(order: Order) {\n    return this.pricing.total(order);\n  }\n}"},"architecture/no-orm-in-services":{"bad":"@Injectable()\nexport class UserService {\n  constructor(private readonly prisma: PrismaService) {}\n}","good":"@Injectable()\nexport class UserService {\n  constructor(private readonly userRepo: UserRepository) {}\n}"},"architecture/no-service-locator":{"bad":"@Injectable()\nexport class TaskService {\n  constructor(private readonly moduleRef: ModuleRef) {}\n\n  async run() {\n    const service = this.moduleRef.get(SomeService);\n    service.doWork();\n  }\n}","good":"@Injectable()\nexport class TaskService {\n  constructor(private readonly someService: SomeService) {}\n\n  async run() {\n    this.someService.doWork();\n  }\n}"},"architecture/prefer-constructor-injection":{"bad":"@Injectable()\nexport class UserService {\n  @Inject()\n  private configService: ConfigService;\n}","good":"@Injectable()\nexport class UserService {\n  constructor(private readonly configService: ConfigService) {}\n}"},"architecture/require-module-boundaries":{"bad":"// In user module:\nimport { OrderRepository } from '../order/repositories/order.repository';","good":"// In user module:\nimport { OrderValidator } from '../order';\n// Or better: inject via DI through the module system"},"architecture/no-barrel-export-internals":{"bad":"// user/index.ts\nexport { UserService } from './user.service';\nexport { UserRepository } from './user.repository';  // Internal!","good":"// user/index.ts\nexport { UserService } from './user.service';\n// UserRepository stays internal to the module"},"performance/no-sync-io":{"bad":"@Injectable()\nexport class ConfigService {\n  loadConfig() {\n    const data = readFileSync('config.json', 'utf-8');\n    return JSON.parse(data);\n  }\n}","good":"@Injectable()\nexport class ConfigService {\n  async loadConfig() {\n    const data = await readFile('config.json', 'utf-8');\n    return JSON.parse(data);\n  }\n}"},"performance/no-blocking-constructor":{"bad":"@Injectable()\nexport class CacheService {\n  constructor() {\n    // Blocks startup\n    for (let i = 0; i < 10000; i++) {\n      this.cache.set(i, computeExpensiveValue(i));\n    }\n  }\n}","good":"@Injectable()\nexport class CacheService implements OnModuleInit {\n  async onModuleInit() {\n    // Runs after construction, non-blocking\n    await this.warmCache();\n  }\n}"},"performance/no-dynamic-require":{"bad":"@Injectable()\nexport class PluginLoader {\n  load(name: string) {\n    return require(`./plugins/${name}`);\n  }\n}","good":"@Injectable()\nexport class PluginLoader {\n  private readonly plugins = new Map<string, Plugin>();\n\n  register(name: string, plugin: Plugin) {\n    this.plugins.set(name, plugin);\n  }\n\n  load(name: string) {\n    return this.plugins.get(name);\n  }\n}"},"performance/no-unused-providers":{"bad":"// Never injected anywhere\n@Injectable()\nexport class LegacyService {\n  doOldStuff() { /* ... */ }\n}\n\n@Module({ providers: [LegacyService, UserService] })\nexport class UserModule {}","good":"// Remove unused provider\n@Module({ providers: [UserService] })\nexport class UserModule {}"},"performance/no-request-scope-abuse":{"bad":"@Injectable({ scope: Scope.REQUEST })\nexport class UserService {\n  // New instance created for EVERY request\n}","good":"@Injectable()  // Default singleton scope\nexport class UserService {\n  // Single instance shared across all requests\n}"},"performance/no-unused-module-exports":{"bad":"@Module({\n  providers: [SharedService],\n  exports: [SharedService],  // No other module imports SharedModule\n})\nexport class SharedModule {}","good":"// Either remove the export:\n@Module({ providers: [SharedService] })\nexport class SharedModule {}\n\n// Or import SharedModule where it's needed:\n@Module({ imports: [SharedModule] })\nexport class UserModule {}"},"performance/no-orphan-modules":{"bad":"// analytics.module.ts — never imported anywhere\n@Module({\n  providers: [AnalyticsService],\n})\nexport class AnalyticsModule {}","good":"// Import it in the parent module:\n@Module({\n  imports: [AnalyticsModule],\n})\nexport class AppModule {}"},"schema/require-primary-key":{"bad":"@Entity()\nexport class AuditLog {\n  @Column()\n  action: string;\n\n  @Column()\n  timestamp: Date;\n  // No primary key column!\n}","good":"@Entity()\nexport class AuditLog {\n  @PrimaryGeneratedColumn('uuid')\n  id: string;\n\n  @Column()\n  action: string;\n\n  @Column()\n  timestamp: Date;\n}"},"schema/require-timestamps":{"bad":"@Entity()\nexport class Product {\n  @PrimaryGeneratedColumn()\n  id: number;\n\n  @Column()\n  name: string;\n  // No createdAt / updatedAt columns\n}","good":"@Entity()\nexport class Product {\n  @PrimaryGeneratedColumn()\n  id: number;\n\n  @Column()\n  name: string;\n\n  @CreateDateColumn()\n  createdAt: Date;\n\n  @UpdateDateColumn()\n  updatedAt: Date;\n}"},"schema/require-cascade-rule":{"bad":"@Entity()\nexport class Order {\n  @ManyToOne(() => User, (user) => user.orders)\n  user: User;  // No onDelete — the database default decides\n}","good":"@Entity()\nexport class Order {\n  @ManyToOne(() => User, (user) => user.orders, {\n    onDelete: 'CASCADE',\n  })\n  user: User;\n}"}},"share":{"filename":"nestjs-doctor-shared.json","findingsByCategory":{"security":{"findings":[{"filePath":"apps/api/src/app.module.ts","message":"TypeORM 'synchronize: true' can auto-drop columns and tables in production.","help":"Set synchronize: false and use migrations for production schema changes.","line":27,"column":1,"rule":"security/no-synchronize-in-production","category":"security","scope":"file","severity":"error","sourceLines":[{"line":22,"text":"        port: Number(config.getOrThrow<string>('DATABASE_PORT')),"},{"line":23,"text":"        username: config.getOrThrow<string>('DATABASE_USER'),"},{"line":24,"text":"        password: config.getOrThrow<string>('DATABASE_PASSWORD'),"},{"line":25,"text":"        database: config.getOrThrow<string>('DATABASE_NAME'),"},{"line":26,"text":"        autoLoadEntities: true,"},{"line":27,"text":"        synchronize: true,"},{"line":28,"text":"      }),"},{"line":29,"text":"    }),"},{"line":30,"text":"    BullModule.forRootAsync({"},{"line":31,"text":"      inject: [ConfigService],"},{"line":32,"text":"      useFactory: (config: ConfigService) => ({"}]},{"filePath":"apps/api/src/notifications/notifications.service.ts","message":"Direct 'process.env.NOTIFICATIONS_FROM' access in 'NotificationsService'. Use ConfigService instead.","help":"Inject ConfigService and use configService.get('VAR_NAME') instead of process.env.VAR_NAME.","line":12,"column":1,"rule":"security/no-exposed-env-vars","category":"security","scope":"file","severity":"warning","sourceLines":[{"line":7,"text":"export type NotificationKind = 'receipt' | 'refund' | 'welcome' | 'payment-reminder';"},{"line":8,"text":""},{"line":9,"text":"@Injectable()"},{"line":10,"text":"export class NotificationsService implements OnApplicationBootstrap {"},{"line":11,"text":"  private readonly logger = new Logger(NotificationsService.name);"},{"line":12,"text":"  private readonly from = process.env.NOTIFICATIONS_FROM ?? 'shop@example.com';"},{"line":13,"text":""},{"line":14,"text":"  constructor("},{"line":15,"text":"    @InjectQueue('notifications') private readonly queue: Queue,"},{"line":16,"text":"    @Inject(forwardRef(() => OrdersService))"},{"line":17,"text":"    private readonly ordersService: OrdersService,"}]},{"filePath":"apps/api/src/payments/payments.controller.ts","message":"Endpoint 'list' has no @UseGuards() at class or method level.","help":"Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.","line":8,"column":1,"rule":"security/require-guards-on-endpoints","category":"security","scope":"file","severity":"warning","sourceLines":[{"line":3,"text":""},{"line":4,"text":"@Controller('payments')"},{"line":5,"text":"export class PaymentsController {"},{"line":6,"text":"  constructor(private readonly paymentsService: PaymentsService) {}"},{"line":7,"text":""},{"line":8,"text":"  @Get()"},{"line":9,"text":"  list() {"},{"line":10,"text":"    return this.paymentsService.findAll();"},{"line":11,"text":"  }"},{"line":12,"text":""},{"line":13,"text":"  @Post(':id/refund')"}]},{"filePath":"apps/api/src/payments/payments.controller.ts","message":"Endpoint 'refund' has no @UseGuards() at class or method level.","help":"Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.","line":13,"column":1,"rule":"security/require-guards-on-endpoints","category":"security","scope":"file","severity":"warning","sourceLines":[{"line":8,"text":"  @Get()"},{"line":9,"text":"  list() {"},{"line":10,"text":"    return this.paymentsService.findAll();"},{"line":11,"text":"  }"},{"line":12,"text":""},{"line":13,"text":"  @Post(':id/refund')"},{"line":14,"text":"  refund(@Param('id') id: string) {"},{"line":15,"text":"    return this.paymentsService.refund(id);"},{"line":16,"text":"  }"},{"line":17,"text":"}"},{"line":18,"text":""}]},{"filePath":"apps/api/src/payments/payments.service.ts","message":"Property 'webhookSecret' appears to contain a hardcoded secret.","help":"Move secrets to environment variables and access them via ConfigService.","line":28,"column":1,"rule":"security/no-hardcoded-secrets","category":"security","scope":"file","severity":"error","sourceLines":[{"line":23,"text":"@Injectable()"},{"line":24,"text":"export class PaymentsService implements OnModuleInit, OnApplicationBootstrap {"},{"line":25,"text":"  private readonly logger = new Logger(PaymentsService.name);"},{"line":26,"text":"  // Pending amount per order id, warmed at boot so refunds can check quickly."},{"line":27,"text":"  private readonly pendingByOrder = new Map<string, number>();"},{"line":28,"text":"  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';"},{"line":29,"text":""},{"line":30,"text":"  constructor("},{"line":31,"text":"    @InjectRepository(Payment) private readonly payments: Repository<Payment>,"},{"line":32,"text":"    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,"},{"line":33,"text":"    private readonly cardGateway: CardGateway,"}]},{"filePath":"apps/api/src/payments/payments.service.ts","message":"Weak hashing algorithm 'md5' used in createHash().","help":"Use a stronger algorithm like SHA-256 or bcrypt for password hashing.","line":144,"column":1,"rule":"security/no-weak-crypto","category":"security","scope":"file","severity":"warning","sourceLines":[{"line":139,"text":"    return expected.length === signature.length && timingSafeEqual(Buffer.from(expected), Buffer.from(signature));"},{"line":140,"text":"  }"},{"line":141,"text":""},{"line":142,"text":"  private nextInvoiceNumber(order: Order): string {"},{"line":143,"text":"    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');"},{"line":144,"text":"    const suffix = createHash('md5').update(order.id).digest('hex').slice(0, 8);"},{"line":145,"text":"    return `INV-${stamp}-${suffix.toUpperCase()}`;"},{"line":146,"text":"  }"},{"line":147,"text":"}"},{"line":148,"text":""}]}],"schemaIssues":[],"summary":{"total":6,"errors":2,"warnings":4,"info":0,"byCategory":{"security":6,"performance":0,"correctness":0,"architecture":0,"schema":0}}},"performance":{"findings":[{"filePath":"apps/api/src/main.ts","message":"Synchronous I/O call 'writeFileSync()' blocks the event loop.","help":"Use the async variant (e.g., readFile instead of readFileSync) with await.","line":59,"column":1,"rule":"performance/no-sync-io","category":"performance","scope":"file","severity":"warning","sourceLines":[{"line":54,"text":"  Logger.log(`API listening on http://localhost:${port}`, 'Bootstrap');"},{"line":55,"text":""},{"line":56,"text":"  if (traceEnabled) {"},{"line":57,"text":"    const graph = JSON.parse(app.get(SerializedGraph).toString());"},{"line":58,"text":"    Object.assign(graph, { createMs, initMs, moduleInitMs, startupMs, hookTimings });"},{"line":59,"text":"    writeFileSync('nestjs-doctor-timings.json', JSON.stringify(graph));"},{"line":60,"text":"    Logger.log(`Boot trace written to nestjs-doctor-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');"},{"line":61,"text":"    await app.close();"},{"line":62,"text":"    process.exit(0);"},{"line":63,"text":"  }"},{"line":64,"text":"}"}]},{"filePath":"apps/api/src/audit/audit-archiver.service.ts","message":"Provider 'AuditArchiverService' is never injected by any other provider or controller.","help":"Remove the unused provider, inject it where needed, or verify the framework activates it, through a decorator such as @Cron or @OnEvent or a contract such as OnModuleInit or CanActivate.","line":4,"column":1,"rule":"performance/no-unused-providers","category":"performance","scope":"project","severity":"warning","tags":["module-graph"]},{"filePath":"apps/api/src/reports/reports.module.ts","message":"Module 'ReportsModule' is never imported by any other module.","help":"Import this module in another module or remove it if it is unused.","line":5,"column":1,"rule":"performance/no-orphan-modules","category":"performance","scope":"project","severity":"info","tags":["module-graph"]},{"filePath":"apps/worker/src/jobs/jobs.module.ts","message":"Module 'JobsModule' exports 'JobsService' but no importing module uses it.","help":"Remove the unused export or use the provider in an importing module.","line":6,"column":1,"rule":"performance/no-unused-module-exports","category":"performance","scope":"project","severity":"info","tags":["module-graph"]},{"filePath":"libs/shared/src/request-context.service.ts","message":"Scope.REQUEST creates a new instance per request, which impacts performance and propagates request scope to all dependents.","help":"Remove Scope.REQUEST unless the provider genuinely needs per-request state (e.g., request-scoped context). Consider Scope.DEFAULT or Scope.TRANSIENT instead.","line":4,"column":1,"rule":"performance/no-request-scope-abuse","category":"performance","scope":"file","severity":"warning","tags":["module-graph"],"sourceLines":[{"line":1,"text":"import { Injectable, Scope } from '@nestjs/common';"},{"line":2,"text":"import { randomUUID } from 'node:crypto';"},{"line":3,"text":""},{"line":4,"text":"@Injectable({ scope: Scope.REQUEST })"},{"line":5,"text":"export class RequestContextService {"},{"line":6,"text":"  readonly requestId = randomUUID();"},{"line":7,"text":"  readonly startedAt = new Date();"},{"line":8,"text":"}"},{"line":9,"text":""}]}],"schemaIssues":[],"summary":{"total":5,"errors":0,"warnings":3,"info":2,"byCategory":{"security":0,"performance":5,"correctness":0,"architecture":0,"schema":0}}},"correctness":{"findings":[{"filePath":"apps/api/src/audit/audit.service.ts","message":"Constructor parameter 'logs' should be readonly.","help":"Add the 'readonly' modifier to the constructor parameter.","line":15,"column":13,"rule":"correctness/prefer-readonly-injection","category":"correctness","scope":"file","severity":"warning","surfaces":["cli"],"sourceLines":[{"line":10,"text":""},{"line":11,"text":"@Injectable()"},{"line":12,"text":"export class AuditService {"},{"line":13,"text":"  constructor("},{"line":14,"text":"    @Inject(AUDIT_OPTIONS) private readonly options: AuditOptions,"},{"line":15,"text":"    private logs: AuditRepository,"},{"line":16,"text":"  ) {}"},{"line":17,"text":""},{"line":18,"text":"  record(action: string, actor: string, payload: Record<string, unknown> = {}): Promise<AuditLog> {"},{"line":19,"text":"    return this.logs.insert(action, actor, payload);"},{"line":20,"text":"  }"}]},{"filePath":"apps/api/src/orders/orders.service.ts","message":"Async call 'record()' is not awaited — unhandled rejections will crash the process.","help":"Add await before the async call, or use void with explicit error handling if fire-and-forget is intentional.","line":135,"column":1,"rule":"correctness/no-fire-and-forget-async","category":"correctness","scope":"file","severity":"warning","sourceLines":[{"line":130,"text":"  }"},{"line":131,"text":""},{"line":132,"text":"  async markRefunded(id: string): Promise<void> {"},{"line":133,"text":"    const order = await this.findOne(id);"},{"line":134,"text":"    await this.orders.update({ id }, { status: OrderStatus.Refunded });"},{"line":135,"text":"    this.audit.record('order.refunded', order.user.email, { orderId: id });"},{"line":136,"text":"  }"},{"line":137,"text":""},{"line":138,"text":"  // Demo orders for the system user, one payment each, spread over the last 30 days."},{"line":139,"text":"  private async seedDemoOrders(): Promise<number> {"},{"line":140,"text":"    if ((await this.orders.count()) > 0) {"}]},{"filePath":"apps/api/src/users/dto/update-user.dto.ts","message":"Property 'addresses' is an array with @ValidateNested() but missing { each: true }.","help":"Change @ValidateNested() to @ValidateNested({ each: true }) for array properties.","line":23,"column":1,"rule":"correctness/validate-nested-array-each","category":"correctness","scope":"file","severity":"warning","sourceLines":[{"line":18,"text":"  @IsString()"},{"line":19,"text":"  @MinLength(2)"},{"line":20,"text":"  name?: string;"},{"line":21,"text":""},{"line":22,"text":"  @IsOptional()"},{"line":23,"text":"  @ValidateNested()"},{"line":24,"text":"  @Type(() => AddressDto)"},{"line":25,"text":"  addresses: AddressDto[];"},{"line":26,"text":"}"},{"line":27,"text":""}]},{"filePath":"apps/worker/src/jobs/notifications.processor.ts","message":"Async method 'process()' has no await expression.","help":"Either add an await expression or remove the async keyword. Framework entry points are exempted, since Nest awaits what they return: route handlers, GraphQL resolvers, WebSocket, microservice, ts-rest and gRPC handlers.","line":14,"column":1,"rule":"correctness/no-async-without-await","category":"correctness","scope":"file","severity":"warning","surfaces":["cli"],"sourceLines":[{"line":9,"text":""},{"line":10,"text":"  constructor(private readonly metrics: MetricsService) {"},{"line":11,"text":"    super();"},{"line":12,"text":"  }"},{"line":13,"text":""},{"line":14,"text":"  async process(job: Job<{ message?: string; orderId?: string }>): Promise<void> {"},{"line":15,"text":"    this.logger.log(`[${job.name}] #${job.id} ${job.data.message ?? ''}`);"},{"line":16,"text":"    this.metrics.increment(`notifications.${job.name}`);"},{"line":17,"text":"  }"},{"line":18,"text":"}"},{"line":19,"text":""}]},{"filePath":"libs/shared/src/metrics.service.ts","message":"Class 'MetricsService' has 'onModuleInit()' but does not implement 'OnModuleInit'.","help":"Add 'implements OnModuleInit' (or the appropriate interface) to the class declaration.","line":9,"column":1,"rule":"correctness/require-lifecycle-interface","category":"correctness","scope":"file","severity":"warning","sourceLines":[{"line":4,"text":""},{"line":5,"text":"@Injectable({ scope: Scope.TRANSIENT })"},{"line":6,"text":"export class MetricsService {"},{"line":7,"text":"  private readonly counters = new Map<string, number>();"},{"line":8,"text":""},{"line":9,"text":"  async onModuleInit(): Promise<void> {"},{"line":10,"text":"    await new Promise((resolve) => setTimeout(resolve, 5));"},{"line":11,"text":"    for (const name of SEED_COUNTERS) {"},{"line":12,"text":"      this.counters.set(name, 0);"},{"line":13,"text":"    }"},{"line":14,"text":"  }"}]}],"schemaIssues":[],"summary":{"total":5,"errors":0,"warnings":5,"info":0,"byCategory":{"security":0,"performance":0,"correctness":5,"architecture":0,"schema":0}}},"architecture":{"findings":[{"filePath":"apps/api/src/orders/orders.controller.ts","message":"Controller method 'pay' contains business logic (0 if, 0 loops, 1 switch). Move to a service.","help":"Extract branches, loops, and complex calculations into a service method.","line":22,"column":1,"rule":"architecture/no-business-logic-in-controllers","category":"architecture","scope":"file","severity":"error","sourceLines":[{"line":17,"text":"  @Post()"},{"line":18,"text":"  create(@Body(new ValidationPipe({ whitelist: true, transform: true })) dto: CreateOrderDto) {"},{"line":19,"text":"    return this.ordersService.create(dto);"},{"line":20,"text":"  }"},{"line":21,"text":""},{"line":22,"text":"  @Post(':id/pay')"},{"line":23,"text":"  pay(@Param('id') id: string, @Body() body: { provider?: string }) {"},{"line":24,"text":"    let surchargeCents: number;"},{"line":25,"text":"    switch (body.provider) {"},{"line":26,"text":"      case 'card':"},{"line":27,"text":"        surchargeCents = 30;"}]},{"filePath":"apps/api/src/orders/orders.service.ts","message":"Service uses @InjectRepository() directly. Consider wrapping in a repository class.","help":"Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.","line":30,"column":1,"rule":"architecture/no-orm-in-services","category":"architecture","scope":"file","severity":"info","sourceLines":[{"line":25,"text":"@Injectable()"},{"line":26,"text":"export class OrdersService implements OnModuleInit, OnApplicationBootstrap {"},{"line":27,"text":"  private readonly logger = new Logger(OrdersService.name);"},{"line":28,"text":""},{"line":29,"text":"  constructor("},{"line":30,"text":"    @InjectRepository(Order) private readonly orders: Repository<Order>,"},{"line":31,"text":"    @InjectRepository(OrderItem) private readonly items: Repository<OrderItem>,"},{"line":32,"text":"    private readonly usersService: UsersService,"},{"line":33,"text":"    private readonly catalogService: CatalogService,"},{"line":34,"text":"    private readonly audit: AuditService,"},{"line":35,"text":"    private readonly metrics: MetricsService,"}]},{"filePath":"apps/api/src/payments/payments.service.ts","message":"Service uses @InjectRepository() directly. Consider wrapping in a repository class.","help":"Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.","line":31,"column":1,"rule":"architecture/no-orm-in-services","category":"architecture","scope":"file","severity":"info","sourceLines":[{"line":26,"text":"  // Pending amount per order id, warmed at boot so refunds can check quickly."},{"line":27,"text":"  private readonly pendingByOrder = new Map<string, number>();"},{"line":28,"text":"  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';"},{"line":29,"text":""},{"line":30,"text":"  constructor("},{"line":31,"text":"    @InjectRepository(Payment) private readonly payments: Repository<Payment>,"},{"line":32,"text":"    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,"},{"line":33,"text":"    private readonly cardGateway: CardGateway,"},{"line":34,"text":"    private readonly sepaGateway: SepaGateway,"},{"line":35,"text":"    private readonly metrics: MetricsService,"},{"line":36,"text":"    private readonly audit: AuditService,"}]},{"filePath":"apps/api/src/orders/orders.module.ts","message":"Circular module dependency detected: OrdersModule -> PaymentsModule -> NotificationsModule","help":"OrdersModule -> PaymentsModule: OrdersService (in OrdersModule) injects PaymentsService (from PaymentsModule)\nPaymentsModule -> NotificationsModule: PaymentsService (in PaymentsModule) injects NotificationsService (from NotificationsModule)\nNotificationsModule -> OrdersModule: NotificationsService (in NotificationsModule) injects OrdersService (from OrdersModule)\nConsider extracting PaymentsService into a shared module — it would break the OrdersModule -> PaymentsModule edge (1 dependency).","line":12,"column":1,"rule":"architecture/no-circular-module-deps","category":"architecture","scope":"project","severity":"error","tags":["module-graph"]},{"filePath":"libs/shared/src/index.ts","message":"Barrel file re-exports internal module './redis.strategy'.","help":"Only export the module's public API (services, DTOs, interfaces) from the index.ts beside its module file.","line":5,"column":1,"rule":"architecture/no-barrel-export-internals","category":"architecture","scope":"file","severity":"info","sourceLines":[{"line":1,"text":"export * from './shared.module';"},{"line":2,"text":"export * from './metrics.service';"},{"line":3,"text":"export * from './app-config.service';"},{"line":4,"text":"export * from './request-context.service';"},{"line":5,"text":"export * from './redis.strategy';"},{"line":6,"text":""}]}],"schemaIssues":[],"summary":{"total":5,"errors":2,"warnings":0,"info":3,"byCategory":{"security":0,"performance":0,"correctness":0,"architecture":5,"schema":0}}},"schema":{"findings":[],"schemaIssues":[{"filePath":"apps/api/src/catalog/category.entity.ts","entity":"Category","message":"Entity 'Category' has no timestamp columns (createdAt/updatedAt).","help":"Add createdAt/updatedAt columns to track when records are created and modified.","rule":"schema/require-timestamps","category":"schema","scope":"schema","severity":"warning"},{"filePath":"apps/api/src/payments/invoice.entity.ts","entity":"Invoice","message":"Entity 'Invoice' has no timestamp columns (createdAt/updatedAt).","help":"Add createdAt/updatedAt columns to track when records are created and modified.","rule":"schema/require-timestamps","category":"schema","scope":"schema","severity":"warning"},{"filePath":"apps/api/src/catalog/product.entity.ts","entity":"Product","message":"Relation 'category' on 'Product' has no explicit onDelete behavior.","help":"Add an explicit onDelete option (e.g. CASCADE, SET NULL) to avoid relying on database defaults.","rule":"schema/require-cascade-rule","category":"schema","scope":"schema","severity":"info"},{"filePath":"apps/api/src/orders/order.entity.ts","entity":"Order","message":"Relation 'user' on 'Order' has no explicit onDelete behavior.","help":"Add an explicit onDelete option (e.g. CASCADE, SET NULL) to avoid relying on database defaults.","rule":"schema/require-cascade-rule","category":"schema","scope":"schema","severity":"info"}],"summary":{"total":4,"errors":0,"warnings":2,"info":2,"byCategory":{"security":0,"performance":0,"correctness":0,"architecture":0,"schema":4}}}},"project":{"name":"monorepo","nestVersion":"12.0.1","orm":"typeorm","framework":"express","fileCount":58,"moduleCount":12},"sections":[{"id":"score","count":93,"label":"Health score and project info"},{"id":"findings:security","count":6,"label":"Findings · security"},{"id":"findings:performance","count":5,"label":"Findings · performance"},{"id":"findings:correctness","count":5,"label":"Findings · correctness"},{"id":"findings:architecture","count":5,"label":"Findings · architecture"},{"id":"findings:schema","count":4,"label":"Findings · schema"},{"id":"endpoints","count":15,"label":"HTTP endpoints"},{"id":"schema","count":9,"label":"Relational schema"},{"id":"modules","count":12,"label":"Module graph"}],"score":{"value":93,"label":"Excellent"},"version":1,"endpoints":[{"controllerClass":"AppController","handlerMethod":"health","httpMethod":"GET","routePath":"/health"},{"controllerClass":"CatalogController","handlerMethod":"list","httpMethod":"GET","routePath":"/products"},{"controllerClass":"CatalogController","handlerMethod":"get","httpMethod":"GET","routePath":"/products/:id"},{"controllerClass":"CatalogController","handlerMethod":"update","httpMethod":"PUT","routePath":"/products/:id"},{"controllerClass":"OrdersController","handlerMethod":"list","httpMethod":"GET","routePath":"/orders"},{"controllerClass":"OrdersController","handlerMethod":"create","httpMethod":"POST","routePath":"/orders"},{"controllerClass":"OrdersController","handlerMethod":"pay","httpMethod":"POST","routePath":"/orders/:id/pay"},{"controllerClass":"OrdersController","handlerMethod":"updateStatus","httpMethod":"PATCH","routePath":"/orders/:id/status"},{"controllerClass":"PaymentsController","handlerMethod":"list","httpMethod":"GET","routePath":"/payments"},{"controllerClass":"PaymentsController","handlerMethod":"refund","httpMethod":"POST","routePath":"/payments/:id/refund"},{"controllerClass":"UsersController","handlerMethod":"list","httpMethod":"GET","routePath":"/users"},{"controllerClass":"UsersController","handlerMethod":"get","httpMethod":"GET","routePath":"/users/:id"},{"controllerClass":"UsersController","handlerMethod":"create","httpMethod":"POST","routePath":"/users"},{"controllerClass":"UsersController","handlerMethod":"update","httpMethod":"PATCH","routePath":"/users/:id"},{"controllerClass":"UsersController","handlerMethod":"remove","httpMethod":"DELETE","routePath":"/users/:id"}],"schema":{"entities":[{"name":"AuditLog","tableName":"audit_logs","filePath":"apps/api/src/audit/audit-log.entity.ts","columns":[{"name":"action","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"actor","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"payload","type":"jsonb","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"{}"},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[],"indexes":[]},{"name":"Category","tableName":"categories","filePath":"apps/api/src/catalog/category.entity.ts","columns":[{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"slug","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"name","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false}],"relations":[{"type":"one-to-many","fromEntity":"Category","toEntity":"Product","propertyName":"products","isNullable":false}],"indexes":[]},{"name":"Product","tableName":"products","filePath":"apps/api/src/catalog/product.entity.ts","columns":[{"name":"sku","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"name","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"priceCents","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"many-to-one","fromEntity":"Product","toEntity":"Category","propertyName":"category","isNullable":false},{"type":"many-to-many","fromEntity":"Product","toEntity":"Tag","propertyName":"tags","isNullable":false},{"type":"one-to-many","fromEntity":"Product","toEntity":"OrderItem","propertyName":"orderItems","isNullable":false}],"indexes":[]},{"name":"Tag","tableName":"tags","filePath":"apps/api/src/catalog/tag.entity.ts","columns":[{"name":"slug","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"name","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[],"indexes":[]},{"name":"OrderItem","tableName":"order_items","filePath":"apps/api/src/orders/order-item.entity.ts","columns":[{"name":"quantity","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"unitPriceCents","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"many-to-one","fromEntity":"OrderItem","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"},{"type":"many-to-one","fromEntity":"OrderItem","toEntity":"Product","propertyName":"product","isNullable":false,"onDelete":"RESTRICT"}],"indexes":[]},{"name":"Order","tableName":"orders","filePath":"apps/api/src/orders/order.entity.ts","columns":[{"name":"status","type":"enum","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"OrderStatus.Pending","hasIndex":true},{"name":"totalCents","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"0"},{"name":"note","type":"text","isPrimary":false,"isNullable":true,"isGenerated":false,"isUnique":false},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false,"hasIndex":true},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"many-to-one","fromEntity":"Order","toEntity":"User","propertyName":"user","isNullable":false},{"type":"one-to-many","fromEntity":"Order","toEntity":"OrderItem","propertyName":"items","isNullable":false}],"indexes":[{"columns":["status","createdAt"],"isUnique":false}]},{"name":"Invoice","tableName":"invoices","filePath":"apps/api/src/payments/invoice.entity.ts","columns":[{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"number","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"issuedAt","type":"timestamptz","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false}],"relations":[{"type":"one-to-one","fromEntity":"Invoice","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"}],"indexes":[]},{"name":"Payment","tableName":"payments","filePath":"apps/api/src/payments/payment.entity.ts","columns":[{"name":"provider","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"hasIndex":true},{"name":"amountCents","type":"int","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"status","type":"enum","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"PaymentStatus.Pending"},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"many-to-one","fromEntity":"Payment","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"}],"indexes":[{"columns":["provider"],"isUnique":false}]},{"name":"User","tableName":"users","filePath":"apps/api/src/users/user.entity.ts","columns":[{"name":"email","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":true},{"name":"name","type":"unknown","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false},{"name":"addresses","type":"jsonb","isPrimary":false,"isNullable":false,"isGenerated":false,"isUnique":false,"defaultValue":"[]"},{"name":"id","type":"uuid","isPrimary":true,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"createdAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false},{"name":"updatedAt","type":"timestamp","isPrimary":false,"isNullable":false,"isGenerated":true,"isUnique":false}],"relations":[{"type":"one-to-many","fromEntity":"User","toEntity":"Order","propertyName":"orders","isNullable":false}],"indexes":[]}],"orm":"typeorm","relations":[{"type":"one-to-many","fromEntity":"Category","toEntity":"Product","propertyName":"products","isNullable":false},{"type":"many-to-one","fromEntity":"Product","toEntity":"Category","propertyName":"category","isNullable":false},{"type":"many-to-many","fromEntity":"Product","toEntity":"Tag","propertyName":"tags","isNullable":false},{"type":"one-to-many","fromEntity":"Product","toEntity":"OrderItem","propertyName":"orderItems","isNullable":false},{"type":"many-to-one","fromEntity":"OrderItem","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"},{"type":"many-to-one","fromEntity":"OrderItem","toEntity":"Product","propertyName":"product","isNullable":false,"onDelete":"RESTRICT"},{"type":"many-to-one","fromEntity":"Order","toEntity":"User","propertyName":"user","isNullable":false},{"type":"one-to-many","fromEntity":"Order","toEntity":"OrderItem","propertyName":"items","isNullable":false},{"type":"one-to-one","fromEntity":"Invoice","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"},{"type":"many-to-one","fromEntity":"Payment","toEntity":"Order","propertyName":"order","isNullable":false,"onDelete":"CASCADE"},{"type":"one-to-many","fromEntity":"User","toEntity":"Order","propertyName":"orders","isNullable":false}]},"modules":{"bootstrapRoots":["api/AppModule","worker/WorkerModule"],"circularDeps":[["api/OrdersModule","api/PaymentsModule","api/NotificationsModule"]],"edges":[{"from":"api/AppModule","to":"shared/SharedModule"},{"from":"api/AppModule","to":"api/UsersModule"},{"from":"api/AppModule","to":"api/CatalogModule"},{"from":"api/AppModule","to":"api/OrdersModule"},{"from":"api/AppModule","to":"api/PaymentsModule"},{"from":"api/AppModule","to":"api/NotificationsModule"},{"from":"api/AppModule","to":"api/AuditModule"},{"from":"api/NotificationsModule","to":"api/OrdersModule"},{"from":"api/OrdersModule","to":"api/UsersModule"},{"from":"api/OrdersModule","to":"api/CatalogModule"},{"from":"api/OrdersModule","to":"api/AuditModule"},{"from":"api/OrdersModule","to":"api/PaymentsModule"},{"from":"api/PaymentsModule","to":"api/AuditModule"},{"from":"api/PaymentsModule","to":"api/NotificationsModule"},{"from":"worker/WorkerModule","to":"shared/SharedModule"},{"from":"worker/WorkerModule","to":"worker/JobsModule"},{"from":"worker/WorkerModule","to":"worker/SyncModule"}],"modules":[{"name":"api/AppModule","filePath":"apps/api/src/app.module.ts","imports":["ConfigModule","TypeOrmModule","BullModule","shared/SharedModule","api/UsersModule","api/CatalogModule","api/OrdersModule","api/PaymentsModule","api/NotificationsModule","api/AuditModule"],"exports":[],"providers":[],"providerTokens":[],"controllers":["AppController"],"project":"api","isGlobal":false,"line":14,"dynamicImports":{"ConfigModule":"forRoot","TypeOrmModule":"forRootAsync","BullModule":"forRootAsync","api/AuditModule":"register"}},{"name":"api/AuditModule","filePath":"apps/api/src/audit/audit.module.ts","imports":["TypeOrmModule"],"exports":["AuditService"],"providers":["AuditService","AuditRepository","AuditArchiverService"],"providerTokens":[],"controllers":[],"project":"api","isGlobal":false,"line":8,"dynamicImports":{"TypeOrmModule":"forFeature"}},{"name":"api/CatalogModule","filePath":"apps/api/src/catalog/catalog.module.ts","imports":["TypeOrmModule"],"exports":["CatalogService"],"providers":["CatalogService","CatalogRepository"],"providerTokens":[],"controllers":["CatalogController"],"project":"api","isGlobal":false,"line":10,"dynamicImports":{"TypeOrmModule":"forFeature"}},{"name":"api/NotificationsModule","filePath":"apps/api/src/notifications/notifications.module.ts","imports":["BullModule","api/OrdersModule"],"exports":["NotificationsService"],"providers":["NotificationsService"],"providerTokens":[],"controllers":[],"project":"api","isGlobal":false,"line":6},{"name":"api/OrdersModule","filePath":"apps/api/src/orders/orders.module.ts","imports":["TypeOrmModule","api/UsersModule","api/CatalogModule","api/AuditModule","api/PaymentsModule"],"exports":["OrdersService"],"providers":["OrdersService"],"providerTokens":[],"controllers":["OrdersController"],"project":"api","isGlobal":false,"line":12,"dynamicImports":{"TypeOrmModule":"forFeature","api/AuditModule":"register"}},{"name":"api/PaymentsModule","filePath":"apps/api/src/payments/payments.module.ts","imports":["TypeOrmModule","api/AuditModule","api/NotificationsModule"],"exports":["PaymentsService"],"providers":["PaymentsService","CardGateway","SepaGateway"],"providerTokens":[],"controllers":["PaymentsController"],"project":"api","isGlobal":false,"line":12,"dynamicImports":{"TypeOrmModule":"forFeature","api/AuditModule":"register"}},{"name":"api/ReportsModule","filePath":"apps/api/src/reports/reports.module.ts","imports":[],"exports":["SalesReportService"],"providers":["SalesReportRepository","SalesReportService"],"providerTokens":[],"controllers":[],"project":"api","isGlobal":false,"line":5},{"name":"api/UsersModule","filePath":"apps/api/src/users/users.module.ts","imports":["TypeOrmModule"],"exports":["UsersService"],"providers":["UsersService","UsersRepository"],"providerTokens":[],"controllers":["UsersController"],"project":"api","isGlobal":false,"line":8,"dynamicImports":{"TypeOrmModule":"forFeature"}},{"name":"worker/JobsModule","filePath":"apps/worker/src/jobs/jobs.module.ts","imports":["BullModule"],"exports":["JobsService"],"providers":["NotificationsProcessor","JobsService"],"providerTokens":[],"controllers":[],"project":"worker","isGlobal":false,"line":6},{"name":"worker/SyncModule","filePath":"apps/worker/src/sync/sync.module.ts","imports":[],"exports":[],"providers":["SyncService","SyncRepository"],"providerTokens":[],"controllers":[],"project":"worker","isGlobal":false,"line":5},{"name":"worker/WorkerModule","filePath":"apps/worker/src/worker.module.ts","imports":["ConfigModule","BullModule","TypeOrmModule","shared/SharedModule","worker/JobsModule","worker/SyncModule"],"exports":[],"providers":[],"providerTokens":[],"controllers":[],"project":"worker","isGlobal":false,"line":9,"dynamicImports":{"ConfigModule":"forRoot","BullModule":"forRootAsync","TypeOrmModule":"forRootAsync"}},{"name":"shared/SharedModule","filePath":"libs/shared/src/shared.module.ts","imports":["ConfigModule"],"exports":["MetricsService","AppConfigService","RequestContextService","RedisStrategy"],"providers":["MetricsService","AppConfigService","RequestContextService","RedisStrategy"],"providerTokens":[],"controllers":[],"project":"shared","isGlobal":true,"line":8}],"projects":["api","worker","shared"]}},"sources":{"/demo/nest-shop/apps/api/src/app.controller.ts":"import { Controller, Get } from '@nestjs/common';\nimport { MetricsService, RequestContextService } from '@app/shared';\nimport { Public } from './auth/public.decorator';\n\n@Controller()\nexport class AppController {\n  constructor(\n    private readonly metrics: MetricsService,\n    private readonly requestContext: RequestContextService,\n  ) {}\n\n  @Public()\n  @Get('health')\n  health() {\n    return {\n      status: 'ok',\n      requestId: this.requestContext.requestId,\n      uptimeSeconds: Math.round(process.uptime()),\n      metrics: this.metrics.snapshot(),\n    };\n  }\n}\n","/demo/nest-shop/apps/api/src/app.module.ts":"import { BullModule } from '@nestjs/bullmq';\nimport { Module } from '@nestjs/common';\nimport { ConfigModule, ConfigService } from '@nestjs/config';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { SharedModule } from '@app/shared';\nimport { AuditModule } from './audit/audit.module';\nimport { CatalogModule } from './catalog/catalog.module';\nimport { NotificationsModule } from './notifications/notifications.module';\nimport { OrdersModule } from './orders/orders.module';\nimport { PaymentsModule } from './payments/payments.module';\nimport { AppController } from './app.controller';\nimport { UsersModule } from './users/users.module';\n\n@Module({\n  imports: [\n    ConfigModule.forRoot({ isGlobal: true, envFilePath: ['.env'] }),\n    TypeOrmModule.forRootAsync({\n      inject: [ConfigService],\n      useFactory: (config: ConfigService) => ({\n        type: 'postgres',\n        host: config.getOrThrow<string>('DATABASE_HOST'),\n        port: Number(config.getOrThrow<string>('DATABASE_PORT')),\n        username: config.getOrThrow<string>('DATABASE_USER'),\n        password: config.getOrThrow<string>('DATABASE_PASSWORD'),\n        database: config.getOrThrow<string>('DATABASE_NAME'),\n        autoLoadEntities: true,\n        synchronize: true,\n      }),\n    }),\n    BullModule.forRootAsync({\n      inject: [ConfigService],\n      useFactory: (config: ConfigService) => ({\n        connection: {\n          host: config.getOrThrow<string>('REDIS_HOST'),\n          port: Number(config.getOrThrow<string>('REDIS_PORT')),\n        },\n      }),\n    }),\n    SharedModule,\n    UsersModule,\n    CatalogModule,\n    OrdersModule,\n    PaymentsModule,\n    NotificationsModule,\n    AuditModule.register({ retentionDays: 90 }),\n  ],\n  controllers: [AppController],\n})\nexport class AppModule {}\n","/demo/nest-shop/apps/api/src/audit/audit-archiver.service.ts":"import { Injectable, Logger } from '@nestjs/common';\nimport { AuditRepository } from './audit.repository';\n\n@Injectable()\nexport class AuditArchiverService {\n  private readonly logger = new Logger(AuditArchiverService.name);\n\n  constructor(private readonly logs: AuditRepository) {}\n\n  async archiveOlderThan(days: number): Promise<number> {\n    const cutoff = new Date(Date.now() - days * 86_400_000);\n    const removed = await this.logs.deleteOlderThan(cutoff);\n    this.logger.log(`Archived ${removed} audit entries older than ${days} days`);\n    return removed;\n  }\n}\n","/demo/nest-shop/apps/api/src/audit/audit-log.entity.ts":"import { Column, Entity } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\n\n@Entity({ name: 'audit_logs' })\nexport class AuditLog extends BaseEntity {\n  @Column()\n  action: string;\n\n  @Column()\n  actor: string;\n\n  @Column({ type: 'jsonb', default: {} })\n  payload: Record<string, unknown>;\n}\n","/demo/nest-shop/apps/api/src/audit/audit.module.ts":"import { DynamicModule, Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { AuditArchiverService } from './audit-archiver.service';\nimport { AuditLog } from './audit-log.entity';\nimport { AuditRepository } from './audit.repository';\nimport { AUDIT_OPTIONS, AuditOptions, AuditService } from './audit.service';\n\n@Module({\n  imports: [TypeOrmModule.forFeature([AuditLog])],\n  providers: [AuditService, AuditRepository, AuditArchiverService],\n  exports: [AuditService],\n})\nexport class AuditModule {\n  static register(options: AuditOptions): DynamicModule {\n    return {\n      module: AuditModule,\n      providers: [{ provide: AUDIT_OPTIONS, useValue: options }],\n    };\n  }\n}\n","/demo/nest-shop/apps/api/src/audit/audit.repository.ts":"import { Injectable } from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { LessThan, Repository } from 'typeorm';\nimport { AuditLog } from './audit-log.entity';\n\n@Injectable()\nexport class AuditRepository {\n  constructor(@InjectRepository(AuditLog) private readonly logs: Repository<AuditLog>) {}\n\n  insert(action: string, actor: string, payload: Record<string, unknown>): Promise<AuditLog> {\n    return this.logs.save(this.logs.create({ action, actor, payload }));\n  }\n\n  recent(limit: number): Promise<AuditLog[]> {\n    return this.logs.find({ order: { createdAt: 'DESC' }, take: limit });\n  }\n\n  async deleteOlderThan(cutoff: Date): Promise<number> {\n    const result = await this.logs.delete({ createdAt: LessThan(cutoff) });\n    return result.affected ?? 0;\n  }\n}\n","/demo/nest-shop/apps/api/src/audit/audit.service.ts":"import { Inject, Injectable } from '@nestjs/common';\nimport { AuditLog } from './audit-log.entity';\nimport { AuditRepository } from './audit.repository';\n\nexport const AUDIT_OPTIONS = Symbol('AUDIT_OPTIONS');\n\nexport interface AuditOptions {\n  retentionDays: number;\n}\n\n@Injectable()\nexport class AuditService {\n  constructor(\n    @Inject(AUDIT_OPTIONS) private readonly options: AuditOptions,\n    private logs: AuditRepository,\n  ) {}\n\n  record(action: string, actor: string, payload: Record<string, unknown> = {}): Promise<AuditLog> {\n    return this.logs.insert(action, actor, payload);\n  }\n\n  recent(limit = 50): Promise<AuditLog[]> {\n    return this.logs.recent(limit);\n  }\n\n  get retentionDays(): number {\n    return this.options.retentionDays;\n  }\n}\n","/demo/nest-shop/apps/api/src/auth/jwt-auth.guard.ts":"import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';\n\n@Injectable()\nexport class JwtAuthGuard implements CanActivate {\n  canActivate(ctx: ExecutionContext): boolean {\n    return Boolean(ctx.switchToHttp().getRequest().headers.authorization);\n  }\n}\n","/demo/nest-shop/apps/api/src/auth/public.decorator.ts":"import { SetMetadata } from '@nestjs/common';\n\nexport const IS_PUBLIC_KEY = 'isPublic';\n\nexport const Public = () => SetMetadata(IS_PUBLIC_KEY, true);\n","/demo/nest-shop/apps/api/src/catalog/catalog-data.ts":"export interface CategorySeed {\n  slug: string;\n  name: string;\n}\n\nexport interface TagSeed {\n  slug: string;\n  name: string;\n}\n\nexport interface ProductSeed {\n  sku: string;\n  name: string;\n  priceCents: number;\n  category: string;\n  tags: string[];\n}\n\nexport const CATEGORY_SEED: CategorySeed[] = [\n  { slug: 'coffee', name: 'Coffee' },\n  { slug: 'tea', name: 'Tea' },\n  { slug: 'gear', name: 'Brewing gear' },\n];\n\nexport const TAG_SEED: TagSeed[] = [\n  { slug: 'aged', name: 'Aged' },\n  { slug: 'black', name: 'Black' },\n  { slug: 'breakfast', name: 'Breakfast' },\n  { slug: 'bulk', name: 'Bulk' },\n  { slug: 'caffeine-free', name: 'Caffeine free' },\n  { slug: 'ceramic', name: 'Ceramic' },\n  { slug: 'chinese', name: 'Chinese' },\n  { slug: 'consumable', name: 'Consumable' },\n  { slug: 'dark', name: 'Dark' },\n  { slug: 'dark-roast', name: 'Dark roast' },\n  { slug: 'decaf', name: 'Decaf' },\n  { slug: 'electronic', name: 'Electronic' },\n  { slug: 'espresso', name: 'Espresso' },\n  { slug: 'filter', name: 'Filter' },\n  { slug: 'flavoured', name: 'Flavoured' },\n  { slug: 'glass', name: 'Glass' },\n  { slug: 'green', name: 'Green' },\n  { slug: 'grinder', name: 'Grinder' },\n  { slug: 'herbal', name: 'Herbal' },\n  { slug: 'immersion', name: 'Immersion' },\n  { slug: 'japanese', name: 'Japanese' },\n  { slug: 'light-roast', name: 'Light roast' },\n  { slug: 'medium-roast', name: 'Medium roast' },\n  { slug: 'oolong', name: 'Oolong' },\n  { slug: 'organic', name: 'Organic' },\n  { slug: 'pour-over', name: 'Pour over' },\n  { slug: 'powder', name: 'Powder' },\n  { slug: 'scale', name: 'Scale' },\n  { slug: 'single-estate', name: 'Single estate' },\n  { slug: 'single-origin', name: 'Single origin' },\n  { slug: 'steel', name: 'Steel' },\n  { slug: 'tea', name: 'Tea' },\n  { slug: 'travel', name: 'Travel' },\n];\n\nexport const PRODUCT_SEED: ProductSeed[] = [\n  {\n    sku: 'COF-001',\n    name: 'Ethiopia Yirgacheffe 250g',\n    priceCents: 1450,\n    category: 'coffee',\n    tags: ['single-origin', 'light-roast'],\n  },\n  {\n    sku: 'COF-002',\n    name: 'Colombia Huila 250g',\n    priceCents: 1290,\n    category: 'coffee',\n    tags: ['single-origin', 'medium-roast'],\n  },\n  {\n    sku: 'COF-003',\n    name: 'Brazil Cerrado 1kg',\n    priceCents: 3200,\n    category: 'coffee',\n    tags: ['espresso', 'medium-roast', 'bulk'],\n  },\n  {\n    sku: 'COF-004',\n    name: 'Decaf Swiss Water 250g',\n    priceCents: 1350,\n    category: 'coffee',\n    tags: ['decaf', 'medium-roast'],\n  },\n  {\n    sku: 'COF-005',\n    name: 'Kenya AA Nyeri 250g',\n    priceCents: 1590,\n    category: 'coffee',\n    tags: ['single-origin', 'light-roast'],\n  },\n  {\n    sku: 'COF-006',\n    name: 'Guatemala Antigua 250g',\n    priceCents: 1390,\n    category: 'coffee',\n    tags: ['single-origin', 'medium-roast'],\n  },\n  {\n    sku: 'COF-007',\n    name: 'Sumatra Mandheling 250g',\n    priceCents: 1290,\n    category: 'coffee',\n    tags: ['single-origin', 'dark-roast'],\n  },\n  {\n    sku: 'COF-008',\n    name: 'House Espresso Blend 500g',\n    priceCents: 2100,\n    category: 'coffee',\n    tags: ['espresso', 'dark-roast'],\n  },\n  {\n    sku: 'COF-009',\n    name: 'Morning Blend 500g',\n    priceCents: 1890,\n    category: 'coffee',\n    tags: ['filter', 'medium-roast'],\n  },\n  {\n    sku: 'COF-010',\n    name: 'Costa Rica Tarrazu 250g',\n    priceCents: 1490,\n    category: 'coffee',\n    tags: ['single-origin', 'light-roast'],\n  },\n  {\n    sku: 'COF-011',\n    name: 'Peru Cajamarca Organic 250g',\n    priceCents: 1390,\n    category: 'coffee',\n    tags: ['single-origin', 'organic'],\n  },\n  {\n    sku: 'COF-012',\n    name: 'Honduras Marcala 1kg',\n    priceCents: 3400,\n    category: 'coffee',\n    tags: ['single-origin', 'bulk'],\n  },\n  {\n    sku: 'COF-013',\n    name: 'Rwanda Nyamasheke 250g',\n    priceCents: 1550,\n    category: 'coffee',\n    tags: ['single-origin', 'light-roast'],\n  },\n  {\n    sku: 'COF-014',\n    name: 'Italian Roast 500g',\n    priceCents: 1790,\n    category: 'coffee',\n    tags: ['espresso', 'dark-roast'],\n  },\n  {\n    sku: 'COF-015',\n    name: 'Cold Brew Grind 500g',\n    priceCents: 1990,\n    category: 'coffee',\n    tags: ['filter', 'bulk'],\n  },\n  {\n    sku: 'COF-016',\n    name: 'Decaf Espresso Blend 500g',\n    priceCents: 2050,\n    category: 'coffee',\n    tags: ['decaf', 'espresso'],\n  },\n  {\n    sku: 'TEA-001',\n    name: 'Sencha 100g',\n    priceCents: 980,\n    category: 'tea',\n    tags: ['green', 'japanese'],\n  },\n  {\n    sku: 'TEA-002',\n    name: 'Earl Grey 100g',\n    priceCents: 760,\n    category: 'tea',\n    tags: ['black', 'flavoured'],\n  },\n  {\n    sku: 'TEA-003',\n    name: 'Rooibos 100g',\n    priceCents: 690,\n    category: 'tea',\n    tags: ['herbal', 'caffeine-free'],\n  },\n  {\n    sku: 'TEA-004',\n    name: 'Jasmine Pearls 50g',\n    priceCents: 1190,\n    category: 'tea',\n    tags: ['green', 'flavoured'],\n  },\n  {\n    sku: 'TEA-005',\n    name: 'Assam TGFOP 100g',\n    priceCents: 820,\n    category: 'tea',\n    tags: ['black', 'breakfast'],\n  },\n  {\n    sku: 'TEA-006',\n    name: 'Darjeeling First Flush 50g',\n    priceCents: 1290,\n    category: 'tea',\n    tags: ['black', 'single-estate'],\n  },\n  {\n    sku: 'TEA-007',\n    name: 'Gyokuro 50g',\n    priceCents: 1890,\n    category: 'tea',\n    tags: ['green', 'japanese'],\n  },\n  {\n    sku: 'TEA-008',\n    name: 'Matcha Ceremonial 30g',\n    priceCents: 2490,\n    category: 'tea',\n    tags: ['green', 'japanese', 'powder'],\n  },\n  {\n    sku: 'TEA-009',\n    name: 'Chamomile 50g',\n    priceCents: 590,\n    category: 'tea',\n    tags: ['herbal', 'caffeine-free'],\n  },\n  {\n    sku: 'TEA-010',\n    name: 'Peppermint 50g',\n    priceCents: 560,\n    category: 'tea',\n    tags: ['herbal', 'caffeine-free'],\n  },\n  {\n    sku: 'TEA-011',\n    name: 'Oolong Tie Guan Yin 100g',\n    priceCents: 1390,\n    category: 'tea',\n    tags: ['oolong', 'chinese'],\n  },\n  {\n    sku: 'TEA-012',\n    name: 'Pu-erh Cake 200g',\n    priceCents: 2890,\n    category: 'tea',\n    tags: ['dark', 'chinese', 'aged'],\n  },\n  {\n    sku: 'GEAR-001',\n    name: 'V60 Dripper 02',\n    priceCents: 2400,\n    category: 'gear',\n    tags: ['pour-over', 'ceramic'],\n  },\n  {\n    sku: 'GEAR-002',\n    name: 'Paper Filters 02 x100',\n    priceCents: 650,\n    category: 'gear',\n    tags: ['pour-over', 'consumable'],\n  },\n  {\n    sku: 'GEAR-003',\n    name: 'Gooseneck Kettle 1L',\n    priceCents: 5900,\n    category: 'gear',\n    tags: ['pour-over', 'steel'],\n  },\n  {\n    sku: 'GEAR-004',\n    name: 'Hand Grinder Steel Burr',\n    priceCents: 7400,\n    category: 'gear',\n    tags: ['grinder', 'steel'],\n  },\n  {\n    sku: 'GEAR-005',\n    name: 'AeroPress',\n    priceCents: 3490,\n    category: 'gear',\n    tags: ['immersion', 'travel'],\n  },\n  {\n    sku: 'GEAR-006',\n    name: 'French Press 1L',\n    priceCents: 3290,\n    category: 'gear',\n    tags: ['immersion', 'glass'],\n  },\n  {\n    sku: 'GEAR-007',\n    name: 'Digital Scale 0.1g',\n    priceCents: 4200,\n    category: 'gear',\n    tags: ['scale', 'electronic'],\n  },\n  {\n    sku: 'GEAR-008',\n    name: 'Chemex 6 Cup',\n    priceCents: 4990,\n    category: 'gear',\n    tags: ['pour-over', 'glass'],\n  },\n  {\n    sku: 'GEAR-009',\n    name: 'Chemex Filters x100',\n    priceCents: 1190,\n    category: 'gear',\n    tags: ['pour-over', 'consumable'],\n  },\n  {\n    sku: 'GEAR-010',\n    name: 'Electric Burr Grinder',\n    priceCents: 15900,\n    category: 'gear',\n    tags: ['grinder', 'electronic'],\n  },\n  {\n    sku: 'GEAR-011',\n    name: 'Teapot Kyusu 300ml',\n    priceCents: 4490,\n    category: 'gear',\n    tags: ['tea', 'ceramic'],\n  },\n  {\n    sku: 'GEAR-012',\n    name: 'Tea Infuser Basket',\n    priceCents: 1290,\n    category: 'gear',\n    tags: ['tea', 'steel'],\n  },\n];\n","/demo/nest-shop/apps/api/src/catalog/catalog.controller.ts":"import { Body, Controller, Get, Param, ParseIntPipe, Put } from '@nestjs/common';\nimport { Public } from '../auth/public.decorator';\nimport { CatalogService } from './catalog.service';\n\n@Controller('products')\nexport class CatalogController {\n  constructor(private readonly catalog: CatalogService) {}\n\n  @Public()\n  @Get()\n  list() {\n    return this.catalog.findAll();\n  }\n\n  @Public()\n  @Get(':id')\n  get(@Param('id') id: string) {\n    return this.catalog.findOne(id);\n  }\n\n  @Public()\n  @Put(':id')\n  update(@Param('id') id: string, @Body('priceCents', ParseIntPipe) priceCents: number) {\n    return this.catalog.updatePrice(id, priceCents);\n  }\n}\n","/demo/nest-shop/apps/api/src/catalog/catalog.module.ts":"import { Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { CatalogController } from './catalog.controller';\nimport { CatalogRepository } from './catalog.repository';\nimport { CatalogService } from './catalog.service';\nimport { Category } from './category.entity';\nimport { Product } from './product.entity';\nimport { Tag } from './tag.entity';\n\n@Module({\n  imports: [TypeOrmModule.forFeature([Category, Product, Tag])],\n  controllers: [CatalogController],\n  providers: [CatalogService, CatalogRepository],\n  exports: [CatalogService],\n})\nexport class CatalogModule {}\n","/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts":"import { Injectable } from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { In, Repository } from 'typeorm';\nimport { Category } from './category.entity';\nimport { Product } from './product.entity';\nimport { Tag } from './tag.entity';\n\n@Injectable()\nexport class CatalogRepository {\n  constructor(\n    @InjectRepository(Category) private readonly categories: Repository<Category>,\n    @InjectRepository(Product) private readonly products: Repository<Product>,\n    @InjectRepository(Tag) private readonly tags: Repository<Tag>,\n  ) {}\n\n  countProducts(): Promise<number> {\n    return this.products.count();\n  }\n\n  async upsertCategory(row: Partial<Category>): Promise<void> {\n    await this.categories.upsert(row, ['slug']);\n  }\n\n  async upsertTag(row: Partial<Tag>): Promise<void> {\n    await this.tags.upsert(row, ['slug']);\n  }\n\n  async upsertProduct(row: Partial<Product>): Promise<void> {\n    await this.products.upsert(row, ['sku']);\n  }\n\n  findCategories(): Promise<Category[]> {\n    return this.categories.find();\n  }\n\n  findTags(): Promise<Tag[]> {\n    return this.tags.find();\n  }\n\n  saveProduct(row: Partial<Product>): Promise<Product> {\n    return this.products.save(this.products.create(row));\n  }\n\n  findAll(): Promise<Product[]> {\n    return this.products.find({ relations: { category: true, tags: true }, order: { sku: 'ASC' } });\n  }\n\n  findOne(id: string): Promise<Product | null> {\n    return this.products.findOne({ where: { id }, relations: { category: true, tags: true } });\n  }\n\n  findByIds(ids: string[]): Promise<Product[]> {\n    return this.products.find({ where: { id: In(ids) } });\n  }\n\n  async updatePrice(id: string, priceCents: number): Promise<void> {\n    await this.products.update({ id }, { priceCents });\n  }\n}\n","/demo/nest-shop/apps/api/src/catalog/catalog.service.ts":"import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';\nimport { CatalogRepository } from './catalog.repository';\nimport { CATEGORY_SEED, PRODUCT_SEED, TAG_SEED } from './catalog-data';\nimport { Product } from './product.entity';\n\n@Injectable()\nexport class CatalogService implements OnModuleInit {\n  private readonly logger = new Logger(CatalogService.name);\n  // Whole catalog with relations, keyed by SKU, refreshed on every boot.\n  private readonly bySku = new Map<string, Product>();\n\n  constructor(private readonly catalog: CatalogRepository) {}\n\n  async onModuleInit(): Promise<void> {\n    for (const seed of CATEGORY_SEED) {\n      await this.catalog.upsertCategory(seed);\n    }\n    for (const seed of TAG_SEED) {\n      await this.catalog.upsertTag(seed);\n    }\n    const categoryBySlug = new Map((await this.catalog.findCategories()).map((c) => [c.slug, c]));\n    const tagBySlug = new Map((await this.catalog.findTags()).map((t) => [t.slug, t]));\n    for (const seed of PRODUCT_SEED) {\n      await this.catalog.upsertProduct({\n        sku: seed.sku,\n        name: seed.name,\n        priceCents: seed.priceCents,\n        category: categoryBySlug.get(seed.category),\n      });\n    }\n    const idBySku = new Map((await this.catalog.findAll()).map((p) => [p.sku, p.id]));\n    for (const seed of PRODUCT_SEED) {\n      await this.catalog.saveProduct({\n        id: idBySku.get(seed.sku),\n        tags: seed.tags.map((slug) => tagBySlug.get(slug)).filter(Boolean),\n      });\n    }\n    for (const product of await this.catalog.findAll()) {\n      this.bySku.set(product.sku, product);\n    }\n    const total = await this.catalog.countProducts();\n    this.logger.log(\n      `Catalog ready: ${this.bySku.size} of ${total} products, ${categoryBySlug.size} categories, ${tagBySlug.size} tags`,\n    );\n  }\n\n  findAll(): Promise<Product[]> {\n    return this.catalog.findAll();\n  }\n\n  async findOne(id: string): Promise<Product> {\n    const product = await this.catalog.findOne(id);\n    if (!product) {\n      throw new NotFoundException(`Product ${id} not found`);\n    }\n    return product;\n  }\n\n  findByIds(ids: string[]): Promise<Product[]> {\n    return this.catalog.findByIds(ids);\n  }\n\n  async updatePrice(id: string, priceCents: number): Promise<Product> {\n    await this.findOne(id);\n    await this.catalog.updatePrice(id, priceCents);\n    return this.findOne(id);\n  }\n}\n","/demo/nest-shop/apps/api/src/catalog/category.entity.ts":"import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';\nimport { Product } from './product.entity';\n\n@Entity({ name: 'categories' })\nexport class Category {\n  @PrimaryGeneratedColumn('uuid')\n  id: string;\n\n  @Column({ unique: true })\n  slug: string;\n\n  @Column()\n  name: string;\n\n  @OneToMany(() => Product, (product) => product.category)\n  products: Product[];\n}\n","/demo/nest-shop/apps/api/src/catalog/product.entity.ts":"import { Column, Entity, JoinTable, ManyToMany, ManyToOne, OneToMany } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\nimport { OrderItem } from '../orders/order-item.entity';\nimport { Category } from './category.entity';\nimport { Tag } from './tag.entity';\n\n@Entity({ name: 'products' })\nexport class Product extends BaseEntity {\n  @Column({ unique: true })\n  sku: string;\n\n  @Column()\n  name: string;\n\n  @Column({ name: 'price_cents', type: 'int' })\n  priceCents: number;\n\n  @ManyToOne(() => Category, (category) => category.products, { nullable: false })\n  category: Category;\n\n  @ManyToMany(() => Tag)\n  @JoinTable({ name: 'product_tags' })\n  tags: Tag[];\n\n  @OneToMany(() => OrderItem, (item) => item.product)\n  orderItems: OrderItem[];\n}\n","/demo/nest-shop/apps/api/src/catalog/tag.entity.ts":"import { Column, Entity } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\n\n@Entity({ name: 'tags' })\nexport class Tag extends BaseEntity {\n  @Column({ unique: true })\n  slug: string;\n\n  @Column()\n  name: string;\n}\n","/demo/nest-shop/apps/api/src/common/base.entity.ts":"import { CreateDateColumn, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';\n\nexport abstract class BaseEntity {\n  @PrimaryGeneratedColumn('uuid')\n  id: string;\n\n  @CreateDateColumn()\n  createdAt: Date;\n\n  @UpdateDateColumn()\n  updatedAt: Date;\n}\n","/demo/nest-shop/apps/api/src/main.ts":"import 'reflect-metadata';\nimport { writeFileSync } from 'node:fs';\nimport { performance } from 'node:perf_hooks';\nimport { Logger } from '@nestjs/common';\nimport { ConfigService } from '@nestjs/config';\nimport { NestFactory, SerializedGraph } from '@nestjs/core';\nimport { AppModule } from './app.module';\n\nconst traceEnabled = process.env.NEST_BOOT_TRACE === '1';\nconst hookTimings: { className: string; hook: string; ms: number; startMs: number }[] = [];\n\nasync function bootstrap() {\n  const t0 = performance.now();\n  const app = await NestFactory.create(AppModule, {\n    snapshot: traceEnabled,\n    instrument: traceEnabled\n      ? {\n          instanceDecorator(instance: any) {\n            if (!instance || typeof instance !== 'object') return instance;\n            for (const hook of ['onModuleInit', 'onApplicationBootstrap']) {\n              const original = instance[hook];\n              if (typeof original !== 'function') continue;\n              try {\n                instance[hook] = async function (...args: unknown[]) {\n                  const start = performance.now();\n                  try {\n                    return await original.apply(this, args);\n                  } finally {\n                    hookTimings.push({\n                      className: this.constructor.name,\n                      hook,\n                      ms: performance.now() - start,\n                      startMs: start - t0,\n                    });\n                  }\n                };\n              } catch {} // frozen instances stay untimed\n            }\n            return instance;\n          },\n        }\n      : undefined,\n  });\n  const createMs = performance.now() - t0;\n  await app.init();\n  const initMs = performance.now() - t0;\n  const moduleInits = hookTimings.filter((h) => h.hook === 'onModuleInit');\n  const moduleInitMs = moduleInits.length\n    ? Math.max(...moduleInits.map((h) => h.startMs + h.ms))\n    : undefined;\n  const port = Number(app.get(ConfigService).get<string>('PORT') ?? 3000);\n  await app.listen(port);\n  const startupMs = performance.now() - t0;\n  Logger.log(`API listening on http://localhost:${port}`, 'Bootstrap');\n\n  if (traceEnabled) {\n    const graph = JSON.parse(app.get(SerializedGraph).toString());\n    Object.assign(graph, { createMs, initMs, moduleInitMs, startupMs, hookTimings });\n    writeFileSync('nestjs-doctor-timings.json', JSON.stringify(graph));\n    Logger.log(`Boot trace written to nestjs-doctor-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');\n    await app.close();\n    process.exit(0);\n  }\n}\n\nbootstrap().catch((err) => {\n  console.error('API failed to start', err);\n  process.exit(1);\n});\n","/demo/nest-shop/apps/api/src/notifications/notifications.module.ts":"import { BullModule } from '@nestjs/bullmq';\nimport { forwardRef, Module } from '@nestjs/common';\nimport { OrdersModule } from '../orders/orders.module';\nimport { NotificationsService } from './notifications.service';\n\n@Module({\n  imports: [BullModule.registerQueue({ name: 'notifications' }), forwardRef(() => OrdersModule)],\n  providers: [NotificationsService],\n  exports: [NotificationsService],\n})\nexport class NotificationsModule {}\n","/demo/nest-shop/apps/api/src/notifications/notifications.service.ts":"import { InjectQueue } from '@nestjs/bullmq';\nimport { forwardRef, Inject, Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';\nimport { Queue } from 'bullmq';\nimport { OrderStatus } from '../orders/order.entity';\nimport { OrdersService } from '../orders/orders.service';\n\nexport type NotificationKind = 'receipt' | 'refund' | 'welcome' | 'payment-reminder';\n\n@Injectable()\nexport class NotificationsService implements OnApplicationBootstrap {\n  private readonly logger = new Logger(NotificationsService.name);\n  private readonly from = process.env.NOTIFICATIONS_FROM ?? 'shop@example.com';\n\n  constructor(\n    @InjectQueue('notifications') private readonly queue: Queue,\n    @Inject(forwardRef(() => OrdersService))\n    private readonly ordersService: OrdersService,\n  ) {}\n\n  async onApplicationBootstrap(): Promise<void> {\n    await this.queue.waitUntilReady();\n    const counts = await this.queue.getJobCounts('waiting', 'active', 'failed');\n    // TODO: requeue jobs that failed while the API was down.\n    for (const kind of ['receipt', 'refund', 'welcome'] as NotificationKind[]) {\n      await this.queue.upsertJobScheduler(\n        `digest:${kind}`,\n        { every: 3_600_000 },\n        { name: 'digest', data: { kind, from: this.from } },\n      );\n    }\n    const schedulers = await this.queue.getJobSchedulers();\n    const cleaned = await this.queue.clean(0, 100, 'completed');\n    await this.queue.trimEvents(1000);\n    const awaitingPayment = (await this.ordersService.findAll()).filter((order) => order.status === OrderStatus.Pending);\n    for (const order of awaitingPayment) {\n      await this.queue.add('payment-reminder', { orderId: order.id, from: this.from }, { jobId: `reminder-${order.id}` });\n    }\n    await new Promise((resolve) => setTimeout(resolve, 8));\n    this.logger.log(\n      `Queue ready: ${JSON.stringify(counts)}, ${schedulers.length} schedulers, ${cleaned.length} completed jobs cleaned, ${awaitingPayment.length} payment reminders`,\n    );\n  }\n\n  async enqueue(kind: NotificationKind, payload: Record<string, unknown>): Promise<string> {\n    const message = await this.buildMessage(kind, payload);\n    const job = await this.queue.add(kind, { ...payload, from: this.from, message }, { removeOnComplete: 100 });\n    this.logger.debug(`Enqueued ${kind} job ${job.id}`);\n    return job.id;\n  }\n\n  private async buildMessage(kind: NotificationKind, payload: Record<string, unknown>): Promise<string> {\n    const orderId = typeof payload.orderId === 'string' ? payload.orderId : undefined;\n    if (!orderId) {\n      return `${kind}`;\n    }\n    const order = await this.ordersService.findOne(orderId);\n    // FIXME: localise these messages once users carry a locale.\n    switch (kind) {\n      case 'receipt':\n        return `Thanks ${order.user.name}, we received ${order.totalCents / 100} for order ${order.id}`;\n      case 'refund':\n        return `Hi ${order.user.name}, order ${order.id} was refunded`;\n      default:\n        return `Update on order ${order.id}`;\n    }\n  }\n}\n","/demo/nest-shop/apps/api/src/orders/create-order.dto.ts":"import { Type } from 'class-transformer';\nimport { ArrayMinSize, IsInt, IsUUID, Min, ValidateNested } from 'class-validator';\n\nexport class OrderLineDto {\n  @IsUUID()\n  productId: string;\n\n  @IsInt()\n  @Min(1)\n  quantity: number;\n}\n\nexport class CreateOrderDto {\n  @IsUUID()\n  userId: string;\n\n  @ArrayMinSize(1)\n  @ValidateNested({ each: true })\n  @Type(() => OrderLineDto)\n  lines: OrderLineDto[];\n}\n","/demo/nest-shop/apps/api/src/orders/order-item.entity.ts":"import { Column, Entity, ManyToOne } from 'typeorm';\nimport { Product } from '../catalog/product.entity';\nimport { BaseEntity } from '../common/base.entity';\nimport { Order } from './order.entity';\n\n@Entity({ name: 'order_items' })\nexport class OrderItem extends BaseEntity {\n  @Column({ type: 'int' })\n  quantity: number;\n\n  @Column({ name: 'unit_price_cents', type: 'int' })\n  unitPriceCents: number;\n\n  @ManyToOne(() => Order, (order) => order.items, { nullable: false, onDelete: 'CASCADE' })\n  order: Order;\n\n  @ManyToOne(() => Product, (product) => product.orderItems, { nullable: false, onDelete: 'RESTRICT' })\n  product: Product;\n}\n","/demo/nest-shop/apps/api/src/orders/order.entity.ts":"import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\nimport { User } from '../users/user.entity';\nimport { OrderItem } from './order-item.entity';\n\nexport enum OrderStatus {\n  Pending = 'pending',\n  Paid = 'paid',\n  Refunded = 'refunded',\n}\n\n@Entity({ name: 'orders' })\n@Index(['status', 'createdAt'])\nexport class Order extends BaseEntity {\n  @Column({ type: 'enum', enum: OrderStatus, default: OrderStatus.Pending })\n  status: OrderStatus;\n\n  @Column({ name: 'total_cents', type: 'int', default: 0 })\n  totalCents: number;\n\n  @Column({ type: 'text', nullable: true })\n  note?: string;\n\n  @ManyToOne(() => User, (user) => user.orders, { nullable: false })\n  user: User;\n\n  @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })\n  items: OrderItem[];\n}\n","/demo/nest-shop/apps/api/src/orders/orders.controller.ts":"import { Body, Controller, Get, Param, Patch, Post, UseGuards, ValidationPipe } from '@nestjs/common';\nimport { JwtAuthGuard } from '../auth/jwt-auth.guard';\nimport { CreateOrderDto } from './create-order.dto';\nimport { OrderStatus } from './order.entity';\nimport { OrdersService } from './orders.service';\n\n@Controller('orders')\n@UseGuards(JwtAuthGuard)\nexport class OrdersController {\n  constructor(private readonly ordersService: OrdersService) {}\n\n  @Get()\n  list() {\n    return this.ordersService.findAll();\n  }\n\n  @Post()\n  create(@Body(new ValidationPipe({ whitelist: true, transform: true })) dto: CreateOrderDto) {\n    return this.ordersService.create(dto);\n  }\n\n  @Post(':id/pay')\n  pay(@Param('id') id: string, @Body() body: { provider?: string }) {\n    let surchargeCents: number;\n    switch (body.provider) {\n      case 'card':\n        surchargeCents = 30;\n        break;\n      case 'sepa':\n        surchargeCents = 0;\n        break;\n      default:\n        surchargeCents = 50;\n    }\n    return this.ordersService.pay(id, body.provider ?? 'card', surchargeCents);\n  }\n\n  @Patch(':id/status')\n  updateStatus(@Param('id') id: string, @Body('status') status: OrderStatus) {\n    return this.ordersService.updateStatus(id, status);\n  }\n}\n","/demo/nest-shop/apps/api/src/orders/orders.module.ts":"import { forwardRef, Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { AuditModule } from '../audit/audit.module';\nimport { CatalogModule } from '../catalog/catalog.module';\nimport { PaymentsModule } from '../payments/payments.module';\nimport { UsersModule } from '../users/users.module';\nimport { OrderItem } from './order-item.entity';\nimport { Order } from './order.entity';\nimport { OrdersController } from './orders.controller';\nimport { OrdersService } from './orders.service';\n\n@Module({\n  imports: [\n    TypeOrmModule.forFeature([Order, OrderItem]),\n    UsersModule,\n    CatalogModule,\n    AuditModule.register({ retentionDays: 90 }),\n    forwardRef(() => PaymentsModule),\n  ],\n  controllers: [OrdersController],\n  providers: [OrdersService],\n  exports: [OrdersService],\n})\nexport class OrdersModule {}\n","/demo/nest-shop/apps/api/src/orders/orders.service.ts":"import {\n  BadRequestException,\n  forwardRef,\n  Inject,\n  Injectable,\n  Logger,\n  NotFoundException,\n  OnApplicationBootstrap,\n  OnModuleInit,\n} from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { MetricsService } from '@app/shared';\nimport { LessThan, Repository } from 'typeorm';\nimport { AuditService } from '../audit/audit.service';\nimport { CatalogService } from '../catalog/catalog.service';\nimport { PaymentStatus } from '../payments/payment.entity';\nimport { PaymentsService } from '../payments/payments.service';\nimport { UsersService } from '../users/users.service';\nimport { CreateOrderDto } from './create-order.dto';\nimport { OrderItem } from './order-item.entity';\nimport { Order, OrderStatus } from './order.entity';\n\nconst DEMO_ORDER_COUNT = 240;\n\n@Injectable()\nexport class OrdersService implements OnModuleInit, OnApplicationBootstrap {\n  private readonly logger = new Logger(OrdersService.name);\n\n  constructor(\n    @InjectRepository(Order) private readonly orders: Repository<Order>,\n    @InjectRepository(OrderItem) private readonly items: Repository<OrderItem>,\n    private readonly usersService: UsersService,\n    private readonly catalogService: CatalogService,\n    private readonly audit: AuditService,\n    private readonly metrics: MetricsService,\n    @Inject(forwardRef(() => PaymentsService))\n    private readonly paymentsService: PaymentsService,\n  ) {}\n\n  async onModuleInit(): Promise<void> {\n    const seeded = await this.seedDemoOrders();\n    const orders = await this.orders.find({ relations: { items: true } });\n    for (const order of orders) {\n      const totalCents = order.items.reduce((sum, item) => sum + item.quantity * item.unitPriceCents, 0);\n      await this.orders.update({ id: order.id }, { totalCents });\n    }\n    this.logger.log(`Seeded ${seeded} demo orders, reconciled totals for ${orders.length}`);\n  }\n\n  async onApplicationBootstrap(): Promise<void> {\n    const rows: { status: OrderStatus; count: string }[] = await this.orders\n      .createQueryBuilder('o')\n      .select('o.status', 'status')\n      .addSelect('COUNT(*)', 'count')\n      .groupBy('o.status')\n      .getRawMany();\n    for (const row of rows) {\n      this.metrics.increment(`orders.${row.status}`, Number(row.count));\n    }\n    const stale = await this.orders.update(\n      { status: OrderStatus.Pending, createdAt: LessThan(new Date(Date.now() - 86_400_000)) },\n      { updatedAt: new Date() },\n    );\n    await this.audit.record('orders.reconciled', 'system', { counts: rows, stalePending: stale.affected ?? 0 });\n    this.logger.log(`Order counts ${JSON.stringify(rows)}, touched ${stale.affected ?? 0} stale pending orders`);\n  }\n\n  findAll(): Promise<Order[]> {\n    return this.orders.find({\n      relations: { user: true, items: { product: true } },\n      order: { createdAt: 'DESC' },\n    });\n  }\n\n  async findOne(id: string): Promise<Order> {\n    const order = await this.orders.findOne({\n      where: { id },\n      relations: { user: true, items: { product: true } },\n    });\n    if (!order) {\n      throw new NotFoundException(`Order ${id} not found`);\n    }\n    return order;\n  }\n\n  async create(dto: CreateOrderDto): Promise<Order> {\n    const user = await this.usersService.findOne(dto.userId);\n    const products = await this.catalogService.findByIds(dto.lines.map((l) => l.productId));\n    if (products.length !== dto.lines.length) {\n      throw new BadRequestException('One or more products do not exist');\n    }\n    const byId = new Map(products.map((p) => [p.id, p]));\n    const items = dto.lines.map((line) => {\n      const product = byId.get(line.productId);\n      return this.items.create({\n        product,\n        quantity: line.quantity,\n        unitPriceCents: product.priceCents,\n      });\n    });\n    const totalCents = items.reduce((sum, item) => sum + item.quantity * item.unitPriceCents, 0);\n    const order = await this.orders.save(this.orders.create({ user, items, totalCents }));\n    await this.audit.record('order.created', user.email, { orderId: order.id, totalCents });\n    this.metrics.increment('orders.created');\n    this.logger.log(`Order ${order.id} created for ${user.email} (${totalCents} cents)`);\n    return order;\n  }\n\n  async pay(id: string, provider: string, surchargeCents = 0): Promise<Order> {\n    const order = await this.findOne(id);\n    if (order.status !== OrderStatus.Pending) {\n      throw new BadRequestException(`Order ${id} is ${order.status}, cannot pay`);\n    }\n    order.totalCents += surchargeCents;\n    await this.paymentsService.charge(order, provider);\n    order.status = OrderStatus.Paid;\n    await this.orders.save(order);\n    await this.audit.record('order.paid', order.user.email, { orderId: order.id, provider });\n    this.metrics.increment('orders.paid');\n    return order;\n  }\n\n  async updateStatus(id: string, status: OrderStatus): Promise<Order> {\n    const order = await this.findOne(id);\n    if (!Object.values(OrderStatus).includes(status)) {\n      throw new BadRequestException(`Unknown status ${status}`);\n    }\n    order.status = status;\n    return this.orders.save(order);\n  }\n\n  async markRefunded(id: string): Promise<void> {\n    const order = await this.findOne(id);\n    await this.orders.update({ id }, { status: OrderStatus.Refunded });\n    this.audit.record('order.refunded', order.user.email, { orderId: id });\n  }\n\n  // Demo orders for the system user, one payment each, spread over the last 30 days.\n  private async seedDemoOrders(): Promise<number> {\n    if ((await this.orders.count()) > 0) {\n      return 0;\n    }\n    const email = 'system@shop.local';\n    const user = (await this.usersService.findByEmail(email)) ?? (await this.usersService.create({ email, name: 'System' }));\n    const products = await this.catalogService.findAll();\n    if (products.length === 0) {\n      return 0;\n    }\n    const statuses = Object.values(OrderStatus);\n    const paymentStatus = {\n      [OrderStatus.Pending]: PaymentStatus.Pending,\n      [OrderStatus.Paid]: PaymentStatus.Captured,\n      [OrderStatus.Refunded]: PaymentStatus.Refunded,\n    };\n    for (let i = 0; i < DEMO_ORDER_COUNT; i++) {\n      const items = Array.from({ length: 1 + (i % 3) }, (_, k) => {\n        const product = products[(i * 7 + k * 13) % products.length];\n        return this.items.create({ product, quantity: 1 + ((i + k) % 3), unitPriceCents: product.priceCents });\n      });\n      const status = statuses[i % statuses.length];\n      const createdAt = new Date(Date.now() - (1 + (i * 29) / DEMO_ORDER_COUNT) * 86_400_000);\n      const totalCents = items.reduce((sum, item) => sum + item.quantity * item.unitPriceCents, 0);\n      const order = await this.orders.save(this.orders.create({ user, items, status, createdAt, totalCents }));\n      await this.paymentsService.createPayment(order, i % 2 ? 'sepa' : 'card', paymentStatus[status], createdAt);\n    }\n    return DEMO_ORDER_COUNT;\n  }\n}\n","/demo/nest-shop/apps/api/src/payments/gateways/card.gateway.ts":"import { Injectable, Logger } from '@nestjs/common';\n\n@Injectable()\nexport class CardGateway {\n  private readonly logger = new Logger(CardGateway.name);\n\n  async refund(paymentId: string, amountCents: number): Promise<void> {\n    await new Promise((resolve) => setTimeout(resolve, 20));\n    this.logger.log(`Card refund for ${paymentId}: ${amountCents} cents`);\n  }\n}\n","/demo/nest-shop/apps/api/src/payments/gateways/sepa.gateway.ts":"import { Injectable, Logger } from '@nestjs/common';\n\n@Injectable()\nexport class SepaGateway {\n  private readonly logger = new Logger(SepaGateway.name);\n\n  async refund(paymentId: string, amountCents: number): Promise<void> {\n    await new Promise((resolve) => setTimeout(resolve, 40));\n    this.logger.log(`SEPA credit transfer for ${paymentId}: ${amountCents} cents`);\n  }\n}\n","/demo/nest-shop/apps/api/src/payments/invoice.entity.ts":"import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';\nimport { Order } from '../orders/order.entity';\n\n@Entity({ name: 'invoices' })\nexport class Invoice {\n  @PrimaryGeneratedColumn('uuid')\n  id: string;\n\n  @Column({ unique: true })\n  number: string;\n\n  @Column({ name: 'issued_at', type: 'timestamptz' })\n  issuedAt: Date;\n\n  @OneToOne(() => Order, { nullable: false, onDelete: 'CASCADE' })\n  @JoinColumn()\n  order: Order;\n}\n","/demo/nest-shop/apps/api/src/payments/payment.entity.ts":"import { Column, Entity, Index, ManyToOne } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\nimport { Order } from '../orders/order.entity';\n\nexport enum PaymentStatus {\n  Pending = 'pending',\n  Captured = 'captured',\n  Refunded = 'refunded',\n  Failed = 'failed',\n}\n\n@Entity({ name: 'payments' })\nexport class Payment extends BaseEntity {\n  @Index()\n  @Column()\n  provider: string;\n\n  @Column({ name: 'amount_cents', type: 'int' })\n  amountCents: number;\n\n  @Column({ type: 'enum', enum: PaymentStatus, default: PaymentStatus.Pending })\n  status: PaymentStatus;\n\n  @ManyToOne(() => Order, { nullable: false, onDelete: 'CASCADE' })\n  order: Order;\n}\n","/demo/nest-shop/apps/api/src/payments/payments.controller.ts":"import { Controller, Get, Param, Post } from '@nestjs/common';\nimport { PaymentsService } from './payments.service';\n\n@Controller('payments')\nexport class PaymentsController {\n  constructor(private readonly paymentsService: PaymentsService) {}\n\n  @Get()\n  list() {\n    return this.paymentsService.findAll();\n  }\n\n  @Post(':id/refund')\n  refund(@Param('id') id: string) {\n    return this.paymentsService.refund(id);\n  }\n}\n","/demo/nest-shop/apps/api/src/payments/payments.module.ts":"import { forwardRef, Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { AuditModule } from '../audit/audit.module';\nimport { NotificationsModule } from '../notifications/notifications.module';\nimport { CardGateway } from './gateways/card.gateway';\nimport { SepaGateway } from './gateways/sepa.gateway';\nimport { Invoice } from './invoice.entity';\nimport { Payment } from './payment.entity';\nimport { PaymentsController } from './payments.controller';\nimport { PaymentsService } from './payments.service';\n\n@Module({\n  imports: [\n    TypeOrmModule.forFeature([Payment, Invoice]),\n    AuditModule.register({ retentionDays: 90 }),\n    forwardRef(() => NotificationsModule),\n  ],\n  controllers: [PaymentsController],\n  providers: [PaymentsService, CardGateway, SepaGateway],\n  exports: [PaymentsService],\n})\nexport class PaymentsModule {}\n","/demo/nest-shop/apps/api/src/payments/payments.service.ts":"import {\n  BadRequestException,\n  forwardRef,\n  Inject,\n  Injectable,\n  Logger,\n  NotFoundException,\n  OnApplicationBootstrap,\n  OnModuleInit,\n} from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { MetricsService } from '@app/shared';\nimport { createHash, createHmac, timingSafeEqual } from 'node:crypto';\nimport { LessThan, Repository } from 'typeorm';\nimport { AuditService } from '../audit/audit.service';\nimport { NotificationsService } from '../notifications/notifications.service';\nimport { Order } from '../orders/order.entity';\nimport { CardGateway } from './gateways/card.gateway';\nimport { SepaGateway } from './gateways/sepa.gateway';\nimport { Invoice } from './invoice.entity';\nimport { Payment, PaymentStatus } from './payment.entity';\n\n@Injectable()\nexport class PaymentsService implements OnModuleInit, OnApplicationBootstrap {\n  private readonly logger = new Logger(PaymentsService.name);\n  // Pending amount per order id, warmed at boot so refunds can check quickly.\n  private readonly pendingByOrder = new Map<string, number>();\n  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';\n\n  constructor(\n    @InjectRepository(Payment) private readonly payments: Repository<Payment>,\n    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,\n    private readonly cardGateway: CardGateway,\n    private readonly sepaGateway: SepaGateway,\n    private readonly metrics: MetricsService,\n    private readonly audit: AuditService,\n    @Inject(forwardRef(() => NotificationsService))\n    private readonly notifications: NotificationsService,\n  ) {}\n\n  async onModuleInit(): Promise<void> {\n    const pending = await this.payments.find({\n      where: { status: PaymentStatus.Pending },\n      relations: { order: true },\n    });\n    for (const payment of pending) {\n      this.pendingByOrder.set(payment.order.id, payment.amountCents);\n    }\n    const perProvider: { provider: string; count: string }[] = await this.payments\n      .createQueryBuilder('p')\n      .select('p.provider', 'provider')\n      .addSelect('COUNT(*)', 'count')\n      .where('p.status = :status', { status: PaymentStatus.Pending })\n      .groupBy('p.provider')\n      .getRawMany();\n    const total = await this.payments.count();\n    const invoiced = await this.invoices.count();\n    await this.audit.record('payments.reconciled', 'system', { pending: pending.length, total, invoiced, perProvider });\n    this.logger.log(`Warmed ${pending.length} pending payments (${total} total)`);\n  }\n\n  async onApplicationBootstrap(): Promise<void> {\n    const expired = await this.payments.find({\n      where: { status: PaymentStatus.Pending, createdAt: LessThan(new Date(Date.now() - 3_600_000)) },\n      relations: { order: true },\n    });\n    for (const payment of expired) {\n      await this.audit.record('payment.expired', 'system', {\n        paymentId: payment.id,\n        orderId: payment.order.id,\n        provider: payment.provider,\n        amountCents: payment.amountCents,\n      });\n    }\n    this.logger.log(`Flagged ${expired.length} pending payments older than one hour`);\n  }\n\n  findAll(): Promise<Payment[]> {\n    return this.payments.find({ relations: { order: true }, order: { createdAt: 'DESC' } });\n  }\n\n  async charge(order: Order, provider: string): Promise<Payment> {\n    // TODO: run the charge through the provider gateway instead of capturing directly.\n    const payment = await this.payments.save(\n      this.payments.create({\n        order,\n        provider,\n        amountCents: order.totalCents,\n        status: PaymentStatus.Captured,\n      }),\n    );\n    const invoice = await this.invoices.save(\n      this.invoices.create({ order, number: this.nextInvoiceNumber(order), issuedAt: new Date() }),\n    );\n    this.pendingByOrder.delete(order.id);\n    await this.notifications.enqueue('receipt', {\n      orderId: order.id,\n      paymentId: payment.id,\n      invoiceNumber: invoice.number,\n    });\n    return payment;\n  }\n\n  async createPayment(order: Order, provider: string, status: PaymentStatus, createdAt: Date): Promise<Payment> {\n    const payment = await this.payments.save(\n      this.payments.create({ order, provider, amountCents: order.totalCents, status, createdAt }),\n    );\n    if (status !== PaymentStatus.Pending) {\n      await this.invoices.save(\n        this.invoices.create({ order, number: this.nextInvoiceNumber(order), issuedAt: createdAt }),\n      );\n    }\n    return payment;\n  }\n\n  async refund(paymentId: string): Promise<Payment> {\n    const payment = await this.payments.findOne({ where: { id: paymentId }, relations: { order: true } });\n    if (!payment) {\n      throw new NotFoundException(`Payment ${paymentId} not found`);\n    }\n    if (payment.status !== PaymentStatus.Captured) {\n      throw new BadRequestException(`Payment ${paymentId} is ${payment.status}, cannot refund`);\n    }\n    if (payment.provider === 'card') {\n      await this.cardGateway.refund(payment.id, payment.amountCents);\n    } else {\n      await this.sepaGateway.refund(payment.id, payment.amountCents);\n    }\n    payment.status = PaymentStatus.Refunded;\n    await this.payments.save(payment);\n    this.metrics.increment('payments.refunded');\n    // FIXME: the order stays \"paid\" until the notification job runs.\n    await this.notifications.enqueue('refund', { orderId: payment.order.id, paymentId });\n    return payment;\n  }\n\n  verifyWebhookSignature(rawBody: string, signature: string): boolean {\n    const expected = createHmac('sha256', this.webhookSecret).update(rawBody).digest('hex');\n    return expected.length === signature.length && timingSafeEqual(Buffer.from(expected), Buffer.from(signature));\n  }\n\n  private nextInvoiceNumber(order: Order): string {\n    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');\n    const suffix = createHash('md5').update(order.id).digest('hex').slice(0, 8);\n    return `INV-${stamp}-${suffix.toUpperCase()}`;\n  }\n}\n","/demo/nest-shop/apps/api/src/reports/reports.module.ts":"import { Module } from '@nestjs/common';\nimport { SalesReportRepository } from './reports.repository';\nimport { SalesReportService } from './reports.service';\n\n@Module({\n  providers: [SalesReportRepository, SalesReportService],\n  exports: [SalesReportService],\n})\nexport class ReportsModule {}\n","/demo/nest-shop/apps/api/src/reports/reports.repository.ts":"import { Injectable } from '@nestjs/common';\nimport { InjectDataSource } from '@nestjs/typeorm';\nimport { DataSource } from 'typeorm';\n\nexport interface DailyTotal {\n  day: string;\n  orders: number;\n  totalCents: number;\n}\n\n@Injectable()\nexport class SalesReportRepository {\n  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}\n\n  dailyTotals(days: number): Promise<DailyTotal[]> {\n    return this.dataSource.query(\n      `SELECT to_char(\"createdAt\", 'YYYY-MM-DD') AS day,\n              count(*)::int AS orders,\n              coalesce(sum(total_cents), 0)::int AS \"totalCents\"\n         FROM orders\n        WHERE status = 'paid' AND \"createdAt\" > now() - ($1 || ' days')::interval\n        GROUP BY 1 ORDER BY 1 DESC`,\n      [String(days)],\n    );\n  }\n}\n","/demo/nest-shop/apps/api/src/reports/reports.service.ts":"import { Injectable } from '@nestjs/common';\nimport { DailyTotal, SalesReportRepository } from './reports.repository';\n\n@Injectable()\nexport class SalesReportService {\n  constructor(private readonly reports: SalesReportRepository) {}\n\n  dailyTotals(days = 30): Promise<DailyTotal[]> {\n    return this.reports.dailyTotals(days);\n  }\n}\n","/demo/nest-shop/apps/api/src/users/create-user.dto.ts":"import { IsEmail, IsString, MinLength } from 'class-validator';\n\nexport class CreateUserDto {\n  @IsEmail()\n  email: string;\n\n  @IsString()\n  @MinLength(2)\n  name: string;\n}\n","/demo/nest-shop/apps/api/src/users/dto/update-user.dto.ts":"import { Type } from 'class-transformer';\nimport { IsOptional, IsString, MinLength, ValidateNested } from 'class-validator';\n\nexport class AddressDto {\n  @IsString()\n  street: string;\n\n  @IsString()\n  city: string;\n\n  @IsString()\n  @MinLength(2)\n  country: string;\n}\n\nexport class UpdateUserDto {\n  @IsOptional()\n  @IsString()\n  @MinLength(2)\n  name?: string;\n\n  @IsOptional()\n  @ValidateNested()\n  @Type(() => AddressDto)\n  addresses: AddressDto[];\n}\n","/demo/nest-shop/apps/api/src/users/user.entity.ts":"import { Column, Entity, OneToMany } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\nimport { Order } from '../orders/order.entity';\n\nexport interface Address {\n  street: string;\n  city: string;\n  country: string;\n}\n\n@Entity({ name: 'users' })\nexport class User extends BaseEntity {\n  @Column({ unique: true })\n  email: string;\n\n  @Column()\n  name: string;\n\n  @Column({ type: 'jsonb', default: [] })\n  addresses: Address[];\n\n  @OneToMany(() => Order, (order) => order.user)\n  orders: Order[];\n}\n","/demo/nest-shop/apps/api/src/users/users.controller.ts":"import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards, ValidationPipe } from '@nestjs/common';\nimport { JwtAuthGuard } from '../auth/jwt-auth.guard';\nimport { CreateUserDto } from './create-user.dto';\nimport { UpdateUserDto } from './dto/update-user.dto';\nimport { UsersService } from './users.service';\n\n@Controller('users')\n@UseGuards(JwtAuthGuard)\nexport class UsersController {\n  constructor(private readonly usersService: UsersService) {}\n\n  @Get()\n  list() {\n    return this.usersService.findAll();\n  }\n\n  @Get(':id')\n  get(@Param('id') id: string) {\n    return this.usersService.findOne(id);\n  }\n\n  @Post()\n  create(@Body(new ValidationPipe({ whitelist: true })) dto: CreateUserDto) {\n    return this.usersService.create(dto);\n  }\n\n  @Patch(':id')\n  update(\n    @Param('id') id: string,\n    @Body(new ValidationPipe({ whitelist: true, transform: true })) dto: UpdateUserDto,\n  ) {\n    return this.usersService.update(id, dto);\n  }\n\n  @Delete(':id')\n  remove(@Param('id') id: string) {\n    return this.usersService.remove(id);\n  }\n}\n","/demo/nest-shop/apps/api/src/users/users.module.ts":"import { Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { User } from './user.entity';\nimport { UsersController } from './users.controller';\nimport { UsersRepository } from './users.repository';\nimport { UsersService } from './users.service';\n\n@Module({\n  imports: [TypeOrmModule.forFeature([User])],\n  controllers: [UsersController],\n  providers: [UsersService, UsersRepository],\n  exports: [UsersService],\n})\nexport class UsersModule {}\n","/demo/nest-shop/apps/api/src/users/users.repository.ts":"import { Injectable } from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { Repository } from 'typeorm';\nimport { User } from './user.entity';\n\n@Injectable()\nexport class UsersRepository {\n  constructor(@InjectRepository(User) private readonly users: Repository<User>) {}\n\n  findAll(): Promise<User[]> {\n    return this.users.find({ order: { createdAt: 'DESC' } });\n  }\n\n  findOne(id: string): Promise<User | null> {\n    return this.users.findOne({ where: { id } });\n  }\n\n  findByEmail(email: string): Promise<User | null> {\n    return this.users.findOne({ where: { email } });\n  }\n\n  save(row: Partial<User>): Promise<User> {\n    return this.users.save(this.users.create(row));\n  }\n\n  async upsert(row: Partial<User>): Promise<void> {\n    await this.users.upsert(row, ['email']);\n  }\n\n  async remove(id: string): Promise<void> {\n    await this.users.delete({ id });\n  }\n}\n","/demo/nest-shop/apps/api/src/users/users.service.ts":"import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';\nimport { CreateUserDto } from './create-user.dto';\nimport { UpdateUserDto } from './dto/update-user.dto';\nimport { User } from './user.entity';\nimport { UsersRepository } from './users.repository';\n\n@Injectable()\nexport class UsersService implements OnModuleInit {\n  private readonly logger = new Logger(UsersService.name);\n  private readonly byEmail = new Map<string, User>();\n  private systemUser: User;\n\n  constructor(private readonly users: UsersRepository) {}\n\n  async onModuleInit(): Promise<void> {\n    await this.users.upsert({ email: 'system@shop.local', name: 'System', addresses: [] });\n    this.systemUser = await this.users.findByEmail('system@shop.local');\n    for (const user of await this.users.findAll()) {\n      this.byEmail.set(user.email, user);\n    }\n    this.logger.log(`Warmed ${this.byEmail.size} users, system user ${this.systemUser.id}`);\n  }\n\n  findAll(): Promise<User[]> {\n    return this.users.findAll();\n  }\n\n  async findOne(id: string): Promise<User> {\n    const user = await this.users.findOne(id);\n    if (!user) {\n      throw new NotFoundException(`User ${id} not found`);\n    }\n    return user;\n  }\n\n  findByEmail(email: string): Promise<User | null> {\n    return this.users.findByEmail(email);\n  }\n\n  create(dto: CreateUserDto): Promise<User> {\n    return this.users.save({ email: dto.email.toLowerCase(), name: dto.name, addresses: [] });\n  }\n\n  async update(id: string, dto: UpdateUserDto): Promise<User> {\n    const user = await this.findOne(id);\n    return this.users.save({ ...user, name: dto.name ?? user.name, addresses: dto.addresses ?? user.addresses });\n  }\n\n  async remove(id: string): Promise<void> {\n    await this.findOne(id);\n    await this.users.remove(id);\n  }\n}\n","/demo/nest-shop/apps/worker/src/jobs/jobs.module.ts":"import { BullModule } from '@nestjs/bullmq';\nimport { Module } from '@nestjs/common';\nimport { JobsService } from './jobs.service';\nimport { NotificationsProcessor } from './notifications.processor';\n\n@Module({\n  imports: [BullModule.registerQueue({ name: 'notifications' })],\n  providers: [NotificationsProcessor, JobsService],\n  exports: [JobsService],\n})\nexport class JobsModule {}\n","/demo/nest-shop/apps/worker/src/jobs/jobs.service.ts":"import { InjectQueue } from '@nestjs/bullmq';\nimport { Injectable } from '@nestjs/common';\nimport { MetricsService } from '@app/shared';\nimport { Queue } from 'bullmq';\n\n@Injectable()\nexport class JobsService {\n  constructor(\n    @InjectQueue('notifications') private readonly queue: Queue,\n    private readonly metrics: MetricsService,\n  ) {}\n\n  async stats() {\n    const counts = await this.queue.getJobCounts('waiting', 'active', 'completed', 'failed');\n    return { queue: counts, processed: this.metrics.snapshot() };\n  }\n}\n","/demo/nest-shop/apps/worker/src/jobs/notifications.processor.ts":"import { Processor, WorkerHost } from '@nestjs/bullmq';\nimport { Logger } from '@nestjs/common';\nimport { MetricsService } from '@app/shared';\nimport { Job } from 'bullmq';\n\n@Processor('notifications')\nexport class NotificationsProcessor extends WorkerHost {\n  private readonly logger = new Logger(NotificationsProcessor.name);\n\n  constructor(private readonly metrics: MetricsService) {\n    super();\n  }\n\n  async process(job: Job<{ message?: string; orderId?: string }>): Promise<void> {\n    this.logger.log(`[${job.name}] #${job.id} ${job.data.message ?? ''}`);\n    this.metrics.increment(`notifications.${job.name}`);\n  }\n}\n","/demo/nest-shop/apps/worker/src/main.ts":"import 'reflect-metadata';\nimport { Logger } from '@nestjs/common';\nimport { NestFactory } from '@nestjs/core';\nimport { WorkerModule } from './worker.module';\n\nasync function bootstrap() {\n  const app = await NestFactory.createApplicationContext(WorkerModule);\n  app.enableShutdownHooks();\n  Logger.log('Worker started, waiting for jobs', 'Bootstrap');\n}\n\nbootstrap().catch((err) => {\n  console.error('Worker failed to start', err);\n  process.exit(1);\n});\n","/demo/nest-shop/apps/worker/src/sync/sync.module.ts":"import { Module } from '@nestjs/common';\nimport { SyncRepository } from './sync.repository';\nimport { SyncService } from './sync.service';\n\n@Module({\n  providers: [SyncService, SyncRepository],\n})\nexport class SyncModule {}\n","/demo/nest-shop/apps/worker/src/sync/sync.repository.ts":"import { Injectable } from '@nestjs/common';\nimport { InjectDataSource } from '@nestjs/typeorm';\nimport { DataSource } from 'typeorm';\n\nexport interface CatalogCounts {\n  products: number;\n  categories: number;\n}\n\n@Injectable()\nexport class SyncRepository {\n  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}\n\n  async catalogCounts(): Promise<CatalogCounts> {\n    const [row] = await this.dataSource.query(\n      'SELECT count(*)::int AS products, count(DISTINCT \"categoryId\")::int AS categories FROM products',\n    );\n    return row;\n  }\n}\n","/demo/nest-shop/apps/worker/src/sync/sync.service.ts":"import { Injectable, Logger, OnModuleInit } from '@nestjs/common';\nimport { MetricsService } from '@app/shared';\nimport { SyncRepository } from './sync.repository';\n\n@Injectable()\nexport class SyncService implements OnModuleInit {\n  private readonly logger = new Logger(SyncService.name);\n\n  constructor(\n    private readonly sync: SyncRepository,\n    private readonly metrics: MetricsService,\n  ) {}\n\n  async onModuleInit(): Promise<void> {\n    // TODO: compare against the upstream feed and flag drift.\n    const counts = await this.sync.catalogCounts();\n    this.metrics.increment('sync.checks');\n    // FIXME: schedule this on an interval instead of running once at boot.\n    this.logger.log(`Catalog check: ${counts.products} products across ${counts.categories} categories`);\n  }\n}\n","/demo/nest-shop/apps/worker/src/worker.module.ts":"import { BullModule } from '@nestjs/bullmq';\nimport { Module } from '@nestjs/common';\nimport { ConfigModule, ConfigService } from '@nestjs/config';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { SharedModule } from '@app/shared';\nimport { JobsModule } from './jobs/jobs.module';\nimport { SyncModule } from './sync/sync.module';\n\n@Module({\n  imports: [\n    ConfigModule.forRoot({ isGlobal: true, envFilePath: ['.env'] }),\n    BullModule.forRootAsync({\n      inject: [ConfigService],\n      useFactory: (config: ConfigService) => ({\n        connection: {\n          host: config.getOrThrow<string>('REDIS_HOST'),\n          port: Number(config.getOrThrow<string>('REDIS_PORT')),\n        },\n      }),\n    }),\n    TypeOrmModule.forRootAsync({\n      inject: [ConfigService],\n      useFactory: (config: ConfigService) => ({\n        type: 'postgres',\n        host: config.getOrThrow<string>('DATABASE_HOST'),\n        port: Number(config.getOrThrow<string>('DATABASE_PORT')),\n        username: config.getOrThrow<string>('DATABASE_USER'),\n        password: config.getOrThrow<string>('DATABASE_PASSWORD'),\n        database: config.getOrThrow<string>('DATABASE_NAME'),\n        autoLoadEntities: true,\n      }),\n    }),\n    SharedModule,\n    JobsModule,\n    SyncModule,\n  ],\n})\nexport class WorkerModule {}\n","/demo/nest-shop/libs/shared/src/app-config.service.ts":"import { Injectable } from '@nestjs/common';\nimport { ConfigService } from '@nestjs/config';\n\nexport interface DatabaseOptions {\n  host: string;\n  port: number;\n  username: string;\n  password: string;\n  database: string;\n}\n\nexport interface RedisOptions {\n  host: string;\n  port: number;\n}\n\n@Injectable()\nexport class AppConfigService {\n  constructor(private readonly config: ConfigService) {}\n\n  databaseOptions(): DatabaseOptions {\n    return {\n      host: this.config.getOrThrow<string>('DATABASE_HOST'),\n      port: Number(this.config.getOrThrow<string>('DATABASE_PORT')),\n      username: this.config.getOrThrow<string>('DATABASE_USER'),\n      password: this.config.getOrThrow<string>('DATABASE_PASSWORD'),\n      database: this.config.getOrThrow<string>('DATABASE_NAME'),\n    };\n  }\n\n  redisOptions(): RedisOptions {\n    return {\n      host: this.config.getOrThrow<string>('REDIS_HOST'),\n      port: Number(this.config.getOrThrow<string>('REDIS_PORT')),\n    };\n  }\n\n  get port(): number {\n    return Number(this.config.get<string>('PORT') ?? 3000);\n  }\n}\n","/demo/nest-shop/libs/shared/src/index.ts":"export * from './shared.module';\nexport * from './metrics.service';\nexport * from './app-config.service';\nexport * from './request-context.service';\nexport * from './redis.strategy';\n","/demo/nest-shop/libs/shared/src/metrics.service.ts":"import { Injectable, Scope } from '@nestjs/common';\n\nconst SEED_COUNTERS = ['orders.created', 'orders.paid', 'payments.refunded'];\n\n@Injectable({ scope: Scope.TRANSIENT })\nexport class MetricsService {\n  private readonly counters = new Map<string, number>();\n\n  async onModuleInit(): Promise<void> {\n    await new Promise((resolve) => setTimeout(resolve, 5));\n    for (const name of SEED_COUNTERS) {\n      this.counters.set(name, 0);\n    }\n  }\n\n  increment(name: string, by = 1): void {\n    this.counters.set(name, (this.counters.get(name) ?? 0) + by);\n  }\n\n  snapshot(): Record<string, number> {\n    return Object.fromEntries(this.counters);\n  }\n}\n","/demo/nest-shop/libs/shared/src/redis.strategy.ts":"import { Injectable } from '@nestjs/common';\nimport { AppConfigService } from './app-config.service';\n\nexport interface RedisConnectionOptions {\n  host: string;\n  port: number;\n  maxRetriesPerRequest: null;\n  enableReadyCheck: boolean;\n}\n\n@Injectable()\nexport class RedisStrategy {\n  constructor(private readonly config: AppConfigService) {}\n\n  connectionOptions(): RedisConnectionOptions {\n    return { ...this.config.redisOptions(), maxRetriesPerRequest: null, enableReadyCheck: true };\n  }\n}\n","/demo/nest-shop/libs/shared/src/request-context.service.ts":"import { Injectable, Scope } from '@nestjs/common';\nimport { randomUUID } from 'node:crypto';\n\n@Injectable({ scope: Scope.REQUEST })\nexport class RequestContextService {\n  readonly requestId = randomUUID();\n  readonly startedAt = new Date();\n}\n","/demo/nest-shop/libs/shared/src/shared.module.ts":"import { Global, Module } from '@nestjs/common';\nimport { ConfigModule } from '@nestjs/config';\nimport { AppConfigService } from './app-config.service';\nimport { MetricsService } from './metrics.service';\nimport { RedisStrategy } from './redis.strategy';\nimport { RequestContextService } from './request-context.service';\n\n@Global()\n@Module({\n  imports: [ConfigModule],\n  providers: [MetricsService, AppConfigService, RequestContextService, RedisStrategy],\n  exports: [MetricsService, AppConfigService, RequestContextService, RedisStrategy],\n})\nexport class SharedModule {}\n"}}
+{
+  "schemaVersion": 1,
+  "generator": {
+    "name": "nestjs-doctor",
+    "version": "0.9.3"
+  },
+  "generatedAt": "2026-08-31T17:44:35.188Z",
+  "monorepo": true,
+  "project": {
+    "name": "monorepo",
+    "nestVersion": "12.0.1",
+    "orm": "typeorm",
+    "framework": "express",
+    "fileCount": 58,
+    "moduleCount": 12
+  },
+  "score": {
+    "value": 93,
+    "label": "Excellent"
+  },
+  "summary": {
+    "total": 26,
+    "errors": 4,
+    "warnings": 15,
+    "info": 7,
+    "byCategory": {
+      "security": 6,
+      "performance": 6,
+      "correctness": 5,
+      "architecture": 5,
+      "schema": 4
+    }
+  },
+  "diagnostics": [
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/app.module.ts",
+      "message": "TypeORM 'synchronize: true' can auto-drop columns and tables in production.",
+      "help": "Set synchronize: false and use migrations for production schema changes.",
+      "line": 27,
+      "column": 1,
+      "rule": "security/no-synchronize-in-production",
+      "category": "security",
+      "scope": "file",
+      "severity": "error",
+      "sourceLines": [
+        {
+          "line": 22,
+          "text": "        port: Number(config.getOrThrow<string>('DATABASE_PORT')),"
+        },
+        {
+          "line": 23,
+          "text": "        username: config.getOrThrow<string>('DATABASE_USER'),"
+        },
+        {
+          "line": 24,
+          "text": "        password: config.getOrThrow<string>('DATABASE_PASSWORD'),"
+        },
+        {
+          "line": 25,
+          "text": "        database: config.getOrThrow<string>('DATABASE_NAME'),"
+        },
+        {
+          "line": 26,
+          "text": "        autoLoadEntities: true,"
+        },
+        {
+          "line": 27,
+          "text": "        synchronize: true,"
+        },
+        {
+          "line": 28,
+          "text": "      }),"
+        },
+        {
+          "line": 29,
+          "text": "    }),"
+        },
+        {
+          "line": 30,
+          "text": "    BullModule.forRootAsync({"
+        },
+        {
+          "line": 31,
+          "text": "      inject: [ConfigService],"
+        },
+        {
+          "line": 32,
+          "text": "      useFactory: (config: ConfigService) => ({"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/audit/audit.service.ts",
+      "message": "Constructor parameter 'logs' should be readonly.",
+      "help": "Add the 'readonly' modifier to the constructor parameter.",
+      "line": 15,
+      "column": 13,
+      "rule": "correctness/prefer-readonly-injection",
+      "category": "correctness",
+      "scope": "file",
+      "severity": "warning",
+      "surfaces": [
+        "cli"
+      ],
+      "sourceLines": [
+        {
+          "line": 10,
+          "text": ""
+        },
+        {
+          "line": 11,
+          "text": "@Injectable()"
+        },
+        {
+          "line": 12,
+          "text": "export class AuditService {"
+        },
+        {
+          "line": 13,
+          "text": "  constructor("
+        },
+        {
+          "line": 14,
+          "text": "    @Inject(AUDIT_OPTIONS) private readonly options: AuditOptions,"
+        },
+        {
+          "line": 15,
+          "text": "    private logs: AuditRepository,"
+        },
+        {
+          "line": 16,
+          "text": "  ) {}"
+        },
+        {
+          "line": 17,
+          "text": ""
+        },
+        {
+          "line": 18,
+          "text": "  record(action: string, actor: string, payload: Record<string, unknown> = {}): Promise<AuditLog> {"
+        },
+        {
+          "line": 19,
+          "text": "    return this.logs.insert(action, actor, payload);"
+        },
+        {
+          "line": 20,
+          "text": "  }"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/main.ts",
+      "message": "Synchronous I/O call 'writeFileSync()' blocks the event loop.",
+      "help": "Use the async variant (e.g., readFile instead of readFileSync) with await.",
+      "line": 59,
+      "column": 1,
+      "rule": "performance/no-sync-io",
+      "category": "performance",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 54,
+          "text": "  Logger.log(`API listening on http://localhost:${port}`, 'Bootstrap');"
+        },
+        {
+          "line": 55,
+          "text": ""
+        },
+        {
+          "line": 56,
+          "text": "  if (traceEnabled) {"
+        },
+        {
+          "line": 57,
+          "text": "    const graph = JSON.parse(app.get(SerializedGraph).toString());"
+        },
+        {
+          "line": 58,
+          "text": "    Object.assign(graph, { createMs, initMs, moduleInitMs, startupMs, hookTimings });"
+        },
+        {
+          "line": 59,
+          "text": "    writeFileSync('nestjs-doctor-timings.json', JSON.stringify(graph));"
+        },
+        {
+          "line": 60,
+          "text": "    Logger.log(`Boot trace written to nestjs-doctor-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');"
+        },
+        {
+          "line": 61,
+          "text": "    await app.close();"
+        },
+        {
+          "line": 62,
+          "text": "    process.exit(0);"
+        },
+        {
+          "line": 63,
+          "text": "  }"
+        },
+        {
+          "line": 64,
+          "text": "}"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/notifications/notifications.service.ts",
+      "message": "Direct 'process.env.NOTIFICATIONS_FROM' access in 'NotificationsService'. Use ConfigService instead.",
+      "help": "Inject ConfigService and use configService.get('VAR_NAME') instead of process.env.VAR_NAME.",
+      "line": 13,
+      "column": 1,
+      "rule": "security/no-exposed-env-vars",
+      "category": "security",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 8,
+          "text": "export type NotificationKind = 'receipt' | 'refund' | 'welcome' | 'payment-reminder';"
+        },
+        {
+          "line": 9,
+          "text": ""
+        },
+        {
+          "line": 10,
+          "text": "@Injectable()"
+        },
+        {
+          "line": 11,
+          "text": "export class NotificationsService implements OnApplicationBootstrap {"
+        },
+        {
+          "line": 12,
+          "text": "  private readonly logger = new Logger(NotificationsService.name);"
+        },
+        {
+          "line": 13,
+          "text": "  private readonly from = process.env.NOTIFICATIONS_FROM ?? 'shop@example.com';"
+        },
+        {
+          "line": 14,
+          "text": ""
+        },
+        {
+          "line": 15,
+          "text": "  constructor("
+        },
+        {
+          "line": 16,
+          "text": "    @InjectQueue('notifications') private readonly queue: Queue,"
+        },
+        {
+          "line": 17,
+          "text": "    private readonly catalogService: CatalogService,"
+        },
+        {
+          "line": 18,
+          "text": "    @Inject(forwardRef(() => OrdersService))"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/orders/orders.controller.ts",
+      "message": "Controller method 'pay' contains business logic (0 if, 0 loops, 1 switch). Move to a service.",
+      "help": "Extract branches, loops, and complex calculations into a service method.",
+      "line": 22,
+      "column": 1,
+      "rule": "architecture/no-business-logic-in-controllers",
+      "category": "architecture",
+      "scope": "file",
+      "severity": "error",
+      "sourceLines": [
+        {
+          "line": 17,
+          "text": "  @Post()"
+        },
+        {
+          "line": 18,
+          "text": "  create(@Body(new ValidationPipe({ whitelist: true, transform: true })) dto: CreateOrderDto) {"
+        },
+        {
+          "line": 19,
+          "text": "    return this.ordersService.create(dto);"
+        },
+        {
+          "line": 20,
+          "text": "  }"
+        },
+        {
+          "line": 21,
+          "text": ""
+        },
+        {
+          "line": 22,
+          "text": "  @Post(':id/pay')"
+        },
+        {
+          "line": 23,
+          "text": "  pay(@Param('id') id: string, @Body() body: { provider?: string }) {"
+        },
+        {
+          "line": 24,
+          "text": "    let surchargeCents: number;"
+        },
+        {
+          "line": 25,
+          "text": "    switch (body.provider) {"
+        },
+        {
+          "line": 26,
+          "text": "      case 'card':"
+        },
+        {
+          "line": 27,
+          "text": "        surchargeCents = 30;"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+      "message": "Service uses @InjectRepository() directly. Consider wrapping in a repository class.",
+      "help": "Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.",
+      "line": 30,
+      "column": 1,
+      "rule": "architecture/no-orm-in-services",
+      "category": "architecture",
+      "scope": "file",
+      "severity": "info",
+      "sourceLines": [
+        {
+          "line": 25,
+          "text": "@Injectable()"
+        },
+        {
+          "line": 26,
+          "text": "export class OrdersService implements OnModuleInit, OnApplicationBootstrap {"
+        },
+        {
+          "line": 27,
+          "text": "  private readonly logger = new Logger(OrdersService.name);"
+        },
+        {
+          "line": 28,
+          "text": ""
+        },
+        {
+          "line": 29,
+          "text": "  constructor("
+        },
+        {
+          "line": 30,
+          "text": "    @InjectRepository(Order) private readonly orders: Repository<Order>,"
+        },
+        {
+          "line": 31,
+          "text": "    @InjectRepository(OrderItem) private readonly items: Repository<OrderItem>,"
+        },
+        {
+          "line": 32,
+          "text": "    private readonly usersService: UsersService,"
+        },
+        {
+          "line": 33,
+          "text": "    private readonly catalogService: CatalogService,"
+        },
+        {
+          "line": 34,
+          "text": "    private readonly audit: AuditService,"
+        },
+        {
+          "line": 35,
+          "text": "    private readonly metrics: MetricsService,"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+      "message": "Async call 'record()' is not awaited — unhandled rejections will crash the process.",
+      "help": "Add await before the async call, or use void with explicit error handling if fire-and-forget is intentional.",
+      "line": 137,
+      "column": 1,
+      "rule": "correctness/no-fire-and-forget-async",
+      "category": "correctness",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 132,
+          "text": "  }"
+        },
+        {
+          "line": 133,
+          "text": ""
+        },
+        {
+          "line": 134,
+          "text": "  async markRefunded(id: string): Promise<void> {"
+        },
+        {
+          "line": 135,
+          "text": "    const order = await this.findOne(id);"
+        },
+        {
+          "line": 136,
+          "text": "    await this.orders.update({ id }, { status: OrderStatus.Refunded });"
+        },
+        {
+          "line": 137,
+          "text": "    this.audit.record('order.refunded', order.user.email, { orderId: id });"
+        },
+        {
+          "line": 138,
+          "text": "  }"
+        },
+        {
+          "line": 139,
+          "text": ""
+        },
+        {
+          "line": 140,
+          "text": "  // Demo orders for the system user, one payment each, spread over the last 30 days."
+        },
+        {
+          "line": 141,
+          "text": "  private async seedDemoOrders(): Promise<number> {"
+        },
+        {
+          "line": 142,
+          "text": "    if ((await this.orders.count()) > 0) {"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/payments/payments.controller.ts",
+      "message": "Endpoint 'list' has no @UseGuards() at class or method level.",
+      "help": "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.",
+      "line": 8,
+      "column": 1,
+      "rule": "security/require-guards-on-endpoints",
+      "category": "security",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 3,
+          "text": ""
+        },
+        {
+          "line": 4,
+          "text": "@Controller('payments')"
+        },
+        {
+          "line": 5,
+          "text": "export class PaymentsController {"
+        },
+        {
+          "line": 6,
+          "text": "  constructor(private readonly paymentsService: PaymentsService) {}"
+        },
+        {
+          "line": 7,
+          "text": ""
+        },
+        {
+          "line": 8,
+          "text": "  @Get()"
+        },
+        {
+          "line": 9,
+          "text": "  list() {"
+        },
+        {
+          "line": 10,
+          "text": "    return this.paymentsService.findAll();"
+        },
+        {
+          "line": 11,
+          "text": "  }"
+        },
+        {
+          "line": 12,
+          "text": ""
+        },
+        {
+          "line": 13,
+          "text": "  @Post(':id/refund')"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/payments/payments.controller.ts",
+      "message": "Endpoint 'refund' has no @UseGuards() at class or method level.",
+      "help": "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.",
+      "line": 13,
+      "column": 1,
+      "rule": "security/require-guards-on-endpoints",
+      "category": "security",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 8,
+          "text": "  @Get()"
+        },
+        {
+          "line": 9,
+          "text": "  list() {"
+        },
+        {
+          "line": 10,
+          "text": "    return this.paymentsService.findAll();"
+        },
+        {
+          "line": 11,
+          "text": "  }"
+        },
+        {
+          "line": 12,
+          "text": ""
+        },
+        {
+          "line": 13,
+          "text": "  @Post(':id/refund')"
+        },
+        {
+          "line": 14,
+          "text": "  refund(@Param('id') id: string) {"
+        },
+        {
+          "line": 15,
+          "text": "    return this.paymentsService.refund(id);"
+        },
+        {
+          "line": 16,
+          "text": "  }"
+        },
+        {
+          "line": 17,
+          "text": "}"
+        },
+        {
+          "line": 18,
+          "text": ""
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+      "message": "Service uses @InjectRepository() directly. Consider wrapping in a repository class.",
+      "help": "Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.",
+      "line": 31,
+      "column": 1,
+      "rule": "architecture/no-orm-in-services",
+      "category": "architecture",
+      "scope": "file",
+      "severity": "info",
+      "sourceLines": [
+        {
+          "line": 26,
+          "text": "  // Pending amount per order id, warmed at boot so refunds can check quickly."
+        },
+        {
+          "line": 27,
+          "text": "  private readonly pendingByOrder = new Map<string, number>();"
+        },
+        {
+          "line": 28,
+          "text": "  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';"
+        },
+        {
+          "line": 29,
+          "text": ""
+        },
+        {
+          "line": 30,
+          "text": "  constructor("
+        },
+        {
+          "line": 31,
+          "text": "    @InjectRepository(Payment) private readonly payments: Repository<Payment>,"
+        },
+        {
+          "line": 32,
+          "text": "    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,"
+        },
+        {
+          "line": 33,
+          "text": "    private readonly cardGateway: CardGateway,"
+        },
+        {
+          "line": 34,
+          "text": "    private readonly sepaGateway: SepaGateway,"
+        },
+        {
+          "line": 35,
+          "text": "    private readonly metrics: MetricsService,"
+        },
+        {
+          "line": 36,
+          "text": "    private readonly audit: AuditService,"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+      "message": "Property 'webhookSecret' appears to contain a hardcoded secret.",
+      "help": "Move secrets to environment variables and access them via ConfigService.",
+      "line": 28,
+      "column": 1,
+      "rule": "security/no-hardcoded-secrets",
+      "category": "security",
+      "scope": "file",
+      "severity": "error",
+      "sourceLines": [
+        {
+          "line": 23,
+          "text": "@Injectable()"
+        },
+        {
+          "line": 24,
+          "text": "export class PaymentsService implements OnModuleInit, OnApplicationBootstrap {"
+        },
+        {
+          "line": 25,
+          "text": "  private readonly logger = new Logger(PaymentsService.name);"
+        },
+        {
+          "line": 26,
+          "text": "  // Pending amount per order id, warmed at boot so refunds can check quickly."
+        },
+        {
+          "line": 27,
+          "text": "  private readonly pendingByOrder = new Map<string, number>();"
+        },
+        {
+          "line": 28,
+          "text": "  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';"
+        },
+        {
+          "line": 29,
+          "text": ""
+        },
+        {
+          "line": 30,
+          "text": "  constructor("
+        },
+        {
+          "line": 31,
+          "text": "    @InjectRepository(Payment) private readonly payments: Repository<Payment>,"
+        },
+        {
+          "line": 32,
+          "text": "    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,"
+        },
+        {
+          "line": 33,
+          "text": "    private readonly cardGateway: CardGateway,"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+      "message": "Weak hashing algorithm 'md5' used in createHash().",
+      "help": "Use a stronger algorithm like SHA-256 or bcrypt for password hashing.",
+      "line": 144,
+      "column": 1,
+      "rule": "security/no-weak-crypto",
+      "category": "security",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 139,
+          "text": "    return expected.length === signature.length && timingSafeEqual(Buffer.from(expected), Buffer.from(signature));"
+        },
+        {
+          "line": 140,
+          "text": "  }"
+        },
+        {
+          "line": 141,
+          "text": ""
+        },
+        {
+          "line": 142,
+          "text": "  private nextInvoiceNumber(order: Order): string {"
+        },
+        {
+          "line": 143,
+          "text": "    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');"
+        },
+        {
+          "line": 144,
+          "text": "    const suffix = createHash('md5').update(order.id).digest('hex').slice(0, 8);"
+        },
+        {
+          "line": 145,
+          "text": "    return `INV-${stamp}-${suffix.toUpperCase()}`;"
+        },
+        {
+          "line": 146,
+          "text": "  }"
+        },
+        {
+          "line": 147,
+          "text": "}"
+        },
+        {
+          "line": 148,
+          "text": ""
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/users/dto/update-user.dto.ts",
+      "message": "Property 'addresses' is an array with @ValidateNested() but missing { each: true }.",
+      "help": "Change @ValidateNested() to @ValidateNested({ each: true }) for array properties.",
+      "line": 23,
+      "column": 1,
+      "rule": "correctness/validate-nested-array-each",
+      "category": "correctness",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 18,
+          "text": "  @IsString()"
+        },
+        {
+          "line": 19,
+          "text": "  @MinLength(2)"
+        },
+        {
+          "line": 20,
+          "text": "  name?: string;"
+        },
+        {
+          "line": 21,
+          "text": ""
+        },
+        {
+          "line": 22,
+          "text": "  @IsOptional()"
+        },
+        {
+          "line": 23,
+          "text": "  @ValidateNested()"
+        },
+        {
+          "line": 24,
+          "text": "  @Type(() => AddressDto)"
+        },
+        {
+          "line": 25,
+          "text": "  addresses: AddressDto[];"
+        },
+        {
+          "line": 26,
+          "text": "}"
+        },
+        {
+          "line": 27,
+          "text": ""
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/orders/orders.module.ts",
+      "message": "Circular module dependency detected: OrdersModule -> PaymentsModule -> NotificationsModule",
+      "help": "OrdersModule -> PaymentsModule: OrdersService (in OrdersModule) injects PaymentsService (from PaymentsModule)\nPaymentsModule -> NotificationsModule: PaymentsService (in PaymentsModule) injects NotificationsService (from NotificationsModule)\nNotificationsModule -> OrdersModule: NotificationsService (in NotificationsModule) injects OrdersService (from OrdersModule)\nConsider extracting PaymentsService into a shared module — it would break the OrdersModule -> PaymentsModule edge (1 dependency).",
+      "line": 11,
+      "column": 1,
+      "rule": "architecture/no-circular-module-deps",
+      "category": "architecture",
+      "scope": "project",
+      "severity": "error",
+      "tags": [
+        "module-graph"
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/audit/audit-archiver.service.ts",
+      "message": "Provider 'AuditArchiverService' is never injected by any other provider or controller.",
+      "help": "Remove the unused provider, inject it where needed, or verify the framework activates it, through a decorator such as @Cron or @OnEvent or a contract such as OnModuleInit or CanActivate.",
+      "line": 4,
+      "column": 1,
+      "rule": "performance/no-unused-providers",
+      "category": "performance",
+      "scope": "project",
+      "severity": "warning",
+      "tags": [
+        "module-graph"
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/reports/reports.module.ts",
+      "message": "Module 'ReportsModule' is never imported by any other module.",
+      "help": "Import this module in another module or remove it if it is unused.",
+      "line": 5,
+      "column": 1,
+      "rule": "performance/no-orphan-modules",
+      "category": "performance",
+      "scope": "project",
+      "severity": "info",
+      "tags": [
+        "module-graph"
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/catalog/category.entity.ts",
+      "entity": "Category",
+      "message": "Entity 'Category' has no timestamp columns (createdAt/updatedAt).",
+      "help": "Add createdAt/updatedAt columns to track when records are created and modified.",
+      "rule": "schema/require-timestamps",
+      "category": "schema",
+      "scope": "schema",
+      "severity": "warning"
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/payments/invoice.entity.ts",
+      "entity": "Invoice",
+      "message": "Entity 'Invoice' has no timestamp columns (createdAt/updatedAt).",
+      "help": "Add createdAt/updatedAt columns to track when records are created and modified.",
+      "rule": "schema/require-timestamps",
+      "category": "schema",
+      "scope": "schema",
+      "severity": "warning"
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/catalog/product.entity.ts",
+      "entity": "Product",
+      "message": "Relation 'category' on 'Product' has no explicit onDelete behavior.",
+      "help": "Add an explicit onDelete option (e.g. CASCADE, SET NULL) to avoid relying on database defaults.",
+      "rule": "schema/require-cascade-rule",
+      "category": "schema",
+      "scope": "schema",
+      "severity": "info"
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/api/src/orders/order.entity.ts",
+      "entity": "Order",
+      "message": "Relation 'user' on 'Order' has no explicit onDelete behavior.",
+      "help": "Add an explicit onDelete option (e.g. CASCADE, SET NULL) to avoid relying on database defaults.",
+      "rule": "schema/require-cascade-rule",
+      "category": "schema",
+      "scope": "schema",
+      "severity": "info"
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/worker/src/jobs/notifications.processor.ts",
+      "message": "Async method 'process()' has no await expression.",
+      "help": "Either add an await expression or remove the async keyword. Framework entry points are exempted, since Nest awaits what they return: route handlers, GraphQL resolvers, WebSocket, microservice, ts-rest and gRPC handlers.",
+      "line": 14,
+      "column": 1,
+      "rule": "correctness/no-async-without-await",
+      "category": "correctness",
+      "scope": "file",
+      "severity": "warning",
+      "surfaces": [
+        "cli"
+      ],
+      "sourceLines": [
+        {
+          "line": 9,
+          "text": ""
+        },
+        {
+          "line": 10,
+          "text": "  constructor(private readonly metrics: MetricsService) {"
+        },
+        {
+          "line": 11,
+          "text": "    super();"
+        },
+        {
+          "line": 12,
+          "text": "  }"
+        },
+        {
+          "line": 13,
+          "text": ""
+        },
+        {
+          "line": 14,
+          "text": "  async process(job: Job<{ message?: string; orderId?: string }>): Promise<void> {"
+        },
+        {
+          "line": 15,
+          "text": "    this.logger.log(`[${job.name}] #${job.id} ${job.data.message ?? ''}`);"
+        },
+        {
+          "line": 16,
+          "text": "    this.metrics.increment(`notifications.${job.name}`);"
+        },
+        {
+          "line": 17,
+          "text": "  }"
+        },
+        {
+          "line": 18,
+          "text": "}"
+        },
+        {
+          "line": 19,
+          "text": ""
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/worker/src/main.ts",
+      "message": "Synchronous I/O call 'writeFileSync()' blocks the event loop.",
+      "help": "Use the async variant (e.g., readFile instead of readFileSync) with await.",
+      "line": 50,
+      "column": 1,
+      "rule": "performance/no-sync-io",
+      "category": "performance",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 45,
+          "text": "  Logger.log('Worker started, waiting for jobs', 'Bootstrap');"
+        },
+        {
+          "line": 46,
+          "text": ""
+        },
+        {
+          "line": 47,
+          "text": "  if (traceEnabled) {"
+        },
+        {
+          "line": 48,
+          "text": "    const graph = JSON.parse(app.get(SerializedGraph).toString());"
+        },
+        {
+          "line": 49,
+          "text": "    Object.assign(graph, { startupMs, hookTimings });"
+        },
+        {
+          "line": 50,
+          "text": "    writeFileSync('worker-timings.json', JSON.stringify(graph));"
+        },
+        {
+          "line": 51,
+          "text": "    Logger.log(`Boot trace written to worker-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');"
+        },
+        {
+          "line": 52,
+          "text": "  }"
+        },
+        {
+          "line": 53,
+          "text": "}"
+        },
+        {
+          "line": 54,
+          "text": ""
+        },
+        {
+          "line": 55,
+          "text": "bootstrap().catch((err) => {"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/apps/worker/src/jobs/jobs.module.ts",
+      "message": "Module 'JobsModule' exports 'JobsService' but no importing module uses it.",
+      "help": "Remove the unused export or use the provider in an importing module.",
+      "line": 6,
+      "column": 1,
+      "rule": "performance/no-unused-module-exports",
+      "category": "performance",
+      "scope": "project",
+      "severity": "info",
+      "tags": [
+        "module-graph"
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/libs/shared/src/index.ts",
+      "message": "Barrel file re-exports internal module './redis.strategy'.",
+      "help": "Only export the module's public API (services, DTOs, interfaces) from the index.ts beside its module file.",
+      "line": 5,
+      "column": 1,
+      "rule": "architecture/no-barrel-export-internals",
+      "category": "architecture",
+      "scope": "file",
+      "severity": "info",
+      "sourceLines": [
+        {
+          "line": 1,
+          "text": "export * from './shared.module';"
+        },
+        {
+          "line": 2,
+          "text": "export * from './metrics.service';"
+        },
+        {
+          "line": 3,
+          "text": "export * from './app-config.service';"
+        },
+        {
+          "line": 4,
+          "text": "export * from './request-context.service';"
+        },
+        {
+          "line": 5,
+          "text": "export * from './redis.strategy';"
+        },
+        {
+          "line": 6,
+          "text": ""
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/libs/shared/src/metrics.service.ts",
+      "message": "Class 'MetricsService' has 'onModuleInit()' but does not implement 'OnModuleInit'.",
+      "help": "Add 'implements OnModuleInit' (or the appropriate interface) to the class declaration.",
+      "line": 9,
+      "column": 1,
+      "rule": "correctness/require-lifecycle-interface",
+      "category": "correctness",
+      "scope": "file",
+      "severity": "warning",
+      "sourceLines": [
+        {
+          "line": 4,
+          "text": ""
+        },
+        {
+          "line": 5,
+          "text": "@Injectable({ scope: Scope.TRANSIENT })"
+        },
+        {
+          "line": 6,
+          "text": "export class MetricsService {"
+        },
+        {
+          "line": 7,
+          "text": "  private readonly counters = new Map<string, number>();"
+        },
+        {
+          "line": 8,
+          "text": ""
+        },
+        {
+          "line": 9,
+          "text": "  async onModuleInit(): Promise<void> {"
+        },
+        {
+          "line": 10,
+          "text": "    await new Promise((resolve) => setTimeout(resolve, 5));"
+        },
+        {
+          "line": 11,
+          "text": "    for (const name of SEED_COUNTERS) {"
+        },
+        {
+          "line": 12,
+          "text": "      this.counters.set(name, 0);"
+        },
+        {
+          "line": 13,
+          "text": "    }"
+        },
+        {
+          "line": 14,
+          "text": "  }"
+        }
+      ]
+    },
+    {
+      "filePath": "/demo/nest-shop/libs/shared/src/request-context.service.ts",
+      "message": "Scope.REQUEST creates a new instance per request, which impacts performance and propagates request scope to all dependents.",
+      "help": "Remove Scope.REQUEST unless the provider genuinely needs per-request state (e.g., request-scoped context). Consider Scope.DEFAULT or Scope.TRANSIENT instead.",
+      "line": 4,
+      "column": 1,
+      "rule": "performance/no-request-scope-abuse",
+      "category": "performance",
+      "scope": "file",
+      "severity": "warning",
+      "tags": [
+        "module-graph"
+      ],
+      "sourceLines": [
+        {
+          "line": 1,
+          "text": "import { Injectable, Scope } from '@nestjs/common';"
+        },
+        {
+          "line": 2,
+          "text": "import { randomUUID } from 'node:crypto';"
+        },
+        {
+          "line": 3,
+          "text": ""
+        },
+        {
+          "line": 4,
+          "text": "@Injectable({ scope: Scope.REQUEST })"
+        },
+        {
+          "line": 5,
+          "text": "export class RequestContextService {"
+        },
+        {
+          "line": 6,
+          "text": "  readonly requestId = randomUUID();"
+        },
+        {
+          "line": 7,
+          "text": "  readonly startedAt = new Date();"
+        },
+        {
+          "line": 8,
+          "text": "}"
+        },
+        {
+          "line": 9,
+          "text": ""
+        }
+      ]
+    }
+  ],
+  "ruleErrors": [],
+  "elapsedMs": 1947.3004580000002,
+  "graph": {
+    "modules": [
+      {
+        "name": "api/AppModule",
+        "filePath": "/demo/nest-shop/apps/api/src/app.module.ts",
+        "imports": [
+          "ConfigModule",
+          "TypeOrmModule",
+          "BullModule",
+          "shared/SharedModule",
+          "api/UsersModule",
+          "api/CatalogModule",
+          "api/OrdersModule",
+          "api/PaymentsModule",
+          "api/NotificationsModule",
+          "api/AuditModule"
+        ],
+        "exports": [],
+        "providers": [],
+        "providerTokens": [],
+        "controllers": [
+          "AppController"
+        ],
+        "project": "api",
+        "isGlobal": false,
+        "line": 14,
+        "dynamicImports": {
+          "ConfigModule": "forRoot",
+          "TypeOrmModule": "forRootAsync",
+          "BullModule": "forRootAsync",
+          "api/AuditModule": "register"
+        }
+      },
+      {
+        "name": "api/AuditModule",
+        "filePath": "/demo/nest-shop/apps/api/src/audit/audit.module.ts",
+        "imports": [
+          "TypeOrmModule"
+        ],
+        "exports": [
+          "AuditService"
+        ],
+        "providers": [
+          "AuditService",
+          "AuditRepository",
+          "AuditArchiverService"
+        ],
+        "providerTokens": [],
+        "controllers": [],
+        "project": "api",
+        "isGlobal": true,
+        "line": 8,
+        "dynamicImports": {
+          "TypeOrmModule": "forFeature"
+        },
+        "initTimings": [
+          {
+            "id": "t1105836877",
+            "name": "AuditService",
+            "type": "provider",
+            "initTime": 79.50295799999992
+          },
+          {
+            "id": "t873810013",
+            "name": "AuditArchiverService",
+            "type": "provider",
+            "initTime": 79.49470799999995
+          },
+          {
+            "id": "t339160962",
+            "name": "AuditRepository",
+            "type": "provider",
+            "initTime": 79.3559580000001
+          }
+        ]
+      },
+      {
+        "name": "api/CatalogModule",
+        "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.module.ts",
+        "imports": [
+          "TypeOrmModule"
+        ],
+        "exports": [
+          "CatalogService"
+        ],
+        "providers": [
+          "CatalogService",
+          "CatalogRepository"
+        ],
+        "providerTokens": [],
+        "controllers": [
+          "CatalogController"
+        ],
+        "project": "api",
+        "isGlobal": false,
+        "line": 10,
+        "dynamicImports": {
+          "TypeOrmModule": "forFeature"
+        },
+        "initTimings": [
+          {
+            "id": "t-427628343",
+            "name": "CatalogService",
+            "type": "provider",
+            "initTime": 79.70425
+          },
+          {
+            "id": "t-588828542",
+            "name": "CatalogRepository",
+            "type": "provider",
+            "initTime": 79.55512500000009
+          },
+          {
+            "id": "t-1460465701",
+            "name": "ParseIntPipe",
+            "type": "injectable",
+            "initTime": 0.31904100000008384
+          },
+          {
+            "id": "t414662000",
+            "name": "CatalogController",
+            "type": "controller",
+            "initTime": 0.05245800000000145
+          }
+        ]
+      },
+      {
+        "name": "api/NotificationsModule",
+        "filePath": "/demo/nest-shop/apps/api/src/notifications/notifications.module.ts",
+        "imports": [
+          "BullModule",
+          "api/CatalogModule",
+          "api/OrdersModule"
+        ],
+        "exports": [
+          "NotificationsService"
+        ],
+        "providers": [
+          "NotificationsService"
+        ],
+        "providerTokens": [],
+        "controllers": [],
+        "project": "api",
+        "isGlobal": false,
+        "line": 7,
+        "initTimings": [
+          {
+            "id": "t1223435111",
+            "name": "NotificationsService",
+            "type": "provider",
+            "initTime": 79.70829200000003
+          }
+        ]
+      },
+      {
+        "name": "api/OrdersModule",
+        "filePath": "/demo/nest-shop/apps/api/src/orders/orders.module.ts",
+        "imports": [
+          "TypeOrmModule",
+          "api/UsersModule",
+          "api/CatalogModule",
+          "api/PaymentsModule"
+        ],
+        "exports": [
+          "OrdersService"
+        ],
+        "providers": [
+          "OrdersService"
+        ],
+        "providerTokens": [],
+        "controllers": [
+          "OrdersController"
+        ],
+        "project": "api",
+        "isGlobal": false,
+        "line": 11,
+        "dynamicImports": {
+          "TypeOrmModule": "forFeature"
+        },
+        "initTimings": [
+          {
+            "id": "t1382773185",
+            "name": "OrdersService",
+            "type": "provider",
+            "initTime": 79.788542
+          },
+          {
+            "id": "t-1209639726",
+            "name": "OrdersController",
+            "type": "controller",
+            "initTime": 0.060791999999992186
+          },
+          {
+            "id": "t-772216377",
+            "name": "JwtAuthGuard",
+            "type": "injectable",
+            "initTime": 0.02616699999998673
+          }
+        ]
+      },
+      {
+        "name": "api/PaymentsModule",
+        "filePath": "/demo/nest-shop/apps/api/src/payments/payments.module.ts",
+        "imports": [
+          "TypeOrmModule",
+          "api/NotificationsModule"
+        ],
+        "exports": [
+          "PaymentsService"
+        ],
+        "providers": [
+          "PaymentsService",
+          "CardGateway",
+          "SepaGateway"
+        ],
+        "providerTokens": [],
+        "controllers": [
+          "PaymentsController"
+        ],
+        "project": "api",
+        "isGlobal": false,
+        "line": 11,
+        "dynamicImports": {
+          "TypeOrmModule": "forFeature"
+        },
+        "initTimings": [
+          {
+            "id": "t1716640961",
+            "name": "PaymentsService",
+            "type": "provider",
+            "initTime": 79.74479199999996
+          },
+          {
+            "id": "t-1882040819",
+            "name": "CardGateway",
+            "type": "provider",
+            "initTime": 0.61362500000007
+          },
+          {
+            "id": "t-1696006342",
+            "name": "SepaGateway",
+            "type": "provider",
+            "initTime": 0.6120829999999842
+          },
+          {
+            "id": "t-1622328542",
+            "name": "PaymentsController",
+            "type": "controller",
+            "initTime": 0.07470899999998437
+          }
+        ]
+      },
+      {
+        "name": "api/ReportsModule",
+        "filePath": "/demo/nest-shop/apps/api/src/reports/reports.module.ts",
+        "imports": [],
+        "exports": [
+          "SalesReportService"
+        ],
+        "providers": [
+          "SalesReportRepository",
+          "SalesReportService"
+        ],
+        "providerTokens": [],
+        "controllers": [],
+        "project": "api",
+        "isGlobal": false,
+        "line": 5
+      },
+      {
+        "name": "api/UsersModule",
+        "filePath": "/demo/nest-shop/apps/api/src/users/users.module.ts",
+        "imports": [
+          "TypeOrmModule"
+        ],
+        "exports": [
+          "UsersService"
+        ],
+        "providers": [
+          "UsersService",
+          "UsersRepository"
+        ],
+        "providerTokens": [],
+        "controllers": [
+          "UsersController"
+        ],
+        "project": "api",
+        "isGlobal": false,
+        "line": 8,
+        "dynamicImports": {
+          "TypeOrmModule": "forFeature"
+        },
+        "initTimings": [
+          {
+            "id": "t603011239",
+            "name": "UsersService",
+            "type": "provider",
+            "initTime": 79.73645800000008
+          },
+          {
+            "id": "t27207650",
+            "name": "UsersRepository",
+            "type": "provider",
+            "initTime": 79.58912500000008
+          },
+          {
+            "id": "t-21681218",
+            "name": "JwtAuthGuard",
+            "type": "injectable",
+            "initTime": 0.08679100000006201
+          },
+          {
+            "id": "t-1102473136",
+            "name": "UsersController",
+            "type": "controller",
+            "initTime": 0.07891699999993307
+          }
+        ]
+      },
+      {
+        "name": "worker/JobsModule",
+        "filePath": "/demo/nest-shop/apps/worker/src/jobs/jobs.module.ts",
+        "imports": [
+          "BullModule"
+        ],
+        "exports": [
+          "JobsService"
+        ],
+        "providers": [
+          "NotificationsProcessor",
+          "JobsService"
+        ],
+        "providerTokens": [],
+        "controllers": [],
+        "project": "worker",
+        "isGlobal": false,
+        "line": 6,
+        "initTimings": [
+          {
+            "id": "t-443087583",
+            "name": "JobsService",
+            "type": "provider",
+            "initTime": 56.603875000000016
+          },
+          {
+            "id": "t728002220",
+            "name": "NotificationsProcessor",
+            "type": "provider",
+            "initTime": 1.5463330000000042
+          }
+        ]
+      },
+      {
+        "name": "worker/SyncModule",
+        "filePath": "/demo/nest-shop/apps/worker/src/sync/sync.module.ts",
+        "imports": [],
+        "exports": [],
+        "providers": [
+          "SyncService",
+          "SyncRepository"
+        ],
+        "providerTokens": [],
+        "controllers": [],
+        "project": "worker",
+        "isGlobal": false,
+        "line": 5,
+        "initTimings": [
+          {
+            "id": "t-1349242879",
+            "name": "SyncService",
+            "type": "provider",
+            "initTime": 131.26433299999985
+          },
+          {
+            "id": "t1808058156",
+            "name": "SyncRepository",
+            "type": "provider",
+            "initTime": 131.17574999999988
+          }
+        ]
+      },
+      {
+        "name": "worker/WorkerModule",
+        "filePath": "/demo/nest-shop/apps/worker/src/worker.module.ts",
+        "imports": [
+          "ConfigModule",
+          "BullModule",
+          "TypeOrmModule",
+          "shared/SharedModule",
+          "worker/JobsModule",
+          "worker/SyncModule"
+        ],
+        "exports": [],
+        "providers": [],
+        "providerTokens": [],
+        "controllers": [],
+        "project": "worker",
+        "isGlobal": false,
+        "line": 9,
+        "dynamicImports": {
+          "ConfigModule": "forRoot",
+          "BullModule": "forRootAsync",
+          "TypeOrmModule": "forRootAsync"
+        }
+      },
+      {
+        "name": "shared/SharedModule",
+        "filePath": "/demo/nest-shop/libs/shared/src/shared.module.ts",
+        "imports": [
+          "ConfigModule"
+        ],
+        "exports": [
+          "MetricsService",
+          "AppConfigService",
+          "RequestContextService",
+          "RedisStrategy"
+        ],
+        "providers": [
+          "MetricsService",
+          "AppConfigService",
+          "RequestContextService",
+          "RedisStrategy"
+        ],
+        "providerTokens": [],
+        "controllers": [],
+        "project": "shared",
+        "isGlobal": true,
+        "line": 8,
+        "initTimings": [
+          {
+            "id": "t2027583",
+            "name": "RedisStrategy",
+            "type": "provider",
+            "initTime": 10.282375000000002
+          },
+          {
+            "id": "t-339153693",
+            "name": "AppConfigService",
+            "type": "provider",
+            "initTime": 1.654292000000055
+          },
+          {
+            "id": "t961691875",
+            "name": "MetricsService",
+            "type": "provider",
+            "initTime": 0.04216699999994944
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from": "api/AppModule",
+        "to": "shared/SharedModule"
+      },
+      {
+        "from": "api/AppModule",
+        "to": "api/UsersModule"
+      },
+      {
+        "from": "api/AppModule",
+        "to": "api/CatalogModule"
+      },
+      {
+        "from": "api/AppModule",
+        "to": "api/OrdersModule"
+      },
+      {
+        "from": "api/AppModule",
+        "to": "api/PaymentsModule"
+      },
+      {
+        "from": "api/AppModule",
+        "to": "api/NotificationsModule"
+      },
+      {
+        "from": "api/AppModule",
+        "to": "api/AuditModule"
+      },
+      {
+        "from": "api/NotificationsModule",
+        "to": "api/CatalogModule"
+      },
+      {
+        "from": "api/NotificationsModule",
+        "to": "api/OrdersModule"
+      },
+      {
+        "from": "api/OrdersModule",
+        "to": "api/UsersModule"
+      },
+      {
+        "from": "api/OrdersModule",
+        "to": "api/CatalogModule"
+      },
+      {
+        "from": "api/OrdersModule",
+        "to": "api/PaymentsModule"
+      },
+      {
+        "from": "api/PaymentsModule",
+        "to": "api/NotificationsModule"
+      },
+      {
+        "from": "worker/WorkerModule",
+        "to": "shared/SharedModule"
+      },
+      {
+        "from": "worker/WorkerModule",
+        "to": "worker/JobsModule"
+      },
+      {
+        "from": "worker/WorkerModule",
+        "to": "worker/SyncModule"
+      }
+    ],
+    "circularDeps": [
+      [
+        "api/OrdersModule",
+        "api/PaymentsModule",
+        "api/NotificationsModule"
+      ]
+    ],
+    "circularDepRecommendations": {},
+    "projects": [
+      "api",
+      "worker",
+      "shared"
+    ],
+    "bootstrapRoots": [
+      "api/AppModule",
+      "worker/WorkerModule"
+    ],
+    "phases": {
+      "createMs": 130.06045899999992,
+      "initMs": 358.2500419999999,
+      "moduleInitMs": 256.50691699999993
+    },
+    "startupMs": 358.820209,
+    "timingsAvailable": true,
+    "timingsTrace": {
+      "t2027583": {
+        "name": "RedisStrategy",
+        "type": "provider",
+        "initTime": 10.282375000000002,
+        "deps": [
+          "t-339153693"
+        ],
+        "module": "SharedModule"
+      },
+      "t27207650": {
+        "name": "UsersRepository",
+        "type": "provider",
+        "initTime": 79.58912500000008,
+        "deps": [
+          "t-1488832441"
+        ],
+        "module": "UsersModule"
+      },
+      "t266839889": {
+        "name": "EntityManager",
+        "type": "provider",
+        "initTime": 79.58295799999996,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmCoreModule"
+      },
+      "t339160962": {
+        "name": "AuditRepository",
+        "type": "provider",
+        "initTime": 79.3559580000001,
+        "deps": [
+          "t750781673"
+        ],
+        "module": "AuditModule"
+      },
+      "t400681591": {
+        "name": "DiscoveryService",
+        "type": "provider",
+        "initTime": 0.8022090000000617,
+        "deps": [],
+        "module": "DiscoveryModule",
+        "via": "BullModule"
+      },
+      "t414662000": {
+        "name": "CatalogController",
+        "type": "controller",
+        "initTime": 0.05245800000000145,
+        "deps": [
+          "t-427628343",
+          "t-1460465701"
+        ],
+        "module": "CatalogModule"
+      },
+      "t603011239": {
+        "name": "UsersService",
+        "type": "provider",
+        "initTime": 79.73645800000008,
+        "deps": [
+          "t27207650"
+        ],
+        "module": "UsersModule",
+        "hooks": [
+          {
+            "hook": "onModuleInit",
+            "ms": 1.6981670000000122,
+            "startMs": 218.73904199999993
+          }
+        ]
+      },
+      "t750781673": {
+        "name": "AuditLogRepository",
+        "type": "provider",
+        "initTime": 79.25687500000004,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "AuditModule"
+      },
+      "t820073489": {
+        "name": "OrderItemRepository",
+        "type": "provider",
+        "initTime": 79.3927920000001,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "OrdersModule"
+      },
+      "t873810013": {
+        "name": "AuditArchiverService",
+        "type": "provider",
+        "initTime": 79.49470799999995,
+        "deps": [
+          "t339160962"
+        ],
+        "module": "AuditModule"
+      },
+      "t930519593": {
+        "name": "ConfigService",
+        "type": "provider",
+        "initTime": 1.1310829999999896,
+        "deps": [
+          "t1063746662"
+        ],
+        "module": "ConfigHostModule"
+      },
+      "t945124753": {
+        "name": "BullExplorer",
+        "type": "provider",
+        "initTime": 1.1227499999999964,
+        "deps": [
+          "t-2122099672",
+          "t400681591",
+          "t2129637643",
+          "t-438112115"
+        ],
+        "module": "BullModule"
+      },
+      "t961691875": {
+        "name": "MetricsService",
+        "type": "provider",
+        "initTime": 0.04216699999994944,
+        "deps": [],
+        "module": "SharedModule",
+        "hooks": [
+          {
+            "hook": "onModuleInit",
+            "ms": 5.7225420000000895,
+            "startMs": 133.1920419999999
+          },
+          {
+            "hook": "onModuleInit",
+            "ms": 5.71895799999993,
+            "startMs": 133.21420899999998
+          }
+        ]
+      },
+      "t985056236": {
+        "name": "PaymentRepository",
+        "type": "provider",
+        "initTime": 79.35987499999999,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "PaymentsModule"
+      },
+      "t1063746662": {
+        "name": "CONFIGURATION_TOKEN",
+        "type": "provider",
+        "initTime": 0.8623750000000427,
+        "deps": [],
+        "module": "ConfigHostModule"
+      },
+      "t1105836877": {
+        "name": "AuditService",
+        "type": "provider",
+        "initTime": 79.50295799999992,
+        "deps": [
+          "t339160962"
+        ],
+        "module": "AuditModule"
+      },
+      "t1223435111": {
+        "name": "NotificationsService",
+        "type": "provider",
+        "initTime": 79.70829200000003,
+        "deps": [
+          "t1382773185",
+          "t-427628343",
+          "t-1737543994"
+        ],
+        "module": "NotificationsModule",
+        "hooks": [
+          {
+            "hook": "onApplicationBootstrap",
+            "ms": 45.049375000000055,
+            "startMs": 256.86199999999985
+          }
+        ]
+      },
+      "t1382773185": {
+        "name": "OrdersService",
+        "type": "provider",
+        "initTime": 79.788542,
+        "deps": [
+          "t1716640961",
+          "t603011239",
+          "t-427628343",
+          "t1105836877",
+          "t1513522596",
+          "t820073489",
+          "t961691875"
+        ],
+        "module": "OrdersModule",
+        "hooks": [
+          {
+            "hook": "onModuleInit",
+            "ms": 36.04620799999998,
+            "startMs": 220.46070899999995
+          },
+          {
+            "hook": "onApplicationBootstrap",
+            "ms": 2.7008749999999964,
+            "startMs": 355.5090419999999
+          }
+        ]
+      },
+      "t1513522596": {
+        "name": "OrderRepository",
+        "type": "provider",
+        "initTime": 79.39537500000006,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "OrdersModule"
+      },
+      "t1716640961": {
+        "name": "PaymentsService",
+        "type": "provider",
+        "initTime": 79.74479199999996,
+        "deps": [
+          "t1223435111",
+          "t1105836877",
+          "t985056236",
+          "t-2072619291",
+          "t-1882040819",
+          "t-1696006342",
+          "t961691875"
+        ],
+        "module": "PaymentsModule",
+        "hooks": [
+          {
+            "hook": "onModuleInit",
+            "ms": 5.637208999999984,
+            "startMs": 213.05825000000004
+          },
+          {
+            "hook": "onApplicationBootstrap",
+            "ms": 53.48900000000003,
+            "startMs": 301.97137499999985
+          }
+        ]
+      },
+      "t2075644217": {
+        "name": "TypeOrmModuleOptions",
+        "type": "provider",
+        "initTime": 1.6967499999999518,
+        "deps": [
+          "t-503631789"
+        ],
+        "module": "TypeOrmCoreModule"
+      },
+      "t2129637643": {
+        "name": "ProcessorDecoratorService",
+        "type": "provider",
+        "initTime": 0.544667000000004,
+        "deps": [],
+        "module": "BullModule"
+      },
+      "t-503631789": {
+        "name": "ConfigService",
+        "type": "provider",
+        "initTime": 1.4232920000000604,
+        "deps": [
+          "t930519593"
+        ],
+        "module": "ConfigModule"
+      },
+      "t-2103415210": {
+        "name": "DataSource",
+        "type": "provider",
+        "initTime": 79.47450000000003,
+        "deps": [
+          "t2075644217"
+        ],
+        "module": "TypeOrmCoreModule"
+      },
+      "t-1579533083": {
+        "name": "BULLMQ_CONFIG(default)",
+        "type": "provider",
+        "initTime": 1.668374999999969,
+        "deps": [
+          "t-503631789"
+        ],
+        "module": "BullModule"
+      },
+      "t-339153693": {
+        "name": "AppConfigService",
+        "type": "provider",
+        "initTime": 1.654292000000055,
+        "deps": [
+          "t-503631788"
+        ],
+        "module": "SharedModule"
+      },
+      "t-503631788": {
+        "name": "ConfigService",
+        "type": "provider",
+        "initTime": 1.2580410000000484,
+        "deps": [
+          "t930519593"
+        ],
+        "module": "ConfigModule",
+        "via": "SharedModule"
+      },
+      "t-21681218": {
+        "name": "JwtAuthGuard",
+        "type": "injectable",
+        "initTime": 0.08679100000006201,
+        "deps": [],
+        "module": "UsersModule"
+      },
+      "t-1102473136": {
+        "name": "UsersController",
+        "type": "controller",
+        "initTime": 0.07891699999993307,
+        "deps": [
+          "t603011239",
+          "t-21681218"
+        ],
+        "module": "UsersModule"
+      },
+      "t-1488832441": {
+        "name": "UserRepository",
+        "type": "provider",
+        "initTime": 79.48424999999997,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "UsersModule"
+      },
+      "t-427628343": {
+        "name": "CatalogService",
+        "type": "provider",
+        "initTime": 79.70425,
+        "deps": [
+          "t-588828542"
+        ],
+        "module": "CatalogModule",
+        "hooks": [
+          {
+            "hook": "onModuleInit",
+            "ms": 73.6779170000001,
+            "startMs": 139.31566699999996
+          }
+        ]
+      },
+      "t-588828542": {
+        "name": "CatalogRepository",
+        "type": "provider",
+        "initTime": 79.55512500000009,
+        "deps": [
+          "t-1223438924",
+          "t-58527005",
+          "t-2127282216"
+        ],
+        "module": "CatalogModule"
+      },
+      "t-1460465701": {
+        "name": "ParseIntPipe",
+        "type": "injectable",
+        "initTime": 0.31904100000008384,
+        "deps": [],
+        "module": "CatalogModule"
+      },
+      "t-1223438924": {
+        "name": "CategoryRepository",
+        "type": "provider",
+        "initTime": 79.44295899999997,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "CatalogModule"
+      },
+      "t-58527005": {
+        "name": "ProductRepository",
+        "type": "provider",
+        "initTime": 79.43833299999994,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "CatalogModule"
+      },
+      "t-2127282216": {
+        "name": "TagRepository",
+        "type": "provider",
+        "initTime": 79.43537499999991,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "CatalogModule"
+      },
+      "t-772216377": {
+        "name": "JwtAuthGuard",
+        "type": "injectable",
+        "initTime": 0.02616699999998673,
+        "deps": [],
+        "module": "OrdersModule"
+      },
+      "t-1209639726": {
+        "name": "OrdersController",
+        "type": "controller",
+        "initTime": 0.060791999999992186,
+        "deps": [
+          "t1382773185",
+          "t-772216377"
+        ],
+        "module": "OrdersModule"
+      },
+      "t-1882040819": {
+        "name": "CardGateway",
+        "type": "provider",
+        "initTime": 0.61362500000007,
+        "deps": [],
+        "module": "PaymentsModule"
+      },
+      "t-1696006342": {
+        "name": "SepaGateway",
+        "type": "provider",
+        "initTime": 0.6120829999999842,
+        "deps": [],
+        "module": "PaymentsModule"
+      },
+      "t-1622328542": {
+        "name": "PaymentsController",
+        "type": "controller",
+        "initTime": 0.07470899999998437,
+        "deps": [
+          "t1716640961"
+        ],
+        "module": "PaymentsModule"
+      },
+      "t-2072619291": {
+        "name": "InvoiceRepository",
+        "type": "provider",
+        "initTime": 79.35737500000005,
+        "deps": [
+          "t-2103415210"
+        ],
+        "module": "TypeOrmModule",
+        "via": "PaymentsModule"
+      },
+      "t-599847804": {
+        "name": "33b786715d1f16a60c5b0",
+        "type": "provider",
+        "initTime": 10.083749999999895,
+        "deps": [
+          "t-1579533083"
+        ],
+        "module": "BullModule",
+        "via": "NotificationsModule"
+      },
+      "t-1315419860": {
+        "name": "BullMQQueueOptions_notifications",
+        "type": "provider",
+        "initTime": 10.203333000000043,
+        "deps": [
+          "t-599847804"
+        ],
+        "module": "BullModule",
+        "via": "NotificationsModule"
+      },
+      "t-1737543994": {
+        "name": "BullQueue_notifications",
+        "type": "provider",
+        "initTime": 19.226833000000056,
+        "deps": [
+          "t-1315419860"
+        ],
+        "module": "BullModule",
+        "via": "NotificationsModule"
+      },
+      "t-2122099672": {
+        "name": "BullMetadataAccessor",
+        "type": "provider",
+        "initTime": 0.88737500000002,
+        "deps": [],
+        "module": "BullModule"
+      },
+      "t-1667609095": {
+        "name": "BullRegistrar",
+        "type": "provider",
+        "initTime": 1.460292000000095,
+        "deps": [
+          "t945124753"
+        ],
+        "module": "BullModule",
+        "hooks": [
+          {
+            "hook": "onModuleInit",
+            "ms": 0.3207909999999856,
+            "startMs": 138.9672089999999
+          }
+        ]
+      },
+      "t-438112115": {
+        "name": "MetadataScanner",
+        "type": "provider",
+        "initTime": 0.5361669999999776,
+        "deps": [],
+        "module": "DiscoveryModule",
+        "via": "BullModule"
+      }
+    },
+    "traces": [
+      {
+        "label": "api",
+        "phases": {
+          "createMs": 130.06045899999992,
+          "initMs": 358.2500419999999,
+          "moduleInitMs": 256.50691699999993
+        },
+        "project": "api",
+        "startupMs": 358.820209,
+        "trace": {
+          "t2027583": {
+            "name": "RedisStrategy",
+            "type": "provider",
+            "initTime": 10.282375000000002,
+            "deps": [
+              "t-339153693"
+            ],
+            "module": "SharedModule"
+          },
+          "t27207650": {
+            "name": "UsersRepository",
+            "type": "provider",
+            "initTime": 79.58912500000008,
+            "deps": [
+              "t-1488832441"
+            ],
+            "module": "UsersModule"
+          },
+          "t266839889": {
+            "name": "EntityManager",
+            "type": "provider",
+            "initTime": 79.58295799999996,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmCoreModule"
+          },
+          "t339160962": {
+            "name": "AuditRepository",
+            "type": "provider",
+            "initTime": 79.3559580000001,
+            "deps": [
+              "t750781673"
+            ],
+            "module": "AuditModule"
+          },
+          "t400681591": {
+            "name": "DiscoveryService",
+            "type": "provider",
+            "initTime": 0.8022090000000617,
+            "deps": [],
+            "module": "DiscoveryModule",
+            "via": "BullModule"
+          },
+          "t414662000": {
+            "name": "CatalogController",
+            "type": "controller",
+            "initTime": 0.05245800000000145,
+            "deps": [
+              "t-427628343",
+              "t-1460465701"
+            ],
+            "module": "CatalogModule"
+          },
+          "t603011239": {
+            "name": "UsersService",
+            "type": "provider",
+            "initTime": 79.73645800000008,
+            "deps": [
+              "t27207650"
+            ],
+            "module": "UsersModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 1.6981670000000122,
+                "startMs": 218.73904199999993
+              }
+            ]
+          },
+          "t750781673": {
+            "name": "AuditLogRepository",
+            "type": "provider",
+            "initTime": 79.25687500000004,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "AuditModule"
+          },
+          "t820073489": {
+            "name": "OrderItemRepository",
+            "type": "provider",
+            "initTime": 79.3927920000001,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "OrdersModule"
+          },
+          "t873810013": {
+            "name": "AuditArchiverService",
+            "type": "provider",
+            "initTime": 79.49470799999995,
+            "deps": [
+              "t339160962"
+            ],
+            "module": "AuditModule"
+          },
+          "t930519593": {
+            "name": "ConfigService",
+            "type": "provider",
+            "initTime": 1.1310829999999896,
+            "deps": [
+              "t1063746662"
+            ],
+            "module": "ConfigHostModule"
+          },
+          "t945124753": {
+            "name": "BullExplorer",
+            "type": "provider",
+            "initTime": 1.1227499999999964,
+            "deps": [
+              "t-2122099672",
+              "t400681591",
+              "t2129637643",
+              "t-438112115"
+            ],
+            "module": "BullModule"
+          },
+          "t961691875": {
+            "name": "MetricsService",
+            "type": "provider",
+            "initTime": 0.04216699999994944,
+            "deps": [],
+            "module": "SharedModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 5.7225420000000895,
+                "startMs": 133.1920419999999
+              },
+              {
+                "hook": "onModuleInit",
+                "ms": 5.71895799999993,
+                "startMs": 133.21420899999998
+              }
+            ]
+          },
+          "t985056236": {
+            "name": "PaymentRepository",
+            "type": "provider",
+            "initTime": 79.35987499999999,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "PaymentsModule"
+          },
+          "t1063746662": {
+            "name": "CONFIGURATION_TOKEN",
+            "type": "provider",
+            "initTime": 0.8623750000000427,
+            "deps": [],
+            "module": "ConfigHostModule"
+          },
+          "t1105836877": {
+            "name": "AuditService",
+            "type": "provider",
+            "initTime": 79.50295799999992,
+            "deps": [
+              "t339160962"
+            ],
+            "module": "AuditModule"
+          },
+          "t1223435111": {
+            "name": "NotificationsService",
+            "type": "provider",
+            "initTime": 79.70829200000003,
+            "deps": [
+              "t1382773185",
+              "t-427628343",
+              "t-1737543994"
+            ],
+            "module": "NotificationsModule",
+            "hooks": [
+              {
+                "hook": "onApplicationBootstrap",
+                "ms": 45.049375000000055,
+                "startMs": 256.86199999999985
+              }
+            ]
+          },
+          "t1382773185": {
+            "name": "OrdersService",
+            "type": "provider",
+            "initTime": 79.788542,
+            "deps": [
+              "t1716640961",
+              "t603011239",
+              "t-427628343",
+              "t1105836877",
+              "t1513522596",
+              "t820073489",
+              "t961691875"
+            ],
+            "module": "OrdersModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 36.04620799999998,
+                "startMs": 220.46070899999995
+              },
+              {
+                "hook": "onApplicationBootstrap",
+                "ms": 2.7008749999999964,
+                "startMs": 355.5090419999999
+              }
+            ]
+          },
+          "t1513522596": {
+            "name": "OrderRepository",
+            "type": "provider",
+            "initTime": 79.39537500000006,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "OrdersModule"
+          },
+          "t1716640961": {
+            "name": "PaymentsService",
+            "type": "provider",
+            "initTime": 79.74479199999996,
+            "deps": [
+              "t1223435111",
+              "t1105836877",
+              "t985056236",
+              "t-2072619291",
+              "t-1882040819",
+              "t-1696006342",
+              "t961691875"
+            ],
+            "module": "PaymentsModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 5.637208999999984,
+                "startMs": 213.05825000000004
+              },
+              {
+                "hook": "onApplicationBootstrap",
+                "ms": 53.48900000000003,
+                "startMs": 301.97137499999985
+              }
+            ]
+          },
+          "t2075644217": {
+            "name": "TypeOrmModuleOptions",
+            "type": "provider",
+            "initTime": 1.6967499999999518,
+            "deps": [
+              "t-503631789"
+            ],
+            "module": "TypeOrmCoreModule"
+          },
+          "t2129637643": {
+            "name": "ProcessorDecoratorService",
+            "type": "provider",
+            "initTime": 0.544667000000004,
+            "deps": [],
+            "module": "BullModule"
+          },
+          "t-503631789": {
+            "name": "ConfigService",
+            "type": "provider",
+            "initTime": 1.4232920000000604,
+            "deps": [
+              "t930519593"
+            ],
+            "module": "ConfigModule"
+          },
+          "t-2103415210": {
+            "name": "DataSource",
+            "type": "provider",
+            "initTime": 79.47450000000003,
+            "deps": [
+              "t2075644217"
+            ],
+            "module": "TypeOrmCoreModule"
+          },
+          "t-1579533083": {
+            "name": "BULLMQ_CONFIG(default)",
+            "type": "provider",
+            "initTime": 1.668374999999969,
+            "deps": [
+              "t-503631789"
+            ],
+            "module": "BullModule"
+          },
+          "t-339153693": {
+            "name": "AppConfigService",
+            "type": "provider",
+            "initTime": 1.654292000000055,
+            "deps": [
+              "t-503631788"
+            ],
+            "module": "SharedModule"
+          },
+          "t-503631788": {
+            "name": "ConfigService",
+            "type": "provider",
+            "initTime": 1.2580410000000484,
+            "deps": [
+              "t930519593"
+            ],
+            "module": "ConfigModule",
+            "via": "SharedModule"
+          },
+          "t-21681218": {
+            "name": "JwtAuthGuard",
+            "type": "injectable",
+            "initTime": 0.08679100000006201,
+            "deps": [],
+            "module": "UsersModule"
+          },
+          "t-1102473136": {
+            "name": "UsersController",
+            "type": "controller",
+            "initTime": 0.07891699999993307,
+            "deps": [
+              "t603011239",
+              "t-21681218"
+            ],
+            "module": "UsersModule"
+          },
+          "t-1488832441": {
+            "name": "UserRepository",
+            "type": "provider",
+            "initTime": 79.48424999999997,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "UsersModule"
+          },
+          "t-427628343": {
+            "name": "CatalogService",
+            "type": "provider",
+            "initTime": 79.70425,
+            "deps": [
+              "t-588828542"
+            ],
+            "module": "CatalogModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 73.6779170000001,
+                "startMs": 139.31566699999996
+              }
+            ]
+          },
+          "t-588828542": {
+            "name": "CatalogRepository",
+            "type": "provider",
+            "initTime": 79.55512500000009,
+            "deps": [
+              "t-1223438924",
+              "t-58527005",
+              "t-2127282216"
+            ],
+            "module": "CatalogModule"
+          },
+          "t-1460465701": {
+            "name": "ParseIntPipe",
+            "type": "injectable",
+            "initTime": 0.31904100000008384,
+            "deps": [],
+            "module": "CatalogModule"
+          },
+          "t-1223438924": {
+            "name": "CategoryRepository",
+            "type": "provider",
+            "initTime": 79.44295899999997,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "CatalogModule"
+          },
+          "t-58527005": {
+            "name": "ProductRepository",
+            "type": "provider",
+            "initTime": 79.43833299999994,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "CatalogModule"
+          },
+          "t-2127282216": {
+            "name": "TagRepository",
+            "type": "provider",
+            "initTime": 79.43537499999991,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "CatalogModule"
+          },
+          "t-772216377": {
+            "name": "JwtAuthGuard",
+            "type": "injectable",
+            "initTime": 0.02616699999998673,
+            "deps": [],
+            "module": "OrdersModule"
+          },
+          "t-1209639726": {
+            "name": "OrdersController",
+            "type": "controller",
+            "initTime": 0.060791999999992186,
+            "deps": [
+              "t1382773185",
+              "t-772216377"
+            ],
+            "module": "OrdersModule"
+          },
+          "t-1882040819": {
+            "name": "CardGateway",
+            "type": "provider",
+            "initTime": 0.61362500000007,
+            "deps": [],
+            "module": "PaymentsModule"
+          },
+          "t-1696006342": {
+            "name": "SepaGateway",
+            "type": "provider",
+            "initTime": 0.6120829999999842,
+            "deps": [],
+            "module": "PaymentsModule"
+          },
+          "t-1622328542": {
+            "name": "PaymentsController",
+            "type": "controller",
+            "initTime": 0.07470899999998437,
+            "deps": [
+              "t1716640961"
+            ],
+            "module": "PaymentsModule"
+          },
+          "t-2072619291": {
+            "name": "InvoiceRepository",
+            "type": "provider",
+            "initTime": 79.35737500000005,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmModule",
+            "via": "PaymentsModule"
+          },
+          "t-599847804": {
+            "name": "33b786715d1f16a60c5b0",
+            "type": "provider",
+            "initTime": 10.083749999999895,
+            "deps": [
+              "t-1579533083"
+            ],
+            "module": "BullModule",
+            "via": "NotificationsModule"
+          },
+          "t-1315419860": {
+            "name": "BullMQQueueOptions_notifications",
+            "type": "provider",
+            "initTime": 10.203333000000043,
+            "deps": [
+              "t-599847804"
+            ],
+            "module": "BullModule",
+            "via": "NotificationsModule"
+          },
+          "t-1737543994": {
+            "name": "BullQueue_notifications",
+            "type": "provider",
+            "initTime": 19.226833000000056,
+            "deps": [
+              "t-1315419860"
+            ],
+            "module": "BullModule",
+            "via": "NotificationsModule"
+          },
+          "t-2122099672": {
+            "name": "BullMetadataAccessor",
+            "type": "provider",
+            "initTime": 0.88737500000002,
+            "deps": [],
+            "module": "BullModule"
+          },
+          "t-1667609095": {
+            "name": "BullRegistrar",
+            "type": "provider",
+            "initTime": 1.460292000000095,
+            "deps": [
+              "t945124753"
+            ],
+            "module": "BullModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 0.3207909999999856,
+                "startMs": 138.9672089999999
+              }
+            ]
+          },
+          "t-438112115": {
+            "name": "MetadataScanner",
+            "type": "provider",
+            "initTime": 0.5361669999999776,
+            "deps": [],
+            "module": "DiscoveryModule",
+            "via": "BullModule"
+          }
+        }
+      },
+      {
+        "label": "worker",
+        "phases": {
+          "createMs": 139.92650000000003,
+          "initMs": 170.84383400000002,
+          "moduleInitMs": 170.1423339999999
+        },
+        "project": "worker",
+        "startupMs": 170.84383400000002,
+        "trace": {
+          "t2027583": {
+            "name": "RedisStrategy",
+            "type": "provider",
+            "initTime": 28.065292,
+            "deps": [
+              "t-339153693"
+            ],
+            "module": "SharedModule"
+          },
+          "t266839889": {
+            "name": "EntityManager",
+            "type": "provider",
+            "initTime": 131.4008339999998,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "TypeOrmCoreModule"
+          },
+          "t400681591": {
+            "name": "DiscoveryService",
+            "type": "provider",
+            "initTime": 1.028833000000077,
+            "deps": [],
+            "module": "DiscoveryModule",
+            "via": "BullModule"
+          },
+          "t728002220": {
+            "name": "NotificationsProcessor",
+            "type": "provider",
+            "initTime": 1.5463330000000042,
+            "deps": [
+              "t961691875"
+            ],
+            "module": "JobsModule",
+            "via": "WorkerModule"
+          },
+          "t765216426": {
+            "name": "c2453eb1c65eae042d5ae",
+            "type": "provider",
+            "initTime": 27.988416000000143,
+            "deps": [
+              "t-1579533083"
+            ],
+            "module": "BullModule",
+            "via": "JobsModule"
+          },
+          "t930519593": {
+            "name": "ConfigService",
+            "type": "provider",
+            "initTime": 1.2416249999998854,
+            "deps": [
+              "t1063746662"
+            ],
+            "module": "ConfigHostModule"
+          },
+          "t945124753": {
+            "name": "BullExplorer",
+            "type": "provider",
+            "initTime": 1.407666000000063,
+            "deps": [
+              "t-2122099672",
+              "t400681591",
+              "t2129637643",
+              "t-438112115"
+            ],
+            "module": "BullModule"
+          },
+          "t961691875": {
+            "name": "MetricsService",
+            "type": "provider",
+            "initTime": 0.20254099999988284,
+            "deps": [],
+            "module": "SharedModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 5.718124999999873,
+                "startMs": 139.92650000000003
+              },
+              {
+                "hook": "onModuleInit",
+                "ms": 5.626332999999931,
+                "startMs": 140.03445899999997
+              },
+              {
+                "hook": "onModuleInit",
+                "ms": 5.6384160000000065,
+                "startMs": 140.03920900000003
+              }
+            ]
+          },
+          "t1063746662": {
+            "name": "CONFIGURATION_TOKEN",
+            "type": "provider",
+            "initTime": 1.003624999999829,
+            "deps": [],
+            "module": "ConfigHostModule"
+          },
+          "t1808058156": {
+            "name": "SyncRepository",
+            "type": "provider",
+            "initTime": 131.17574999999988,
+            "deps": [
+              "t-2103415210"
+            ],
+            "module": "SyncModule",
+            "via": "WorkerModule"
+          },
+          "t2075644217": {
+            "name": "TypeOrmModuleOptions",
+            "type": "provider",
+            "initTime": 1.9715830000000096,
+            "deps": [
+              "t-503631789"
+            ],
+            "module": "TypeOrmCoreModule"
+          },
+          "t2129637643": {
+            "name": "ProcessorDecoratorService",
+            "type": "provider",
+            "initTime": 0.7525829999999587,
+            "deps": [],
+            "module": "BullModule"
+          },
+          "t-503631789": {
+            "name": "ConfigService",
+            "type": "provider",
+            "initTime": 1.6410419999999704,
+            "deps": [
+              "t930519593"
+            ],
+            "module": "ConfigModule"
+          },
+          "t-1579533083": {
+            "name": "BULLMQ_CONFIG(default)",
+            "type": "provider",
+            "initTime": 2.0045420000001286,
+            "deps": [
+              "t-503631789"
+            ],
+            "module": "BullModule"
+          },
+          "t-2103415210": {
+            "name": "DataSource",
+            "type": "provider",
+            "initTime": 131.286834,
+            "deps": [
+              "t2075644217"
+            ],
+            "module": "TypeOrmCoreModule"
+          },
+          "t-339153693": {
+            "name": "AppConfigService",
+            "type": "provider",
+            "initTime": 1.9389999999998508,
+            "deps": [
+              "t-503631788"
+            ],
+            "module": "SharedModule"
+          },
+          "t-503631788": {
+            "name": "ConfigService",
+            "type": "provider",
+            "initTime": 1.416915999999901,
+            "deps": [
+              "t930519593"
+            ],
+            "module": "ConfigModule",
+            "via": "SharedModule"
+          },
+          "t-443087583": {
+            "name": "JobsService",
+            "type": "provider",
+            "initTime": 56.603875000000016,
+            "deps": [
+              "t-1737543994",
+              "t961691875"
+            ],
+            "module": "JobsModule",
+            "via": "WorkerModule"
+          },
+          "t-1315419860": {
+            "name": "BullMQQueueOptions_notifications",
+            "type": "provider",
+            "initTime": 28.481667000000016,
+            "deps": [
+              "t765216426"
+            ],
+            "module": "BullModule",
+            "via": "JobsModule"
+          },
+          "t-1737543994": {
+            "name": "BullQueue_notifications",
+            "type": "provider",
+            "initTime": 56.51716600000009,
+            "deps": [
+              "t-1315419860"
+            ],
+            "module": "BullModule",
+            "via": "JobsModule"
+          },
+          "t-2122099672": {
+            "name": "BullMetadataAccessor",
+            "type": "provider",
+            "initTime": 1.1806249999999636,
+            "deps": [],
+            "module": "BullModule"
+          },
+          "t-1667609095": {
+            "name": "BullRegistrar",
+            "type": "provider",
+            "initTime": 1.824041999999963,
+            "deps": [
+              "t945124753"
+            ],
+            "module": "BullModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 2.22458400000005,
+                "startMs": 145.76487499999985
+              }
+            ]
+          },
+          "t-438112115": {
+            "name": "MetadataScanner",
+            "type": "provider",
+            "initTime": 0.7477080000001024,
+            "deps": [],
+            "module": "DiscoveryModule",
+            "via": "BullModule"
+          },
+          "t-1349242879": {
+            "name": "SyncService",
+            "type": "provider",
+            "initTime": 131.26433299999985,
+            "deps": [
+              "t1808058156",
+              "t961691875"
+            ],
+            "module": "SyncModule",
+            "via": "WorkerModule",
+            "hooks": [
+              {
+                "hook": "onModuleInit",
+                "ms": 21.828666999999996,
+                "startMs": 148.3136669999999
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "providers": [
+    {
+      "dependencies": [
+        "AuditRepository"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/audit/audit-archiver.service.ts",
+      "name": "AuditArchiverService",
+      "publicMethodCount": 1,
+      "module": "api/AuditModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "Repository"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/audit/audit.repository.ts",
+      "name": "AuditRepository",
+      "publicMethodCount": 3,
+      "module": "api/AuditModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "AuditOptions",
+        "AuditRepository"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/audit/audit.service.ts",
+      "name": "AuditService",
+      "publicMethodCount": 2,
+      "module": "api/AuditModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [],
+      "filePath": "/demo/nest-shop/apps/api/src/auth/jwt-auth.guard.ts",
+      "name": "JwtAuthGuard",
+      "publicMethodCount": 1,
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "Repository",
+        "Repository",
+        "Repository"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts",
+      "name": "CatalogRepository",
+      "publicMethodCount": 12,
+      "module": "api/CatalogModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "CatalogRepository"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.service.ts",
+      "name": "CatalogService",
+      "publicMethodCount": 5,
+      "module": "api/CatalogModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "Queue",
+        "CatalogService",
+        "OrdersService"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/notifications/notifications.service.ts",
+      "name": "NotificationsService",
+      "publicMethodCount": 2,
+      "module": "api/NotificationsModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "Repository",
+        "Repository",
+        "UsersService",
+        "CatalogService",
+        "AuditService",
+        "MetricsService",
+        "PaymentsService"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+      "name": "OrdersService",
+      "publicMethodCount": 8,
+      "module": "api/OrdersModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [],
+      "filePath": "/demo/nest-shop/apps/api/src/payments/gateways/card.gateway.ts",
+      "name": "CardGateway",
+      "publicMethodCount": 1,
+      "module": "api/PaymentsModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [],
+      "filePath": "/demo/nest-shop/apps/api/src/payments/gateways/sepa.gateway.ts",
+      "name": "SepaGateway",
+      "publicMethodCount": 1,
+      "module": "api/PaymentsModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "Repository",
+        "Repository",
+        "CardGateway",
+        "SepaGateway",
+        "MetricsService",
+        "AuditService",
+        "NotificationsService"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+      "name": "PaymentsService",
+      "publicMethodCount": 7,
+      "module": "api/PaymentsModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "DataSource"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/reports/reports.repository.ts",
+      "name": "SalesReportRepository",
+      "publicMethodCount": 1,
+      "module": "api/ReportsModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "SalesReportRepository"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/reports/reports.service.ts",
+      "name": "SalesReportService",
+      "publicMethodCount": 1,
+      "module": "api/ReportsModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "Repository"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+      "name": "UsersRepository",
+      "publicMethodCount": 6,
+      "module": "api/UsersModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "UsersRepository"
+      ],
+      "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+      "name": "UsersService",
+      "publicMethodCount": 7,
+      "module": "api/UsersModule",
+      "project": "api"
+    },
+    {
+      "dependencies": [
+        "Queue",
+        "MetricsService"
+      ],
+      "filePath": "/demo/nest-shop/apps/worker/src/jobs/jobs.service.ts",
+      "name": "JobsService",
+      "publicMethodCount": 1,
+      "module": "worker/JobsModule",
+      "project": "worker"
+    },
+    {
+      "dependencies": [
+        "DataSource"
+      ],
+      "filePath": "/demo/nest-shop/apps/worker/src/sync/sync.repository.ts",
+      "name": "SyncRepository",
+      "publicMethodCount": 1,
+      "module": "worker/SyncModule",
+      "project": "worker"
+    },
+    {
+      "dependencies": [
+        "SyncRepository",
+        "MetricsService"
+      ],
+      "filePath": "/demo/nest-shop/apps/worker/src/sync/sync.service.ts",
+      "name": "SyncService",
+      "publicMethodCount": 1,
+      "module": "worker/SyncModule",
+      "project": "worker"
+    },
+    {
+      "dependencies": [
+        "ConfigService"
+      ],
+      "filePath": "/demo/nest-shop/libs/shared/src/app-config.service.ts",
+      "name": "AppConfigService",
+      "publicMethodCount": 2,
+      "module": "shared/SharedModule",
+      "project": "shared"
+    },
+    {
+      "dependencies": [],
+      "filePath": "/demo/nest-shop/libs/shared/src/metrics.service.ts",
+      "name": "MetricsService",
+      "publicMethodCount": 3,
+      "scope": "transient",
+      "module": "shared/SharedModule",
+      "project": "shared"
+    },
+    {
+      "dependencies": [
+        "AppConfigService"
+      ],
+      "filePath": "/demo/nest-shop/libs/shared/src/redis.strategy.ts",
+      "name": "RedisStrategy",
+      "publicMethodCount": 1,
+      "module": "shared/SharedModule",
+      "project": "shared"
+    },
+    {
+      "dependencies": [],
+      "filePath": "/demo/nest-shop/libs/shared/src/request-context.service.ts",
+      "name": "RequestContextService",
+      "publicMethodCount": 0,
+      "scope": "request",
+      "module": "shared/SharedModule",
+      "project": "shared"
+    }
+  ],
+  "endpoints": {
+    "endpoints": [
+      {
+        "controllerClass": "AppController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 19,
+            "className": "MetricsService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [],
+            "endLine": 0,
+            "filePath": "",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 0,
+            "methodName": "snapshot",
+            "order": 0,
+            "parameters": [],
+            "returnType": null,
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 0,
+            "type": "service"
+          }
+        ],
+        "endLine": 21,
+        "filePath": "/demo/nest-shop/apps/api/src/app.controller.ts",
+        "handlerMethod": "health",
+        "httpMethod": "GET",
+        "line": 12,
+        "returnType": null,
+        "routePath": "/health",
+        "swagger": null
+      },
+      {
+        "controllerClass": "CatalogController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 12,
+            "className": "CatalogService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 57,
+                "className": "CatalogRepository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 45,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "find",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 46,
+                "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 44,
+                "methodName": "findAll",
+                "order": 0,
+                "parameters": [],
+                "returnType": "Product[]",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 12,
+                "type": "repository"
+              }
+            ],
+            "endLine": 58,
+            "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 56,
+            "methodName": "findAll",
+            "order": 0,
+            "parameters": [],
+            "returnType": "Product[]",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 5,
+            "type": "service"
+          }
+        ],
+        "endLine": 13,
+        "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.controller.ts",
+        "handlerMethod": "list",
+        "httpMethod": "GET",
+        "line": 9,
+        "returnType": null,
+        "routePath": "/products",
+        "swagger": null
+      },
+      {
+        "controllerClass": "CatalogController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 18,
+            "className": "CatalogService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": "product",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 61,
+                "className": "CatalogRepository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 53,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 54,
+                "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts",
+                "guardThrow": {
+                  "branchKind": "if",
+                  "callSiteLine": 63,
+                  "className": "NotFoundException",
+                  "conditionText": "!product",
+                  "message": "Product ${id} not found"
+                },
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 52,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "Product | null",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 12,
+                "type": "repository"
+              }
+            ],
+            "endLine": 66,
+            "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 60,
+            "methodName": "findOne",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "id",
+                "type": "string"
+              }
+            ],
+            "returnType": "Product",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 5,
+            "type": "service"
+          }
+        ],
+        "endLine": 19,
+        "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.controller.ts",
+        "handlerMethod": "get",
+        "httpMethod": "GET",
+        "line": 15,
+        "returnType": null,
+        "routePath": "/products/:id",
+        "swagger": null
+      },
+      {
+        "controllerClass": "CatalogController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 24,
+            "className": "CatalogService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 74,
+                "className": "CatalogRepository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 61,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "update",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 62,
+                "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 60,
+                "methodName": "updatePrice",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "priceCents",
+                    "type": "number"
+                  }
+                ],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 12,
+                "type": "repository"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 73,
+                "className": "CatalogService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "product",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 61,
+                    "className": "CatalogRepository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 54,
+                    "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts",
+                    "guardThrow": {
+                      "branchKind": "if",
+                      "callSiteLine": 63,
+                      "className": "NotFoundException",
+                      "conditionText": "!product",
+                      "message": "Product ${id} not found"
+                    },
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 52,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "id",
+                        "type": "string"
+                      }
+                    ],
+                    "returnType": "Product | null",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 12,
+                    "type": "repository",
+                    "expandedElsewhere": true
+                  }
+                ],
+                "endLine": 66,
+                "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 60,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "Product",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 5,
+                "type": "service"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 75,
+                "className": "CatalogService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "product",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 61,
+                    "className": "CatalogRepository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 54,
+                    "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts",
+                    "guardThrow": {
+                      "branchKind": "if",
+                      "callSiteLine": 63,
+                      "className": "NotFoundException",
+                      "conditionText": "!product",
+                      "message": "Product ${id} not found"
+                    },
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 52,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "id",
+                        "type": "string"
+                      }
+                    ],
+                    "returnType": "Product | null",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 12,
+                    "type": "repository",
+                    "expandedElsewhere": true
+                  }
+                ],
+                "endLine": 66,
+                "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 60,
+                "methodName": "findOne",
+                "order": 2,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "Product",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 5,
+                "type": "service"
+              }
+            ],
+            "endLine": 76,
+            "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 72,
+            "methodName": "updatePrice",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "priceCents",
+                "type": "number"
+              }
+            ],
+            "returnType": "Product",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 5,
+            "type": "service"
+          }
+        ],
+        "endLine": 25,
+        "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.controller.ts",
+        "handlerMethod": "update",
+        "httpMethod": "PUT",
+        "line": 21,
+        "returnType": null,
+        "routePath": "/products/:id",
+        "swagger": {
+          "body": {
+            "description": null,
+            "type": "number"
+          },
+          "description": null,
+          "params": [],
+          "queryParams": [],
+          "responses": [],
+          "summary": null
+        }
+      },
+      {
+        "controllerClass": "OrdersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 14,
+            "className": "OrdersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 71,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "find",
+                "order": 0,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              }
+            ],
+            "endLine": 75,
+            "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 70,
+            "methodName": "findAll",
+            "order": 0,
+            "parameters": [],
+            "returnType": "Order[]",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 8,
+            "type": "service"
+          }
+        ],
+        "endLine": 15,
+        "filePath": "/demo/nest-shop/apps/api/src/orders/orders.controller.ts",
+        "handlerMethod": "list",
+        "httpMethod": "GET",
+        "line": 12,
+        "returnType": null,
+        "routePath": "/orders",
+        "swagger": null
+      },
+      {
+        "controllerClass": "OrdersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 19,
+            "className": "OrdersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": "user",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 89,
+                "className": "UsersService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "user",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 29,
+                    "className": "UsersRepository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [
+                      {
+                        "assignedTo": null,
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 15,
+                        "className": "Repository",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 0,
+                        "filePath": "",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 0,
+                        "methodName": "findOne",
+                        "order": 0,
+                        "parameters": [],
+                        "returnType": null,
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 0,
+                        "type": "repository"
+                      }
+                    ],
+                    "endLine": 16,
+                    "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+                    "guardThrow": {
+                      "branchKind": "if",
+                      "callSiteLine": 31,
+                      "className": "NotFoundException",
+                      "conditionText": "!user",
+                      "message": "User ${id} not found"
+                    },
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 14,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "id",
+                        "type": "string"
+                      }
+                    ],
+                    "returnType": "User | null",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 6,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 34,
+                "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 28,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "User",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 7,
+                "type": "service"
+              },
+              {
+                "assignedTo": "products",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 90,
+                "className": "CatalogService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 69,
+                    "className": "CatalogRepository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [
+                      {
+                        "assignedTo": null,
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 57,
+                        "className": "Repository",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 0,
+                        "filePath": "",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 0,
+                        "methodName": "find",
+                        "order": 0,
+                        "parameters": [],
+                        "returnType": null,
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 0,
+                        "type": "repository"
+                      }
+                    ],
+                    "endLine": 58,
+                    "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 56,
+                    "methodName": "findByIds",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "ids",
+                        "type": "string[]"
+                      }
+                    ],
+                    "returnType": "Product[]",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 12,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 70,
+                "filePath": "/demo/nest-shop/apps/api/src/catalog/catalog.service.ts",
+                "guardThrow": {
+                  "branchKind": "if",
+                  "callSiteLine": 92,
+                  "className": "BadRequestException",
+                  "conditionText": "products.length !== dto.lines.length",
+                  "message": "One or more products do not exist"
+                },
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 68,
+                "methodName": "findByIds",
+                "order": 1,
+                "parameters": [
+                  {
+                    "name": "ids",
+                    "type": "string[]"
+                  }
+                ],
+                "returnType": "Product[]",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 5,
+                "type": "service"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 97,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": "callback",
+                "iterationLabel": "map",
+                "line": 0,
+                "methodName": "create",
+                "order": 2,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              },
+              {
+                "assignedTo": "order",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 104,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "save",
+                "order": 3,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 104,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "create",
+                "order": 4,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 105,
+                "className": "AuditService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 19,
+                    "className": "AuditRepository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [
+                      {
+                        "assignedTo": null,
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 11,
+                        "className": "Repository",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 0,
+                        "filePath": "",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 0,
+                        "methodName": "save",
+                        "order": 0,
+                        "parameters": [],
+                        "returnType": null,
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 0,
+                        "type": "repository"
+                      },
+                      {
+                        "assignedTo": null,
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 11,
+                        "className": "Repository",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 0,
+                        "filePath": "",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 0,
+                        "methodName": "create",
+                        "order": 1,
+                        "parameters": [],
+                        "returnType": null,
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 0,
+                        "type": "repository"
+                      }
+                    ],
+                    "endLine": 12,
+                    "filePath": "/demo/nest-shop/apps/api/src/audit/audit.repository.ts",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 10,
+                    "methodName": "insert",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "action",
+                        "type": "string"
+                      },
+                      {
+                        "name": "actor",
+                        "type": "string"
+                      },
+                      {
+                        "name": "payload",
+                        "type": "Record<string, unknown>"
+                      }
+                    ],
+                    "returnType": "AuditLog",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 3,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 20,
+                "filePath": "/demo/nest-shop/apps/api/src/audit/audit.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 18,
+                "methodName": "record",
+                "order": 5,
+                "parameters": [
+                  {
+                    "name": "action",
+                    "type": "string"
+                  },
+                  {
+                    "name": "actor",
+                    "type": "string"
+                  },
+                  {
+                    "name": "payload",
+                    "type": "Record<string, unknown>"
+                  }
+                ],
+                "returnType": "AuditLog",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 2,
+                "type": "service"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 106,
+                "className": "MetricsService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "increment",
+                "order": 6,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "service"
+              }
+            ],
+            "endLine": 109,
+            "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 88,
+            "methodName": "create",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "dto",
+                "type": "CreateOrderDto"
+              }
+            ],
+            "returnType": "Order",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 8,
+            "type": "service"
+          }
+        ],
+        "endLine": 20,
+        "filePath": "/demo/nest-shop/apps/api/src/orders/orders.controller.ts",
+        "handlerMethod": "create",
+        "httpMethod": "POST",
+        "line": 17,
+        "returnType": null,
+        "routePath": "/orders",
+        "swagger": {
+          "body": {
+            "description": null,
+            "type": "CreateOrderDto"
+          },
+          "description": null,
+          "params": [],
+          "queryParams": [],
+          "responses": [],
+          "summary": null
+        }
+      },
+      {
+        "controllerClass": "OrdersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 35,
+            "className": "OrdersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": "order",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 112,
+                "className": "OrdersService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "order",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 78,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": {
+                      "branchKind": "if",
+                      "callSiteLine": 83,
+                      "className": "NotFoundException",
+                      "conditionText": "!order",
+                      "message": "Order ${id} not found"
+                    },
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 86,
+                "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 77,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "Order",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 8,
+                "type": "service"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": "L113",
+                "branchKind": "if",
+                "callSiteLine": 114,
+                "className": "BadRequestException",
+                "comment": null,
+                "conditional": true,
+                "conditionText": "order.status !== OrderStatus.Pending",
+                "dependencies": [],
+                "endLine": 114,
+                "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 114,
+                "methodName": null,
+                "order": 0,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": "Order ${id} is ${order.status}, cannot pay",
+                "totalMethods": 0,
+                "type": "throw"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 117,
+                "className": "PaymentsService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "payment",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 84,
+                    "className": "Repository",
+                    "comment": "TODO: run the charge through the provider gateway instead of capturing directly.",
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "save",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  },
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 85,
+                    "className": "Repository",
+                    "comment": "TODO: run the charge through the provider gateway instead of capturing directly.",
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "create",
+                    "order": 1,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  },
+                  {
+                    "assignedTo": "invoice",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 92,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "save",
+                    "order": 2,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  },
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 93,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "create",
+                    "order": 3,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  },
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 96,
+                    "className": "NotificationsService",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [
+                      {
+                        "assignedTo": "job",
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 69,
+                        "className": "Queue",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 0,
+                        "filePath": "",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 0,
+                        "methodName": "add",
+                        "order": 0,
+                        "parameters": [],
+                        "returnType": null,
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 0,
+                        "type": "service"
+                      },
+                      {
+                        "assignedTo": "message",
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 68,
+                        "className": "NotificationsService",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 89,
+                        "filePath": "/demo/nest-shop/apps/api/src/notifications/notifications.service.ts",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 74,
+                        "methodName": "buildMessage",
+                        "order": 0,
+                        "parameters": [
+                          {
+                            "name": "kind",
+                            "type": "NotificationKind"
+                          },
+                          {
+                            "name": "payload",
+                            "type": "Record<string, unknown>"
+                          }
+                        ],
+                        "returnType": "string",
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 2,
+                        "type": "service"
+                      }
+                    ],
+                    "endLine": 72,
+                    "filePath": "/demo/nest-shop/apps/api/src/notifications/notifications.service.ts",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 67,
+                    "methodName": "enqueue",
+                    "order": 4,
+                    "parameters": [
+                      {
+                        "name": "kind",
+                        "type": "NotificationKind"
+                      },
+                      {
+                        "name": "payload",
+                        "type": "Record<string, unknown>"
+                      }
+                    ],
+                    "returnType": "string",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 2,
+                    "type": "service"
+                  },
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 93,
+                    "className": "PaymentsService",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [
+                      {
+                        "assignedTo": null,
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 143,
+                        "className": "local",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 143,
+                        "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 143,
+                        "methodName": null,
+                        "order": 0,
+                        "parameters": [],
+                        "returnType": null,
+                        "stepStatements": [
+                          {
+                            "assignedTo": "stamp",
+                            "text": "stamp = new Date().toISOString().slice(0, 10).replace(/…"
+                          },
+                          {
+                            "assignedTo": "suffix",
+                            "text": "suffix = createHash('md5').update(order.id).digest('hex'…"
+                          }
+                        ],
+                        "throwMessage": null,
+                        "totalMethods": 0,
+                        "type": "step"
+                      }
+                    ],
+                    "endLine": 146,
+                    "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 142,
+                    "methodName": "nextInvoiceNumber",
+                    "order": 4,
+                    "parameters": [
+                      {
+                        "name": "order",
+                        "type": "Order"
+                      }
+                    ],
+                    "returnType": "string",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 7,
+                    "type": "service"
+                  }
+                ],
+                "endLine": 102,
+                "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 82,
+                "methodName": "charge",
+                "order": 1,
+                "parameters": [
+                  {
+                    "name": "order",
+                    "type": "Order"
+                  },
+                  {
+                    "name": "provider",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "Payment",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 7,
+                "type": "service"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 119,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "save",
+                "order": 2,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 120,
+                "className": "AuditService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 19,
+                    "className": "AuditRepository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [
+                      {
+                        "assignedTo": null,
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 11,
+                        "className": "Repository",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 0,
+                        "filePath": "",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 0,
+                        "methodName": "save",
+                        "order": 0,
+                        "parameters": [],
+                        "returnType": null,
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 0,
+                        "type": "repository"
+                      },
+                      {
+                        "assignedTo": null,
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 11,
+                        "className": "Repository",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [],
+                        "endLine": 0,
+                        "filePath": "",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 0,
+                        "methodName": "create",
+                        "order": 1,
+                        "parameters": [],
+                        "returnType": null,
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 0,
+                        "type": "repository"
+                      }
+                    ],
+                    "endLine": 12,
+                    "filePath": "/demo/nest-shop/apps/api/src/audit/audit.repository.ts",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 10,
+                    "methodName": "insert",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "action",
+                        "type": "string"
+                      },
+                      {
+                        "name": "actor",
+                        "type": "string"
+                      },
+                      {
+                        "name": "payload",
+                        "type": "Record<string, unknown>"
+                      }
+                    ],
+                    "returnType": "AuditLog",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 3,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 20,
+                "filePath": "/demo/nest-shop/apps/api/src/audit/audit.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 18,
+                "methodName": "record",
+                "order": 3,
+                "parameters": [
+                  {
+                    "name": "action",
+                    "type": "string"
+                  },
+                  {
+                    "name": "actor",
+                    "type": "string"
+                  },
+                  {
+                    "name": "payload",
+                    "type": "Record<string, unknown>"
+                  }
+                ],
+                "returnType": "AuditLog",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 2,
+                "type": "service"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 121,
+                "className": "MetricsService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "increment",
+                "order": 4,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "service"
+              }
+            ],
+            "endLine": 123,
+            "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 111,
+            "methodName": "pay",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "provider",
+                "type": "string"
+              },
+              {
+                "name": "surchargeCents",
+                "type": null
+              }
+            ],
+            "returnType": "Order",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 8,
+            "type": "service"
+          }
+        ],
+        "endLine": 36,
+        "filePath": "/demo/nest-shop/apps/api/src/orders/orders.controller.ts",
+        "handlerMethod": "pay",
+        "httpMethod": "POST",
+        "line": 22,
+        "returnType": null,
+        "routePath": "/orders/:id/pay",
+        "swagger": {
+          "body": {
+            "description": null,
+            "type": "{ provider?: string }"
+          },
+          "description": null,
+          "params": [],
+          "queryParams": [],
+          "responses": [],
+          "summary": null
+        }
+      },
+      {
+        "controllerClass": "OrdersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 40,
+            "className": "OrdersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": "order",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 126,
+                "className": "OrdersService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "order",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 78,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": {
+                      "branchKind": "if",
+                      "callSiteLine": 83,
+                      "className": "NotFoundException",
+                      "conditionText": "!order",
+                      "message": "Order ${id} not found"
+                    },
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 86,
+                "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 77,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "Order",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 8,
+                "type": "service"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": "L127",
+                "branchKind": "if",
+                "callSiteLine": 128,
+                "className": "BadRequestException",
+                "comment": null,
+                "conditional": true,
+                "conditionText": "!Object.values(OrderStatus).includes(status)",
+                "dependencies": [],
+                "endLine": 128,
+                "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 128,
+                "methodName": null,
+                "order": 0,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": "Unknown status ${status}",
+                "totalMethods": 0,
+                "type": "throw"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 131,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "save",
+                "order": 1,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              }
+            ],
+            "endLine": 132,
+            "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 125,
+            "methodName": "updateStatus",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "status",
+                "type": "OrderStatus"
+              }
+            ],
+            "returnType": "Order",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 8,
+            "type": "service"
+          }
+        ],
+        "endLine": 41,
+        "filePath": "/demo/nest-shop/apps/api/src/orders/orders.controller.ts",
+        "handlerMethod": "updateStatus",
+        "httpMethod": "PATCH",
+        "line": 38,
+        "returnType": null,
+        "routePath": "/orders/:id/status",
+        "swagger": {
+          "body": {
+            "description": null,
+            "type": "OrderStatus"
+          },
+          "description": null,
+          "params": [],
+          "queryParams": [],
+          "responses": [],
+          "summary": null
+        }
+      },
+      {
+        "controllerClass": "PaymentsController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 10,
+            "className": "PaymentsService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 79,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "find",
+                "order": 0,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              }
+            ],
+            "endLine": 80,
+            "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 78,
+            "methodName": "findAll",
+            "order": 0,
+            "parameters": [],
+            "returnType": "Payment[]",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 7,
+            "type": "service"
+          }
+        ],
+        "endLine": 11,
+        "filePath": "/demo/nest-shop/apps/api/src/payments/payments.controller.ts",
+        "handlerMethod": "list",
+        "httpMethod": "GET",
+        "line": 8,
+        "returnType": null,
+        "routePath": "/payments",
+        "swagger": null
+      },
+      {
+        "controllerClass": "PaymentsController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 15,
+            "className": "PaymentsService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": "payment",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 117,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": {
+                  "branchKind": "if",
+                  "callSiteLine": 122,
+                  "className": "BadRequestException",
+                  "conditionText": "payment.status !== PaymentStatus.Captured",
+                  "message": "Payment ${paymentId} is ${payment.status}, cannot refund"
+                },
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": "L124",
+                "branchKind": "if",
+                "callSiteLine": 125,
+                "className": "CardGateway",
+                "comment": null,
+                "conditional": true,
+                "conditionText": "payment.provider === 'card'",
+                "dependencies": [],
+                "endLine": 10,
+                "filePath": "/demo/nest-shop/apps/api/src/payments/gateways/card.gateway.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 7,
+                "methodName": "refund",
+                "order": 2,
+                "parameters": [
+                  {
+                    "name": "paymentId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "amountCents",
+                    "type": "number"
+                  }
+                ],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 1,
+                "type": "gateway"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": "L124",
+                "branchKind": "else",
+                "callSiteLine": 127,
+                "className": "SepaGateway",
+                "comment": null,
+                "conditional": true,
+                "conditionText": "payment.provider === 'card'",
+                "dependencies": [],
+                "endLine": 10,
+                "filePath": "/demo/nest-shop/apps/api/src/payments/gateways/sepa.gateway.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 7,
+                "methodName": "refund",
+                "order": 3,
+                "parameters": [
+                  {
+                    "name": "paymentId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "amountCents",
+                    "type": "number"
+                  }
+                ],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 1,
+                "type": "gateway"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 130,
+                "className": "Repository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "save",
+                "order": 4,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "repository"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 131,
+                "className": "MetricsService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [],
+                "endLine": 0,
+                "filePath": "",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 0,
+                "methodName": "increment",
+                "order": 5,
+                "parameters": [],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 0,
+                "type": "service"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 133,
+                "className": "NotificationsService",
+                "comment": "FIXME: the order stays \"paid\" until the notification job runs.",
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "job",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 69,
+                    "className": "Queue",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "add",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "service"
+                  },
+                  {
+                    "assignedTo": "message",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 68,
+                    "className": "NotificationsService",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [
+                      {
+                        "assignedTo": "order",
+                        "branchGroupId": null,
+                        "branchKind": null,
+                        "callSiteLine": 79,
+                        "className": "OrdersService",
+                        "comment": null,
+                        "conditional": false,
+                        "conditionText": null,
+                        "dependencies": [
+                          {
+                            "assignedTo": "order",
+                            "branchGroupId": null,
+                            "branchKind": null,
+                            "callSiteLine": 78,
+                            "className": "Repository",
+                            "comment": null,
+                            "conditional": false,
+                            "conditionText": null,
+                            "dependencies": [],
+                            "endLine": 0,
+                            "filePath": "",
+                            "guardThrow": {
+                              "branchKind": "if",
+                              "callSiteLine": 83,
+                              "className": "NotFoundException",
+                              "conditionText": "!order",
+                              "message": "Order ${id} not found"
+                            },
+                            "iterationKind": null,
+                            "iterationLabel": null,
+                            "line": 0,
+                            "methodName": "findOne",
+                            "order": 0,
+                            "parameters": [],
+                            "returnType": null,
+                            "stepStatements": [],
+                            "throwMessage": null,
+                            "totalMethods": 0,
+                            "type": "repository"
+                          }
+                        ],
+                        "endLine": 86,
+                        "filePath": "/demo/nest-shop/apps/api/src/orders/orders.service.ts",
+                        "guardThrow": null,
+                        "iterationKind": null,
+                        "iterationLabel": null,
+                        "line": 77,
+                        "methodName": "findOne",
+                        "order": 0,
+                        "parameters": [
+                          {
+                            "name": "id",
+                            "type": "string"
+                          }
+                        ],
+                        "returnType": "Order",
+                        "stepStatements": [],
+                        "throwMessage": null,
+                        "totalMethods": 8,
+                        "type": "service"
+                      }
+                    ],
+                    "endLine": 89,
+                    "filePath": "/demo/nest-shop/apps/api/src/notifications/notifications.service.ts",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 74,
+                    "methodName": "buildMessage",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "kind",
+                        "type": "NotificationKind"
+                      },
+                      {
+                        "name": "payload",
+                        "type": "Record<string, unknown>"
+                      }
+                    ],
+                    "returnType": "string",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 2,
+                    "type": "service"
+                  }
+                ],
+                "endLine": 72,
+                "filePath": "/demo/nest-shop/apps/api/src/notifications/notifications.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 67,
+                "methodName": "enqueue",
+                "order": 6,
+                "parameters": [
+                  {
+                    "name": "kind",
+                    "type": "NotificationKind"
+                  },
+                  {
+                    "name": "payload",
+                    "type": "Record<string, unknown>"
+                  }
+                ],
+                "returnType": "string",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 2,
+                "type": "service"
+              }
+            ],
+            "endLine": 135,
+            "filePath": "/demo/nest-shop/apps/api/src/payments/payments.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 116,
+            "methodName": "refund",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "paymentId",
+                "type": "string"
+              }
+            ],
+            "returnType": "Payment",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 7,
+            "type": "service"
+          }
+        ],
+        "endLine": 16,
+        "filePath": "/demo/nest-shop/apps/api/src/payments/payments.controller.ts",
+        "handlerMethod": "refund",
+        "httpMethod": "POST",
+        "line": 13,
+        "returnType": null,
+        "routePath": "/payments/:id/refund",
+        "swagger": null
+      },
+      {
+        "controllerClass": "UsersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 14,
+            "className": "UsersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 25,
+                "className": "UsersRepository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 11,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "find",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 12,
+                "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 10,
+                "methodName": "findAll",
+                "order": 0,
+                "parameters": [],
+                "returnType": "User[]",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 6,
+                "type": "repository"
+              }
+            ],
+            "endLine": 26,
+            "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 24,
+            "methodName": "findAll",
+            "order": 0,
+            "parameters": [],
+            "returnType": "User[]",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 7,
+            "type": "service"
+          }
+        ],
+        "endLine": 15,
+        "filePath": "/demo/nest-shop/apps/api/src/users/users.controller.ts",
+        "handlerMethod": "list",
+        "httpMethod": "GET",
+        "line": 12,
+        "returnType": null,
+        "routePath": "/users",
+        "swagger": null
+      },
+      {
+        "controllerClass": "UsersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 19,
+            "className": "UsersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": "user",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 29,
+                "className": "UsersRepository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 15,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 16,
+                "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+                "guardThrow": {
+                  "branchKind": "if",
+                  "callSiteLine": 31,
+                  "className": "NotFoundException",
+                  "conditionText": "!user",
+                  "message": "User ${id} not found"
+                },
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 14,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "User | null",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 6,
+                "type": "repository"
+              }
+            ],
+            "endLine": 34,
+            "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 28,
+            "methodName": "findOne",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "id",
+                "type": "string"
+              }
+            ],
+            "returnType": "User",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 7,
+            "type": "service"
+          }
+        ],
+        "endLine": 20,
+        "filePath": "/demo/nest-shop/apps/api/src/users/users.controller.ts",
+        "handlerMethod": "get",
+        "httpMethod": "GET",
+        "line": 17,
+        "returnType": null,
+        "routePath": "/users/:id",
+        "swagger": null
+      },
+      {
+        "controllerClass": "UsersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 24,
+            "className": "UsersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 41,
+                "className": "UsersRepository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 23,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "save",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  },
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 23,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "create",
+                    "order": 1,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 24,
+                "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 22,
+                "methodName": "save",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "row",
+                    "type": "Partial<User>"
+                  }
+                ],
+                "returnType": "User",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 6,
+                "type": "repository"
+              }
+            ],
+            "endLine": 42,
+            "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 40,
+            "methodName": "create",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "dto",
+                "type": "CreateUserDto"
+              }
+            ],
+            "returnType": "User",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 7,
+            "type": "service"
+          }
+        ],
+        "endLine": 25,
+        "filePath": "/demo/nest-shop/apps/api/src/users/users.controller.ts",
+        "handlerMethod": "create",
+        "httpMethod": "POST",
+        "line": 22,
+        "returnType": null,
+        "routePath": "/users",
+        "swagger": {
+          "body": {
+            "description": null,
+            "type": "CreateUserDto"
+          },
+          "description": null,
+          "params": [],
+          "queryParams": [],
+          "responses": [],
+          "summary": null
+        }
+      },
+      {
+        "controllerClass": "UsersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 32,
+            "className": "UsersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 46,
+                "className": "UsersRepository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 23,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "save",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  },
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 23,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "create",
+                    "order": 1,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 24,
+                "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 22,
+                "methodName": "save",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "row",
+                    "type": "Partial<User>"
+                  }
+                ],
+                "returnType": "User",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 6,
+                "type": "repository"
+              },
+              {
+                "assignedTo": "user",
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 45,
+                "className": "UsersService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "user",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 29,
+                    "className": "UsersRepository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 16,
+                    "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+                    "guardThrow": {
+                      "branchKind": "if",
+                      "callSiteLine": 31,
+                      "className": "NotFoundException",
+                      "conditionText": "!user",
+                      "message": "User ${id} not found"
+                    },
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 14,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "id",
+                        "type": "string"
+                      }
+                    ],
+                    "returnType": "User | null",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 6,
+                    "type": "repository",
+                    "expandedElsewhere": true
+                  }
+                ],
+                "endLine": 34,
+                "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 28,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "User",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 7,
+                "type": "service"
+              }
+            ],
+            "endLine": 47,
+            "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 44,
+            "methodName": "update",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "dto",
+                "type": "UpdateUserDto"
+              }
+            ],
+            "returnType": "User",
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 7,
+            "type": "service"
+          }
+        ],
+        "endLine": 33,
+        "filePath": "/demo/nest-shop/apps/api/src/users/users.controller.ts",
+        "handlerMethod": "update",
+        "httpMethod": "PATCH",
+        "line": 27,
+        "returnType": null,
+        "routePath": "/users/:id",
+        "swagger": {
+          "body": {
+            "description": null,
+            "type": "UpdateUserDto"
+          },
+          "description": null,
+          "params": [],
+          "queryParams": [],
+          "responses": [],
+          "summary": null
+        }
+      },
+      {
+        "controllerClass": "UsersController",
+        "dependencies": [
+          {
+            "assignedTo": null,
+            "branchGroupId": null,
+            "branchKind": null,
+            "callSiteLine": 37,
+            "className": "UsersService",
+            "comment": null,
+            "conditional": false,
+            "conditionText": null,
+            "dependencies": [
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 51,
+                "className": "UsersRepository",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": null,
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 31,
+                    "className": "Repository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 0,
+                    "filePath": "",
+                    "guardThrow": null,
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 0,
+                    "methodName": "delete",
+                    "order": 0,
+                    "parameters": [],
+                    "returnType": null,
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 0,
+                    "type": "repository"
+                  }
+                ],
+                "endLine": 32,
+                "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 30,
+                "methodName": "remove",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": null,
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 6,
+                "type": "repository"
+              },
+              {
+                "assignedTo": null,
+                "branchGroupId": null,
+                "branchKind": null,
+                "callSiteLine": 50,
+                "className": "UsersService",
+                "comment": null,
+                "conditional": false,
+                "conditionText": null,
+                "dependencies": [
+                  {
+                    "assignedTo": "user",
+                    "branchGroupId": null,
+                    "branchKind": null,
+                    "callSiteLine": 29,
+                    "className": "UsersRepository",
+                    "comment": null,
+                    "conditional": false,
+                    "conditionText": null,
+                    "dependencies": [],
+                    "endLine": 16,
+                    "filePath": "/demo/nest-shop/apps/api/src/users/users.repository.ts",
+                    "guardThrow": {
+                      "branchKind": "if",
+                      "callSiteLine": 31,
+                      "className": "NotFoundException",
+                      "conditionText": "!user",
+                      "message": "User ${id} not found"
+                    },
+                    "iterationKind": null,
+                    "iterationLabel": null,
+                    "line": 14,
+                    "methodName": "findOne",
+                    "order": 0,
+                    "parameters": [
+                      {
+                        "name": "id",
+                        "type": "string"
+                      }
+                    ],
+                    "returnType": "User | null",
+                    "stepStatements": [],
+                    "throwMessage": null,
+                    "totalMethods": 6,
+                    "type": "repository",
+                    "expandedElsewhere": true
+                  }
+                ],
+                "endLine": 34,
+                "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+                "guardThrow": null,
+                "iterationKind": null,
+                "iterationLabel": null,
+                "line": 28,
+                "methodName": "findOne",
+                "order": 0,
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "string"
+                  }
+                ],
+                "returnType": "User",
+                "stepStatements": [],
+                "throwMessage": null,
+                "totalMethods": 7,
+                "type": "service"
+              }
+            ],
+            "endLine": 52,
+            "filePath": "/demo/nest-shop/apps/api/src/users/users.service.ts",
+            "guardThrow": null,
+            "iterationKind": null,
+            "iterationLabel": null,
+            "line": 49,
+            "methodName": "remove",
+            "order": 0,
+            "parameters": [
+              {
+                "name": "id",
+                "type": "string"
+              }
+            ],
+            "returnType": null,
+            "stepStatements": [],
+            "throwMessage": null,
+            "totalMethods": 7,
+            "type": "service"
+          }
+        ],
+        "endLine": 38,
+        "filePath": "/demo/nest-shop/apps/api/src/users/users.controller.ts",
+        "handlerMethod": "remove",
+        "httpMethod": "DELETE",
+        "line": 35,
+        "returnType": null,
+        "routePath": "/users/:id",
+        "swagger": null
+      }
+    ]
+  },
+  "schema": {
+    "entities": [
+      {
+        "name": "AuditLog",
+        "tableName": "audit_logs",
+        "filePath": "/demo/nest-shop/apps/api/src/audit/audit-log.entity.ts",
+        "columns": [
+          {
+            "name": "action",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "actor",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "payload",
+            "type": "jsonb",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false,
+            "defaultValue": "{}"
+          },
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "createdAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "updatedAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          }
+        ],
+        "relations": [],
+        "indexes": []
+      },
+      {
+        "name": "Category",
+        "tableName": "categories",
+        "filePath": "/demo/nest-shop/apps/api/src/catalog/category.entity.ts",
+        "columns": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "slug",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": true
+          },
+          {
+            "name": "name",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          }
+        ],
+        "relations": [
+          {
+            "type": "one-to-many",
+            "fromEntity": "Category",
+            "toEntity": "Product",
+            "propertyName": "products",
+            "isNullable": false
+          }
+        ],
+        "indexes": []
+      },
+      {
+        "name": "Product",
+        "tableName": "products",
+        "filePath": "/demo/nest-shop/apps/api/src/catalog/product.entity.ts",
+        "columns": [
+          {
+            "name": "sku",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": true
+          },
+          {
+            "name": "name",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "priceCents",
+            "type": "int",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "createdAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "updatedAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          }
+        ],
+        "relations": [
+          {
+            "type": "many-to-one",
+            "fromEntity": "Product",
+            "toEntity": "Category",
+            "propertyName": "category",
+            "isNullable": false
+          },
+          {
+            "type": "many-to-many",
+            "fromEntity": "Product",
+            "toEntity": "Tag",
+            "propertyName": "tags",
+            "isNullable": false
+          },
+          {
+            "type": "one-to-many",
+            "fromEntity": "Product",
+            "toEntity": "OrderItem",
+            "propertyName": "orderItems",
+            "isNullable": false
+          }
+        ],
+        "indexes": []
+      },
+      {
+        "name": "Tag",
+        "tableName": "tags",
+        "filePath": "/demo/nest-shop/apps/api/src/catalog/tag.entity.ts",
+        "columns": [
+          {
+            "name": "slug",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": true
+          },
+          {
+            "name": "name",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "createdAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "updatedAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          }
+        ],
+        "relations": [],
+        "indexes": []
+      },
+      {
+        "name": "OrderItem",
+        "tableName": "order_items",
+        "filePath": "/demo/nest-shop/apps/api/src/orders/order-item.entity.ts",
+        "columns": [
+          {
+            "name": "quantity",
+            "type": "int",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "unitPriceCents",
+            "type": "int",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "createdAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "updatedAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          }
+        ],
+        "relations": [
+          {
+            "type": "many-to-one",
+            "fromEntity": "OrderItem",
+            "toEntity": "Order",
+            "propertyName": "order",
+            "isNullable": false,
+            "onDelete": "CASCADE"
+          },
+          {
+            "type": "many-to-one",
+            "fromEntity": "OrderItem",
+            "toEntity": "Product",
+            "propertyName": "product",
+            "isNullable": false,
+            "onDelete": "RESTRICT"
+          }
+        ],
+        "indexes": []
+      },
+      {
+        "name": "Order",
+        "tableName": "orders",
+        "filePath": "/demo/nest-shop/apps/api/src/orders/order.entity.ts",
+        "columns": [
+          {
+            "name": "status",
+            "type": "enum",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false,
+            "defaultValue": "OrderStatus.Pending",
+            "hasIndex": true
+          },
+          {
+            "name": "totalCents",
+            "type": "int",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false,
+            "defaultValue": "0"
+          },
+          {
+            "name": "note",
+            "type": "text",
+            "isPrimary": false,
+            "isNullable": true,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "createdAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false,
+            "hasIndex": true
+          },
+          {
+            "name": "updatedAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          }
+        ],
+        "relations": [
+          {
+            "type": "many-to-one",
+            "fromEntity": "Order",
+            "toEntity": "User",
+            "propertyName": "user",
+            "isNullable": false
+          },
+          {
+            "type": "one-to-many",
+            "fromEntity": "Order",
+            "toEntity": "OrderItem",
+            "propertyName": "items",
+            "isNullable": false
+          }
+        ],
+        "indexes": [
+          {
+            "columns": [
+              "status",
+              "createdAt"
+            ],
+            "isUnique": false
+          }
+        ]
+      },
+      {
+        "name": "Invoice",
+        "tableName": "invoices",
+        "filePath": "/demo/nest-shop/apps/api/src/payments/invoice.entity.ts",
+        "columns": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "number",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": true
+          },
+          {
+            "name": "issuedAt",
+            "type": "timestamptz",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          }
+        ],
+        "relations": [
+          {
+            "type": "one-to-one",
+            "fromEntity": "Invoice",
+            "toEntity": "Order",
+            "propertyName": "order",
+            "isNullable": false,
+            "onDelete": "CASCADE"
+          }
+        ],
+        "indexes": []
+      },
+      {
+        "name": "Payment",
+        "tableName": "payments",
+        "filePath": "/demo/nest-shop/apps/api/src/payments/payment.entity.ts",
+        "columns": [
+          {
+            "name": "provider",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false,
+            "hasIndex": true
+          },
+          {
+            "name": "amountCents",
+            "type": "int",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "status",
+            "type": "enum",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false,
+            "defaultValue": "PaymentStatus.Pending"
+          },
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "createdAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "updatedAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          }
+        ],
+        "relations": [
+          {
+            "type": "many-to-one",
+            "fromEntity": "Payment",
+            "toEntity": "Order",
+            "propertyName": "order",
+            "isNullable": false,
+            "onDelete": "CASCADE"
+          }
+        ],
+        "indexes": [
+          {
+            "columns": [
+              "provider"
+            ],
+            "isUnique": false
+          }
+        ]
+      },
+      {
+        "name": "User",
+        "tableName": "users",
+        "filePath": "/demo/nest-shop/apps/api/src/users/user.entity.ts",
+        "columns": [
+          {
+            "name": "email",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": true
+          },
+          {
+            "name": "name",
+            "type": "unknown",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false
+          },
+          {
+            "name": "addresses",
+            "type": "jsonb",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": false,
+            "isUnique": false,
+            "defaultValue": "[]"
+          },
+          {
+            "name": "id",
+            "type": "uuid",
+            "isPrimary": true,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "createdAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          },
+          {
+            "name": "updatedAt",
+            "type": "timestamp",
+            "isPrimary": false,
+            "isNullable": false,
+            "isGenerated": true,
+            "isUnique": false
+          }
+        ],
+        "relations": [
+          {
+            "type": "one-to-many",
+            "fromEntity": "User",
+            "toEntity": "Order",
+            "propertyName": "orders",
+            "isNullable": false
+          }
+        ],
+        "indexes": []
+      }
+    ],
+    "relations": [
+      {
+        "type": "one-to-many",
+        "fromEntity": "Category",
+        "toEntity": "Product",
+        "propertyName": "products",
+        "isNullable": false
+      },
+      {
+        "type": "many-to-one",
+        "fromEntity": "Product",
+        "toEntity": "Category",
+        "propertyName": "category",
+        "isNullable": false
+      },
+      {
+        "type": "many-to-many",
+        "fromEntity": "Product",
+        "toEntity": "Tag",
+        "propertyName": "tags",
+        "isNullable": false
+      },
+      {
+        "type": "one-to-many",
+        "fromEntity": "Product",
+        "toEntity": "OrderItem",
+        "propertyName": "orderItems",
+        "isNullable": false
+      },
+      {
+        "type": "many-to-one",
+        "fromEntity": "OrderItem",
+        "toEntity": "Order",
+        "propertyName": "order",
+        "isNullable": false,
+        "onDelete": "CASCADE"
+      },
+      {
+        "type": "many-to-one",
+        "fromEntity": "OrderItem",
+        "toEntity": "Product",
+        "propertyName": "product",
+        "isNullable": false,
+        "onDelete": "RESTRICT"
+      },
+      {
+        "type": "many-to-one",
+        "fromEntity": "Order",
+        "toEntity": "User",
+        "propertyName": "user",
+        "isNullable": false
+      },
+      {
+        "type": "one-to-many",
+        "fromEntity": "Order",
+        "toEntity": "OrderItem",
+        "propertyName": "items",
+        "isNullable": false
+      },
+      {
+        "type": "one-to-one",
+        "fromEntity": "Invoice",
+        "toEntity": "Order",
+        "propertyName": "order",
+        "isNullable": false,
+        "onDelete": "CASCADE"
+      },
+      {
+        "type": "many-to-one",
+        "fromEntity": "Payment",
+        "toEntity": "Order",
+        "propertyName": "order",
+        "isNullable": false,
+        "onDelete": "CASCADE"
+      },
+      {
+        "type": "one-to-many",
+        "fromEntity": "User",
+        "toEntity": "Order",
+        "propertyName": "orders",
+        "isNullable": false
+      }
+    ],
+    "orm": "typeorm"
+  },
+  "examples": {
+    "security/no-hardcoded-secrets": {
+      "bad": "@Injectable()\nexport class AuthService {\n  private readonly apiKey = 'sk-1234567890abcdef';\n  private readonly dbPassword = 'super_secret_password';\n}",
+      "good": "@Injectable()\nexport class AuthService {\n  constructor(private readonly config: ConfigService) {}\n\n  getApiKey() {\n    return this.config.get('API_KEY');\n  }\n}"
+    },
+    "security/no-eval": {
+      "bad": "@Injectable()\nexport class CalcService {\n  evaluate(expression: string) {\n    return eval(expression);\n  }\n}",
+      "good": "@Injectable()\nexport class CalcService {\n  evaluate(expression: string) {\n    return JSON.parse(expression);\n  }\n}"
+    },
+    "security/no-csrf-disabled": {
+      "bad": "app.use(csurf({ cookie: false }));\n// or\nconst csrfOptions = { csrf: false };",
+      "good": "app.use(csurf({ cookie: true }));"
+    },
+    "security/no-dangerous-redirects": {
+      "bad": "@Controller('go')\nexport class GoController {\n  @Get('redirect')\n  redirect(@Query('url') url: string, @Res() res: Response) {\n    res.redirect(url);\n  }\n}",
+      "good": "@Controller('go')\nexport class GoController {\n  @Get('redirect')\n  redirect(@Query('to') to: string, @Res() res: Response) {\n    const targets: Record<string, string> = { home: '/', docs: '/docs' };\n    res.redirect(targets[to] ?? '/');\n  }\n}"
+    },
+    "security/no-synchronize-in-production": {
+      "bad": "TypeOrmModule.forRoot({\n  type: 'postgres',\n  synchronize: true,\n})",
+      "good": "TypeOrmModule.forRoot({\n  type: 'postgres',\n  synchronize: false,\n  // Use migrations instead\n})"
+    },
+    "security/no-weak-crypto": {
+      "bad": "import { createHash } from 'crypto';\nconst hash = createHash('md5').update(data).digest('hex');",
+      "good": "import { createHash } from 'crypto';\nconst hash = createHash('sha256').update(data).digest('hex');"
+    },
+    "security/no-exposed-env-vars": {
+      "bad": "@Injectable()\nexport class MailService {\n  private readonly apiKey = process.env.MAIL_API_KEY;\n}",
+      "good": "@Injectable()\nexport class MailService {\n  constructor(private readonly config: ConfigService) {}\n\n  getApiKey() {\n    return this.config.get('MAIL_API_KEY');\n  }\n}"
+    },
+    "security/no-exposed-stack-trace": {
+      "bad": "@Catch()\nexport class AllExceptionsFilter implements ExceptionFilter {\n  catch(exception: Error, host: ArgumentsHost) {\n    response.json({ message: exception.message, stack: exception.stack });\n  }\n}",
+      "good": "@Catch()\nexport class AllExceptionsFilter implements ExceptionFilter {\n  catch(exception: Error, host: ArgumentsHost) {\n    this.logger.error(exception.stack);\n    response.json({ message: 'Internal server error' });\n  }\n}"
+    },
+    "security/no-raw-entity-in-response": {
+      "bad": "@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string): Promise<UserEntity> {\n    return this.userRepo.findOne(id); // Every column ships\n  }\n}",
+      "good": "@Controller('users')\nexport class UserController {\n  @Get(':id')\n  async findOne(@Param('id') id: string): Promise<UserResponseDto> {\n    const user = await this.userService.findOne(id);\n    return new UserResponseDto(user); // Controlled shape\n  }\n}"
+    },
+    "security/require-guards-on-endpoints": {
+      "bad": "@Controller('orders')\nexport class OrderController {\n  @Get()\n  findAll() {\n    return this.orderService.findAll(); // No guard, no @Public()\n  }\n}",
+      "good": "@UseGuards(AuthGuard)\n@Controller('orders')\nexport class OrderController {\n  @Get()\n  findAll() {\n    return this.orderService.findAll();\n  }\n}"
+    },
+    "correctness/no-missing-injectable": {
+      "bad": "// user.service.ts\nexport class UserService {  // Missing @Injectable()\n  constructor(private readonly db: DatabaseService) {}\n}\n\n// user.module.ts\n@Module({ providers: [UserService] })\nexport class UserModule {}",
+      "good": "@Injectable()\nexport class UserService {\n  constructor(private readonly db: DatabaseService) {}\n}"
+    },
+    "correctness/no-duplicate-routes": {
+      "bad": "@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string) { /* ... */ }\n\n  @Get(':id')  // Duplicate!\n  getUser(@Param('id') id: string) { /* ... */ }\n}",
+      "good": "@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string) { /* ... */ }\n\n  @Get(':id/profile')\n  getProfile(@Param('id') id: string) { /* ... */ }\n}"
+    },
+    "correctness/no-missing-guard-method": {
+      "bad": "@Injectable()\nexport class AuthGuard implements CanActivate {\n  // Missing canActivate()!\n}",
+      "good": "@Injectable()\nexport class AuthGuard implements CanActivate {\n  canActivate(context: ExecutionContext): boolean {\n    return this.validateRequest(context);\n  }\n}"
+    },
+    "correctness/no-missing-pipe-method": {
+      "bad": "@Injectable()\nexport class ParseIntPipe implements PipeTransform {\n  // Missing transform()!\n}",
+      "good": "@Injectable()\nexport class ParseIntPipe implements PipeTransform {\n  transform(value: string): number {\n    return parseInt(value, 10);\n  }\n}"
+    },
+    "correctness/no-missing-filter-catch": {
+      "bad": "@Catch(HttpException)\nexport class HttpFilter implements ExceptionFilter {\n  // Missing catch()!\n}",
+      "good": "@Catch(HttpException)\nexport class HttpFilter implements ExceptionFilter {\n  catch(exception: HttpException, host: ArgumentsHost) {\n    const response = host.switchToHttp().getResponse();\n    response.status(exception.getStatus()).json({ error: exception.message });\n  }\n}"
+    },
+    "correctness/no-missing-interceptor-method": {
+      "bad": "@Injectable()\nexport class LoggingInterceptor implements NestInterceptor {\n  // Missing intercept()!\n}",
+      "good": "@Injectable()\nexport class LoggingInterceptor implements NestInterceptor {\n  intercept(context: ExecutionContext, next: CallHandler) {\n    console.log('Before...');\n    return next.handle();\n  }\n}"
+    },
+    "correctness/require-inject-decorator": {
+      "bad": "@Injectable()\nexport class UserService {\n  constructor(private readonly connection) {} // No type, no @Inject()\n}",
+      "good": "@Injectable()\nexport class UserService {\n  constructor(\n    @Inject('DATABASE_CONNECTION')\n    private readonly connection: Connection,\n  ) {}\n}"
+    },
+    "correctness/prefer-readonly-injection": {
+      "bad": "@Injectable()\nexport class UserService {\n  constructor(private db: DatabaseService) {}\n}",
+      "good": "@Injectable()\nexport class UserService {\n  constructor(private readonly db: DatabaseService) {}\n}"
+    },
+    "correctness/require-lifecycle-interface": {
+      "bad": "@Injectable()\nexport class AppService {\n  onModuleInit() {  // No OnModuleInit interface\n    // ...\n  }\n}",
+      "good": "@Injectable()\nexport class AppService implements OnModuleInit {\n  onModuleInit() {\n    // ...\n  }\n}"
+    },
+    "correctness/no-empty-handlers": {
+      "bad": "@Controller('users')\nexport class UserController {\n  @Get()\n  findAll() {}  // Empty body\n}",
+      "good": "@Controller('users')\nexport class UserController {\n  @Get()\n  findAll() {\n    return this.userService.findAll();\n  }\n}"
+    },
+    "correctness/no-async-without-await": {
+      "bad": "@Injectable()\nexport class UserService {\n  async findAll() {\n    return this.users;  // No await needed\n  }\n}",
+      "good": "@Injectable()\nexport class UserService {\n  findAll() {\n    return this.users;\n  }\n\n  // Or, if async is needed:\n  async findById(id: string) {\n    return await this.db.user.findUnique({ where: { id } });\n  }\n}"
+    },
+    "correctness/no-duplicate-module-metadata": {
+      "bad": "@Module({\n  providers: [UserService, AuthService, UserService],  // Duplicate!\n})\nexport class UserModule {}",
+      "good": "@Module({\n  providers: [UserService, AuthService],\n})\nexport class UserModule {}"
+    },
+    "correctness/no-missing-module-decorator": {
+      "bad": "export class UserModule {  // Missing @Module()\n  // ...\n}",
+      "good": "@Module({\n  controllers: [UserController],\n  providers: [UserService],\n})\nexport class UserModule {}"
+    },
+    "correctness/no-fire-and-forget-async": {
+      "bad": "@Injectable()\nexport class OrderService {\n  complete(orderId: string) {\n    this.notificationService.sendEmail(orderId);  // No await!\n    this.analyticsService.track('order_completed');  // No await!\n  }\n}",
+      "good": "@Injectable()\nexport class OrderService {\n  async complete(orderId: string) {\n    await this.notificationService.sendEmail(orderId);\n    await this.analyticsService.track('order_completed');\n  }\n}"
+    },
+    "correctness/factory-inject-matches-params": {
+      "bad": "@Module({\n  providers: [{\n    provide: 'DATA_SOURCE',\n    useFactory: (config: ConfigService) => createDataSource(config),\n    inject: [ConfigService, Logger],  // 2 tokens but 1 param!\n  }],\n})\nexport class AppModule {}",
+      "good": "@Module({\n  providers: [{\n    provide: 'DATA_SOURCE',\n    useFactory: (config: ConfigService, logger: Logger) =>\n      createDataSource(config, logger),\n    inject: [ConfigService, Logger],  // 2 tokens, 2 params\n  }],\n})\nexport class AppModule {}"
+    },
+    "correctness/injectable-must-be-provided": {
+      "bad": "@Injectable()\nexport class CacheService {  // Not in any module's providers\n  get(key: string) { /* ... */ }\n}",
+      "good": "@Injectable()\nexport class CacheService {\n  get(key: string) { /* ... */ }\n}\n\n@Module({ providers: [CacheService] })\nexport class CacheModule {}"
+    },
+    "correctness/no-duplicate-decorators": {
+      "bad": "@Controller('users')\nexport class UserController {\n  @Get(':id')\n  @Get(':id')  // Duplicate decorator!\n  findOne(@Param('id') id: string) { /* ... */ }\n}",
+      "good": "@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string) { /* ... */ }\n}"
+    },
+    "correctness/param-decorator-matches-route": {
+      "bad": "@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('userId') userId: string) {  // 'userId' not in route\n    return this.userService.findOne(userId);\n  }\n}",
+      "good": "@Controller('users')\nexport class UserController {\n  @Get(':id')\n  findOne(@Param('id') id: string) {  // 'id' matches :id in route\n    return this.userService.findOne(id);\n  }\n}"
+    },
+    "correctness/validate-nested-array-each": {
+      "bad": "export class CreateOrderDto {\n  @ValidateNested()  // Missing { each: true } for array\n  @Type(() => OrderItemDto)\n  items: OrderItemDto[];\n}",
+      "good": "export class CreateOrderDto {\n  @ValidateNested({ each: true })  // Validates each item in the array\n  @Type(() => OrderItemDto)\n  items: OrderItemDto[];\n}"
+    },
+    "correctness/validated-non-primitive-needs-type": {
+      "bad": "export class CreateUserDto {\n  @ValidateNested()\n  address: AddressDto;  // Missing @Type() — validator can't instantiate\n}",
+      "good": "export class CreateUserDto {\n  @ValidateNested()\n  @Type(() => AddressDto)\n  address: AddressDto;\n}"
+    },
+    "architecture/no-business-logic-in-controllers": {
+      "bad": "@Controller('orders')\nexport class OrderController {\n  @Post()\n  create(@Body() dto: CreateOrderDto) {\n    const items = [];\n    for (const item of dto.items) {  // Logic in controller\n      if (item.quantity > 0) {\n        items.push({ ...item, total: item.price * item.quantity });\n      }\n    }\n    return this.orderRepo.save({ items });\n  }\n}",
+      "good": "@Controller('orders')\nexport class OrderController {\n  @Post()\n  create(@Body() dto: CreateOrderDto) {\n    return this.orderService.create(dto);\n  }\n}"
+    },
+    "architecture/no-repository-in-controllers": {
+      "bad": "@Controller('users')\nexport class UserController {\n  constructor(\n    @InjectRepository(User)\n    private readonly userRepo: Repository<User>,\n  ) {}\n}",
+      "good": "@Controller('users')\nexport class UserController {\n  constructor(private readonly userService: UserService) {}\n}"
+    },
+    "architecture/no-orm-in-controllers": {
+      "bad": "@Controller('users')\nexport class UserController {\n  constructor(private readonly prisma: PrismaService) {}\n\n  @Get()\n  findAll() {\n    return this.prisma.user.findMany();\n  }\n}",
+      "good": "@Controller('users')\nexport class UserController {\n  constructor(private readonly userService: UserService) {}\n\n  @Get()\n  findAll() {\n    return this.userService.findAll();\n  }\n}"
+    },
+    "architecture/no-circular-module-deps": {
+      "bad": "// user.module.ts\n@Module({ imports: [OrderModule] })\nexport class UserModule {}\n\n// order.module.ts\n@Module({ imports: [UserModule] })  // Circular!\nexport class OrderModule {}",
+      "good": "// shared.module.ts — extract shared logic\n@Module({ providers: [SharedService], exports: [SharedService] })\nexport class SharedModule {}\n\n// user.module.ts\n@Module({ imports: [SharedModule] })\nexport class UserModule {}\n\n// order.module.ts\n@Module({ imports: [SharedModule] })\nexport class OrderModule {}"
+    },
+    "architecture/no-manual-instantiation": {
+      "bad": "@Injectable()\nexport class OrderService {\n  processOrder(order: Order) {\n    const pricing = new PricingService();  // Bypasses the injector\n    return pricing.total(order);\n  }\n}",
+      "good": "@Injectable()\nexport class OrderService {\n  constructor(private readonly pricing: PricingService) {}\n\n  processOrder(order: Order) {\n    return this.pricing.total(order);\n  }\n}"
+    },
+    "architecture/no-orm-in-services": {
+      "bad": "@Injectable()\nexport class UserService {\n  constructor(private readonly prisma: PrismaService) {}\n}",
+      "good": "@Injectable()\nexport class UserService {\n  constructor(private readonly userRepo: UserRepository) {}\n}"
+    },
+    "architecture/no-service-locator": {
+      "bad": "@Injectable()\nexport class TaskService {\n  constructor(private readonly moduleRef: ModuleRef) {}\n\n  async run() {\n    const service = this.moduleRef.get(SomeService);\n    service.doWork();\n  }\n}",
+      "good": "@Injectable()\nexport class TaskService {\n  constructor(private readonly someService: SomeService) {}\n\n  async run() {\n    this.someService.doWork();\n  }\n}"
+    },
+    "architecture/prefer-constructor-injection": {
+      "bad": "@Injectable()\nexport class UserService {\n  @Inject()\n  private configService: ConfigService;\n}",
+      "good": "@Injectable()\nexport class UserService {\n  constructor(private readonly configService: ConfigService) {}\n}"
+    },
+    "architecture/require-module-boundaries": {
+      "bad": "// In user module:\nimport { OrderRepository } from '../order/repositories/order.repository';",
+      "good": "// In user module:\nimport { OrderValidator } from '../order';\n// Or better: inject via DI through the module system"
+    },
+    "architecture/no-barrel-export-internals": {
+      "bad": "// user/index.ts\nexport { UserService } from './user.service';\nexport { UserRepository } from './user.repository';  // Internal!",
+      "good": "// user/index.ts\nexport { UserService } from './user.service';\n// UserRepository stays internal to the module"
+    },
+    "performance/no-sync-io": {
+      "bad": "@Injectable()\nexport class ConfigService {\n  loadConfig() {\n    const data = readFileSync('config.json', 'utf-8');\n    return JSON.parse(data);\n  }\n}",
+      "good": "@Injectable()\nexport class ConfigService {\n  async loadConfig() {\n    const data = await readFile('config.json', 'utf-8');\n    return JSON.parse(data);\n  }\n}"
+    },
+    "performance/no-blocking-constructor": {
+      "bad": "@Injectable()\nexport class CacheService {\n  constructor() {\n    // Blocks startup\n    for (let i = 0; i < 10000; i++) {\n      this.cache.set(i, computeExpensiveValue(i));\n    }\n  }\n}",
+      "good": "@Injectable()\nexport class CacheService implements OnModuleInit {\n  async onModuleInit() {\n    // Runs after construction, non-blocking\n    await this.warmCache();\n  }\n}"
+    },
+    "performance/no-dynamic-require": {
+      "bad": "@Injectable()\nexport class PluginLoader {\n  load(name: string) {\n    return require(`./plugins/${name}`);\n  }\n}",
+      "good": "@Injectable()\nexport class PluginLoader {\n  private readonly plugins = new Map<string, Plugin>();\n\n  register(name: string, plugin: Plugin) {\n    this.plugins.set(name, plugin);\n  }\n\n  load(name: string) {\n    return this.plugins.get(name);\n  }\n}"
+    },
+    "performance/no-unused-providers": {
+      "bad": "// Never injected anywhere\n@Injectable()\nexport class LegacyService {\n  doOldStuff() { /* ... */ }\n}\n\n@Module({ providers: [LegacyService, UserService] })\nexport class UserModule {}",
+      "good": "// Remove unused provider\n@Module({ providers: [UserService] })\nexport class UserModule {}"
+    },
+    "performance/no-request-scope-abuse": {
+      "bad": "@Injectable({ scope: Scope.REQUEST })\nexport class UserService {\n  // New instance created for EVERY request\n}",
+      "good": "@Injectable()  // Default singleton scope\nexport class UserService {\n  // Single instance shared across all requests\n}"
+    },
+    "performance/no-unused-module-exports": {
+      "bad": "@Module({\n  providers: [SharedService],\n  exports: [SharedService],  // No other module imports SharedModule\n})\nexport class SharedModule {}",
+      "good": "// Either remove the export:\n@Module({ providers: [SharedService] })\nexport class SharedModule {}\n\n// Or import SharedModule where it's needed:\n@Module({ imports: [SharedModule] })\nexport class UserModule {}"
+    },
+    "performance/no-orphan-modules": {
+      "bad": "// analytics.module.ts — never imported anywhere\n@Module({\n  providers: [AnalyticsService],\n})\nexport class AnalyticsModule {}",
+      "good": "// Import it in the parent module:\n@Module({\n  imports: [AnalyticsModule],\n})\nexport class AppModule {}"
+    },
+    "schema/require-primary-key": {
+      "bad": "@Entity()\nexport class AuditLog {\n  @Column()\n  action: string;\n\n  @Column()\n  timestamp: Date;\n  // No primary key column!\n}",
+      "good": "@Entity()\nexport class AuditLog {\n  @PrimaryGeneratedColumn('uuid')\n  id: string;\n\n  @Column()\n  action: string;\n\n  @Column()\n  timestamp: Date;\n}"
+    },
+    "schema/require-timestamps": {
+      "bad": "@Entity()\nexport class Product {\n  @PrimaryGeneratedColumn()\n  id: number;\n\n  @Column()\n  name: string;\n  // No createdAt / updatedAt columns\n}",
+      "good": "@Entity()\nexport class Product {\n  @PrimaryGeneratedColumn()\n  id: number;\n\n  @Column()\n  name: string;\n\n  @CreateDateColumn()\n  createdAt: Date;\n\n  @UpdateDateColumn()\n  updatedAt: Date;\n}"
+    },
+    "schema/require-cascade-rule": {
+      "bad": "@Entity()\nexport class Order {\n  @ManyToOne(() => User, (user) => user.orders)\n  user: User;  // No onDelete — the database default decides\n}",
+      "good": "@Entity()\nexport class Order {\n  @ManyToOne(() => User, (user) => user.orders, {\n    onDelete: 'CASCADE',\n  })\n  user: User;\n}"
+    }
+  },
+  "share": {
+    "filename": "nestjs-doctor-shared.json",
+    "findingsByCategory": {
+      "security": {
+        "findings": [
+          {
+            "filePath": "apps/api/src/app.module.ts",
+            "message": "TypeORM 'synchronize: true' can auto-drop columns and tables in production.",
+            "help": "Set synchronize: false and use migrations for production schema changes.",
+            "line": 27,
+            "column": 1,
+            "rule": "security/no-synchronize-in-production",
+            "category": "security",
+            "scope": "file",
+            "severity": "error",
+            "sourceLines": [
+              {
+                "line": 22,
+                "text": "        port: Number(config.getOrThrow<string>('DATABASE_PORT')),"
+              },
+              {
+                "line": 23,
+                "text": "        username: config.getOrThrow<string>('DATABASE_USER'),"
+              },
+              {
+                "line": 24,
+                "text": "        password: config.getOrThrow<string>('DATABASE_PASSWORD'),"
+              },
+              {
+                "line": 25,
+                "text": "        database: config.getOrThrow<string>('DATABASE_NAME'),"
+              },
+              {
+                "line": 26,
+                "text": "        autoLoadEntities: true,"
+              },
+              {
+                "line": 27,
+                "text": "        synchronize: true,"
+              },
+              {
+                "line": 28,
+                "text": "      }),"
+              },
+              {
+                "line": 29,
+                "text": "    }),"
+              },
+              {
+                "line": 30,
+                "text": "    BullModule.forRootAsync({"
+              },
+              {
+                "line": 31,
+                "text": "      inject: [ConfigService],"
+              },
+              {
+                "line": 32,
+                "text": "      useFactory: (config: ConfigService) => ({"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/notifications/notifications.service.ts",
+            "message": "Direct 'process.env.NOTIFICATIONS_FROM' access in 'NotificationsService'. Use ConfigService instead.",
+            "help": "Inject ConfigService and use configService.get('VAR_NAME') instead of process.env.VAR_NAME.",
+            "line": 13,
+            "column": 1,
+            "rule": "security/no-exposed-env-vars",
+            "category": "security",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 8,
+                "text": "export type NotificationKind = 'receipt' | 'refund' | 'welcome' | 'payment-reminder';"
+              },
+              {
+                "line": 9,
+                "text": ""
+              },
+              {
+                "line": 10,
+                "text": "@Injectable()"
+              },
+              {
+                "line": 11,
+                "text": "export class NotificationsService implements OnApplicationBootstrap {"
+              },
+              {
+                "line": 12,
+                "text": "  private readonly logger = new Logger(NotificationsService.name);"
+              },
+              {
+                "line": 13,
+                "text": "  private readonly from = process.env.NOTIFICATIONS_FROM ?? 'shop@example.com';"
+              },
+              {
+                "line": 14,
+                "text": ""
+              },
+              {
+                "line": 15,
+                "text": "  constructor("
+              },
+              {
+                "line": 16,
+                "text": "    @InjectQueue('notifications') private readonly queue: Queue,"
+              },
+              {
+                "line": 17,
+                "text": "    private readonly catalogService: CatalogService,"
+              },
+              {
+                "line": 18,
+                "text": "    @Inject(forwardRef(() => OrdersService))"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/payments/payments.controller.ts",
+            "message": "Endpoint 'list' has no @UseGuards() at class or method level.",
+            "help": "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.",
+            "line": 8,
+            "column": 1,
+            "rule": "security/require-guards-on-endpoints",
+            "category": "security",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 3,
+                "text": ""
+              },
+              {
+                "line": 4,
+                "text": "@Controller('payments')"
+              },
+              {
+                "line": 5,
+                "text": "export class PaymentsController {"
+              },
+              {
+                "line": 6,
+                "text": "  constructor(private readonly paymentsService: PaymentsService) {}"
+              },
+              {
+                "line": 7,
+                "text": ""
+              },
+              {
+                "line": 8,
+                "text": "  @Get()"
+              },
+              {
+                "line": 9,
+                "text": "  list() {"
+              },
+              {
+                "line": 10,
+                "text": "    return this.paymentsService.findAll();"
+              },
+              {
+                "line": 11,
+                "text": "  }"
+              },
+              {
+                "line": 12,
+                "text": ""
+              },
+              {
+                "line": 13,
+                "text": "  @Post(':id/refund')"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/payments/payments.controller.ts",
+            "message": "Endpoint 'refund' has no @UseGuards() at class or method level.",
+            "help": "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but only when the token is written as APP_GUARD, not through an aliased import.",
+            "line": 13,
+            "column": 1,
+            "rule": "security/require-guards-on-endpoints",
+            "category": "security",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 8,
+                "text": "  @Get()"
+              },
+              {
+                "line": 9,
+                "text": "  list() {"
+              },
+              {
+                "line": 10,
+                "text": "    return this.paymentsService.findAll();"
+              },
+              {
+                "line": 11,
+                "text": "  }"
+              },
+              {
+                "line": 12,
+                "text": ""
+              },
+              {
+                "line": 13,
+                "text": "  @Post(':id/refund')"
+              },
+              {
+                "line": 14,
+                "text": "  refund(@Param('id') id: string) {"
+              },
+              {
+                "line": 15,
+                "text": "    return this.paymentsService.refund(id);"
+              },
+              {
+                "line": 16,
+                "text": "  }"
+              },
+              {
+                "line": 17,
+                "text": "}"
+              },
+              {
+                "line": 18,
+                "text": ""
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/payments/payments.service.ts",
+            "message": "Property 'webhookSecret' appears to contain a hardcoded secret.",
+            "help": "Move secrets to environment variables and access them via ConfigService.",
+            "line": 28,
+            "column": 1,
+            "rule": "security/no-hardcoded-secrets",
+            "category": "security",
+            "scope": "file",
+            "severity": "error",
+            "sourceLines": [
+              {
+                "line": 23,
+                "text": "@Injectable()"
+              },
+              {
+                "line": 24,
+                "text": "export class PaymentsService implements OnModuleInit, OnApplicationBootstrap {"
+              },
+              {
+                "line": 25,
+                "text": "  private readonly logger = new Logger(PaymentsService.name);"
+              },
+              {
+                "line": 26,
+                "text": "  // Pending amount per order id, warmed at boot so refunds can check quickly."
+              },
+              {
+                "line": 27,
+                "text": "  private readonly pendingByOrder = new Map<string, number>();"
+              },
+              {
+                "line": 28,
+                "text": "  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';"
+              },
+              {
+                "line": 29,
+                "text": ""
+              },
+              {
+                "line": 30,
+                "text": "  constructor("
+              },
+              {
+                "line": 31,
+                "text": "    @InjectRepository(Payment) private readonly payments: Repository<Payment>,"
+              },
+              {
+                "line": 32,
+                "text": "    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,"
+              },
+              {
+                "line": 33,
+                "text": "    private readonly cardGateway: CardGateway,"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/payments/payments.service.ts",
+            "message": "Weak hashing algorithm 'md5' used in createHash().",
+            "help": "Use a stronger algorithm like SHA-256 or bcrypt for password hashing.",
+            "line": 144,
+            "column": 1,
+            "rule": "security/no-weak-crypto",
+            "category": "security",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 139,
+                "text": "    return expected.length === signature.length && timingSafeEqual(Buffer.from(expected), Buffer.from(signature));"
+              },
+              {
+                "line": 140,
+                "text": "  }"
+              },
+              {
+                "line": 141,
+                "text": ""
+              },
+              {
+                "line": 142,
+                "text": "  private nextInvoiceNumber(order: Order): string {"
+              },
+              {
+                "line": 143,
+                "text": "    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');"
+              },
+              {
+                "line": 144,
+                "text": "    const suffix = createHash('md5').update(order.id).digest('hex').slice(0, 8);"
+              },
+              {
+                "line": 145,
+                "text": "    return `INV-${stamp}-${suffix.toUpperCase()}`;"
+              },
+              {
+                "line": 146,
+                "text": "  }"
+              },
+              {
+                "line": 147,
+                "text": "}"
+              },
+              {
+                "line": 148,
+                "text": ""
+              }
+            ]
+          }
+        ],
+        "schemaIssues": [],
+        "summary": {
+          "total": 6,
+          "errors": 2,
+          "warnings": 4,
+          "info": 0,
+          "byCategory": {
+            "security": 6,
+            "performance": 0,
+            "correctness": 0,
+            "architecture": 0,
+            "schema": 0
+          }
+        }
+      },
+      "performance": {
+        "findings": [
+          {
+            "filePath": "apps/api/src/main.ts",
+            "message": "Synchronous I/O call 'writeFileSync()' blocks the event loop.",
+            "help": "Use the async variant (e.g., readFile instead of readFileSync) with await.",
+            "line": 59,
+            "column": 1,
+            "rule": "performance/no-sync-io",
+            "category": "performance",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 54,
+                "text": "  Logger.log(`API listening on http://localhost:${port}`, 'Bootstrap');"
+              },
+              {
+                "line": 55,
+                "text": ""
+              },
+              {
+                "line": 56,
+                "text": "  if (traceEnabled) {"
+              },
+              {
+                "line": 57,
+                "text": "    const graph = JSON.parse(app.get(SerializedGraph).toString());"
+              },
+              {
+                "line": 58,
+                "text": "    Object.assign(graph, { createMs, initMs, moduleInitMs, startupMs, hookTimings });"
+              },
+              {
+                "line": 59,
+                "text": "    writeFileSync('nestjs-doctor-timings.json', JSON.stringify(graph));"
+              },
+              {
+                "line": 60,
+                "text": "    Logger.log(`Boot trace written to nestjs-doctor-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');"
+              },
+              {
+                "line": 61,
+                "text": "    await app.close();"
+              },
+              {
+                "line": 62,
+                "text": "    process.exit(0);"
+              },
+              {
+                "line": 63,
+                "text": "  }"
+              },
+              {
+                "line": 64,
+                "text": "}"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/audit/audit-archiver.service.ts",
+            "message": "Provider 'AuditArchiverService' is never injected by any other provider or controller.",
+            "help": "Remove the unused provider, inject it where needed, or verify the framework activates it, through a decorator such as @Cron or @OnEvent or a contract such as OnModuleInit or CanActivate.",
+            "line": 4,
+            "column": 1,
+            "rule": "performance/no-unused-providers",
+            "category": "performance",
+            "scope": "project",
+            "severity": "warning",
+            "tags": [
+              "module-graph"
+            ]
+          },
+          {
+            "filePath": "apps/api/src/reports/reports.module.ts",
+            "message": "Module 'ReportsModule' is never imported by any other module.",
+            "help": "Import this module in another module or remove it if it is unused.",
+            "line": 5,
+            "column": 1,
+            "rule": "performance/no-orphan-modules",
+            "category": "performance",
+            "scope": "project",
+            "severity": "info",
+            "tags": [
+              "module-graph"
+            ]
+          },
+          {
+            "filePath": "apps/worker/src/main.ts",
+            "message": "Synchronous I/O call 'writeFileSync()' blocks the event loop.",
+            "help": "Use the async variant (e.g., readFile instead of readFileSync) with await.",
+            "line": 50,
+            "column": 1,
+            "rule": "performance/no-sync-io",
+            "category": "performance",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 45,
+                "text": "  Logger.log('Worker started, waiting for jobs', 'Bootstrap');"
+              },
+              {
+                "line": 46,
+                "text": ""
+              },
+              {
+                "line": 47,
+                "text": "  if (traceEnabled) {"
+              },
+              {
+                "line": 48,
+                "text": "    const graph = JSON.parse(app.get(SerializedGraph).toString());"
+              },
+              {
+                "line": 49,
+                "text": "    Object.assign(graph, { startupMs, hookTimings });"
+              },
+              {
+                "line": 50,
+                "text": "    writeFileSync('worker-timings.json', JSON.stringify(graph));"
+              },
+              {
+                "line": 51,
+                "text": "    Logger.log(`Boot trace written to worker-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');"
+              },
+              {
+                "line": 52,
+                "text": "  }"
+              },
+              {
+                "line": 53,
+                "text": "}"
+              },
+              {
+                "line": 54,
+                "text": ""
+              },
+              {
+                "line": 55,
+                "text": "bootstrap().catch((err) => {"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/worker/src/jobs/jobs.module.ts",
+            "message": "Module 'JobsModule' exports 'JobsService' but no importing module uses it.",
+            "help": "Remove the unused export or use the provider in an importing module.",
+            "line": 6,
+            "column": 1,
+            "rule": "performance/no-unused-module-exports",
+            "category": "performance",
+            "scope": "project",
+            "severity": "info",
+            "tags": [
+              "module-graph"
+            ]
+          },
+          {
+            "filePath": "libs/shared/src/request-context.service.ts",
+            "message": "Scope.REQUEST creates a new instance per request, which impacts performance and propagates request scope to all dependents.",
+            "help": "Remove Scope.REQUEST unless the provider genuinely needs per-request state (e.g., request-scoped context). Consider Scope.DEFAULT or Scope.TRANSIENT instead.",
+            "line": 4,
+            "column": 1,
+            "rule": "performance/no-request-scope-abuse",
+            "category": "performance",
+            "scope": "file",
+            "severity": "warning",
+            "tags": [
+              "module-graph"
+            ],
+            "sourceLines": [
+              {
+                "line": 1,
+                "text": "import { Injectable, Scope } from '@nestjs/common';"
+              },
+              {
+                "line": 2,
+                "text": "import { randomUUID } from 'node:crypto';"
+              },
+              {
+                "line": 3,
+                "text": ""
+              },
+              {
+                "line": 4,
+                "text": "@Injectable({ scope: Scope.REQUEST })"
+              },
+              {
+                "line": 5,
+                "text": "export class RequestContextService {"
+              },
+              {
+                "line": 6,
+                "text": "  readonly requestId = randomUUID();"
+              },
+              {
+                "line": 7,
+                "text": "  readonly startedAt = new Date();"
+              },
+              {
+                "line": 8,
+                "text": "}"
+              },
+              {
+                "line": 9,
+                "text": ""
+              }
+            ]
+          }
+        ],
+        "schemaIssues": [],
+        "summary": {
+          "total": 6,
+          "errors": 0,
+          "warnings": 4,
+          "info": 2,
+          "byCategory": {
+            "security": 0,
+            "performance": 6,
+            "correctness": 0,
+            "architecture": 0,
+            "schema": 0
+          }
+        }
+      },
+      "correctness": {
+        "findings": [
+          {
+            "filePath": "apps/api/src/audit/audit.service.ts",
+            "message": "Constructor parameter 'logs' should be readonly.",
+            "help": "Add the 'readonly' modifier to the constructor parameter.",
+            "line": 15,
+            "column": 13,
+            "rule": "correctness/prefer-readonly-injection",
+            "category": "correctness",
+            "scope": "file",
+            "severity": "warning",
+            "surfaces": [
+              "cli"
+            ],
+            "sourceLines": [
+              {
+                "line": 10,
+                "text": ""
+              },
+              {
+                "line": 11,
+                "text": "@Injectable()"
+              },
+              {
+                "line": 12,
+                "text": "export class AuditService {"
+              },
+              {
+                "line": 13,
+                "text": "  constructor("
+              },
+              {
+                "line": 14,
+                "text": "    @Inject(AUDIT_OPTIONS) private readonly options: AuditOptions,"
+              },
+              {
+                "line": 15,
+                "text": "    private logs: AuditRepository,"
+              },
+              {
+                "line": 16,
+                "text": "  ) {}"
+              },
+              {
+                "line": 17,
+                "text": ""
+              },
+              {
+                "line": 18,
+                "text": "  record(action: string, actor: string, payload: Record<string, unknown> = {}): Promise<AuditLog> {"
+              },
+              {
+                "line": 19,
+                "text": "    return this.logs.insert(action, actor, payload);"
+              },
+              {
+                "line": 20,
+                "text": "  }"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/orders/orders.service.ts",
+            "message": "Async call 'record()' is not awaited — unhandled rejections will crash the process.",
+            "help": "Add await before the async call, or use void with explicit error handling if fire-and-forget is intentional.",
+            "line": 137,
+            "column": 1,
+            "rule": "correctness/no-fire-and-forget-async",
+            "category": "correctness",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 132,
+                "text": "  }"
+              },
+              {
+                "line": 133,
+                "text": ""
+              },
+              {
+                "line": 134,
+                "text": "  async markRefunded(id: string): Promise<void> {"
+              },
+              {
+                "line": 135,
+                "text": "    const order = await this.findOne(id);"
+              },
+              {
+                "line": 136,
+                "text": "    await this.orders.update({ id }, { status: OrderStatus.Refunded });"
+              },
+              {
+                "line": 137,
+                "text": "    this.audit.record('order.refunded', order.user.email, { orderId: id });"
+              },
+              {
+                "line": 138,
+                "text": "  }"
+              },
+              {
+                "line": 139,
+                "text": ""
+              },
+              {
+                "line": 140,
+                "text": "  // Demo orders for the system user, one payment each, spread over the last 30 days."
+              },
+              {
+                "line": 141,
+                "text": "  private async seedDemoOrders(): Promise<number> {"
+              },
+              {
+                "line": 142,
+                "text": "    if ((await this.orders.count()) > 0) {"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/users/dto/update-user.dto.ts",
+            "message": "Property 'addresses' is an array with @ValidateNested() but missing { each: true }.",
+            "help": "Change @ValidateNested() to @ValidateNested({ each: true }) for array properties.",
+            "line": 23,
+            "column": 1,
+            "rule": "correctness/validate-nested-array-each",
+            "category": "correctness",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 18,
+                "text": "  @IsString()"
+              },
+              {
+                "line": 19,
+                "text": "  @MinLength(2)"
+              },
+              {
+                "line": 20,
+                "text": "  name?: string;"
+              },
+              {
+                "line": 21,
+                "text": ""
+              },
+              {
+                "line": 22,
+                "text": "  @IsOptional()"
+              },
+              {
+                "line": 23,
+                "text": "  @ValidateNested()"
+              },
+              {
+                "line": 24,
+                "text": "  @Type(() => AddressDto)"
+              },
+              {
+                "line": 25,
+                "text": "  addresses: AddressDto[];"
+              },
+              {
+                "line": 26,
+                "text": "}"
+              },
+              {
+                "line": 27,
+                "text": ""
+              }
+            ]
+          },
+          {
+            "filePath": "apps/worker/src/jobs/notifications.processor.ts",
+            "message": "Async method 'process()' has no await expression.",
+            "help": "Either add an await expression or remove the async keyword. Framework entry points are exempted, since Nest awaits what they return: route handlers, GraphQL resolvers, WebSocket, microservice, ts-rest and gRPC handlers.",
+            "line": 14,
+            "column": 1,
+            "rule": "correctness/no-async-without-await",
+            "category": "correctness",
+            "scope": "file",
+            "severity": "warning",
+            "surfaces": [
+              "cli"
+            ],
+            "sourceLines": [
+              {
+                "line": 9,
+                "text": ""
+              },
+              {
+                "line": 10,
+                "text": "  constructor(private readonly metrics: MetricsService) {"
+              },
+              {
+                "line": 11,
+                "text": "    super();"
+              },
+              {
+                "line": 12,
+                "text": "  }"
+              },
+              {
+                "line": 13,
+                "text": ""
+              },
+              {
+                "line": 14,
+                "text": "  async process(job: Job<{ message?: string; orderId?: string }>): Promise<void> {"
+              },
+              {
+                "line": 15,
+                "text": "    this.logger.log(`[${job.name}] #${job.id} ${job.data.message ?? ''}`);"
+              },
+              {
+                "line": 16,
+                "text": "    this.metrics.increment(`notifications.${job.name}`);"
+              },
+              {
+                "line": 17,
+                "text": "  }"
+              },
+              {
+                "line": 18,
+                "text": "}"
+              },
+              {
+                "line": 19,
+                "text": ""
+              }
+            ]
+          },
+          {
+            "filePath": "libs/shared/src/metrics.service.ts",
+            "message": "Class 'MetricsService' has 'onModuleInit()' but does not implement 'OnModuleInit'.",
+            "help": "Add 'implements OnModuleInit' (or the appropriate interface) to the class declaration.",
+            "line": 9,
+            "column": 1,
+            "rule": "correctness/require-lifecycle-interface",
+            "category": "correctness",
+            "scope": "file",
+            "severity": "warning",
+            "sourceLines": [
+              {
+                "line": 4,
+                "text": ""
+              },
+              {
+                "line": 5,
+                "text": "@Injectable({ scope: Scope.TRANSIENT })"
+              },
+              {
+                "line": 6,
+                "text": "export class MetricsService {"
+              },
+              {
+                "line": 7,
+                "text": "  private readonly counters = new Map<string, number>();"
+              },
+              {
+                "line": 8,
+                "text": ""
+              },
+              {
+                "line": 9,
+                "text": "  async onModuleInit(): Promise<void> {"
+              },
+              {
+                "line": 10,
+                "text": "    await new Promise((resolve) => setTimeout(resolve, 5));"
+              },
+              {
+                "line": 11,
+                "text": "    for (const name of SEED_COUNTERS) {"
+              },
+              {
+                "line": 12,
+                "text": "      this.counters.set(name, 0);"
+              },
+              {
+                "line": 13,
+                "text": "    }"
+              },
+              {
+                "line": 14,
+                "text": "  }"
+              }
+            ]
+          }
+        ],
+        "schemaIssues": [],
+        "summary": {
+          "total": 5,
+          "errors": 0,
+          "warnings": 5,
+          "info": 0,
+          "byCategory": {
+            "security": 0,
+            "performance": 0,
+            "correctness": 5,
+            "architecture": 0,
+            "schema": 0
+          }
+        }
+      },
+      "architecture": {
+        "findings": [
+          {
+            "filePath": "apps/api/src/orders/orders.controller.ts",
+            "message": "Controller method 'pay' contains business logic (0 if, 0 loops, 1 switch). Move to a service.",
+            "help": "Extract branches, loops, and complex calculations into a service method.",
+            "line": 22,
+            "column": 1,
+            "rule": "architecture/no-business-logic-in-controllers",
+            "category": "architecture",
+            "scope": "file",
+            "severity": "error",
+            "sourceLines": [
+              {
+                "line": 17,
+                "text": "  @Post()"
+              },
+              {
+                "line": 18,
+                "text": "  create(@Body(new ValidationPipe({ whitelist: true, transform: true })) dto: CreateOrderDto) {"
+              },
+              {
+                "line": 19,
+                "text": "    return this.ordersService.create(dto);"
+              },
+              {
+                "line": 20,
+                "text": "  }"
+              },
+              {
+                "line": 21,
+                "text": ""
+              },
+              {
+                "line": 22,
+                "text": "  @Post(':id/pay')"
+              },
+              {
+                "line": 23,
+                "text": "  pay(@Param('id') id: string, @Body() body: { provider?: string }) {"
+              },
+              {
+                "line": 24,
+                "text": "    let surchargeCents: number;"
+              },
+              {
+                "line": 25,
+                "text": "    switch (body.provider) {"
+              },
+              {
+                "line": 26,
+                "text": "      case 'card':"
+              },
+              {
+                "line": 27,
+                "text": "        surchargeCents = 30;"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/orders/orders.service.ts",
+            "message": "Service uses @InjectRepository() directly. Consider wrapping in a repository class.",
+            "help": "Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.",
+            "line": 30,
+            "column": 1,
+            "rule": "architecture/no-orm-in-services",
+            "category": "architecture",
+            "scope": "file",
+            "severity": "info",
+            "sourceLines": [
+              {
+                "line": 25,
+                "text": "@Injectable()"
+              },
+              {
+                "line": 26,
+                "text": "export class OrdersService implements OnModuleInit, OnApplicationBootstrap {"
+              },
+              {
+                "line": 27,
+                "text": "  private readonly logger = new Logger(OrdersService.name);"
+              },
+              {
+                "line": 28,
+                "text": ""
+              },
+              {
+                "line": 29,
+                "text": "  constructor("
+              },
+              {
+                "line": 30,
+                "text": "    @InjectRepository(Order) private readonly orders: Repository<Order>,"
+              },
+              {
+                "line": 31,
+                "text": "    @InjectRepository(OrderItem) private readonly items: Repository<OrderItem>,"
+              },
+              {
+                "line": 32,
+                "text": "    private readonly usersService: UsersService,"
+              },
+              {
+                "line": 33,
+                "text": "    private readonly catalogService: CatalogService,"
+              },
+              {
+                "line": 34,
+                "text": "    private readonly audit: AuditService,"
+              },
+              {
+                "line": 35,
+                "text": "    private readonly metrics: MetricsService,"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/payments/payments.service.ts",
+            "message": "Service uses @InjectRepository() directly. Consider wrapping in a repository class.",
+            "help": "Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.",
+            "line": 31,
+            "column": 1,
+            "rule": "architecture/no-orm-in-services",
+            "category": "architecture",
+            "scope": "file",
+            "severity": "info",
+            "sourceLines": [
+              {
+                "line": 26,
+                "text": "  // Pending amount per order id, warmed at boot so refunds can check quickly."
+              },
+              {
+                "line": 27,
+                "text": "  private readonly pendingByOrder = new Map<string, number>();"
+              },
+              {
+                "line": 28,
+                "text": "  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';"
+              },
+              {
+                "line": 29,
+                "text": ""
+              },
+              {
+                "line": 30,
+                "text": "  constructor("
+              },
+              {
+                "line": 31,
+                "text": "    @InjectRepository(Payment) private readonly payments: Repository<Payment>,"
+              },
+              {
+                "line": 32,
+                "text": "    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,"
+              },
+              {
+                "line": 33,
+                "text": "    private readonly cardGateway: CardGateway,"
+              },
+              {
+                "line": 34,
+                "text": "    private readonly sepaGateway: SepaGateway,"
+              },
+              {
+                "line": 35,
+                "text": "    private readonly metrics: MetricsService,"
+              },
+              {
+                "line": 36,
+                "text": "    private readonly audit: AuditService,"
+              }
+            ]
+          },
+          {
+            "filePath": "apps/api/src/orders/orders.module.ts",
+            "message": "Circular module dependency detected: OrdersModule -> PaymentsModule -> NotificationsModule",
+            "help": "OrdersModule -> PaymentsModule: OrdersService (in OrdersModule) injects PaymentsService (from PaymentsModule)\nPaymentsModule -> NotificationsModule: PaymentsService (in PaymentsModule) injects NotificationsService (from NotificationsModule)\nNotificationsModule -> OrdersModule: NotificationsService (in NotificationsModule) injects OrdersService (from OrdersModule)\nConsider extracting PaymentsService into a shared module — it would break the OrdersModule -> PaymentsModule edge (1 dependency).",
+            "line": 11,
+            "column": 1,
+            "rule": "architecture/no-circular-module-deps",
+            "category": "architecture",
+            "scope": "project",
+            "severity": "error",
+            "tags": [
+              "module-graph"
+            ]
+          },
+          {
+            "filePath": "libs/shared/src/index.ts",
+            "message": "Barrel file re-exports internal module './redis.strategy'.",
+            "help": "Only export the module's public API (services, DTOs, interfaces) from the index.ts beside its module file.",
+            "line": 5,
+            "column": 1,
+            "rule": "architecture/no-barrel-export-internals",
+            "category": "architecture",
+            "scope": "file",
+            "severity": "info",
+            "sourceLines": [
+              {
+                "line": 1,
+                "text": "export * from './shared.module';"
+              },
+              {
+                "line": 2,
+                "text": "export * from './metrics.service';"
+              },
+              {
+                "line": 3,
+                "text": "export * from './app-config.service';"
+              },
+              {
+                "line": 4,
+                "text": "export * from './request-context.service';"
+              },
+              {
+                "line": 5,
+                "text": "export * from './redis.strategy';"
+              },
+              {
+                "line": 6,
+                "text": ""
+              }
+            ]
+          }
+        ],
+        "schemaIssues": [],
+        "summary": {
+          "total": 5,
+          "errors": 2,
+          "warnings": 0,
+          "info": 3,
+          "byCategory": {
+            "security": 0,
+            "performance": 0,
+            "correctness": 0,
+            "architecture": 5,
+            "schema": 0
+          }
+        }
+      },
+      "schema": {
+        "findings": [],
+        "schemaIssues": [
+          {
+            "filePath": "apps/api/src/catalog/category.entity.ts",
+            "entity": "Category",
+            "message": "Entity 'Category' has no timestamp columns (createdAt/updatedAt).",
+            "help": "Add createdAt/updatedAt columns to track when records are created and modified.",
+            "rule": "schema/require-timestamps",
+            "category": "schema",
+            "scope": "schema",
+            "severity": "warning"
+          },
+          {
+            "filePath": "apps/api/src/payments/invoice.entity.ts",
+            "entity": "Invoice",
+            "message": "Entity 'Invoice' has no timestamp columns (createdAt/updatedAt).",
+            "help": "Add createdAt/updatedAt columns to track when records are created and modified.",
+            "rule": "schema/require-timestamps",
+            "category": "schema",
+            "scope": "schema",
+            "severity": "warning"
+          },
+          {
+            "filePath": "apps/api/src/catalog/product.entity.ts",
+            "entity": "Product",
+            "message": "Relation 'category' on 'Product' has no explicit onDelete behavior.",
+            "help": "Add an explicit onDelete option (e.g. CASCADE, SET NULL) to avoid relying on database defaults.",
+            "rule": "schema/require-cascade-rule",
+            "category": "schema",
+            "scope": "schema",
+            "severity": "info"
+          },
+          {
+            "filePath": "apps/api/src/orders/order.entity.ts",
+            "entity": "Order",
+            "message": "Relation 'user' on 'Order' has no explicit onDelete behavior.",
+            "help": "Add an explicit onDelete option (e.g. CASCADE, SET NULL) to avoid relying on database defaults.",
+            "rule": "schema/require-cascade-rule",
+            "category": "schema",
+            "scope": "schema",
+            "severity": "info"
+          }
+        ],
+        "summary": {
+          "total": 4,
+          "errors": 0,
+          "warnings": 2,
+          "info": 2,
+          "byCategory": {
+            "security": 0,
+            "performance": 0,
+            "correctness": 0,
+            "architecture": 0,
+            "schema": 4
+          }
+        }
+      }
+    },
+    "project": {
+      "name": "monorepo",
+      "nestVersion": "12.0.1",
+      "orm": "typeorm",
+      "framework": "express",
+      "fileCount": 58,
+      "moduleCount": 12
+    },
+    "sections": [
+      {
+        "id": "score",
+        "count": 93,
+        "label": "Health score and project info"
+      },
+      {
+        "id": "findings:security",
+        "count": 6,
+        "label": "Findings · security"
+      },
+      {
+        "id": "findings:performance",
+        "count": 6,
+        "label": "Findings · performance"
+      },
+      {
+        "id": "findings:correctness",
+        "count": 5,
+        "label": "Findings · correctness"
+      },
+      {
+        "id": "findings:architecture",
+        "count": 5,
+        "label": "Findings · architecture"
+      },
+      {
+        "id": "findings:schema",
+        "count": 4,
+        "label": "Findings · schema"
+      },
+      {
+        "id": "endpoints",
+        "count": 15,
+        "label": "HTTP endpoints"
+      },
+      {
+        "id": "schema",
+        "count": 9,
+        "label": "Relational schema"
+      },
+      {
+        "id": "modules",
+        "count": 12,
+        "label": "Module graph"
+      }
+    ],
+    "score": {
+      "value": 93,
+      "label": "Excellent"
+    },
+    "version": 1,
+    "endpoints": [
+      {
+        "controllerClass": "AppController",
+        "handlerMethod": "health",
+        "httpMethod": "GET",
+        "routePath": "/health"
+      },
+      {
+        "controllerClass": "CatalogController",
+        "handlerMethod": "list",
+        "httpMethod": "GET",
+        "routePath": "/products"
+      },
+      {
+        "controllerClass": "CatalogController",
+        "handlerMethod": "get",
+        "httpMethod": "GET",
+        "routePath": "/products/:id"
+      },
+      {
+        "controllerClass": "CatalogController",
+        "handlerMethod": "update",
+        "httpMethod": "PUT",
+        "routePath": "/products/:id"
+      },
+      {
+        "controllerClass": "OrdersController",
+        "handlerMethod": "list",
+        "httpMethod": "GET",
+        "routePath": "/orders"
+      },
+      {
+        "controllerClass": "OrdersController",
+        "handlerMethod": "create",
+        "httpMethod": "POST",
+        "routePath": "/orders"
+      },
+      {
+        "controllerClass": "OrdersController",
+        "handlerMethod": "pay",
+        "httpMethod": "POST",
+        "routePath": "/orders/:id/pay"
+      },
+      {
+        "controllerClass": "OrdersController",
+        "handlerMethod": "updateStatus",
+        "httpMethod": "PATCH",
+        "routePath": "/orders/:id/status"
+      },
+      {
+        "controllerClass": "PaymentsController",
+        "handlerMethod": "list",
+        "httpMethod": "GET",
+        "routePath": "/payments"
+      },
+      {
+        "controllerClass": "PaymentsController",
+        "handlerMethod": "refund",
+        "httpMethod": "POST",
+        "routePath": "/payments/:id/refund"
+      },
+      {
+        "controllerClass": "UsersController",
+        "handlerMethod": "list",
+        "httpMethod": "GET",
+        "routePath": "/users"
+      },
+      {
+        "controllerClass": "UsersController",
+        "handlerMethod": "get",
+        "httpMethod": "GET",
+        "routePath": "/users/:id"
+      },
+      {
+        "controllerClass": "UsersController",
+        "handlerMethod": "create",
+        "httpMethod": "POST",
+        "routePath": "/users"
+      },
+      {
+        "controllerClass": "UsersController",
+        "handlerMethod": "update",
+        "httpMethod": "PATCH",
+        "routePath": "/users/:id"
+      },
+      {
+        "controllerClass": "UsersController",
+        "handlerMethod": "remove",
+        "httpMethod": "DELETE",
+        "routePath": "/users/:id"
+      }
+    ],
+    "schema": {
+      "entities": [
+        {
+          "name": "AuditLog",
+          "tableName": "audit_logs",
+          "filePath": "apps/api/src/audit/audit-log.entity.ts",
+          "columns": [
+            {
+              "name": "action",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "actor",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "payload",
+              "type": "jsonb",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false,
+              "defaultValue": "{}"
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "createdAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "updatedAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            }
+          ],
+          "relations": [],
+          "indexes": []
+        },
+        {
+          "name": "Category",
+          "tableName": "categories",
+          "filePath": "apps/api/src/catalog/category.entity.ts",
+          "columns": [
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "slug",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": true
+            },
+            {
+              "name": "name",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            }
+          ],
+          "relations": [
+            {
+              "type": "one-to-many",
+              "fromEntity": "Category",
+              "toEntity": "Product",
+              "propertyName": "products",
+              "isNullable": false
+            }
+          ],
+          "indexes": []
+        },
+        {
+          "name": "Product",
+          "tableName": "products",
+          "filePath": "apps/api/src/catalog/product.entity.ts",
+          "columns": [
+            {
+              "name": "sku",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": true
+            },
+            {
+              "name": "name",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "priceCents",
+              "type": "int",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "createdAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "updatedAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            }
+          ],
+          "relations": [
+            {
+              "type": "many-to-one",
+              "fromEntity": "Product",
+              "toEntity": "Category",
+              "propertyName": "category",
+              "isNullable": false
+            },
+            {
+              "type": "many-to-many",
+              "fromEntity": "Product",
+              "toEntity": "Tag",
+              "propertyName": "tags",
+              "isNullable": false
+            },
+            {
+              "type": "one-to-many",
+              "fromEntity": "Product",
+              "toEntity": "OrderItem",
+              "propertyName": "orderItems",
+              "isNullable": false
+            }
+          ],
+          "indexes": []
+        },
+        {
+          "name": "Tag",
+          "tableName": "tags",
+          "filePath": "apps/api/src/catalog/tag.entity.ts",
+          "columns": [
+            {
+              "name": "slug",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": true
+            },
+            {
+              "name": "name",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "createdAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "updatedAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            }
+          ],
+          "relations": [],
+          "indexes": []
+        },
+        {
+          "name": "OrderItem",
+          "tableName": "order_items",
+          "filePath": "apps/api/src/orders/order-item.entity.ts",
+          "columns": [
+            {
+              "name": "quantity",
+              "type": "int",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "unitPriceCents",
+              "type": "int",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "createdAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "updatedAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            }
+          ],
+          "relations": [
+            {
+              "type": "many-to-one",
+              "fromEntity": "OrderItem",
+              "toEntity": "Order",
+              "propertyName": "order",
+              "isNullable": false,
+              "onDelete": "CASCADE"
+            },
+            {
+              "type": "many-to-one",
+              "fromEntity": "OrderItem",
+              "toEntity": "Product",
+              "propertyName": "product",
+              "isNullable": false,
+              "onDelete": "RESTRICT"
+            }
+          ],
+          "indexes": []
+        },
+        {
+          "name": "Order",
+          "tableName": "orders",
+          "filePath": "apps/api/src/orders/order.entity.ts",
+          "columns": [
+            {
+              "name": "status",
+              "type": "enum",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false,
+              "defaultValue": "OrderStatus.Pending",
+              "hasIndex": true
+            },
+            {
+              "name": "totalCents",
+              "type": "int",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false,
+              "defaultValue": "0"
+            },
+            {
+              "name": "note",
+              "type": "text",
+              "isPrimary": false,
+              "isNullable": true,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "createdAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false,
+              "hasIndex": true
+            },
+            {
+              "name": "updatedAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            }
+          ],
+          "relations": [
+            {
+              "type": "many-to-one",
+              "fromEntity": "Order",
+              "toEntity": "User",
+              "propertyName": "user",
+              "isNullable": false
+            },
+            {
+              "type": "one-to-many",
+              "fromEntity": "Order",
+              "toEntity": "OrderItem",
+              "propertyName": "items",
+              "isNullable": false
+            }
+          ],
+          "indexes": [
+            {
+              "columns": [
+                "status",
+                "createdAt"
+              ],
+              "isUnique": false
+            }
+          ]
+        },
+        {
+          "name": "Invoice",
+          "tableName": "invoices",
+          "filePath": "apps/api/src/payments/invoice.entity.ts",
+          "columns": [
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "number",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": true
+            },
+            {
+              "name": "issuedAt",
+              "type": "timestamptz",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            }
+          ],
+          "relations": [
+            {
+              "type": "one-to-one",
+              "fromEntity": "Invoice",
+              "toEntity": "Order",
+              "propertyName": "order",
+              "isNullable": false,
+              "onDelete": "CASCADE"
+            }
+          ],
+          "indexes": []
+        },
+        {
+          "name": "Payment",
+          "tableName": "payments",
+          "filePath": "apps/api/src/payments/payment.entity.ts",
+          "columns": [
+            {
+              "name": "provider",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false,
+              "hasIndex": true
+            },
+            {
+              "name": "amountCents",
+              "type": "int",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "status",
+              "type": "enum",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false,
+              "defaultValue": "PaymentStatus.Pending"
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "createdAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "updatedAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            }
+          ],
+          "relations": [
+            {
+              "type": "many-to-one",
+              "fromEntity": "Payment",
+              "toEntity": "Order",
+              "propertyName": "order",
+              "isNullable": false,
+              "onDelete": "CASCADE"
+            }
+          ],
+          "indexes": [
+            {
+              "columns": [
+                "provider"
+              ],
+              "isUnique": false
+            }
+          ]
+        },
+        {
+          "name": "User",
+          "tableName": "users",
+          "filePath": "apps/api/src/users/user.entity.ts",
+          "columns": [
+            {
+              "name": "email",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": true
+            },
+            {
+              "name": "name",
+              "type": "unknown",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false
+            },
+            {
+              "name": "addresses",
+              "type": "jsonb",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": false,
+              "isUnique": false,
+              "defaultValue": "[]"
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "isPrimary": true,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "createdAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            },
+            {
+              "name": "updatedAt",
+              "type": "timestamp",
+              "isPrimary": false,
+              "isNullable": false,
+              "isGenerated": true,
+              "isUnique": false
+            }
+          ],
+          "relations": [
+            {
+              "type": "one-to-many",
+              "fromEntity": "User",
+              "toEntity": "Order",
+              "propertyName": "orders",
+              "isNullable": false
+            }
+          ],
+          "indexes": []
+        }
+      ],
+      "orm": "typeorm",
+      "relations": [
+        {
+          "type": "one-to-many",
+          "fromEntity": "Category",
+          "toEntity": "Product",
+          "propertyName": "products",
+          "isNullable": false
+        },
+        {
+          "type": "many-to-one",
+          "fromEntity": "Product",
+          "toEntity": "Category",
+          "propertyName": "category",
+          "isNullable": false
+        },
+        {
+          "type": "many-to-many",
+          "fromEntity": "Product",
+          "toEntity": "Tag",
+          "propertyName": "tags",
+          "isNullable": false
+        },
+        {
+          "type": "one-to-many",
+          "fromEntity": "Product",
+          "toEntity": "OrderItem",
+          "propertyName": "orderItems",
+          "isNullable": false
+        },
+        {
+          "type": "many-to-one",
+          "fromEntity": "OrderItem",
+          "toEntity": "Order",
+          "propertyName": "order",
+          "isNullable": false,
+          "onDelete": "CASCADE"
+        },
+        {
+          "type": "many-to-one",
+          "fromEntity": "OrderItem",
+          "toEntity": "Product",
+          "propertyName": "product",
+          "isNullable": false,
+          "onDelete": "RESTRICT"
+        },
+        {
+          "type": "many-to-one",
+          "fromEntity": "Order",
+          "toEntity": "User",
+          "propertyName": "user",
+          "isNullable": false
+        },
+        {
+          "type": "one-to-many",
+          "fromEntity": "Order",
+          "toEntity": "OrderItem",
+          "propertyName": "items",
+          "isNullable": false
+        },
+        {
+          "type": "one-to-one",
+          "fromEntity": "Invoice",
+          "toEntity": "Order",
+          "propertyName": "order",
+          "isNullable": false,
+          "onDelete": "CASCADE"
+        },
+        {
+          "type": "many-to-one",
+          "fromEntity": "Payment",
+          "toEntity": "Order",
+          "propertyName": "order",
+          "isNullable": false,
+          "onDelete": "CASCADE"
+        },
+        {
+          "type": "one-to-many",
+          "fromEntity": "User",
+          "toEntity": "Order",
+          "propertyName": "orders",
+          "isNullable": false
+        }
+      ]
+    },
+    "modules": {
+      "bootstrapRoots": [
+        "api/AppModule",
+        "worker/WorkerModule"
+      ],
+      "circularDeps": [
+        [
+          "api/OrdersModule",
+          "api/PaymentsModule",
+          "api/NotificationsModule"
+        ]
+      ],
+      "edges": [
+        {
+          "from": "api/AppModule",
+          "to": "shared/SharedModule"
+        },
+        {
+          "from": "api/AppModule",
+          "to": "api/UsersModule"
+        },
+        {
+          "from": "api/AppModule",
+          "to": "api/CatalogModule"
+        },
+        {
+          "from": "api/AppModule",
+          "to": "api/OrdersModule"
+        },
+        {
+          "from": "api/AppModule",
+          "to": "api/PaymentsModule"
+        },
+        {
+          "from": "api/AppModule",
+          "to": "api/NotificationsModule"
+        },
+        {
+          "from": "api/AppModule",
+          "to": "api/AuditModule"
+        },
+        {
+          "from": "api/NotificationsModule",
+          "to": "api/CatalogModule"
+        },
+        {
+          "from": "api/NotificationsModule",
+          "to": "api/OrdersModule"
+        },
+        {
+          "from": "api/OrdersModule",
+          "to": "api/UsersModule"
+        },
+        {
+          "from": "api/OrdersModule",
+          "to": "api/CatalogModule"
+        },
+        {
+          "from": "api/OrdersModule",
+          "to": "api/PaymentsModule"
+        },
+        {
+          "from": "api/PaymentsModule",
+          "to": "api/NotificationsModule"
+        },
+        {
+          "from": "worker/WorkerModule",
+          "to": "shared/SharedModule"
+        },
+        {
+          "from": "worker/WorkerModule",
+          "to": "worker/JobsModule"
+        },
+        {
+          "from": "worker/WorkerModule",
+          "to": "worker/SyncModule"
+        }
+      ],
+      "modules": [
+        {
+          "name": "api/AppModule",
+          "filePath": "apps/api/src/app.module.ts",
+          "imports": [
+            "ConfigModule",
+            "TypeOrmModule",
+            "BullModule",
+            "shared/SharedModule",
+            "api/UsersModule",
+            "api/CatalogModule",
+            "api/OrdersModule",
+            "api/PaymentsModule",
+            "api/NotificationsModule",
+            "api/AuditModule"
+          ],
+          "exports": [],
+          "providers": [],
+          "providerTokens": [],
+          "controllers": [
+            "AppController"
+          ],
+          "project": "api",
+          "isGlobal": false,
+          "line": 14,
+          "dynamicImports": {
+            "ConfigModule": "forRoot",
+            "TypeOrmModule": "forRootAsync",
+            "BullModule": "forRootAsync",
+            "api/AuditModule": "register"
+          }
+        },
+        {
+          "name": "api/AuditModule",
+          "filePath": "apps/api/src/audit/audit.module.ts",
+          "imports": [
+            "TypeOrmModule"
+          ],
+          "exports": [
+            "AuditService"
+          ],
+          "providers": [
+            "AuditService",
+            "AuditRepository",
+            "AuditArchiverService"
+          ],
+          "providerTokens": [],
+          "controllers": [],
+          "project": "api",
+          "isGlobal": true,
+          "line": 8,
+          "dynamicImports": {
+            "TypeOrmModule": "forFeature"
+          }
+        },
+        {
+          "name": "api/CatalogModule",
+          "filePath": "apps/api/src/catalog/catalog.module.ts",
+          "imports": [
+            "TypeOrmModule"
+          ],
+          "exports": [
+            "CatalogService"
+          ],
+          "providers": [
+            "CatalogService",
+            "CatalogRepository"
+          ],
+          "providerTokens": [],
+          "controllers": [
+            "CatalogController"
+          ],
+          "project": "api",
+          "isGlobal": false,
+          "line": 10,
+          "dynamicImports": {
+            "TypeOrmModule": "forFeature"
+          }
+        },
+        {
+          "name": "api/NotificationsModule",
+          "filePath": "apps/api/src/notifications/notifications.module.ts",
+          "imports": [
+            "BullModule",
+            "api/CatalogModule",
+            "api/OrdersModule"
+          ],
+          "exports": [
+            "NotificationsService"
+          ],
+          "providers": [
+            "NotificationsService"
+          ],
+          "providerTokens": [],
+          "controllers": [],
+          "project": "api",
+          "isGlobal": false,
+          "line": 7
+        },
+        {
+          "name": "api/OrdersModule",
+          "filePath": "apps/api/src/orders/orders.module.ts",
+          "imports": [
+            "TypeOrmModule",
+            "api/UsersModule",
+            "api/CatalogModule",
+            "api/PaymentsModule"
+          ],
+          "exports": [
+            "OrdersService"
+          ],
+          "providers": [
+            "OrdersService"
+          ],
+          "providerTokens": [],
+          "controllers": [
+            "OrdersController"
+          ],
+          "project": "api",
+          "isGlobal": false,
+          "line": 11,
+          "dynamicImports": {
+            "TypeOrmModule": "forFeature"
+          }
+        },
+        {
+          "name": "api/PaymentsModule",
+          "filePath": "apps/api/src/payments/payments.module.ts",
+          "imports": [
+            "TypeOrmModule",
+            "api/NotificationsModule"
+          ],
+          "exports": [
+            "PaymentsService"
+          ],
+          "providers": [
+            "PaymentsService",
+            "CardGateway",
+            "SepaGateway"
+          ],
+          "providerTokens": [],
+          "controllers": [
+            "PaymentsController"
+          ],
+          "project": "api",
+          "isGlobal": false,
+          "line": 11,
+          "dynamicImports": {
+            "TypeOrmModule": "forFeature"
+          }
+        },
+        {
+          "name": "api/ReportsModule",
+          "filePath": "apps/api/src/reports/reports.module.ts",
+          "imports": [],
+          "exports": [
+            "SalesReportService"
+          ],
+          "providers": [
+            "SalesReportRepository",
+            "SalesReportService"
+          ],
+          "providerTokens": [],
+          "controllers": [],
+          "project": "api",
+          "isGlobal": false,
+          "line": 5
+        },
+        {
+          "name": "api/UsersModule",
+          "filePath": "apps/api/src/users/users.module.ts",
+          "imports": [
+            "TypeOrmModule"
+          ],
+          "exports": [
+            "UsersService"
+          ],
+          "providers": [
+            "UsersService",
+            "UsersRepository"
+          ],
+          "providerTokens": [],
+          "controllers": [
+            "UsersController"
+          ],
+          "project": "api",
+          "isGlobal": false,
+          "line": 8,
+          "dynamicImports": {
+            "TypeOrmModule": "forFeature"
+          }
+        },
+        {
+          "name": "worker/JobsModule",
+          "filePath": "apps/worker/src/jobs/jobs.module.ts",
+          "imports": [
+            "BullModule"
+          ],
+          "exports": [
+            "JobsService"
+          ],
+          "providers": [
+            "NotificationsProcessor",
+            "JobsService"
+          ],
+          "providerTokens": [],
+          "controllers": [],
+          "project": "worker",
+          "isGlobal": false,
+          "line": 6
+        },
+        {
+          "name": "worker/SyncModule",
+          "filePath": "apps/worker/src/sync/sync.module.ts",
+          "imports": [],
+          "exports": [],
+          "providers": [
+            "SyncService",
+            "SyncRepository"
+          ],
+          "providerTokens": [],
+          "controllers": [],
+          "project": "worker",
+          "isGlobal": false,
+          "line": 5
+        },
+        {
+          "name": "worker/WorkerModule",
+          "filePath": "apps/worker/src/worker.module.ts",
+          "imports": [
+            "ConfigModule",
+            "BullModule",
+            "TypeOrmModule",
+            "shared/SharedModule",
+            "worker/JobsModule",
+            "worker/SyncModule"
+          ],
+          "exports": [],
+          "providers": [],
+          "providerTokens": [],
+          "controllers": [],
+          "project": "worker",
+          "isGlobal": false,
+          "line": 9,
+          "dynamicImports": {
+            "ConfigModule": "forRoot",
+            "BullModule": "forRootAsync",
+            "TypeOrmModule": "forRootAsync"
+          }
+        },
+        {
+          "name": "shared/SharedModule",
+          "filePath": "libs/shared/src/shared.module.ts",
+          "imports": [
+            "ConfigModule"
+          ],
+          "exports": [
+            "MetricsService",
+            "AppConfigService",
+            "RequestContextService",
+            "RedisStrategy"
+          ],
+          "providers": [
+            "MetricsService",
+            "AppConfigService",
+            "RequestContextService",
+            "RedisStrategy"
+          ],
+          "providerTokens": [],
+          "controllers": [],
+          "project": "shared",
+          "isGlobal": true,
+          "line": 8
+        }
+      ],
+      "projects": [
+        "api",
+        "worker",
+        "shared"
+      ]
+    }
+  },
+  "sources": {
+    "/demo/nest-shop/apps/api/src/app.controller.ts": "import { Controller, Get } from '@nestjs/common';\nimport { MetricsService, RequestContextService } from '@app/shared';\nimport { Public } from './auth/public.decorator';\n\n@Controller()\nexport class AppController {\n  constructor(\n    private readonly metrics: MetricsService,\n    private readonly requestContext: RequestContextService,\n  ) {}\n\n  @Public()\n  @Get('health')\n  health() {\n    return {\n      status: 'ok',\n      requestId: this.requestContext.requestId,\n      uptimeSeconds: Math.round(process.uptime()),\n      metrics: this.metrics.snapshot(),\n    };\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/app.module.ts": "import { BullModule } from '@nestjs/bullmq';\nimport { Module } from '@nestjs/common';\nimport { ConfigModule, ConfigService } from '@nestjs/config';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { SharedModule } from '@app/shared';\nimport { AuditModule } from './audit/audit.module';\nimport { CatalogModule } from './catalog/catalog.module';\nimport { NotificationsModule } from './notifications/notifications.module';\nimport { OrdersModule } from './orders/orders.module';\nimport { PaymentsModule } from './payments/payments.module';\nimport { AppController } from './app.controller';\nimport { UsersModule } from './users/users.module';\n\n@Module({\n  imports: [\n    ConfigModule.forRoot({ isGlobal: true, envFilePath: ['.env'] }),\n    TypeOrmModule.forRootAsync({\n      inject: [ConfigService],\n      useFactory: (config: ConfigService) => ({\n        type: 'postgres',\n        host: config.getOrThrow<string>('DATABASE_HOST'),\n        port: Number(config.getOrThrow<string>('DATABASE_PORT')),\n        username: config.getOrThrow<string>('DATABASE_USER'),\n        password: config.getOrThrow<string>('DATABASE_PASSWORD'),\n        database: config.getOrThrow<string>('DATABASE_NAME'),\n        autoLoadEntities: true,\n        synchronize: true,\n      }),\n    }),\n    BullModule.forRootAsync({\n      inject: [ConfigService],\n      useFactory: (config: ConfigService) => ({\n        connection: {\n          host: config.getOrThrow<string>('REDIS_HOST'),\n          port: Number(config.getOrThrow<string>('REDIS_PORT')),\n        },\n      }),\n    }),\n    SharedModule,\n    UsersModule,\n    CatalogModule,\n    OrdersModule,\n    PaymentsModule,\n    NotificationsModule,\n    AuditModule.register({ retentionDays: 90 }),\n  ],\n  controllers: [AppController],\n})\nexport class AppModule {}\n",
+    "/demo/nest-shop/apps/api/src/audit/audit-archiver.service.ts": "import { Injectable, Logger } from '@nestjs/common';\nimport { AuditRepository } from './audit.repository';\n\n@Injectable()\nexport class AuditArchiverService {\n  private readonly logger = new Logger(AuditArchiverService.name);\n\n  constructor(private readonly logs: AuditRepository) {}\n\n  async archiveOlderThan(days: number): Promise<number> {\n    const cutoff = new Date(Date.now() - days * 86_400_000);\n    const removed = await this.logs.deleteOlderThan(cutoff);\n    this.logger.log(`Archived ${removed} audit entries older than ${days} days`);\n    return removed;\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/audit/audit-log.entity.ts": "import { Column, Entity } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\n\n@Entity({ name: 'audit_logs' })\nexport class AuditLog extends BaseEntity {\n  @Column()\n  action: string;\n\n  @Column()\n  actor: string;\n\n  @Column({ type: 'jsonb', default: {} })\n  payload: Record<string, unknown>;\n}\n",
+    "/demo/nest-shop/apps/api/src/audit/audit.module.ts": "import { DynamicModule, Global, Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { AuditArchiverService } from './audit-archiver.service';\nimport { AuditLog } from './audit-log.entity';\nimport { AuditRepository } from './audit.repository';\nimport { AUDIT_OPTIONS, AuditOptions, AuditService } from './audit.service';\n\n@Global()\n@Module({\n  imports: [TypeOrmModule.forFeature([AuditLog])],\n  providers: [AuditService, AuditRepository, AuditArchiverService],\n  exports: [AuditService],\n})\nexport class AuditModule {\n  static register(options: AuditOptions): DynamicModule {\n    return {\n      module: AuditModule,\n      providers: [{ provide: AUDIT_OPTIONS, useValue: options }],\n    };\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/audit/audit.repository.ts": "import { Injectable } from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { LessThan, Repository } from 'typeorm';\nimport { AuditLog } from './audit-log.entity';\n\n@Injectable()\nexport class AuditRepository {\n  constructor(@InjectRepository(AuditLog) private readonly logs: Repository<AuditLog>) {}\n\n  insert(action: string, actor: string, payload: Record<string, unknown>): Promise<AuditLog> {\n    return this.logs.save(this.logs.create({ action, actor, payload }));\n  }\n\n  recent(limit: number): Promise<AuditLog[]> {\n    return this.logs.find({ order: { createdAt: 'DESC' }, take: limit });\n  }\n\n  async deleteOlderThan(cutoff: Date): Promise<number> {\n    const result = await this.logs.delete({ createdAt: LessThan(cutoff) });\n    return result.affected ?? 0;\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/audit/audit.service.ts": "import { Inject, Injectable } from '@nestjs/common';\nimport { AuditLog } from './audit-log.entity';\nimport { AuditRepository } from './audit.repository';\n\nexport const AUDIT_OPTIONS = Symbol('AUDIT_OPTIONS');\n\nexport interface AuditOptions {\n  retentionDays: number;\n}\n\n@Injectable()\nexport class AuditService {\n  constructor(\n    @Inject(AUDIT_OPTIONS) private readonly options: AuditOptions,\n    private logs: AuditRepository,\n  ) {}\n\n  record(action: string, actor: string, payload: Record<string, unknown> = {}): Promise<AuditLog> {\n    return this.logs.insert(action, actor, payload);\n  }\n\n  recent(limit = 50): Promise<AuditLog[]> {\n    return this.logs.recent(limit);\n  }\n\n  get retentionDays(): number {\n    return this.options.retentionDays;\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/auth/jwt-auth.guard.ts": "import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';\n\n@Injectable()\nexport class JwtAuthGuard implements CanActivate {\n  canActivate(ctx: ExecutionContext): boolean {\n    return Boolean(ctx.switchToHttp().getRequest().headers.authorization);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/auth/public.decorator.ts": "import { SetMetadata } from '@nestjs/common';\n\nexport const IS_PUBLIC_KEY = 'isPublic';\n\nexport const Public = () => SetMetadata(IS_PUBLIC_KEY, true);\n",
+    "/demo/nest-shop/apps/api/src/catalog/catalog-data.ts": "export interface CategorySeed {\n  slug: string;\n  name: string;\n}\n\nexport interface TagSeed {\n  slug: string;\n  name: string;\n}\n\nexport interface ProductSeed {\n  sku: string;\n  name: string;\n  priceCents: number;\n  category: string;\n  tags: string[];\n}\n\nexport const CATEGORY_SEED: CategorySeed[] = [\n  { slug: 'coffee', name: 'Coffee' },\n  { slug: 'tea', name: 'Tea' },\n  { slug: 'gear', name: 'Brewing gear' },\n];\n\nexport const TAG_SEED: TagSeed[] = [\n  { slug: 'aged', name: 'Aged' },\n  { slug: 'black', name: 'Black' },\n  { slug: 'breakfast', name: 'Breakfast' },\n  { slug: 'bulk', name: 'Bulk' },\n  { slug: 'caffeine-free', name: 'Caffeine free' },\n  { slug: 'ceramic', name: 'Ceramic' },\n  { slug: 'chinese', name: 'Chinese' },\n  { slug: 'consumable', name: 'Consumable' },\n  { slug: 'dark', name: 'Dark' },\n  { slug: 'dark-roast', name: 'Dark roast' },\n  { slug: 'decaf', name: 'Decaf' },\n  { slug: 'electronic', name: 'Electronic' },\n  { slug: 'espresso', name: 'Espresso' },\n  { slug: 'filter', name: 'Filter' },\n  { slug: 'flavoured', name: 'Flavoured' },\n  { slug: 'glass', name: 'Glass' },\n  { slug: 'green', name: 'Green' },\n  { slug: 'grinder', name: 'Grinder' },\n  { slug: 'herbal', name: 'Herbal' },\n  { slug: 'immersion', name: 'Immersion' },\n  { slug: 'japanese', name: 'Japanese' },\n  { slug: 'light-roast', name: 'Light roast' },\n  { slug: 'medium-roast', name: 'Medium roast' },\n  { slug: 'oolong', name: 'Oolong' },\n  { slug: 'organic', name: 'Organic' },\n  { slug: 'pour-over', name: 'Pour over' },\n  { slug: 'powder', name: 'Powder' },\n  { slug: 'scale', name: 'Scale' },\n  { slug: 'single-estate', name: 'Single estate' },\n  { slug: 'single-origin', name: 'Single origin' },\n  { slug: 'steel', name: 'Steel' },\n  { slug: 'tea', name: 'Tea' },\n  { slug: 'travel', name: 'Travel' },\n];\n\nexport const PRODUCT_SEED: ProductSeed[] = [\n  {\n    sku: 'COF-001',\n    name: 'Ethiopia Yirgacheffe 250g',\n    priceCents: 1450,\n    category: 'coffee',\n    tags: ['single-origin', 'light-roast'],\n  },\n  {\n    sku: 'COF-002',\n    name: 'Colombia Huila 250g',\n    priceCents: 1290,\n    category: 'coffee',\n    tags: ['single-origin', 'medium-roast'],\n  },\n  {\n    sku: 'COF-003',\n    name: 'Brazil Cerrado 1kg',\n    priceCents: 3200,\n    category: 'coffee',\n    tags: ['espresso', 'medium-roast', 'bulk'],\n  },\n  {\n    sku: 'COF-004',\n    name: 'Decaf Swiss Water 250g',\n    priceCents: 1350,\n    category: 'coffee',\n    tags: ['decaf', 'medium-roast'],\n  },\n  {\n    sku: 'COF-005',\n    name: 'Kenya AA Nyeri 250g',\n    priceCents: 1590,\n    category: 'coffee',\n    tags: ['single-origin', 'light-roast'],\n  },\n  {\n    sku: 'COF-006',\n    name: 'Guatemala Antigua 250g',\n    priceCents: 1390,\n    category: 'coffee',\n    tags: ['single-origin', 'medium-roast'],\n  },\n  {\n    sku: 'COF-007',\n    name: 'Sumatra Mandheling 250g',\n    priceCents: 1290,\n    category: 'coffee',\n    tags: ['single-origin', 'dark-roast'],\n  },\n  {\n    sku: 'COF-008',\n    name: 'House Espresso Blend 500g',\n    priceCents: 2100,\n    category: 'coffee',\n    tags: ['espresso', 'dark-roast'],\n  },\n  {\n    sku: 'COF-009',\n    name: 'Morning Blend 500g',\n    priceCents: 1890,\n    category: 'coffee',\n    tags: ['filter', 'medium-roast'],\n  },\n  {\n    sku: 'COF-010',\n    name: 'Costa Rica Tarrazu 250g',\n    priceCents: 1490,\n    category: 'coffee',\n    tags: ['single-origin', 'light-roast'],\n  },\n  {\n    sku: 'COF-011',\n    name: 'Peru Cajamarca Organic 250g',\n    priceCents: 1390,\n    category: 'coffee',\n    tags: ['single-origin', 'organic'],\n  },\n  {\n    sku: 'COF-012',\n    name: 'Honduras Marcala 1kg',\n    priceCents: 3400,\n    category: 'coffee',\n    tags: ['single-origin', 'bulk'],\n  },\n  {\n    sku: 'COF-013',\n    name: 'Rwanda Nyamasheke 250g',\n    priceCents: 1550,\n    category: 'coffee',\n    tags: ['single-origin', 'light-roast'],\n  },\n  {\n    sku: 'COF-014',\n    name: 'Italian Roast 500g',\n    priceCents: 1790,\n    category: 'coffee',\n    tags: ['espresso', 'dark-roast'],\n  },\n  {\n    sku: 'COF-015',\n    name: 'Cold Brew Grind 500g',\n    priceCents: 1990,\n    category: 'coffee',\n    tags: ['filter', 'bulk'],\n  },\n  {\n    sku: 'COF-016',\n    name: 'Decaf Espresso Blend 500g',\n    priceCents: 2050,\n    category: 'coffee',\n    tags: ['decaf', 'espresso'],\n  },\n  {\n    sku: 'TEA-001',\n    name: 'Sencha 100g',\n    priceCents: 980,\n    category: 'tea',\n    tags: ['green', 'japanese'],\n  },\n  {\n    sku: 'TEA-002',\n    name: 'Earl Grey 100g',\n    priceCents: 760,\n    category: 'tea',\n    tags: ['black', 'flavoured'],\n  },\n  {\n    sku: 'TEA-003',\n    name: 'Rooibos 100g',\n    priceCents: 690,\n    category: 'tea',\n    tags: ['herbal', 'caffeine-free'],\n  },\n  {\n    sku: 'TEA-004',\n    name: 'Jasmine Pearls 50g',\n    priceCents: 1190,\n    category: 'tea',\n    tags: ['green', 'flavoured'],\n  },\n  {\n    sku: 'TEA-005',\n    name: 'Assam TGFOP 100g',\n    priceCents: 820,\n    category: 'tea',\n    tags: ['black', 'breakfast'],\n  },\n  {\n    sku: 'TEA-006',\n    name: 'Darjeeling First Flush 50g',\n    priceCents: 1290,\n    category: 'tea',\n    tags: ['black', 'single-estate'],\n  },\n  {\n    sku: 'TEA-007',\n    name: 'Gyokuro 50g',\n    priceCents: 1890,\n    category: 'tea',\n    tags: ['green', 'japanese'],\n  },\n  {\n    sku: 'TEA-008',\n    name: 'Matcha Ceremonial 30g',\n    priceCents: 2490,\n    category: 'tea',\n    tags: ['green', 'japanese', 'powder'],\n  },\n  {\n    sku: 'TEA-009',\n    name: 'Chamomile 50g',\n    priceCents: 590,\n    category: 'tea',\n    tags: ['herbal', 'caffeine-free'],\n  },\n  {\n    sku: 'TEA-010',\n    name: 'Peppermint 50g',\n    priceCents: 560,\n    category: 'tea',\n    tags: ['herbal', 'caffeine-free'],\n  },\n  {\n    sku: 'TEA-011',\n    name: 'Oolong Tie Guan Yin 100g',\n    priceCents: 1390,\n    category: 'tea',\n    tags: ['oolong', 'chinese'],\n  },\n  {\n    sku: 'TEA-012',\n    name: 'Pu-erh Cake 200g',\n    priceCents: 2890,\n    category: 'tea',\n    tags: ['dark', 'chinese', 'aged'],\n  },\n  {\n    sku: 'GEAR-001',\n    name: 'V60 Dripper 02',\n    priceCents: 2400,\n    category: 'gear',\n    tags: ['pour-over', 'ceramic'],\n  },\n  {\n    sku: 'GEAR-002',\n    name: 'Paper Filters 02 x100',\n    priceCents: 650,\n    category: 'gear',\n    tags: ['pour-over', 'consumable'],\n  },\n  {\n    sku: 'GEAR-003',\n    name: 'Gooseneck Kettle 1L',\n    priceCents: 5900,\n    category: 'gear',\n    tags: ['pour-over', 'steel'],\n  },\n  {\n    sku: 'GEAR-004',\n    name: 'Hand Grinder Steel Burr',\n    priceCents: 7400,\n    category: 'gear',\n    tags: ['grinder', 'steel'],\n  },\n  {\n    sku: 'GEAR-005',\n    name: 'AeroPress',\n    priceCents: 3490,\n    category: 'gear',\n    tags: ['immersion', 'travel'],\n  },\n  {\n    sku: 'GEAR-006',\n    name: 'French Press 1L',\n    priceCents: 3290,\n    category: 'gear',\n    tags: ['immersion', 'glass'],\n  },\n  {\n    sku: 'GEAR-007',\n    name: 'Digital Scale 0.1g',\n    priceCents: 4200,\n    category: 'gear',\n    tags: ['scale', 'electronic'],\n  },\n  {\n    sku: 'GEAR-008',\n    name: 'Chemex 6 Cup',\n    priceCents: 4990,\n    category: 'gear',\n    tags: ['pour-over', 'glass'],\n  },\n  {\n    sku: 'GEAR-009',\n    name: 'Chemex Filters x100',\n    priceCents: 1190,\n    category: 'gear',\n    tags: ['pour-over', 'consumable'],\n  },\n  {\n    sku: 'GEAR-010',\n    name: 'Electric Burr Grinder',\n    priceCents: 15900,\n    category: 'gear',\n    tags: ['grinder', 'electronic'],\n  },\n  {\n    sku: 'GEAR-011',\n    name: 'Teapot Kyusu 300ml',\n    priceCents: 4490,\n    category: 'gear',\n    tags: ['tea', 'ceramic'],\n  },\n  {\n    sku: 'GEAR-012',\n    name: 'Tea Infuser Basket',\n    priceCents: 1290,\n    category: 'gear',\n    tags: ['tea', 'steel'],\n  },\n];\n",
+    "/demo/nest-shop/apps/api/src/catalog/catalog.controller.ts": "import { Body, Controller, Get, Param, ParseIntPipe, Put } from '@nestjs/common';\nimport { Public } from '../auth/public.decorator';\nimport { CatalogService } from './catalog.service';\n\n@Controller('products')\nexport class CatalogController {\n  constructor(private readonly catalog: CatalogService) {}\n\n  @Public()\n  @Get()\n  list() {\n    return this.catalog.findAll();\n  }\n\n  @Public()\n  @Get(':id')\n  get(@Param('id') id: string) {\n    return this.catalog.findOne(id);\n  }\n\n  @Public()\n  @Put(':id')\n  update(@Param('id') id: string, @Body('priceCents', ParseIntPipe) priceCents: number) {\n    return this.catalog.updatePrice(id, priceCents);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/catalog/catalog.module.ts": "import { Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { CatalogController } from './catalog.controller';\nimport { CatalogRepository } from './catalog.repository';\nimport { CatalogService } from './catalog.service';\nimport { Category } from './category.entity';\nimport { Product } from './product.entity';\nimport { Tag } from './tag.entity';\n\n@Module({\n  imports: [TypeOrmModule.forFeature([Category, Product, Tag])],\n  controllers: [CatalogController],\n  providers: [CatalogService, CatalogRepository],\n  exports: [CatalogService],\n})\nexport class CatalogModule {}\n",
+    "/demo/nest-shop/apps/api/src/catalog/catalog.repository.ts": "import { Injectable } from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { In, Repository } from 'typeorm';\nimport { Category } from './category.entity';\nimport { Product } from './product.entity';\nimport { Tag } from './tag.entity';\n\n@Injectable()\nexport class CatalogRepository {\n  constructor(\n    @InjectRepository(Category) private readonly categories: Repository<Category>,\n    @InjectRepository(Product) private readonly products: Repository<Product>,\n    @InjectRepository(Tag) private readonly tags: Repository<Tag>,\n  ) {}\n\n  countProducts(): Promise<number> {\n    return this.products.count();\n  }\n\n  async upsertCategory(row: Partial<Category>): Promise<void> {\n    await this.categories.upsert(row, ['slug']);\n  }\n\n  async upsertTag(row: Partial<Tag>): Promise<void> {\n    await this.tags.upsert(row, ['slug']);\n  }\n\n  async upsertProduct(row: Partial<Product>): Promise<void> {\n    await this.products.upsert(row, ['sku']);\n  }\n\n  findCategories(): Promise<Category[]> {\n    return this.categories.find();\n  }\n\n  findTags(): Promise<Tag[]> {\n    return this.tags.find();\n  }\n\n  saveProduct(row: Partial<Product>): Promise<Product> {\n    return this.products.save(this.products.create(row));\n  }\n\n  findAll(): Promise<Product[]> {\n    return this.products.find({ relations: { category: true, tags: true }, order: { sku: 'ASC' } });\n  }\n\n  findBySku(sku: string): Promise<Product | null> {\n    return this.products.findOne({ where: { sku }, relations: { tags: true } });\n  }\n\n  findOne(id: string): Promise<Product | null> {\n    return this.products.findOne({ where: { id }, relations: { category: true, tags: true } });\n  }\n\n  findByIds(ids: string[]): Promise<Product[]> {\n    return this.products.find({ where: { id: In(ids) } });\n  }\n\n  async updatePrice(id: string, priceCents: number): Promise<void> {\n    await this.products.update({ id }, { priceCents });\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/catalog/catalog.service.ts": "import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';\nimport { CatalogRepository } from './catalog.repository';\nimport { CATEGORY_SEED, PRODUCT_SEED, TAG_SEED } from './catalog-data';\nimport { Product } from './product.entity';\n\n@Injectable()\nexport class CatalogService implements OnModuleInit {\n  private readonly logger = new Logger(CatalogService.name);\n  // Whole catalog with relations, keyed by SKU, refreshed on every boot.\n  private readonly bySku = new Map<string, Product>();\n\n  constructor(private readonly catalog: CatalogRepository) {}\n\n  async onModuleInit(): Promise<void> {\n    for (const seed of CATEGORY_SEED) {\n      await this.catalog.upsertCategory(seed);\n    }\n    for (const seed of TAG_SEED) {\n      await this.catalog.upsertTag(seed);\n    }\n    const categoryBySlug = new Map((await this.catalog.findCategories()).map((c) => [c.slug, c]));\n    const tagBySlug = new Map((await this.catalog.findTags()).map((t) => [t.slug, t]));\n    for (const seed of PRODUCT_SEED) {\n      await this.catalog.upsertProduct({\n        sku: seed.sku,\n        name: seed.name,\n        priceCents: seed.priceCents,\n        category: categoryBySlug.get(seed.category),\n      });\n    }\n    let retagged = 0;\n    for (const seed of PRODUCT_SEED) {\n      const row = await this.catalog.findBySku(seed.sku);\n      const have = new Set((row?.tags ?? []).map((t) => t.slug));\n      if (row && have.size === seed.tags.length && seed.tags.every((slug) => have.has(slug))) {\n        this.bySku.set(row.sku, row);\n        continue;\n      }\n      await this.catalog.saveProduct({\n        id: row?.id,\n        tags: seed.tags.map((slug) => tagBySlug.get(slug)).filter(Boolean),\n      });\n      retagged += 1;\n    }\n    if (retagged > 0) {\n      for (const product of await this.catalog.findAll()) {\n        this.bySku.set(product.sku, product);\n      }\n    }\n    const total = await this.catalog.countProducts();\n    this.logger.log(\n      `Catalog ready: ${this.bySku.size} of ${total} products, ${categoryBySlug.size} categories, ${tagBySlug.size} tags, ${retagged} retagged`,\n    );\n  }\n\n  findAll(): Promise<Product[]> {\n    return this.catalog.findAll();\n  }\n\n  async findOne(id: string): Promise<Product> {\n    const product = await this.catalog.findOne(id);\n    if (!product) {\n      throw new NotFoundException(`Product ${id} not found`);\n    }\n    return product;\n  }\n\n  findByIds(ids: string[]): Promise<Product[]> {\n    return this.catalog.findByIds(ids);\n  }\n\n  async updatePrice(id: string, priceCents: number): Promise<Product> {\n    await this.findOne(id);\n    await this.catalog.updatePrice(id, priceCents);\n    return this.findOne(id);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/catalog/category.entity.ts": "import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';\nimport { Product } from './product.entity';\n\n@Entity({ name: 'categories' })\nexport class Category {\n  @PrimaryGeneratedColumn('uuid')\n  id: string;\n\n  @Column({ unique: true })\n  slug: string;\n\n  @Column()\n  name: string;\n\n  @OneToMany(() => Product, (product) => product.category)\n  products: Product[];\n}\n",
+    "/demo/nest-shop/apps/api/src/catalog/product.entity.ts": "import { Column, Entity, JoinTable, ManyToMany, ManyToOne, OneToMany } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\nimport { OrderItem } from '../orders/order-item.entity';\nimport { Category } from './category.entity';\nimport { Tag } from './tag.entity';\n\n@Entity({ name: 'products' })\nexport class Product extends BaseEntity {\n  @Column({ unique: true })\n  sku: string;\n\n  @Column()\n  name: string;\n\n  @Column({ name: 'price_cents', type: 'int' })\n  priceCents: number;\n\n  @ManyToOne(() => Category, (category) => category.products, { nullable: false })\n  category: Category;\n\n  @ManyToMany(() => Tag)\n  @JoinTable({ name: 'product_tags' })\n  tags: Tag[];\n\n  @OneToMany(() => OrderItem, (item) => item.product)\n  orderItems: OrderItem[];\n}\n",
+    "/demo/nest-shop/apps/api/src/catalog/tag.entity.ts": "import { Column, Entity } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\n\n@Entity({ name: 'tags' })\nexport class Tag extends BaseEntity {\n  @Column({ unique: true })\n  slug: string;\n\n  @Column()\n  name: string;\n}\n",
+    "/demo/nest-shop/apps/api/src/common/base.entity.ts": "import { CreateDateColumn, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';\n\nexport abstract class BaseEntity {\n  @PrimaryGeneratedColumn('uuid')\n  id: string;\n\n  @CreateDateColumn()\n  createdAt: Date;\n\n  @UpdateDateColumn()\n  updatedAt: Date;\n}\n",
+    "/demo/nest-shop/apps/api/src/main.ts": "import 'reflect-metadata';\nimport { writeFileSync } from 'node:fs';\nimport { performance } from 'node:perf_hooks';\nimport { Logger } from '@nestjs/common';\nimport { ConfigService } from '@nestjs/config';\nimport { NestFactory, SerializedGraph } from '@nestjs/core';\nimport { AppModule } from './app.module';\n\nconst traceEnabled = process.env.NEST_BOOT_TRACE === '1';\nconst hookTimings: { className: string; hook: string; ms: number; startMs: number }[] = [];\n\nasync function bootstrap() {\n  const t0 = performance.now();\n  const app = await NestFactory.create(AppModule, {\n    snapshot: traceEnabled,\n    instrument: traceEnabled\n      ? {\n          instanceDecorator(instance: any) {\n            if (!instance || typeof instance !== 'object') return instance;\n            for (const hook of ['onModuleInit', 'onApplicationBootstrap']) {\n              const original = instance[hook];\n              if (typeof original !== 'function') continue;\n              try {\n                instance[hook] = async function (...args: unknown[]) {\n                  const start = performance.now();\n                  try {\n                    return await original.apply(this, args);\n                  } finally {\n                    hookTimings.push({\n                      className: this.constructor.name,\n                      hook,\n                      ms: performance.now() - start,\n                      startMs: start - t0,\n                    });\n                  }\n                };\n              } catch {} // frozen instances stay untimed\n            }\n            return instance;\n          },\n        }\n      : undefined,\n  });\n  const createMs = performance.now() - t0;\n  await app.init();\n  const initMs = performance.now() - t0;\n  const moduleInits = hookTimings.filter((h) => h.hook === 'onModuleInit');\n  const moduleInitMs = moduleInits.length\n    ? Math.max(...moduleInits.map((h) => h.startMs + h.ms))\n    : undefined;\n  const port = Number(app.get(ConfigService).get<string>('PORT') ?? 3000);\n  await app.listen(port);\n  const startupMs = performance.now() - t0;\n  Logger.log(`API listening on http://localhost:${port}`, 'Bootstrap');\n\n  if (traceEnabled) {\n    const graph = JSON.parse(app.get(SerializedGraph).toString());\n    Object.assign(graph, { createMs, initMs, moduleInitMs, startupMs, hookTimings });\n    writeFileSync('nestjs-doctor-timings.json', JSON.stringify(graph));\n    Logger.log(`Boot trace written to nestjs-doctor-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');\n    await app.close();\n    process.exit(0);\n  }\n}\n\nbootstrap().catch((err) => {\n  console.error('API failed to start', err);\n  process.exit(1);\n});\n",
+    "/demo/nest-shop/apps/api/src/notifications/notifications.module.ts": "import { BullModule } from '@nestjs/bullmq';\nimport { forwardRef, Module } from '@nestjs/common';\nimport { CatalogModule } from '../catalog/catalog.module';\nimport { OrdersModule } from '../orders/orders.module';\nimport { NotificationsService } from './notifications.service';\n\n@Module({\n  imports: [BullModule.registerQueue({ name: 'notifications' }), CatalogModule, forwardRef(() => OrdersModule)],\n  providers: [NotificationsService],\n  exports: [NotificationsService],\n})\nexport class NotificationsModule {}\n",
+    "/demo/nest-shop/apps/api/src/notifications/notifications.service.ts": "import { InjectQueue } from '@nestjs/bullmq';\nimport { forwardRef, Inject, Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';\nimport { Queue } from 'bullmq';\nimport { CatalogService } from '../catalog/catalog.service';\nimport { OrderStatus } from '../orders/order.entity';\nimport { OrdersService } from '../orders/orders.service';\n\nexport type NotificationKind = 'receipt' | 'refund' | 'welcome' | 'payment-reminder';\n\n@Injectable()\nexport class NotificationsService implements OnApplicationBootstrap {\n  private readonly logger = new Logger(NotificationsService.name);\n  private readonly from = process.env.NOTIFICATIONS_FROM ?? 'shop@example.com';\n\n  constructor(\n    @InjectQueue('notifications') private readonly queue: Queue,\n    private readonly catalogService: CatalogService,\n    @Inject(forwardRef(() => OrdersService))\n    private readonly ordersService: OrdersService,\n  ) {}\n\n  async onApplicationBootstrap(): Promise<void> {\n    await this.queue.waitUntilReady();\n    const counts = await this.queue.getJobCounts('waiting', 'active', 'failed');\n    // TODO: requeue jobs that failed while the API was down.\n    for (const kind of ['receipt', 'refund', 'welcome'] as NotificationKind[]) {\n      await this.queue.upsertJobScheduler(\n        `digest:${kind}`,\n        { every: 3_600_000 },\n        { name: 'digest', data: { kind, from: this.from } },\n      );\n    }\n    const products = await this.catalogService.findAll();\n    for (const slug of [...new Set(products.map((product) => product.category.slug))].sort()) {\n      await this.queue.upsertJobScheduler(\n        `digest:category:${slug}`,\n        { every: 3_600_000 },\n        { name: 'digest', data: { category: slug, from: this.from } },\n      );\n    }\n    const schedulers = await this.queue.getJobSchedulers();\n    const cleaned = await this.queue.clean(0, 100, 'completed');\n    await this.queue.trimEvents(1000);\n    const awaitingPayment = (await this.ordersService.findAll()).filter((order) => order.status === OrderStatus.Pending);\n    for (const order of awaitingPayment) {\n      await this.queue.add('payment-reminder', { orderId: order.id, from: this.from }, { jobId: `reminder-${order.id}` });\n    }\n    const lowStock = products.map((product) => product.sku).filter((sku) => this.pseudoStock(sku) === 0).sort();\n    for (const sku of lowStock) {\n      await this.queue.add('restock-check', { sku, from: this.from }, { jobId: `restock-${sku}` });\n    }\n    await new Promise((resolve) => setTimeout(resolve, 8));\n    this.logger.log(\n      `Queue ready: ${JSON.stringify(counts)}, ${schedulers.length} schedulers, ${cleaned.length} completed jobs cleaned, ${awaitingPayment.length} payment reminders, ${lowStock.length} restock checks`,\n    );\n  }\n\n  // Stable stock bucket per SKU: 0 means low.\n  private pseudoStock(sku: string): number {\n    let hash = 0;\n    for (const ch of sku) {\n      hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;\n    }\n    return hash % 5;\n  }\n\n  async enqueue(kind: NotificationKind, payload: Record<string, unknown>): Promise<string> {\n    const message = await this.buildMessage(kind, payload);\n    const job = await this.queue.add(kind, { ...payload, from: this.from, message }, { removeOnComplete: 100 });\n    this.logger.debug(`Enqueued ${kind} job ${job.id}`);\n    return job.id;\n  }\n\n  private async buildMessage(kind: NotificationKind, payload: Record<string, unknown>): Promise<string> {\n    const orderId = typeof payload.orderId === 'string' ? payload.orderId : undefined;\n    if (!orderId) {\n      return `${kind}`;\n    }\n    const order = await this.ordersService.findOne(orderId);\n    // FIXME: localise these messages once users carry a locale.\n    switch (kind) {\n      case 'receipt':\n        return `Thanks ${order.user.name}, we received ${order.totalCents / 100} for order ${order.id}`;\n      case 'refund':\n        return `Hi ${order.user.name}, order ${order.id} was refunded`;\n      default:\n        return `Update on order ${order.id}`;\n    }\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/orders/create-order.dto.ts": "import { Type } from 'class-transformer';\nimport { ArrayMinSize, IsInt, IsUUID, Min, ValidateNested } from 'class-validator';\n\nexport class OrderLineDto {\n  @IsUUID()\n  productId: string;\n\n  @IsInt()\n  @Min(1)\n  quantity: number;\n}\n\nexport class CreateOrderDto {\n  @IsUUID()\n  userId: string;\n\n  @ArrayMinSize(1)\n  @ValidateNested({ each: true })\n  @Type(() => OrderLineDto)\n  lines: OrderLineDto[];\n}\n",
+    "/demo/nest-shop/apps/api/src/orders/order-item.entity.ts": "import { Column, Entity, ManyToOne } from 'typeorm';\nimport { Product } from '../catalog/product.entity';\nimport { BaseEntity } from '../common/base.entity';\nimport { Order } from './order.entity';\n\n@Entity({ name: 'order_items' })\nexport class OrderItem extends BaseEntity {\n  @Column({ type: 'int' })\n  quantity: number;\n\n  @Column({ name: 'unit_price_cents', type: 'int' })\n  unitPriceCents: number;\n\n  @ManyToOne(() => Order, (order) => order.items, { nullable: false, onDelete: 'CASCADE' })\n  order: Order;\n\n  @ManyToOne(() => Product, (product) => product.orderItems, { nullable: false, onDelete: 'RESTRICT' })\n  product: Product;\n}\n",
+    "/demo/nest-shop/apps/api/src/orders/order.entity.ts": "import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\nimport { User } from '../users/user.entity';\nimport { OrderItem } from './order-item.entity';\n\nexport enum OrderStatus {\n  Pending = 'pending',\n  Paid = 'paid',\n  Refunded = 'refunded',\n}\n\n@Entity({ name: 'orders' })\n@Index(['status', 'createdAt'])\nexport class Order extends BaseEntity {\n  @Column({ type: 'enum', enum: OrderStatus, default: OrderStatus.Pending })\n  status: OrderStatus;\n\n  @Column({ name: 'total_cents', type: 'int', default: 0 })\n  totalCents: number;\n\n  @Column({ type: 'text', nullable: true })\n  note?: string;\n\n  @ManyToOne(() => User, (user) => user.orders, { nullable: false })\n  user: User;\n\n  @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })\n  items: OrderItem[];\n}\n",
+    "/demo/nest-shop/apps/api/src/orders/orders.controller.ts": "import { Body, Controller, Get, Param, Patch, Post, UseGuards, ValidationPipe } from '@nestjs/common';\nimport { JwtAuthGuard } from '../auth/jwt-auth.guard';\nimport { CreateOrderDto } from './create-order.dto';\nimport { OrderStatus } from './order.entity';\nimport { OrdersService } from './orders.service';\n\n@Controller('orders')\n@UseGuards(JwtAuthGuard)\nexport class OrdersController {\n  constructor(private readonly ordersService: OrdersService) {}\n\n  @Get()\n  list() {\n    return this.ordersService.findAll();\n  }\n\n  @Post()\n  create(@Body(new ValidationPipe({ whitelist: true, transform: true })) dto: CreateOrderDto) {\n    return this.ordersService.create(dto);\n  }\n\n  @Post(':id/pay')\n  pay(@Param('id') id: string, @Body() body: { provider?: string }) {\n    let surchargeCents: number;\n    switch (body.provider) {\n      case 'card':\n        surchargeCents = 30;\n        break;\n      case 'sepa':\n        surchargeCents = 0;\n        break;\n      default:\n        surchargeCents = 50;\n    }\n    return this.ordersService.pay(id, body.provider ?? 'card', surchargeCents);\n  }\n\n  @Patch(':id/status')\n  updateStatus(@Param('id') id: string, @Body('status') status: OrderStatus) {\n    return this.ordersService.updateStatus(id, status);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/orders/orders.module.ts": "import { forwardRef, Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { CatalogModule } from '../catalog/catalog.module';\nimport { PaymentsModule } from '../payments/payments.module';\nimport { UsersModule } from '../users/users.module';\nimport { OrderItem } from './order-item.entity';\nimport { Order } from './order.entity';\nimport { OrdersController } from './orders.controller';\nimport { OrdersService } from './orders.service';\n\n@Module({\n  imports: [\n    TypeOrmModule.forFeature([Order, OrderItem]),\n    UsersModule,\n    CatalogModule,\n    forwardRef(() => PaymentsModule),\n  ],\n  controllers: [OrdersController],\n  providers: [OrdersService],\n  exports: [OrdersService],\n})\nexport class OrdersModule {}\n",
+    "/demo/nest-shop/apps/api/src/orders/orders.service.ts": "import {\n  BadRequestException,\n  forwardRef,\n  Inject,\n  Injectable,\n  Logger,\n  NotFoundException,\n  OnApplicationBootstrap,\n  OnModuleInit,\n} from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { MetricsService } from '@app/shared';\nimport { LessThan, Repository } from 'typeorm';\nimport { AuditService } from '../audit/audit.service';\nimport { CatalogService } from '../catalog/catalog.service';\nimport { PaymentStatus } from '../payments/payment.entity';\nimport { PaymentsService } from '../payments/payments.service';\nimport { UsersService } from '../users/users.service';\nimport { CreateOrderDto } from './create-order.dto';\nimport { OrderItem } from './order-item.entity';\nimport { Order, OrderStatus } from './order.entity';\n\nconst DEMO_ORDER_COUNT = 240;\n\n@Injectable()\nexport class OrdersService implements OnModuleInit, OnApplicationBootstrap {\n  private readonly logger = new Logger(OrdersService.name);\n\n  constructor(\n    @InjectRepository(Order) private readonly orders: Repository<Order>,\n    @InjectRepository(OrderItem) private readonly items: Repository<OrderItem>,\n    private readonly usersService: UsersService,\n    private readonly catalogService: CatalogService,\n    private readonly audit: AuditService,\n    private readonly metrics: MetricsService,\n    @Inject(forwardRef(() => PaymentsService))\n    private readonly paymentsService: PaymentsService,\n  ) {}\n\n  async onModuleInit(): Promise<void> {\n    const seeded = await this.seedDemoOrders();\n    const orders = await this.orders.find({ relations: { items: true } });\n    for (const order of orders) {\n      order.totalCents = order.items.reduce((sum, item) => sum + item.quantity * item.unitPriceCents, 0);\n    }\n    for (let i = 0; i < orders.length; i += 20) {\n      await this.orders.save(orders.slice(i, i + 20));\n    }\n    this.logger.log(`Seeded ${seeded} demo orders, reconciled totals for ${orders.length}`);\n  }\n\n  async onApplicationBootstrap(): Promise<void> {\n    const rows: { status: OrderStatus; count: string }[] = await this.orders\n      .createQueryBuilder('o')\n      .select('o.status', 'status')\n      .addSelect('COUNT(*)', 'count')\n      .groupBy('o.status')\n      .getRawMany();\n    for (const row of rows) {\n      this.metrics.increment(`orders.${row.status}`, Number(row.count));\n    }\n    const stale = await this.orders.update(\n      { status: OrderStatus.Pending, createdAt: LessThan(new Date(Date.now() - 86_400_000)) },\n      { updatedAt: new Date() },\n    );\n    await this.audit.record('orders.reconciled', 'system', { counts: rows, stalePending: stale.affected ?? 0 });\n    this.logger.log(`Order counts ${JSON.stringify(rows)}, touched ${stale.affected ?? 0} stale pending orders`);\n  }\n\n  findAll(): Promise<Order[]> {\n    return this.orders.find({\n      relations: { user: true, items: { product: true } },\n      order: { createdAt: 'DESC' },\n    });\n  }\n\n  async findOne(id: string): Promise<Order> {\n    const order = await this.orders.findOne({\n      where: { id },\n      relations: { user: true, items: { product: true } },\n    });\n    if (!order) {\n      throw new NotFoundException(`Order ${id} not found`);\n    }\n    return order;\n  }\n\n  async create(dto: CreateOrderDto): Promise<Order> {\n    const user = await this.usersService.findOne(dto.userId);\n    const products = await this.catalogService.findByIds(dto.lines.map((l) => l.productId));\n    if (products.length !== dto.lines.length) {\n      throw new BadRequestException('One or more products do not exist');\n    }\n    const byId = new Map(products.map((p) => [p.id, p]));\n    const items = dto.lines.map((line) => {\n      const product = byId.get(line.productId);\n      return this.items.create({\n        product,\n        quantity: line.quantity,\n        unitPriceCents: product.priceCents,\n      });\n    });\n    const totalCents = items.reduce((sum, item) => sum + item.quantity * item.unitPriceCents, 0);\n    const order = await this.orders.save(this.orders.create({ user, items, totalCents }));\n    await this.audit.record('order.created', user.email, { orderId: order.id, totalCents });\n    this.metrics.increment('orders.created');\n    this.logger.log(`Order ${order.id} created for ${user.email} (${totalCents} cents)`);\n    return order;\n  }\n\n  async pay(id: string, provider: string, surchargeCents = 0): Promise<Order> {\n    const order = await this.findOne(id);\n    if (order.status !== OrderStatus.Pending) {\n      throw new BadRequestException(`Order ${id} is ${order.status}, cannot pay`);\n    }\n    order.totalCents += surchargeCents;\n    await this.paymentsService.charge(order, provider);\n    order.status = OrderStatus.Paid;\n    await this.orders.save(order);\n    await this.audit.record('order.paid', order.user.email, { orderId: order.id, provider });\n    this.metrics.increment('orders.paid');\n    return order;\n  }\n\n  async updateStatus(id: string, status: OrderStatus): Promise<Order> {\n    const order = await this.findOne(id);\n    if (!Object.values(OrderStatus).includes(status)) {\n      throw new BadRequestException(`Unknown status ${status}`);\n    }\n    order.status = status;\n    return this.orders.save(order);\n  }\n\n  async markRefunded(id: string): Promise<void> {\n    const order = await this.findOne(id);\n    await this.orders.update({ id }, { status: OrderStatus.Refunded });\n    this.audit.record('order.refunded', order.user.email, { orderId: id });\n  }\n\n  // Demo orders for the system user, one payment each, spread over the last 30 days.\n  private async seedDemoOrders(): Promise<number> {\n    if ((await this.orders.count()) > 0) {\n      return 0;\n    }\n    const email = 'system@shop.local';\n    const user = (await this.usersService.findByEmail(email)) ?? (await this.usersService.create({ email, name: 'System' }));\n    const products = await this.catalogService.findAll();\n    if (products.length === 0) {\n      return 0;\n    }\n    const statuses = Object.values(OrderStatus);\n    const paymentStatus = {\n      [OrderStatus.Pending]: PaymentStatus.Pending,\n      [OrderStatus.Paid]: PaymentStatus.Captured,\n      [OrderStatus.Refunded]: PaymentStatus.Refunded,\n    };\n    for (let i = 0; i < DEMO_ORDER_COUNT; i++) {\n      const items = Array.from({ length: 1 + (i % 3) }, (_, k) => {\n        const product = products[(i * 7 + k * 13) % products.length];\n        return this.items.create({ product, quantity: 1 + ((i + k) % 3), unitPriceCents: product.priceCents });\n      });\n      const status = statuses[i % statuses.length];\n      const createdAt = new Date(Date.now() - (1 + (i * 29) / DEMO_ORDER_COUNT) * 86_400_000);\n      const totalCents = items.reduce((sum, item) => sum + item.quantity * item.unitPriceCents, 0);\n      const order = await this.orders.save(this.orders.create({ user, items, status, createdAt, totalCents }));\n      await this.paymentsService.createPayment(order, i % 2 ? 'sepa' : 'card', paymentStatus[status], createdAt);\n    }\n    return DEMO_ORDER_COUNT;\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/payments/gateways/card.gateway.ts": "import { Injectable, Logger } from '@nestjs/common';\n\n@Injectable()\nexport class CardGateway {\n  private readonly logger = new Logger(CardGateway.name);\n\n  async refund(paymentId: string, amountCents: number): Promise<void> {\n    await new Promise((resolve) => setTimeout(resolve, 20));\n    this.logger.log(`Card refund for ${paymentId}: ${amountCents} cents`);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/payments/gateways/sepa.gateway.ts": "import { Injectable, Logger } from '@nestjs/common';\n\n@Injectable()\nexport class SepaGateway {\n  private readonly logger = new Logger(SepaGateway.name);\n\n  async refund(paymentId: string, amountCents: number): Promise<void> {\n    await new Promise((resolve) => setTimeout(resolve, 40));\n    this.logger.log(`SEPA credit transfer for ${paymentId}: ${amountCents} cents`);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/payments/invoice.entity.ts": "import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';\nimport { Order } from '../orders/order.entity';\n\n@Entity({ name: 'invoices' })\nexport class Invoice {\n  @PrimaryGeneratedColumn('uuid')\n  id: string;\n\n  @Column({ unique: true })\n  number: string;\n\n  @Column({ name: 'issued_at', type: 'timestamptz' })\n  issuedAt: Date;\n\n  @OneToOne(() => Order, { nullable: false, onDelete: 'CASCADE' })\n  @JoinColumn()\n  order: Order;\n}\n",
+    "/demo/nest-shop/apps/api/src/payments/payment.entity.ts": "import { Column, Entity, Index, ManyToOne } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\nimport { Order } from '../orders/order.entity';\n\nexport enum PaymentStatus {\n  Pending = 'pending',\n  Captured = 'captured',\n  Refunded = 'refunded',\n  Failed = 'failed',\n}\n\n@Entity({ name: 'payments' })\nexport class Payment extends BaseEntity {\n  @Index()\n  @Column()\n  provider: string;\n\n  @Column({ name: 'amount_cents', type: 'int' })\n  amountCents: number;\n\n  @Column({ type: 'enum', enum: PaymentStatus, default: PaymentStatus.Pending })\n  status: PaymentStatus;\n\n  @ManyToOne(() => Order, { nullable: false, onDelete: 'CASCADE' })\n  order: Order;\n}\n",
+    "/demo/nest-shop/apps/api/src/payments/payments.controller.ts": "import { Controller, Get, Param, Post } from '@nestjs/common';\nimport { PaymentsService } from './payments.service';\n\n@Controller('payments')\nexport class PaymentsController {\n  constructor(private readonly paymentsService: PaymentsService) {}\n\n  @Get()\n  list() {\n    return this.paymentsService.findAll();\n  }\n\n  @Post(':id/refund')\n  refund(@Param('id') id: string) {\n    return this.paymentsService.refund(id);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/payments/payments.module.ts": "import { forwardRef, Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { NotificationsModule } from '../notifications/notifications.module';\nimport { CardGateway } from './gateways/card.gateway';\nimport { SepaGateway } from './gateways/sepa.gateway';\nimport { Invoice } from './invoice.entity';\nimport { Payment } from './payment.entity';\nimport { PaymentsController } from './payments.controller';\nimport { PaymentsService } from './payments.service';\n\n@Module({\n  imports: [\n    TypeOrmModule.forFeature([Payment, Invoice]),\n    forwardRef(() => NotificationsModule),\n  ],\n  controllers: [PaymentsController],\n  providers: [PaymentsService, CardGateway, SepaGateway],\n  exports: [PaymentsService],\n})\nexport class PaymentsModule {}\n",
+    "/demo/nest-shop/apps/api/src/payments/payments.service.ts": "import {\n  BadRequestException,\n  forwardRef,\n  Inject,\n  Injectable,\n  Logger,\n  NotFoundException,\n  OnApplicationBootstrap,\n  OnModuleInit,\n} from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { MetricsService } from '@app/shared';\nimport { createHash, createHmac, timingSafeEqual } from 'node:crypto';\nimport { LessThan, Repository } from 'typeorm';\nimport { AuditService } from '../audit/audit.service';\nimport { NotificationsService } from '../notifications/notifications.service';\nimport { Order } from '../orders/order.entity';\nimport { CardGateway } from './gateways/card.gateway';\nimport { SepaGateway } from './gateways/sepa.gateway';\nimport { Invoice } from './invoice.entity';\nimport { Payment, PaymentStatus } from './payment.entity';\n\n@Injectable()\nexport class PaymentsService implements OnModuleInit, OnApplicationBootstrap {\n  private readonly logger = new Logger(PaymentsService.name);\n  // Pending amount per order id, warmed at boot so refunds can check quickly.\n  private readonly pendingByOrder = new Map<string, number>();\n  private readonly webhookSecret = 'whsec_4b1d9e7f2a6c8e0b3d5f7a9c1e3b5d7f';\n\n  constructor(\n    @InjectRepository(Payment) private readonly payments: Repository<Payment>,\n    @InjectRepository(Invoice) private readonly invoices: Repository<Invoice>,\n    private readonly cardGateway: CardGateway,\n    private readonly sepaGateway: SepaGateway,\n    private readonly metrics: MetricsService,\n    private readonly audit: AuditService,\n    @Inject(forwardRef(() => NotificationsService))\n    private readonly notifications: NotificationsService,\n  ) {}\n\n  async onModuleInit(): Promise<void> {\n    const pending = await this.payments.find({\n      where: { status: PaymentStatus.Pending },\n      relations: { order: true },\n    });\n    for (const payment of pending) {\n      this.pendingByOrder.set(payment.order.id, payment.amountCents);\n    }\n    const perProvider: { provider: string; count: string }[] = await this.payments\n      .createQueryBuilder('p')\n      .select('p.provider', 'provider')\n      .addSelect('COUNT(*)', 'count')\n      .where('p.status = :status', { status: PaymentStatus.Pending })\n      .groupBy('p.provider')\n      .getRawMany();\n    const total = await this.payments.count();\n    const invoiced = await this.invoices.count();\n    await this.audit.record('payments.reconciled', 'system', { pending: pending.length, total, invoiced, perProvider });\n    this.logger.log(`Warmed ${pending.length} pending payments (${total} total)`);\n  }\n\n  async onApplicationBootstrap(): Promise<void> {\n    const expired = await this.payments.find({\n      where: { status: PaymentStatus.Pending, createdAt: LessThan(new Date(Date.now() - 3_600_000)) },\n      relations: { order: true },\n    });\n    for (const payment of expired) {\n      await this.audit.record('payment.expired', 'system', {\n        paymentId: payment.id,\n        orderId: payment.order.id,\n        provider: payment.provider,\n        amountCents: payment.amountCents,\n      });\n    }\n    this.logger.log(`Flagged ${expired.length} pending payments older than one hour`);\n  }\n\n  findAll(): Promise<Payment[]> {\n    return this.payments.find({ relations: { order: true }, order: { createdAt: 'DESC' } });\n  }\n\n  async charge(order: Order, provider: string): Promise<Payment> {\n    // TODO: run the charge through the provider gateway instead of capturing directly.\n    const payment = await this.payments.save(\n      this.payments.create({\n        order,\n        provider,\n        amountCents: order.totalCents,\n        status: PaymentStatus.Captured,\n      }),\n    );\n    const invoice = await this.invoices.save(\n      this.invoices.create({ order, number: this.nextInvoiceNumber(order), issuedAt: new Date() }),\n    );\n    this.pendingByOrder.delete(order.id);\n    await this.notifications.enqueue('receipt', {\n      orderId: order.id,\n      paymentId: payment.id,\n      invoiceNumber: invoice.number,\n    });\n    return payment;\n  }\n\n  async createPayment(order: Order, provider: string, status: PaymentStatus, createdAt: Date): Promise<Payment> {\n    const payment = await this.payments.save(\n      this.payments.create({ order, provider, amountCents: order.totalCents, status, createdAt }),\n    );\n    if (status !== PaymentStatus.Pending) {\n      await this.invoices.save(\n        this.invoices.create({ order, number: this.nextInvoiceNumber(order), issuedAt: createdAt }),\n      );\n    }\n    return payment;\n  }\n\n  async refund(paymentId: string): Promise<Payment> {\n    const payment = await this.payments.findOne({ where: { id: paymentId }, relations: { order: true } });\n    if (!payment) {\n      throw new NotFoundException(`Payment ${paymentId} not found`);\n    }\n    if (payment.status !== PaymentStatus.Captured) {\n      throw new BadRequestException(`Payment ${paymentId} is ${payment.status}, cannot refund`);\n    }\n    if (payment.provider === 'card') {\n      await this.cardGateway.refund(payment.id, payment.amountCents);\n    } else {\n      await this.sepaGateway.refund(payment.id, payment.amountCents);\n    }\n    payment.status = PaymentStatus.Refunded;\n    await this.payments.save(payment);\n    this.metrics.increment('payments.refunded');\n    // FIXME: the order stays \"paid\" until the notification job runs.\n    await this.notifications.enqueue('refund', { orderId: payment.order.id, paymentId });\n    return payment;\n  }\n\n  verifyWebhookSignature(rawBody: string, signature: string): boolean {\n    const expected = createHmac('sha256', this.webhookSecret).update(rawBody).digest('hex');\n    return expected.length === signature.length && timingSafeEqual(Buffer.from(expected), Buffer.from(signature));\n  }\n\n  private nextInvoiceNumber(order: Order): string {\n    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');\n    const suffix = createHash('md5').update(order.id).digest('hex').slice(0, 8);\n    return `INV-${stamp}-${suffix.toUpperCase()}`;\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/reports/reports.module.ts": "import { Module } from '@nestjs/common';\nimport { SalesReportRepository } from './reports.repository';\nimport { SalesReportService } from './reports.service';\n\n@Module({\n  providers: [SalesReportRepository, SalesReportService],\n  exports: [SalesReportService],\n})\nexport class ReportsModule {}\n",
+    "/demo/nest-shop/apps/api/src/reports/reports.repository.ts": "import { Injectable } from '@nestjs/common';\nimport { InjectDataSource } from '@nestjs/typeorm';\nimport { DataSource } from 'typeorm';\n\nexport interface DailyTotal {\n  day: string;\n  orders: number;\n  totalCents: number;\n}\n\n@Injectable()\nexport class SalesReportRepository {\n  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}\n\n  dailyTotals(days: number): Promise<DailyTotal[]> {\n    return this.dataSource.query(\n      `SELECT to_char(\"createdAt\", 'YYYY-MM-DD') AS day,\n              count(*)::int AS orders,\n              coalesce(sum(total_cents), 0)::int AS \"totalCents\"\n         FROM orders\n        WHERE status = 'paid' AND \"createdAt\" > now() - ($1 || ' days')::interval\n        GROUP BY 1 ORDER BY 1 DESC`,\n      [String(days)],\n    );\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/reports/reports.service.ts": "import { Injectable } from '@nestjs/common';\nimport { DailyTotal, SalesReportRepository } from './reports.repository';\n\n@Injectable()\nexport class SalesReportService {\n  constructor(private readonly reports: SalesReportRepository) {}\n\n  dailyTotals(days = 30): Promise<DailyTotal[]> {\n    return this.reports.dailyTotals(days);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/users/create-user.dto.ts": "import { IsEmail, IsString, MinLength } from 'class-validator';\n\nexport class CreateUserDto {\n  @IsEmail()\n  email: string;\n\n  @IsString()\n  @MinLength(2)\n  name: string;\n}\n",
+    "/demo/nest-shop/apps/api/src/users/dto/update-user.dto.ts": "import { Type } from 'class-transformer';\nimport { IsOptional, IsString, MinLength, ValidateNested } from 'class-validator';\n\nexport class AddressDto {\n  @IsString()\n  street: string;\n\n  @IsString()\n  city: string;\n\n  @IsString()\n  @MinLength(2)\n  country: string;\n}\n\nexport class UpdateUserDto {\n  @IsOptional()\n  @IsString()\n  @MinLength(2)\n  name?: string;\n\n  @IsOptional()\n  @ValidateNested()\n  @Type(() => AddressDto)\n  addresses: AddressDto[];\n}\n",
+    "/demo/nest-shop/apps/api/src/users/user.entity.ts": "import { Column, Entity, OneToMany } from 'typeorm';\nimport { BaseEntity } from '../common/base.entity';\nimport { Order } from '../orders/order.entity';\n\nexport interface Address {\n  street: string;\n  city: string;\n  country: string;\n}\n\n@Entity({ name: 'users' })\nexport class User extends BaseEntity {\n  @Column({ unique: true })\n  email: string;\n\n  @Column()\n  name: string;\n\n  @Column({ type: 'jsonb', default: [] })\n  addresses: Address[];\n\n  @OneToMany(() => Order, (order) => order.user)\n  orders: Order[];\n}\n",
+    "/demo/nest-shop/apps/api/src/users/users.controller.ts": "import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards, ValidationPipe } from '@nestjs/common';\nimport { JwtAuthGuard } from '../auth/jwt-auth.guard';\nimport { CreateUserDto } from './create-user.dto';\nimport { UpdateUserDto } from './dto/update-user.dto';\nimport { UsersService } from './users.service';\n\n@Controller('users')\n@UseGuards(JwtAuthGuard)\nexport class UsersController {\n  constructor(private readonly usersService: UsersService) {}\n\n  @Get()\n  list() {\n    return this.usersService.findAll();\n  }\n\n  @Get(':id')\n  get(@Param('id') id: string) {\n    return this.usersService.findOne(id);\n  }\n\n  @Post()\n  create(@Body(new ValidationPipe({ whitelist: true })) dto: CreateUserDto) {\n    return this.usersService.create(dto);\n  }\n\n  @Patch(':id')\n  update(\n    @Param('id') id: string,\n    @Body(new ValidationPipe({ whitelist: true, transform: true })) dto: UpdateUserDto,\n  ) {\n    return this.usersService.update(id, dto);\n  }\n\n  @Delete(':id')\n  remove(@Param('id') id: string) {\n    return this.usersService.remove(id);\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/users/users.module.ts": "import { Module } from '@nestjs/common';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { User } from './user.entity';\nimport { UsersController } from './users.controller';\nimport { UsersRepository } from './users.repository';\nimport { UsersService } from './users.service';\n\n@Module({\n  imports: [TypeOrmModule.forFeature([User])],\n  controllers: [UsersController],\n  providers: [UsersService, UsersRepository],\n  exports: [UsersService],\n})\nexport class UsersModule {}\n",
+    "/demo/nest-shop/apps/api/src/users/users.repository.ts": "import { Injectable } from '@nestjs/common';\nimport { InjectRepository } from '@nestjs/typeorm';\nimport { Repository } from 'typeorm';\nimport { User } from './user.entity';\n\n@Injectable()\nexport class UsersRepository {\n  constructor(@InjectRepository(User) private readonly users: Repository<User>) {}\n\n  findAll(): Promise<User[]> {\n    return this.users.find({ order: { createdAt: 'DESC' } });\n  }\n\n  findOne(id: string): Promise<User | null> {\n    return this.users.findOne({ where: { id } });\n  }\n\n  findByEmail(email: string): Promise<User | null> {\n    return this.users.findOne({ where: { email } });\n  }\n\n  save(row: Partial<User>): Promise<User> {\n    return this.users.save(this.users.create(row));\n  }\n\n  async upsert(row: Partial<User>): Promise<void> {\n    await this.users.upsert(row, ['email']);\n  }\n\n  async remove(id: string): Promise<void> {\n    await this.users.delete({ id });\n  }\n}\n",
+    "/demo/nest-shop/apps/api/src/users/users.service.ts": "import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';\nimport { CreateUserDto } from './create-user.dto';\nimport { UpdateUserDto } from './dto/update-user.dto';\nimport { User } from './user.entity';\nimport { UsersRepository } from './users.repository';\n\n@Injectable()\nexport class UsersService implements OnModuleInit {\n  private readonly logger = new Logger(UsersService.name);\n  private readonly byEmail = new Map<string, User>();\n  private systemUser: User;\n\n  constructor(private readonly users: UsersRepository) {}\n\n  async onModuleInit(): Promise<void> {\n    await this.users.upsert({ email: 'system@shop.local', name: 'System', addresses: [] });\n    this.systemUser = await this.users.findByEmail('system@shop.local');\n    for (const user of await this.users.findAll()) {\n      this.byEmail.set(user.email, user);\n    }\n    this.logger.log(`Warmed ${this.byEmail.size} users, system user ${this.systemUser.id}`);\n  }\n\n  findAll(): Promise<User[]> {\n    return this.users.findAll();\n  }\n\n  async findOne(id: string): Promise<User> {\n    const user = await this.users.findOne(id);\n    if (!user) {\n      throw new NotFoundException(`User ${id} not found`);\n    }\n    return user;\n  }\n\n  findByEmail(email: string): Promise<User | null> {\n    return this.users.findByEmail(email);\n  }\n\n  create(dto: CreateUserDto): Promise<User> {\n    return this.users.save({ email: dto.email.toLowerCase(), name: dto.name, addresses: [] });\n  }\n\n  async update(id: string, dto: UpdateUserDto): Promise<User> {\n    const user = await this.findOne(id);\n    return this.users.save({ ...user, name: dto.name ?? user.name, addresses: dto.addresses ?? user.addresses });\n  }\n\n  async remove(id: string): Promise<void> {\n    await this.findOne(id);\n    await this.users.remove(id);\n  }\n}\n",
+    "/demo/nest-shop/apps/worker/src/jobs/jobs.module.ts": "import { BullModule } from '@nestjs/bullmq';\nimport { Module } from '@nestjs/common';\nimport { JobsService } from './jobs.service';\nimport { NotificationsProcessor } from './notifications.processor';\n\n@Module({\n  imports: [BullModule.registerQueue({ name: 'notifications' })],\n  providers: [NotificationsProcessor, JobsService],\n  exports: [JobsService],\n})\nexport class JobsModule {}\n",
+    "/demo/nest-shop/apps/worker/src/jobs/jobs.service.ts": "import { InjectQueue } from '@nestjs/bullmq';\nimport { Injectable } from '@nestjs/common';\nimport { MetricsService } from '@app/shared';\nimport { Queue } from 'bullmq';\n\n@Injectable()\nexport class JobsService {\n  constructor(\n    @InjectQueue('notifications') private readonly queue: Queue,\n    private readonly metrics: MetricsService,\n  ) {}\n\n  async stats() {\n    const counts = await this.queue.getJobCounts('waiting', 'active', 'completed', 'failed');\n    return { queue: counts, processed: this.metrics.snapshot() };\n  }\n}\n",
+    "/demo/nest-shop/apps/worker/src/jobs/notifications.processor.ts": "import { Processor, WorkerHost } from '@nestjs/bullmq';\nimport { Logger } from '@nestjs/common';\nimport { MetricsService } from '@app/shared';\nimport { Job } from 'bullmq';\n\n@Processor('notifications')\nexport class NotificationsProcessor extends WorkerHost {\n  private readonly logger = new Logger(NotificationsProcessor.name);\n\n  constructor(private readonly metrics: MetricsService) {\n    super();\n  }\n\n  async process(job: Job<{ message?: string; orderId?: string }>): Promise<void> {\n    this.logger.log(`[${job.name}] #${job.id} ${job.data.message ?? ''}`);\n    this.metrics.increment(`notifications.${job.name}`);\n  }\n}\n",
+    "/demo/nest-shop/apps/worker/src/main.ts": "import 'reflect-metadata';\nimport { writeFileSync } from 'node:fs';\nimport { performance } from 'node:perf_hooks';\nimport { Logger } from '@nestjs/common';\nimport { NestFactory, SerializedGraph } from '@nestjs/core';\nimport { WorkerModule } from './worker.module';\n\nconst traceEnabled = process.env.NEST_BOOT_TRACE === '1';\nconst hookTimings: { className: string; hook: string; ms: number; startMs: number }[] = [];\n\nasync function bootstrap() {\n  const t0 = performance.now();\n  const app = await NestFactory.createApplicationContext(WorkerModule, {\n    snapshot: traceEnabled,\n    instrument: traceEnabled\n      ? {\n          instanceDecorator(instance: any) {\n            if (!instance || typeof instance !== 'object') return instance;\n            for (const hook of ['onModuleInit', 'onApplicationBootstrap']) {\n              const original = instance[hook];\n              if (typeof original !== 'function') continue;\n              try {\n                instance[hook] = async function (...args: unknown[]) {\n                  const start = performance.now();\n                  try {\n                    return await original.apply(this, args);\n                  } finally {\n                    hookTimings.push({\n                      className: this.constructor.name,\n                      hook,\n                      ms: performance.now() - start,\n                      startMs: start - t0,\n                    });\n                  }\n                };\n              } catch {} // frozen instances stay untimed\n            }\n            return instance;\n          },\n        }\n      : undefined,\n  });\n  app.enableShutdownHooks();\n  const startupMs = performance.now() - t0;\n  Logger.log('Worker started, waiting for jobs', 'Bootstrap');\n\n  if (traceEnabled) {\n    const graph = JSON.parse(app.get(SerializedGraph).toString());\n    Object.assign(graph, { startupMs, hookTimings });\n    writeFileSync('worker-timings.json', JSON.stringify(graph));\n    Logger.log(`Boot trace written to worker-timings.json (${startupMs.toFixed(0)}ms)`, 'Bootstrap');\n  }\n}\n\nbootstrap().catch((err) => {\n  console.error('Worker failed to start', err);\n  process.exit(1);\n});\n",
+    "/demo/nest-shop/apps/worker/src/sync/sync.module.ts": "import { Module } from '@nestjs/common';\nimport { SyncRepository } from './sync.repository';\nimport { SyncService } from './sync.service';\n\n@Module({\n  providers: [SyncService, SyncRepository],\n})\nexport class SyncModule {}\n",
+    "/demo/nest-shop/apps/worker/src/sync/sync.repository.ts": "import { Injectable } from '@nestjs/common';\nimport { InjectDataSource } from '@nestjs/typeorm';\nimport { DataSource } from 'typeorm';\n\nexport interface CatalogCounts {\n  products: number;\n  categories: number;\n}\n\n@Injectable()\nexport class SyncRepository {\n  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}\n\n  async catalogCounts(): Promise<CatalogCounts> {\n    const [row] = await this.dataSource.query(\n      'SELECT count(*)::int AS products, count(DISTINCT \"categoryId\")::int AS categories FROM products',\n    );\n    return row;\n  }\n}\n",
+    "/demo/nest-shop/apps/worker/src/sync/sync.service.ts": "import { Injectable, Logger, OnModuleInit } from '@nestjs/common';\nimport { MetricsService } from '@app/shared';\nimport { SyncRepository } from './sync.repository';\n\n@Injectable()\nexport class SyncService implements OnModuleInit {\n  private readonly logger = new Logger(SyncService.name);\n\n  constructor(\n    private readonly sync: SyncRepository,\n    private readonly metrics: MetricsService,\n  ) {}\n\n  async onModuleInit(): Promise<void> {\n    // TODO: compare against the upstream feed and flag drift.\n    const counts = await this.sync.catalogCounts();\n    this.metrics.increment('sync.checks');\n    // FIXME: schedule this on an interval instead of running once at boot.\n    this.logger.log(`Catalog check: ${counts.products} products across ${counts.categories} categories`);\n  }\n}\n",
+    "/demo/nest-shop/apps/worker/src/worker.module.ts": "import { BullModule } from '@nestjs/bullmq';\nimport { Module } from '@nestjs/common';\nimport { ConfigModule, ConfigService } from '@nestjs/config';\nimport { TypeOrmModule } from '@nestjs/typeorm';\nimport { SharedModule } from '@app/shared';\nimport { JobsModule } from './jobs/jobs.module';\nimport { SyncModule } from './sync/sync.module';\n\n@Module({\n  imports: [\n    ConfigModule.forRoot({ isGlobal: true, envFilePath: ['.env'] }),\n    BullModule.forRootAsync({\n      inject: [ConfigService],\n      useFactory: (config: ConfigService) => ({\n        connection: {\n          host: config.getOrThrow<string>('REDIS_HOST'),\n          port: Number(config.getOrThrow<string>('REDIS_PORT')),\n        },\n      }),\n    }),\n    TypeOrmModule.forRootAsync({\n      inject: [ConfigService],\n      useFactory: (config: ConfigService) => ({\n        type: 'postgres',\n        host: config.getOrThrow<string>('DATABASE_HOST'),\n        port: Number(config.getOrThrow<string>('DATABASE_PORT')),\n        username: config.getOrThrow<string>('DATABASE_USER'),\n        password: config.getOrThrow<string>('DATABASE_PASSWORD'),\n        database: config.getOrThrow<string>('DATABASE_NAME'),\n        autoLoadEntities: true,\n      }),\n    }),\n    SharedModule,\n    JobsModule,\n    SyncModule,\n  ],\n})\nexport class WorkerModule {}\n",
+    "/demo/nest-shop/libs/shared/src/app-config.service.ts": "import { Injectable } from '@nestjs/common';\nimport { ConfigService } from '@nestjs/config';\n\nexport interface DatabaseOptions {\n  host: string;\n  port: number;\n  username: string;\n  password: string;\n  database: string;\n}\n\nexport interface RedisOptions {\n  host: string;\n  port: number;\n}\n\n@Injectable()\nexport class AppConfigService {\n  constructor(private readonly config: ConfigService) {}\n\n  databaseOptions(): DatabaseOptions {\n    return {\n      host: this.config.getOrThrow<string>('DATABASE_HOST'),\n      port: Number(this.config.getOrThrow<string>('DATABASE_PORT')),\n      username: this.config.getOrThrow<string>('DATABASE_USER'),\n      password: this.config.getOrThrow<string>('DATABASE_PASSWORD'),\n      database: this.config.getOrThrow<string>('DATABASE_NAME'),\n    };\n  }\n\n  redisOptions(): RedisOptions {\n    return {\n      host: this.config.getOrThrow<string>('REDIS_HOST'),\n      port: Number(this.config.getOrThrow<string>('REDIS_PORT')),\n    };\n  }\n\n  get port(): number {\n    return Number(this.config.get<string>('PORT') ?? 3000);\n  }\n}\n",
+    "/demo/nest-shop/libs/shared/src/index.ts": "export * from './shared.module';\nexport * from './metrics.service';\nexport * from './app-config.service';\nexport * from './request-context.service';\nexport * from './redis.strategy';\n",
+    "/demo/nest-shop/libs/shared/src/metrics.service.ts": "import { Injectable, Scope } from '@nestjs/common';\n\nconst SEED_COUNTERS = ['orders.created', 'orders.paid', 'payments.refunded'];\n\n@Injectable({ scope: Scope.TRANSIENT })\nexport class MetricsService {\n  private readonly counters = new Map<string, number>();\n\n  async onModuleInit(): Promise<void> {\n    await new Promise((resolve) => setTimeout(resolve, 5));\n    for (const name of SEED_COUNTERS) {\n      this.counters.set(name, 0);\n    }\n  }\n\n  increment(name: string, by = 1): void {\n    this.counters.set(name, (this.counters.get(name) ?? 0) + by);\n  }\n\n  snapshot(): Record<string, number> {\n    return Object.fromEntries(this.counters);\n  }\n}\n",
+    "/demo/nest-shop/libs/shared/src/redis.strategy.ts": "import { Injectable } from '@nestjs/common';\nimport { AppConfigService } from './app-config.service';\n\nexport interface RedisConnectionOptions {\n  host: string;\n  port: number;\n  maxRetriesPerRequest: null;\n  enableReadyCheck: boolean;\n}\n\n@Injectable()\nexport class RedisStrategy {\n  constructor(private readonly config: AppConfigService) {}\n\n  connectionOptions(): RedisConnectionOptions {\n    return { ...this.config.redisOptions(), maxRetriesPerRequest: null, enableReadyCheck: true };\n  }\n}\n",
+    "/demo/nest-shop/libs/shared/src/request-context.service.ts": "import { Injectable, Scope } from '@nestjs/common';\nimport { randomUUID } from 'node:crypto';\n\n@Injectable({ scope: Scope.REQUEST })\nexport class RequestContextService {\n  readonly requestId = randomUUID();\n  readonly startedAt = new Date();\n}\n",
+    "/demo/nest-shop/libs/shared/src/shared.module.ts": "import { Global, Module } from '@nestjs/common';\nimport { ConfigModule } from '@nestjs/config';\nimport { AppConfigService } from './app-config.service';\nimport { MetricsService } from './metrics.service';\nimport { RedisStrategy } from './redis.strategy';\nimport { RequestContextService } from './request-context.service';\n\n@Global()\n@Module({\n  imports: [ConfigModule],\n  providers: [MetricsService, AppConfigService, RequestContextService, RedisStrategy],\n  exports: [MetricsService, AppConfigService, RequestContextService, RedisStrategy],\n})\nexport class SharedModule {}\n"
+  }
+}


### PR DESCRIPTION
## Context

PR #361 shipped the demo report generated from the real nest-shop boot. Its branch later gained three commits adding a second, real worker boot trace — but #361 had already been merged, so those commits never reached main and the deployed demo carries no `traces` field.

## Problem

nestjs.doctor's report viewer now understands multiple boot traces (#365), but the deployed `demo-report.json` predates them: the Boot tab shows only the api boot and no picker.

## Possible flows

| Flow | Affected |
|---|---|
| Deployed demo at /report | shows api only → gains the api·worker picker |
| A user's own report | unaffected, generated locally |
| Old bookmarked demo JSON | unaffected, replaced wholesale |

## Solution

Re-lands the final demo JSON from the #361 branch (commit a9fcd66 content): the same scrubbed nest-shop artifact, regenerated with `--timings nestjs-doctor-timings.json,worker=worker-timings.json`. The api trace is the original 358.8ms boot; the worker trace is a real 170.8ms `createApplicationContext` boot of `apps/worker` (instrumented main.ts, live Postgres and Redis), with derived phase splits. Nothing else changes.

## Before vs after

| Case | Before | After |
|---|---|---|
| Boot tab on the demo | api timeline, no picker | `api · worker` picker |
| Worker modules' dock | empty | worker's own 170.8ms trace |
| api trace | 358.8ms | identical |

## Example

`https://nestjs.doctor/report` → Boot trace → picker shows `api` (358.8ms) and `worker` (170.8ms: 140ms building modules, 30ms init hooks, woven bootstrap and port sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAT9c3kq2cDxg6DRSiV8b1
