### PR TITLE
fix(report): module graph arrows keep the import direction on selection

### DIFF
--- a/.changeset/module-graph-arrow-direction.md
+++ b/.changeset/module-graph-arrow-direction.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Fixed
+
+- **Module graph arrows no longer flip when a module is selected.** Edges always point from the importer to the module it imports; selecting a node used to reverse the arrowheads on its highlighted edges and on the hovered detail-panel row.

--- a/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
@@ -753,7 +753,7 @@ export class ModulesCanvas {
 			}
 			let lineWidth = e.cross || e.cycle ? 1.6 : 1.3;
 			// Selection edges split by direction: imports vs used-by.
-			// Dashes move along the value flow, from imported to importer.
+			// Arrowheads and dashes keep the import direction, importer to imported.
 			let isSelEdge = false;
 			if (this.selected && !e.cycle) {
 				if (e.from === this.selected.name) {
@@ -783,9 +783,8 @@ export class ModulesCanvas {
 			}
 			ctx.globalAlpha = alpha;
 			if (isSelEdge) {
-				// Arrowheads on selection edges follow the value flow.
 				ctx.lineDashOffset = -this.dashT;
-				this.drawArrow(p2.x, p2.y, p1.x, p1.y, color, dash, lineWidth);
+				this.drawArrow(p1.x, p1.y, p2.x, p2.y, color, dash, lineWidth);
 				ctx.lineDashOffset = 0;
 			} else {
 				this.drawArrow(p1.x, p1.y, p2.x, p2.y, color, dash, lineWidth);
@@ -833,7 +832,7 @@ export class ModulesCanvas {
 			const hp1 = this.boxPort(hoverPair[0], hoverPair[1].x, hoverPair[1].y);
 			const hp2 = this.boxPort(hoverPair[1], hoverPair[0].x, hoverPair[0].y);
 			ctx.lineDashOffset = -this.dashT;
-			this.drawArrow(hp2.x, hp2.y, hp1.x, hp1.y, "#ffffff", [8, 6], 2.6);
+			this.drawArrow(hp1.x, hp1.y, hp2.x, hp2.y, "#ffffff", [8, 6], 2.6);
 			ctx.lineDashOffset = 0;
 			ctx.globalAlpha = 1;
 		}


### PR DESCRIPTION
## Context

The Modules Graph draws each import edge as an arrow. An edge's `from` is the importer and `to` is the imported module, and idle edges draw the arrowhead on the imported side, so `AppModule → UsersModule` reads "AppModule imports UsersModule".

## Problem

Selecting any module reverses its arrows. `drawEdges` in `modules-canvas.ts` deliberately called `drawArrow(p2, p1)` for selection edges ("arrowheads follow the value flow", imported → importer), so the same edge points one way idle and the other way selected. Clicking a node makes every arrow around it flip, which reads as the graph changing its data.

## Possible flows

| Path | Direction before |
| --- | --- |
| Idle edges | importer → imported |
| Edges of the selected module (blue/green) | imported → importer (flipped) |
| White highlight when hovering a detail-panel row | imported → importer (flipped) |
| Focused cycle edges | importer → imported |

## Solution

Both flipped `drawArrow` calls now pass `p1 → p2` / `hp1 → hp2`, and the comment states the invariant: arrowheads and dashes keep the import direction. The dash animation stays; its offset sign is unchanged, so dashes now travel the same way the arrowhead points. Nothing else changed — colors, widths, alpha, and the cycle overlay are untouched.

## Before vs after

| Path | Before | After |
| --- | --- | --- |
| Idle edges | importer → imported | importer → imported (unchanged) |
| Selected module's edges | flipped on selection | importer → imported |
| Detail-row hover highlight | flipped | importer → imported |

## Example

Open any report, Modules tab, click `AppModule`. Before: the edge to `UsersModule` swings around and points back at `AppModule`. After: it keeps pointing at `UsersModule`, with the dashes running toward it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
