### PR TITLE
feat(report): modules graph and schema tab interaction polish

### DIFF
--- a/.changeset/module-detail-covers-sidebar.md
+++ b/.changeset/module-detail-covers-sidebar.md
@@ -4,4 +4,4 @@
 
 ### Changed
 
-- **Selecting a module gives its detail panel the whole sidebar.** The projects list, search, and toggles hide while a module is selected and return when the panel closes, instead of stacking above the detail.
+- **Selecting a module gives its detail panel the whole sidebar.** The projects list, search, and toggles hide while a module is selected and return when the panel closes, instead of stacking above the detail, with a short fade-in either way. The trace badge in the panel now opens the boot-trace drawer at the bottom of the graph instead of switching to the Boot tab.

--- a/.changeset/module-detail-covers-sidebar.md
+++ b/.changeset/module-detail-covers-sidebar.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Changed
+
+- **Selecting a module gives its detail panel the whole sidebar.** The projects list, search, and toggles hide while a module is selected and return when the panel closes, instead of stacking above the detail.

--- a/.changeset/module-dock-camera-anchor.md
+++ b/.changeset/module-dock-camera-anchor.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Fixed
+
+- **Graph no longer drifts when the bottom drawer opens or closes.** The draw transform scales around the canvas centre, so any height change shifted content by half the delta times the zoom factor. The camera now compensates on resize and every node keeps its screen position.

--- a/.changeset/module-dock-resize.md
+++ b/.changeset/module-dock-resize.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Fixed
+
+- **Graph no longer cut after closing the bottom drawer.** The canvas measured its size before the drawer's open or close landed in the DOM, so closing left the graph painted at the shrunken height. It now resizes after the state commits.

--- a/.changeset/module-info-popover-style.md
+++ b/.changeset/module-info-popover-style.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Changed
+
+- **The Modules Graph legend popover matches the panel style.** It reuses the shared modal panel look — square corners, surface background, strong border, and shadow — instead of its own rounded translucent box.

--- a/.changeset/module-info-popover.md
+++ b/.changeset/module-info-popover.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Fixed
+
+- **The legend button on the Modules Graph opens its popover again.** The click that opened it also reached the document-level outside-click closer, which shut the popover in the same instant; the closer now ignores clicks on the button.

--- a/.changeset/module-tree-indent-guides.md
+++ b/.changeset/module-tree-indent-guides.md
@@ -4,4 +4,4 @@
 
 ### Changed
 
-- **Indent guides in the module tree.** Hovering the Projects list on the Modules Graph tab shows the same vertical guide lines the findings file tree draws.
+- **Indent guides in the module tree.** Hovering the Projects list on the Modules Graph tab or the entity list on the Relational Schema tab shows the same vertical guide lines the findings file tree draws.

--- a/.changeset/module-tree-indent-guides.md
+++ b/.changeset/module-tree-indent-guides.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Changed
+
+- **Indent guides in the module tree.** Hovering the Projects list on the Modules Graph tab shows the same vertical guide lines the findings file tree draws.

--- a/.changeset/react-doctor-fixes.md
+++ b/.changeset/react-doctor-fixes.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Changed
+
+- **Two react-doctor findings fixed in the report app.** The share dialog's section set now uses a lazy state initializer instead of rebuilding a Set every render, and the Modules tab derives its unused-provider map with `useMemo` instead of mutating a ref during render.

--- a/.changeset/schema-multi-focus.md
+++ b/.changeset/schema-multi-focus.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Changed
+
+- **Focused schema view keeps every table you open.** Selecting a second entity from the Relational Schema sidebar adds its related tables to the canvas instead of replacing the first; one table draws as a star, several draw with the overview layout. Clicking a selected table removes its group, clicking empty canvas clears them all.

--- a/.changeset/schema-multi-focus.md
+++ b/.changeset/schema-multi-focus.md
@@ -4,4 +4,4 @@
 
 ### Changed
 
-- **Focused schema view keeps every table you open.** Selecting a second entity from the Relational Schema sidebar adds its related tables to the canvas instead of replacing the first; one table draws as a star, several draw with the overview layout. Clicking a selected table removes its group, clicking empty canvas clears them all.
+- **Focused schema view keeps every table you open.** Selecting a second entity from the Relational Schema sidebar adds its related tables to the canvas instead of replacing the first; one table draws as a star, several draw with the overview layout. In the show-all view the highlight works the same way: every opened table's group stays lit instead of dimming when the next one is selected. Clicking a selected table removes its group, clicking empty canvas clears them all.

--- a/.changeset/shared-modal.md
+++ b/.changeset/shared-modal.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Changed
+
+- **One modal component.** The share dialog and the report viewer's open-a-report window render through the same `Modal` molecule, so both get the dimmed, blurred backdrop and shadowed panel; `Modal` is exported from `nestjs-doctor/report-ui`.

--- a/packages/nestjs-doctor/src/report/report-ui.ts
+++ b/packages/nestjs-doctor/src/report/report-ui.ts
@@ -12,5 +12,6 @@ export {
 	sharedReportToArtifact,
 } from "./shared-view.js";
 export * from "./ui/app/entry.js";
+export { Modal } from "./ui/app/molecules/modal.js";
 export { getReportHtml } from "./ui/html.js";
 export { getReportStyles } from "./ui/styles.js";

--- a/packages/nestjs-doctor/src/report/ui/app/entry.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/entry.tsx
@@ -3,6 +3,7 @@ import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import type { ReportArtifact } from "../../../common/artifact.js";
 import { HeaderRow } from "./organisms/header.js";
+
 import {
 	setActiveTab as setActiveTabImpl,
 	setDiagnosisBadge as setDiagnosisBadgeImpl,

--- a/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/modules-canvas.ts
@@ -268,6 +268,12 @@ export class ModulesCanvas {
 			this.scheduleRedraw();
 			return;
 		}
+		// The draw transform scales around the canvas centre, so shift the
+		// camera to keep every world point at its screen position.
+		if (this.w > 0 && this.h > 0) {
+			this.camX += ((w - this.w) / 2) * (1 - 1 / this.zoom);
+			this.camY += ((h - this.h) / 2) * (1 - 1 / this.zoom);
+		}
 		this.w = w;
 		this.h = h;
 		this.canvas.width = this.w * this.dpr;

--- a/packages/nestjs-doctor/src/report/ui/app/lib/schema-canvas.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/schema-canvas.ts
@@ -212,6 +212,7 @@ export class SchemaCanvas {
 	private hoveredEntity: SNode | null = null;
 	private hoveredRelation: SchemaRelation | null = null;
 	selectedEntity: string | null = null;
+	private readonly focusRoots = new Set<string>();
 	private nodes: SNode[] = [];
 	private nodeMap: Record<string, SNode> = {};
 	private edgeRoutes: Record<string, Point[]> = {};
@@ -290,6 +291,15 @@ export class SchemaCanvas {
 		return this.nodes.length > 0;
 	}
 
+	visibleEntities(): string[] {
+		return this.nodes.map((node) => node.name);
+	}
+
+	clearFocus(): void {
+		this.selectedEntity = null;
+		this.setVisibleSubset(null);
+	}
+
 	// ── State entry points driven by React ──
 
 	selectFromSidebar(name: string): void {
@@ -324,6 +334,7 @@ export class SchemaCanvas {
 
 	focusOneTable(): void {
 		this.focusedMode = true;
+		this.focusRoots.clear();
 		this.setVisibleSubset(this.selectedEntity);
 		this.scheduleRedraw();
 	}
@@ -339,8 +350,8 @@ export class SchemaCanvas {
 	setShowCols(showCols: boolean): void {
 		this.showCols = showCols;
 		this.applyNodeSizes(this.nodes);
-		if (this.focusedMode && this.selectedEntity) {
-			this.setVisibleSubset(this.selectedEntity);
+		if (this.focusedMode && this.focusRoots.size > 0) {
+			this.applyFocusRoots();
 		} else {
 			this.computeOverview();
 			this.centerCamera();
@@ -387,10 +398,8 @@ export class SchemaCanvas {
 		this.canvas.style.width = `${this.w}px`;
 		this.canvas.style.height = `${this.h}px`;
 		this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
-		if (this.focusedMode && this.selectedEntity && this.nodes.length > 0) {
-			computeStarLayout(this.nodes, this.selectedEntity, this.w, this.h);
-			this.routeAllEdges();
-			this.centerCamera();
+		if (this.focusedMode && this.focusRoots.size > 0 && this.nodes.length > 0) {
+			this.applyFocusRoots();
 		}
 		this.scheduleRedraw();
 	}
@@ -657,8 +666,8 @@ export class SchemaCanvas {
 
 	private relayoutForSizeChange(): void {
 		this.applyNodeSizes(this.nodes);
-		if (this.focusedMode && this.selectedEntity) {
-			this.setVisibleSubset(this.selectedEntity);
+		if (this.focusedMode && this.focusRoots.size > 0) {
+			this.applyFocusRoots();
 		} else if (!this.focusedMode) {
 			this.computeOverview();
 			this.centerCamera();
@@ -670,19 +679,40 @@ export class SchemaCanvas {
 		if (!this.focusedMode) {
 			return;
 		}
+		if (entityName === null) {
+			this.focusRoots.clear();
+		} else {
+			this.focusRoots.add(entityName);
+		}
+		this.applyFocusRoots();
+	}
+
+	// Every focused table stays visible: the canvas shows the union of each
+	// root's related set, as a star for one root and the overview for more.
+	private applyFocusRoots(): void {
 		this.compGrids = null;
-		if (!entityName) {
+		const roots = [...this.focusRoots];
+		if (roots.length === 0) {
 			this.nodes = [];
 			this.nodeMap = {};
 			this.edgeRoutes = {};
 			this.edgeKeys = [];
 			return;
 		}
-		const related = this.getRelatedEntities(entityName);
-		this.nodes = this.allNodes.filter((node) => related.has(node.name));
+		const visible = new Set<string>();
+		for (const root of roots) {
+			for (const name of this.getRelatedEntities(root)) {
+				visible.add(name);
+			}
+		}
+		this.nodes = this.allNodes.filter((node) => visible.has(node.name));
 		this.rebuildNodeMap();
 		this.applyNodeSizes(this.nodes);
-		computeStarLayout(this.nodes, entityName, this.w, this.h);
+		if (roots.length === 1) {
+			computeStarLayout(this.nodes, roots[0] as string, this.w, this.h);
+		} else {
+			this.computeOverview();
+		}
 		this.routeAllEdges();
 		this.centerCamera();
 		this.scheduleRedraw();
@@ -922,7 +952,12 @@ export class SchemaCanvas {
 						: this.dragging.name;
 				this.callbacks.onSelect(this.selectedEntity);
 				if (this.focusedMode) {
-					this.setVisibleSubset(this.selectedEntity);
+					if (this.selectedEntity === null) {
+						this.focusRoots.delete(this.dragging.name);
+						this.applyFocusRoots();
+					} else {
+						this.setVisibleSubset(this.selectedEntity);
+					}
 				} else {
 					this.scheduleRedraw();
 				}

--- a/packages/nestjs-doctor/src/report/ui/app/lib/schema-canvas.ts
+++ b/packages/nestjs-doctor/src/report/ui/app/lib/schema-canvas.ts
@@ -297,15 +297,21 @@ export class SchemaCanvas {
 
 	clearFocus(): void {
 		this.selectedEntity = null;
-		this.setVisibleSubset(null);
+		this.focusRoots.clear();
+		if (this.focusedMode) {
+			this.applyFocusRoots();
+		} else {
+			this.scheduleRedraw();
+		}
 	}
 
 	// ── State entry points driven by React ──
 
 	selectFromSidebar(name: string): void {
 		this.selectedEntity = name;
+		this.focusRoots.add(name);
 		if (this.focusedMode) {
-			this.setVisibleSubset(name);
+			this.applyFocusRoots();
 		} else {
 			this.panToEntity(name);
 			this.scheduleRedraw();
@@ -314,8 +320,9 @@ export class SchemaCanvas {
 
 	selectFromDrawer(name: string): void {
 		this.selectedEntity = name;
+		this.focusRoots.add(name);
 		if (this.focusedMode) {
-			this.setVisibleSubset(name);
+			this.applyFocusRoots();
 		} else {
 			this.panToEntity(name);
 			this.scheduleRedraw();
@@ -462,6 +469,23 @@ export class SchemaCanvas {
 			}
 		}
 		return null;
+	}
+
+	highlightedEntities(): Set<string> | null {
+		const roots = new Set(this.focusRoots);
+		if (this.selectedEntity) {
+			roots.add(this.selectedEntity);
+		}
+		if (roots.size === 0) {
+			return null;
+		}
+		const related = new Set<string>();
+		for (const root of roots) {
+			for (const name of this.getRelatedEntities(root)) {
+				related.add(name);
+			}
+		}
+		return related;
 	}
 
 	private getRelatedEntities(entityName: string): Set<string> {
@@ -951,21 +975,22 @@ export class SchemaCanvas {
 						? null
 						: this.dragging.name;
 				this.callbacks.onSelect(this.selectedEntity);
+				if (this.selectedEntity === null) {
+					this.focusRoots.delete(this.dragging.name);
+				} else {
+					this.focusRoots.add(this.selectedEntity);
+				}
 				if (this.focusedMode) {
-					if (this.selectedEntity === null) {
-						this.focusRoots.delete(this.dragging.name);
-						this.applyFocusRoots();
-					} else {
-						this.setVisibleSubset(this.selectedEntity);
-					}
+					this.applyFocusRoots();
 				} else {
 					this.scheduleRedraw();
 				}
 			} else if (this.panning && !this.dragMoved && this.selectedEntity) {
 				this.selectedEntity = null;
 				this.callbacks.onSelect(null);
+				this.focusRoots.clear();
 				if (this.focusedMode) {
-					this.setVisibleSubset(null);
+					this.applyFocusRoots();
 				} else {
 					this.scheduleRedraw();
 				}
@@ -1225,9 +1250,7 @@ export class SchemaCanvas {
 		ctx.scale(this.zoom, this.zoom);
 		ctx.translate(-this.w / 2 + this.camX, -this.h / 2 + this.camY);
 
-		const selectedRelated = this.selectedEntity
-			? this.getRelatedEntities(this.selectedEntity)
-			: null;
+		const selectedRelated = this.highlightedEntities();
 
 		this.drawRelations(ctx, selectedRelated);
 

--- a/packages/nestjs-doctor/src/report/ui/app/molecules/modal.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/molecules/modal.tsx
@@ -1,0 +1,47 @@
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect } from "react";
+
+export function Modal({
+	children,
+	onClose,
+	overlayId,
+	panelClasses,
+	panelId,
+	panelStyle,
+}: {
+	children: ReactNode;
+	onClose?: () => void;
+	overlayId?: string;
+	panelClasses?: string;
+	panelId?: string;
+	panelStyle?: CSSProperties;
+}) {
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				onClose?.();
+			}
+		};
+		document.addEventListener("keydown", onKey);
+		return () => document.removeEventListener("keydown", onKey);
+	}, [onClose]);
+	const panel = ["modal-panel", panelClasses].filter(Boolean).join(" ");
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: clicking the backdrop closes, as in the report's CSS
+		// biome-ignore lint/a11y/noNoninteractiveElementInteractions: clicking the backdrop closes, as in the report's CSS
+		// biome-ignore lint/a11y/useKeyWithClickEvents: Escape already closes the overlay
+		<div
+			className="modal-overlay"
+			id={overlayId}
+			onClick={(e) => {
+				if (e.target === e.currentTarget) {
+					onClose?.();
+				}
+			}}
+		>
+			<div className={panel} id={panelId} style={panelStyle}>
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/packages/nestjs-doctor/src/report/ui/app/molecules/tree-row.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/molecules/tree-row.tsx
@@ -33,7 +33,7 @@ export function TreeRow({
 	const rowClasses = ["st-row", classes].filter(Boolean).join(" ");
 	const indents: ReactNode[] = [];
 	for (let i = 0; i < depth; i++) {
-		indents.push(<span className="st-indent" key={i} />);
+		indents.push(<span className="st-indent st-guide" key={i} />);
 	}
 	return (
 		// biome-ignore lint/a11y/noStaticElementInteractions: the whole row is the click target, as in the report's CSS

--- a/packages/nestjs-doctor/src/report/ui/app/organisms/header.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/organisms/header.tsx
@@ -36,7 +36,7 @@ function ShareDialog({
 		})
 		.filter((row) => row.count !== 0);
 	const [picked, setPicked] = useState<ReadonlySet<string>>(
-		new Set(visibleSections.map((row) => row.section.id))
+		() => new Set(visibleSections.map((row) => row.section.id))
 	);
 	const [includeCode, setIncludeCode] = useState(false);
 

--- a/packages/nestjs-doctor/src/report/ui/app/organisms/header.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/organisms/header.tsx
@@ -3,6 +3,7 @@ import type { ReportArtifact } from "../../../../common/artifact.js";
 import { TextButton } from "../atoms/button.js";
 import { installFloatTip } from "../lib/float-tip.js";
 import { buildSharedJson, scoredCount } from "../lib/share-payload.js";
+import { Modal } from "../molecules/modal.js";
 
 function downloadSharedJson(data: unknown): void {
 	const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -39,86 +40,65 @@ function ShareDialog({
 	);
 	const [includeCode, setIncludeCode] = useState(false);
 
-	useEffect(() => {
-		const onKey = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				onClose();
-			}
-		};
-		document.addEventListener("keydown", onKey);
-		return () => document.removeEventListener("keydown", onKey);
-	}, [onClose]);
-
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: clicking the backdrop closes, as in the report's CSS
-		// biome-ignore lint/a11y/noNoninteractiveElementInteractions: clicking the backdrop closes, as in the report's CSS
-		// biome-ignore lint/a11y/useKeyWithClickEvents: Escape already closes the overlay
-		<div
-			className="share-overlay"
-			id="share-overlay"
-			onClick={(e) => {
-				if (e.target === e.currentTarget) {
-					onClose();
-				}
-			}}
+		<Modal
+			onClose={onClose}
+			overlayId="share-overlay"
+			panelClasses="share-panel"
+			panelId="share-panel"
 		>
-			<div className="share-panel" id="share-panel">
-				<div className="share-title">Share the report</div>
-				{visibleSections.map(({ section, count }) => (
-					<label className="share-row" key={section.id}>
-						<input
-							checked={picked.has(section.id)}
-							className="share-section"
-							onChange={(e) =>
-								setPicked((prev) => {
-									const next = new Set(prev);
-									if (e.target.checked) {
-										next.add(section.id);
-									} else {
-										next.delete(section.id);
-									}
-									return next;
-								})
-							}
-							type="checkbox"
-							value={section.id}
-						/>{" "}
-						{section.label} ({count})
-					</label>
-				))}
-				<label className="share-row" style={{ marginTop: 4 }}>
+			<div className="share-title">Share the report</div>
+			{visibleSections.map(({ section, count }) => (
+				<label className="share-row" key={section.id}>
 					<input
-						checked={includeCode}
-						id="share-code"
-						onChange={(e) => setIncludeCode(e.target.checked)}
+						checked={picked.has(section.id)}
+						className="share-section"
+						onChange={(e) =>
+							setPicked((prev) => {
+								const next = new Set(prev);
+								if (e.target.checked) {
+									next.add(section.id);
+								} else {
+									next.delete(section.id);
+								}
+								return next;
+							})
+						}
 						type="checkbox"
+						value={section.id}
 					/>{" "}
-					Include code snippets{" "}
-					<span className="share-hint">a few lines around each finding</span>
+					{section.label} ({count})
 				</label>
-				<div className="share-actions">
-					<TextButton
-						classes="share-download"
-						id="share-download"
-						onClick={() => {
-							if (picked.size === 0) {
-								return;
-							}
-							const data = buildSharedJson(
-								share,
-								report.generator,
-								includeCode,
-								[...picked]
-							);
-							downloadSharedJson(data);
-							onClose();
-						}}
-					>
-						Download .json
-					</TextButton>
-				</div>
+			))}
+			<label className="share-row" style={{ marginTop: 4 }}>
+				<input
+					checked={includeCode}
+					id="share-code"
+					onChange={(e) => setIncludeCode(e.target.checked)}
+					type="checkbox"
+				/>{" "}
+				Include code snippets{" "}
+				<span className="share-hint">a few lines around each finding</span>
+			</label>
+			<div className="share-actions">
+				<TextButton
+					classes="share-download"
+					id="share-download"
+					onClick={() => {
+						if (picked.size === 0) {
+							return;
+						}
+						const data = buildSharedJson(share, report.generator, includeCode, [
+							...picked,
+						]);
+						downloadSharedJson(data);
+						onClose();
+					}}
+				>
+					Download .json
+				</TextButton>
 			</div>
-		</div>
+		</Modal>
 	);
 }
 

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -42,7 +42,7 @@ import { SearchField } from "../molecules/search-field.js";
 import { SidebarHeader, TreeToolbar } from "../molecules/sidebar-header.js";
 import { TreeRow } from "../molecules/tree-row.js";
 import { ZoomBar } from "../molecules/zoom-bar.js";
-import { BootView, focusBootTrace } from "./boot.js";
+import { BootView } from "./boot.js";
 
 const MG_DYNAMIC_TIPS: Record<string, string> = {
 	forRoot: "Configures the module once for the whole app",
@@ -70,10 +70,6 @@ const PROVIDER_NAME_RE = /Provider '([^']+)'/;
 
 function track(event: string): void {
 	(globalThis as { __ndTrack?: (e: string) => void }).__ndTrack?.(event);
-}
-
-function switchTab(name: string): void {
-	(globalThis as { switchTab?: (name: string) => void }).switchTab?.(name);
 }
 
 interface ModulesRegistry {
@@ -1294,8 +1290,9 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 						id="detail-badges"
 						onClick={(ev) => {
 							if ((ev.target as Element).closest("#detail-timings-btn")) {
-								switchTab("boot");
-								focusBootTrace(selected?.initTimings?.[0]?.name);
+								setDockActive("trace");
+								setDockOpen(true);
+								controllerRef.current?.resize();
 							}
 						}}
 					>

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -953,6 +953,11 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 	const treeRef = useRef<HTMLDivElement>(null);
 	const infoPopRef = useRef<HTMLDivElement>(null);
 	const controllerRef = useRef<ModulesCanvas | null>(null);
+	// The dock's height lands after commit, so measure the canvas then.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: the dock state changes the layout the resize measures
+	useLayoutEffect(() => {
+		controllerRef.current?.resize();
+	}, [dockOpen, dockActive]);
 	const resizerRef = useResizer(sidebarRef, controllerRef);
 
 	const unusedProviders = useRef<Record<string, boolean> | null>(null);
@@ -1292,7 +1297,6 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 							if ((ev.target as Element).closest("#detail-timings-btn")) {
 								setDockActive("trace");
 								setDockOpen(true);
-								controllerRef.current?.resize();
 							}
 						}}
 					>
@@ -1553,11 +1557,9 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 							) {
 								setDockActive(tabEl.dataset.dockTab as string);
 								setDockOpen(true);
-								controllerRef.current?.resize();
 								return;
 							}
 							setDockOpen((prev) => !prev);
-							controllerRef.current?.resize();
 						}}
 					>
 						<span

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -1070,7 +1070,8 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 		}
 		const onDocClick = (ev: Event) => {
 			const pop = infoPopRef.current;
-			if (pop && !pop.contains(ev.target as Node)) {
+			const target = ev.target as Element;
+			if (pop && !(pop.contains(target) || target.closest("#mg-info"))) {
 				setInfoOpen(false);
 			}
 		};

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -1135,7 +1135,11 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 
 	return (
 		<>
-			<div id="mg-sidebar" ref={sidebarRef}>
+			<div
+				className={selected ? "mg-detail-open" : undefined}
+				id="mg-sidebar"
+				ref={sidebarRef}
+			>
 				<div className="schema-sidebar-sticky">
 					<SidebarHeader
 						count={projectNames.length}

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -960,18 +960,18 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 	}, [dockOpen, dockActive]);
 	const resizerRef = useResizer(sidebarRef, controllerRef);
 
-	const unusedProviders = useRef<Record<string, boolean> | null>(null);
-	if (unusedProviders.current === null) {
-		unusedProviders.current = {};
+	const unusedProviders = useMemo(() => {
+		const map: Record<string, boolean> = {};
 		for (const d of report.diagnostics) {
 			if (d.rule === "performance/no-unused-providers") {
 				const um = (d.message || "").match(PROVIDER_NAME_RE);
 				if (um) {
-					unusedProviders.current[um[1] as string] = true;
+					map[um[1] as string] = true;
 				}
 			}
 		}
-	}
+		return map;
+	}, [report]);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: the controller mounts once for the page's lifetime
 	useLayoutEffect(() => {
@@ -1375,7 +1375,7 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 								<ProvidersSection
 									n={selected}
 									report={report}
-									unusedProviders={unusedProviders.current}
+									unusedProviders={unusedProviders}
 								/>
 								{selected.imports.length > 0 && (
 									<>

--- a/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
+++ b/packages/nestjs-doctor/src/report/ui/app/templates/modules.tsx
@@ -1642,7 +1642,7 @@ export function ModulesTab({ report }: { report: ReportArtifact }) {
 					</div>
 				</div>
 				<div
-					className={infoOpen ? "visible" : undefined}
+					className={infoOpen ? "modal-panel visible" : "modal-panel"}
 					id="mg-info-pop"
 					ref={infoPopRef}
 				>

--- a/packages/nestjs-doctor/src/report/ui/styles/base.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/base.css
@@ -46,5 +46,17 @@ html { scrollbar-color: #333 transparent; scrollbar-width: thin; }
 .playground-results::-webkit-scrollbar,
 .cm-scroller::-webkit-scrollbar { width: 6px; height: 6px; }
 body { background: var(--bg); color: var(--text); font-family: var(--font); overflow: hidden; }
+
+.modal-overlay {
+  position: fixed; inset: 0; z-index: 9999; padding: 24px;
+  background: rgba(0,0,0,0.7); backdrop-filter: blur(2px);
+  display: flex; align-items: center; justify-content: center;
+}
+.modal-panel {
+  background: var(--surface); border: 1px solid var(--border-strong);
+  box-shadow: 0 25px 50px -12px rgba(0,0,0,0.9);
+  max-width: 90vw; max-height: 85vh; overflow: auto;
+  color: var(--text); font-family: var(--font);
+}
 canvas { display: block; cursor: grab; }
 canvas:active { cursor: grabbing; }

--- a/packages/nestjs-doctor/src/report/ui/styles/header.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/header.css
@@ -36,16 +36,7 @@
 #header-row1 .nav-btn:hover { background: var(--white); border-color: var(--white); color: #000; }
 
 /* ── Share dialog ── */
-.share-overlay {
-  position: fixed; inset: 0; z-index: 9999;
-  background: rgba(0,0,0,0.7);
-  display: flex; align-items: center; justify-content: center;
-}
-.share-panel {
-  background: var(--surface); border: 1px solid var(--border-strong);
-  padding: 20px 22px; width: 360px; max-width: 90vw; max-height: 80vh; overflow: auto;
-  color: var(--text); font-family: var(--font);
-}
+.share-panel { padding: 20px 22px; width: 360px; }
 .share-title {
   font-size: 12px; font-weight: 700; text-transform: uppercase;
   letter-spacing: 0.08em; margin-bottom: 14px; color: var(--text);

--- a/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
@@ -92,6 +92,16 @@
 }
 #mg-sidebar.mg-detail-open #mg-tree,
 #mg-sidebar.mg-detail-open .schema-sidebar-sticky { display: none; }
+@keyframes mg-panel-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
+#mg-sidebar.mg-detail-open #detail,
+#mg-sidebar:not(.mg-detail-open) #mg-tree { animation: mg-panel-in 160ms ease-out; }
+@media (prefers-reduced-motion: reduce) {
+  #mg-sidebar.mg-detail-open #detail,
+  #mg-sidebar:not(.mg-detail-open) #mg-tree { animation: none; }
+}
 #detail h2 { font-size: 15px; font-weight: 600; color: var(--white); margin-bottom: 4px; padding-right: 20px; word-break: break-word; }
 #detail .filepath { font-size: 11px; color: var(--text-muted); word-break: break-all; margin-bottom: 12px; }
 #detail h4 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); margin: 14px 0 4px; }

--- a/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
@@ -91,9 +91,9 @@
   overflow-y: auto;
 }
 /* Indent guides on hover, like the file tree on the findings tab. */
-#mg-tree .st-indent { position: relative; align-self: stretch; }
-#mg-tree:hover .st-indent::before {
-  content: ""; position: absolute; top: 0; bottom: 0; left: 7px;
+#mg-tree .st-guide { position: relative; align-self: stretch; }
+#mg-tree:hover .st-guide::before {
+  content: ""; position: absolute; top: -3px; bottom: -3px; left: 7px;
   border-left: 1px solid rgba(255,255,255,0.14);
 }
 #mg-sidebar.mg-detail-open #mg-tree,

--- a/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
@@ -2,15 +2,10 @@
 #mg-info-pop {
   position: absolute; top: 48px; right: 12px;
   width: 340px; max-height: calc(100% - 60px);
-  background: rgba(17,17,17,0.97);
-  border: 1px solid var(--border); border-radius: 8px;
   padding: 16px;
   font-size: 12px;
   z-index: 20;
-  overflow-y: auto;
-  backdrop-filter: blur(8px);
   display: none;
-  box-shadow: 0 8px 30px rgba(0,0,0,0.5);
 }
 #mg-info-pop.visible{ display: block; }
 #mg-info-pop h3{ font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); margin-bottom: 8px; }

--- a/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
@@ -90,6 +90,12 @@
   display: none;
   overflow-y: auto;
 }
+/* Indent guides on hover, like the file tree on the findings tab. */
+#mg-tree .st-indent { position: relative; align-self: stretch; }
+#mg-tree:hover .st-indent::before {
+  content: ""; position: absolute; top: 0; bottom: 0; left: 7px;
+  border-left: 1px solid rgba(255,255,255,0.14);
+}
 #mg-sidebar.mg-detail-open #mg-tree,
 #mg-sidebar.mg-detail-open .schema-sidebar-sticky { display: none; }
 @keyframes mg-panel-in {

--- a/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
@@ -90,7 +90,8 @@
   display: none;
   overflow-y: auto;
 }
-#mg-sidebar.mg-detail-open #mg-tree { display: none; }
+#mg-sidebar.mg-detail-open #mg-tree,
+#mg-sidebar.mg-detail-open .schema-sidebar-sticky { display: none; }
 #detail h2 { font-size: 15px; font-weight: 600; color: var(--white); margin-bottom: 4px; padding-right: 20px; word-break: break-word; }
 #detail .filepath { font-size: 11px; color: var(--text-muted); word-break: break-all; margin-bottom: 12px; }
 #detail h4 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); margin: 14px 0 4px; }

--- a/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/modules-graph.css
@@ -90,12 +90,6 @@
   display: none;
   overflow-y: auto;
 }
-/* Indent guides on hover, like the file tree on the findings tab. */
-#mg-tree .st-guide { position: relative; align-self: stretch; }
-#mg-tree:hover .st-guide::before {
-  content: ""; position: absolute; top: -3px; bottom: -3px; left: 7px;
-  border-left: 1px solid rgba(255,255,255,0.14);
-}
 #mg-sidebar.mg-detail-open #mg-tree,
 #mg-sidebar.mg-detail-open .schema-sidebar-sticky { display: none; }
 @keyframes mg-panel-in {

--- a/packages/nestjs-doctor/src/report/ui/styles/schema.css
+++ b/packages/nestjs-doctor/src/report/ui/styles/schema.css
@@ -42,6 +42,13 @@
   color: var(--text-dim); user-select: none;
 }
 .st-indent { width: 16px; min-width: 16px; }
+/* Indent guides on hover, like the file tree on the findings tab. */
+.st-guide { position: relative; align-self: stretch; }
+#mg-tree:hover .st-guide::before,
+#schema-entity-list:hover .st-guide::before {
+  content: ""; position: absolute; top: -3px; bottom: -3px; left: 7px;
+  border-left: 1px solid rgba(255,255,255,0.14);
+}
 .st-icon {
   width: 18px; min-width: 18px; height: 18px; display: flex;
   align-items: center; justify-content: center; margin-right: 4px;

--- a/packages/nestjs-doctor/tests/unit/report-dom.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-dom.test.ts
@@ -118,6 +118,16 @@ it("renders every tab into a DOM", () => {
 	]) {
 		expect(detail).toContain(variant);
 	}
+
+	// Selecting covers the sidebar list with the detail panel; closing restores it.
+	win.eval(
+		"REPORT_APP.openModule(" +
+			"document.querySelector('#mg-tree [data-module]').dataset.module)"
+	);
+	const sidebar = win.document.getElementById("mg-sidebar") as HTMLElement;
+	expect(sidebar.className).toContain("mg-detail-open");
+	win.eval("REPORT_APP.openModule(null)");
+	expect(sidebar.className).not.toContain("mg-detail-open");
 });
 
 it("renderChrome host options hide tabs and share and add load file", () => {

--- a/packages/nestjs-doctor/tests/unit/report-schema-focus.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-focus.test.ts
@@ -21,9 +21,9 @@ function stubCanvas(): HTMLCanvasElement {
 	return canvas;
 }
 
-function schemaOf(): SerializedSchemaGraph {
+function schemaOf(count = 10): SerializedSchemaGraph {
 	const entities: SerializedSchemaGraph["entities"] = [];
-	for (let i = 0; i < 10; i++) {
+	for (let i = 0; i < count; i++) {
 		entities.push({
 			columns: [],
 			filePath: `e${i}.ts`,
@@ -42,12 +42,12 @@ function schemaOf(): SerializedSchemaGraph {
 	};
 }
 
-function canvasOf(): SchemaCanvas {
+function canvasOf(count = 10): SchemaCanvas {
 	return new SchemaCanvas({
 		callbacks: { onSelect: () => undefined, onZoom: () => undefined },
 		canvas: stubCanvas(),
 		relBadgeEl: document.createElement("div"),
-		schema: schemaOf(),
+		schema: schemaOf(count),
 		tooltipEl: document.createElement("div"),
 	});
 }
@@ -78,4 +78,16 @@ it("clearing the selection empties the focused canvas", () => {
 	c.selectFromSidebar("e2");
 	c.clearFocus();
 	expect(c.visibleEntities()).toEqual([]);
+});
+
+it("show-all mode highlights the union of every opened table", () => {
+	const c = canvasOf(5);
+	c.init();
+	expect(c.focusedMode).toBe(false);
+	c.selectFromSidebar("e0");
+	c.selectFromSidebar("e2");
+	const lit = c.highlightedEntities();
+	expect(lit && [...lit].sort()).toEqual(["e0", "e1", "e2", "e3"]);
+	c.clearFocus();
+	expect(c.highlightedEntities()).toBeNull();
 });

--- a/packages/nestjs-doctor/tests/unit/report-schema-focus.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-schema-focus.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { expect, it } from "vitest";
+import type { SerializedSchemaGraph } from "../../src/common/schema.js";
+import { SchemaCanvas } from "../../src/report/ui/app/lib/schema-canvas.js";
+
+const CANVAS_STUB: Record<string, unknown> = {
+	canvas: { width: 800, height: 600 },
+	measureText: () => ({ width: 40 }),
+};
+
+function stubCanvas(): HTMLCanvasElement {
+	const ctx = new Proxy(CANVAS_STUB, {
+		get: (target, key) =>
+			key in target ? target[key as string] : () => undefined,
+		set: () => true,
+	});
+	const canvas = document.createElement("canvas");
+	// @ts-expect-error test stub
+	canvas.getContext = () => ctx;
+	document.body.appendChild(canvas);
+	return canvas;
+}
+
+function schemaOf(): SerializedSchemaGraph {
+	const entities: SerializedSchemaGraph["entities"] = [];
+	for (let i = 0; i < 10; i++) {
+		entities.push({
+			columns: [],
+			filePath: `e${i}.ts`,
+			name: `e${i}`,
+			relations: [],
+			tableName: `e${i}`,
+		});
+	}
+	return {
+		entities,
+		orm: "typeorm",
+		relations: [
+			{ fromEntity: "e0", fromField: "a", toEntity: "e1", type: "one-to-many" },
+			{ fromEntity: "e2", fromField: "b", toEntity: "e3", type: "one-to-many" },
+		] as SerializedSchemaGraph["relations"],
+	};
+}
+
+function canvasOf(): SchemaCanvas {
+	return new SchemaCanvas({
+		callbacks: { onSelect: () => undefined, onZoom: () => undefined },
+		canvas: stubCanvas(),
+		relBadgeEl: document.createElement("div"),
+		schema: schemaOf(),
+		tooltipEl: document.createElement("div"),
+	});
+}
+
+it("keeps earlier focused tables when another is selected", () => {
+	const c = canvasOf();
+	c.init();
+	expect(c.focusedMode).toBe(true);
+	c.selectFromSidebar("e0");
+	expect(c.visibleEntities().sort()).toEqual(["e0", "e1"]);
+	c.selectFromSidebar("e2");
+	expect(c.visibleEntities().sort()).toEqual(["e0", "e1", "e2", "e3"]);
+});
+
+it("focusOneTable narrows back to the current selection", () => {
+	const c = canvasOf();
+	c.init();
+	c.selectFromSidebar("e0");
+	c.selectFromSidebar("e2");
+	c.focusOneTable();
+	expect(c.visibleEntities().sort()).toEqual(["e2", "e3"]);
+});
+
+it("clearing the selection empties the focused canvas", () => {
+	const c = canvasOf();
+	c.init();
+	c.selectFromSidebar("e0");
+	c.selectFromSidebar("e2");
+	c.clearFocus();
+	expect(c.visibleEntities()).toEqual([]);
+});

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -38,7 +38,6 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "react-doctor": "^0.9.12",
     "rehype-pretty-code": "^0.14.5",
     "shiki": "^4.4.3",
     "tailwindcss": "^4",

--- a/packages/website/src/app/report/report-viewer.tsx
+++ b/packages/website/src/app/report/report-viewer.tsx
@@ -5,6 +5,7 @@ import {
 	getReportStyles,
 	initialTab,
 	labOpened,
+	Modal,
 	parseReportFile,
 	type ReportArtifact,
 	renderBoot,
@@ -217,200 +218,152 @@ function PickerModal({
 	onClose?: () => void;
 	onFile: (file: File) => void;
 }) {
-	useEffect(() => {
-		if (!onClose) {
-			return;
-		}
-		const onKey = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				onClose();
-			}
-		};
-		document.addEventListener("keydown", onKey);
-		return () => document.removeEventListener("keydown", onKey);
-	}, [onClose]);
-
 	return (
-		// The report page's own stylesheet resets margins on every element, so
-		// the modal styles itself inline to stay independent of it.
-		// biome-ignore lint/a11y/noStaticElementInteractions: clicking the backdrop reveals the example
-		// biome-ignore lint/a11y/noNoninteractiveElementInteractions: clicking the backdrop reveals the example
-		// biome-ignore lint/a11y/useKeyWithClickEvents: Escape already closes the overlay
-		<div
-			onClick={(e) => {
-				if (e.target === e.currentTarget) {
-					onClose?.();
-				}
-			}}
-			style={{
-				alignItems: "center",
-				backdropFilter: "blur(2px)",
-				background: "rgba(0,0,0,0.7)",
-				display: "flex",
-				fontFamily:
-					'"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-				inset: 0,
-				justifyContent: "center",
-				padding: 24,
-				position: "fixed",
-				zIndex: 9999,
-			}}
+		<Modal
+			onClose={onClose}
+			panelStyle={{ maxWidth: 576, padding: 32, width: "100%" }}
 		>
-			<div
+			<p style={{ color: "#737373", fontSize: 12, marginBottom: 24 }}>
+				<a href="/" style={{ color: "#737373", textDecoration: "none" }}>
+					nestjs.doctor
+				</a>
+				<span style={{ margin: "0 8px" }}>/</span>
+				<span style={{ color: "#d4d4d4" }}>report viewer</span>
+			</p>
+			<h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 12 }}>
+				Open a report
+			</h1>
+			<p
 				style={{
-					background: "#000",
-					border: "1px solid #404040",
-					boxShadow: "0 25px 50px -12px rgba(0,0,0,0.9)",
-					color: "#fff",
-					maxWidth: 576,
-					padding: 32,
-					width: "100%",
+					color: "#a3a3a3",
+					fontSize: 14,
+					lineHeight: 1.6,
+					marginBottom: 8,
 				}}
 			>
-				<p style={{ color: "#737373", fontSize: 12, marginBottom: 24 }}>
-					<a href="/" style={{ color: "#737373", textDecoration: "none" }}>
-						nestjs.doctor
-					</a>
-					<span style={{ margin: "0 8px" }}>/</span>
-					<span style={{ color: "#d4d4d4" }}>report viewer</span>
-				</p>
-				<h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 12 }}>
-					Open a report
-				</h1>
-				<p
+				Drop the shared file a teammate sent you.
+			</p>
+			<p
+				style={{
+					color: "#a3a3a3",
+					fontSize: 14,
+					lineHeight: 1.6,
+					marginBottom: 16,
+				}}
+			>
+				You can download it from a report&apos;s{" "}
+				<span style={{ color: "#e5e5e5" }}>share</span> button, or generate the
+				report locally with the command:
+			</p>
+			<pre
+				style={{
+					background: "#0a0a0a",
+					border: "1px solid #262626",
+					color: "#d4d4d4",
+					fontSize: 12,
+					marginBottom: 24,
+					overflowX: "auto",
+					padding: "12px 16px",
+				}}
+			>
+				npx nestjs-doctor@latest .
+			</pre>
+			{/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: the label wraps the file input and takes drops */}
+			<label
+				onDragOver={(e) => e.preventDefault()}
+				onDrop={(e) => {
+					e.preventDefault();
+					const file = e.dataTransfer.files[0];
+					if (file) {
+						onFile(file);
+					}
+				}}
+				style={{
+					border: "1px dashed #404040",
+					cursor: "pointer",
+					display: "block",
+					padding: "40px 24px",
+					textAlign: "center",
+				}}
+			>
+				<span style={{ color: "#d4d4d4", display: "block", fontSize: 14 }}>
+					Drop a report file here
+				</span>
+				<span
 					style={{
-						color: "#a3a3a3",
-						fontSize: 14,
-						lineHeight: 1.6,
-						marginBottom: 8,
-					}}
-				>
-					Drop the shared file a teammate sent you.
-				</p>
-				<p
-					style={{
-						color: "#a3a3a3",
-						fontSize: 14,
-						lineHeight: 1.6,
-						marginBottom: 16,
-					}}
-				>
-					You can download it from a report&apos;s{" "}
-					<span style={{ color: "#e5e5e5" }}>share</span> button, or generate
-					the report locally with the command:
-				</p>
-				<pre
-					style={{
-						background: "#0a0a0a",
-						border: "1px solid #262626",
-						color: "#d4d4d4",
+						color: "#737373",
+						display: "block",
 						fontSize: 12,
-						marginBottom: 24,
-						overflowX: "auto",
-						padding: "12px 16px",
+						marginTop: 8,
 					}}
 				>
-					npx nestjs-doctor@latest .
-				</pre>
-				{/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: the label wraps the file input and takes drops */}
-				<label
-					onDragOver={(e) => e.preventDefault()}
-					onDrop={(e) => {
-						e.preventDefault();
-						const file = e.dataTransfer.files[0];
+					or click to choose one
+				</span>
+				<input
+					accept=".json,application/json"
+					onChange={(e) => {
+						const file = e.target.files?.[0];
 						if (file) {
 							onFile(file);
 						}
+						e.target.value = "";
 					}}
 					style={{
-						border: "1px dashed #404040",
+						height: 1,
+						opacity: 0,
+						overflow: "hidden",
+						position: "absolute",
+						width: 1,
+					}}
+					type="file"
+				/>
+			</label>
+			{error && (
+				<p style={{ color: "#f87171", fontSize: 14, marginTop: 16 }}>{error}</p>
+			)}
+			{onClose && (
+				<button
+					onClick={onClose}
+					style={{
+						background: "transparent",
+						border: "1px solid #404040",
+						color: "#d4d4d4",
 						cursor: "pointer",
 						display: "block",
-						padding: "40px 24px",
-						textAlign: "center",
-					}}
-				>
-					<span style={{ color: "#d4d4d4", display: "block", fontSize: 14 }}>
-						Drop a report file here
-					</span>
-					<span
-						style={{
-							color: "#737373",
-							display: "block",
-							fontSize: 12,
-							marginTop: 8,
-						}}
-					>
-						or click to choose one
-					</span>
-					<input
-						accept=".json,application/json"
-						onChange={(e) => {
-							const file = e.target.files?.[0];
-							if (file) {
-								onFile(file);
-							}
-							e.target.value = "";
-						}}
-						style={{
-							height: 1,
-							opacity: 0,
-							overflow: "hidden",
-							position: "absolute",
-							width: 1,
-						}}
-						type="file"
-					/>
-				</label>
-				{error && (
-					<p style={{ color: "#f87171", fontSize: 14, marginTop: 16 }}>
-						{error}
-					</p>
-				)}
-				{onClose && (
-					<button
-						onClick={onClose}
-						style={{
-							background: "transparent",
-							border: "1px solid #404040",
-							color: "#d4d4d4",
-							cursor: "pointer",
-							display: "block",
-							fontFamily: "inherit",
-							fontSize: 14,
-							marginTop: 24,
-							padding: "10px 16px",
-							textAlign: "center",
-							width: "100%",
-						}}
-						type="button"
-					>
-						or explore the example report behind this window
-					</button>
-				)}
-				<p
-					style={{
-						color: "#525252",
-						fontSize: 12,
-						lineHeight: 1.6,
+						fontFamily: "inherit",
+						fontSize: 14,
 						marginTop: 24,
+						padding: "10px 16px",
+						textAlign: "center",
+						width: "100%",
 					}}
+					type="button"
 				>
-					Everything is read in your browser and never uploaded.
-				</p>
-				<p
-					style={{
-						color: "#525252",
-						fontSize: 11,
-						lineHeight: 1.6,
-						marginTop: 6,
-					}}
-				>
-					The full report as a file:{" "}
-					<code style={{ color: "#737373" }}>--format report-json</code>
-				</p>
-			</div>
-		</div>
+					or explore the example report behind this window
+				</button>
+			)}
+			<p
+				style={{
+					color: "#525252",
+					fontSize: 12,
+					lineHeight: 1.6,
+					marginTop: 24,
+				}}
+			>
+				Everything is read in your browser and never uploaded.
+			</p>
+			<p
+				style={{
+					color: "#525252",
+					fontSize: 11,
+					lineHeight: 1.6,
+					marginTop: 6,
+				}}
+			>
+				The full report as a file:{" "}
+				<code style={{ color: "#737373" }}>--format report-json</code>
+			</p>
+		</Modal>
 	);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,10 +142,10 @@ importers:
         version: 16.1.6(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.3))
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.1(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@xyflow/react':
         specifier: 12.10.1
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -163,7 +163,7 @@ importers:
         version: link:../nestjs-doctor
       next:
         specifier: 16.3.2
-        version: 16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.2(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       posthog-js:
         specifier: ^1.418.10
         version: 1.418.10
@@ -198,9 +198,6 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
-      react-doctor:
-        specifier: ^0.9.12
-        version: 0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.9.0(jiti@2.7.0))
       rehype-pretty-code:
         specifier: ^0.14.5
         version: 0.14.5(shiki@4.4.3)
@@ -224,17 +221,6 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
-    resolution: {integrity: sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@apm-js-collab/code-transformer@0.18.1':
-    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
-    hasBin: true
-
-  '@apm-js-collab/tracing-hooks@0.13.0':
-    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
-
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -246,75 +232,17 @@ packages:
     resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
     engines: {node: ^22.13.0 || >=24.0.0}
 
-  '@astrojs/compiler@4.0.0':
-    resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
-
-  '@babel/code-frame@7.29.7':
-    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.29.7':
-    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.7':
-    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.8':
-    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@8.0.0-rc.1':
     resolution: {integrity: sha512-3ypWOOiC4AYHKr8vYRVtWtWmyvcoItHtVqF8paFax+ydpmUdPsJpLBkBBs5ItmhdrwC3a0ZSqqFAdzls4ODP3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@babel/helper-compilation-targets@7.29.7':
-    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.29.7':
-    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.29.7':
-    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.29.7':
-    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-string-parser@7.29.7':
-    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@8.0.0-rc.2':
     resolution: {integrity: sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/helper-validator-identifier@7.29.7':
-    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@8.0.0-rc.1':
     resolution: {integrity: sha512-I4YnARytXC2RzkLNVnf5qFNFMzp679qZpmtw/V3Jt2uGnWiIxyJtaukjG7R8pSx8nG2NamICpGfljQsogj+FbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@babel/helper-validator-option@7.29.7':
-    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.29.7':
-    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.8':
-    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@8.0.0-rc.1':
     resolution: {integrity: sha512-6HyyU5l1yK/7h9Ki52i5h6mDAx4qJdiLQO4FdCyJNoB/gy3T3GGJdhQzzbZgvgZCugYBvwtQiWRt94QKedHnkA==}
@@ -323,18 +251,6 @@ packages:
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/template@7.29.7':
-    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.8':
-    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.8':
-    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.0-rc.1':
@@ -730,36 +646,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.10.1':
-    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.2':
-    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/config-array@0.23.5':
-    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/config-helpers@0.7.0':
-    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/core@1.2.1':
-    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/object-schema@3.0.5':
-    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/plugin-kit@0.7.2':
-    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
   '@exodus/bytes@1.15.1':
     resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -768,29 +654,6 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
-
-  '@humanfs/core@0.19.2':
-    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/node@0.16.8':
-    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/types@0.15.0':
-    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
-
-  '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
-
-  '@iarna/toml@2.2.5':
-    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1085,167 +948,12 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opentelemetry/api-logs@0.220.0':
-    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
-    engines: {node: '>=8.0.0'}
-
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/core@2.10.0':
-    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/instrumentation@0.220.0':
-    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/resources@2.10.0':
-    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@2.10.0':
-    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace@2.10.0':
-    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/semantic-conventions@1.43.0':
-    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
-    engines: {node: '>=14'}
-
-  '@oxc-parser/binding-android-arm-eabi@0.143.0':
-    resolution: {integrity: sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.143.0':
-    resolution: {integrity: sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-darwin-arm64@0.143.0':
-    resolution: {integrity: sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.143.0':
-    resolution: {integrity: sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-freebsd-x64@0.143.0':
-    resolution: {integrity: sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
-    resolution: {integrity: sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
-    resolution: {integrity: sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
-    resolution: {integrity: sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.143.0':
-    resolution: {integrity: sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
-    resolution: {integrity: sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
-    resolution: {integrity: sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
-    resolution: {integrity: sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
-    resolution: {integrity: sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.143.0':
-    resolution: {integrity: sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-x64-musl@0.143.0':
-    resolution: {integrity: sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-parser/binding-openharmony-arm64@0.143.0':
-    resolution: {integrity: sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
-    resolution: {integrity: sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
-    resolution: {integrity: sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.143.0':
-    resolution: {integrity: sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
-
-  '@oxc-project/types@0.143.0':
-    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
@@ -1773,55 +1481,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sentry/conventions@0.16.0':
-    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
-    engines: {node: '>=14'}
-
-  '@sentry/core@10.70.0':
-    resolution: {integrity: sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==}
-    engines: {node: '>=18'}
-
-  '@sentry/node-core@10.70.0':
-    resolution: {integrity: sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/core': ^1.30.1 || ^2.1.0
-      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
-      '@opentelemetry/instrumentation': '>=0.57.1 <1'
-      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@opentelemetry/core':
-        optional: true
-      '@opentelemetry/exporter-trace-otlp-http':
-        optional: true
-      '@opentelemetry/instrumentation':
-        optional: true
-      '@opentelemetry/sdk-trace-base':
-        optional: true
-
-  '@sentry/node@10.70.0':
-    resolution: {integrity: sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==}
-    engines: {node: '>=18'}
-
-  '@sentry/opentelemetry@10.70.0':
-    resolution: {integrity: sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/core': ^1.30.1 || ^2.1.0
-      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
-
-  '@sentry/server-utils@10.70.0':
-    resolution: {integrity: sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==}
-    engines: {node: '>=18'}
-
-  '@shaderfrog/glsl-parser@7.0.1':
-    resolution: {integrity: sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw==}
-    engines: {node: '>=16'}
-
   '@shikijs/core@4.4.3':
     resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
     engines: {node: '>=20'}
@@ -1983,9 +1642,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2000,9 +1656,6 @@ packages:
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
-
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -2038,10 +1691,6 @@ packages:
 
   '@types/vscode@1.109.0':
     resolution: {integrity: sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==}
-
-  '@typescript-eslint/types@8.67.0':
-    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -2154,24 +1803,6 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  agent-install@0.0.5:
-    resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
-    hasBin: true
-
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
-  ajv@6.15.0:
-    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
-
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -2218,9 +1849,6 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  atomically@2.1.1:
-    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
-
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2257,18 +1885,9 @@ packages:
     resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
     engines: {node: 20 || >=22}
 
-  brace-expansion@5.0.9:
-    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
-    engines: {node: 20 || >=22}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  browserslist@4.28.8:
-    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2314,9 +1933,6 @@ packages:
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
-  cjs-module-lexer@2.2.1:
-    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
-
   classcat@5.0.5:
     resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
@@ -2354,16 +1970,6 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
-
-  conf@15.1.0:
-    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
-    engines: {node: '>=20'}
-
-  confbox@0.2.4:
-    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
-
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   convert-to-spaces@2.0.1:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
@@ -2439,10 +2045,6 @@ packages:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  debounce-fn@6.0.0:
-    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
-    engines: {node: '>=18'}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2462,9 +2064,6 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
-  deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -2475,9 +2074,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  deslop-js@0.9.12:
-    resolution: {integrity: sha512-Ku6Zngzmu4EISb58WUkRKZytfgWjJ18Cic7lb4wl+/BF0tHWRvpBOLlA0FP35r82mV45Y72AK3RPC1Nw0GLbIw==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -2497,10 +2093,6 @@ packages:
   dompurify@3.4.14:
     resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
-  dot-prop@10.2.0:
-    resolution: {integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==}
-    engines: {node: '>=20'}
-
   dts-resolver@2.1.3:
     resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
     engines: {node: '>=20.19.0'}
@@ -2509,9 +2101,6 @@ packages:
     peerDependenciesMeta:
       oxc-resolver:
         optional: true
-
-  electron-to-chromium@1.5.412:
-    resolution: {integrity: sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2536,19 +2125,12 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
-  env-paths@3.0.0:
-    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
-  es-module-lexer@2.3.2:
-    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-toolkit@1.51.0:
     resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
@@ -2564,70 +2146,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
-
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
-
-  escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-plugin-react-hooks@7.1.1:
-    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
-
-  eslint-scope@9.1.2:
-    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@5.0.1:
-    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  eslint@10.9.0:
-    resolution: {integrity: sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
-  espree@11.2.0:
-    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  esquery@1.7.0:
-    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
-    engines: {node: '>=0.10'}
-
-  esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
 
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
@@ -2650,10 +2180,6 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2664,21 +2190,9 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
-
-  fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-
-  fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2698,10 +2212,6 @@ packages:
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
-  file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2709,17 +2219,6 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
-
-  find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
-
-  flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
-
-  flatted@3.4.4:
-    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
@@ -2739,10 +2238,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
-
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
@@ -2756,10 +2251,6 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
-
-  glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -2805,12 +2296,6 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  hermes-estree@0.25.1:
-    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
-
-  hermes-parser@0.25.1:
-    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
   hookable@6.0.1:
     resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
 
@@ -2854,17 +2339,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  import-in-the-middle@3.3.3:
-    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
-    engines: {node: '>=18'}
-
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
-
-  imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -2941,9 +2418,6 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -2978,38 +2452,11 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
-
-  json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-
-  keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  kleur@3.0.3:
-    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
-    engines: {node: '>=6'}
 
   knip@5.86.0:
     resolution: {integrity: sha512-tGpRCbP+L+VysXnAp1bHTLQ0k/SdC3M3oX18+Cpiqax1qdS25iuCPzpK8LVmAKARZv0Ijri81Wq09Rzk0JTl+Q==}
@@ -3018,10 +2465,6 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
       typescript: '>=5.0.4 <7'
-
-  levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -3167,10 +2610,6 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
-
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
@@ -3194,9 +2633,6 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
   lucide-react@1.27.0:
     resolution: {integrity: sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==}
     peerDependencies:
@@ -3204,9 +2640,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  magicast@0.5.4:
-    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -3269,10 +2702,6 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  meriyah@6.1.4:
-    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
-    engines: {node: '>=18.0.0'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3387,16 +2816,8 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
-  minimatch@10.2.6:
-    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@5.1.9:
@@ -3409,9 +2830,6 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  module-details-from-path@1.0.4:
-    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -3429,9 +2847,6 @@ packages:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   next@16.3.2:
     resolution: {integrity: sha512-/ZCaubUy17Lld1SiPWxuPbCk2ihqAxF2QNQaPZeEaEb7t1I58qhsJN187D7AfpapHAqUPXH0f/thtdW9dWgWFg==}
@@ -3454,10 +2869,6 @@ packages:
       sass:
         optional: true
 
-  node-releases@2.0.53:
-    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
-    engines: {node: '>=18'}
-
   nwsapi@2.2.24:
     resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
@@ -3479,26 +2890,14 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
-  optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
-
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
-
-  oxc-parser@0.143.0:
-    resolution: {integrity: sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
-
-  oxlint-plugin-react-doctor@0.9.12:
-    resolution: {integrity: sha512-BplcCUU/tGByFGgY1YIax6evUmjk0K8zOGGrdPs3A3dqamrzjUvVuJdYpM1Ftyt/B5fFx6+VwRrWi3YZbIz4VQ==}
-    engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.77.0:
     resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
@@ -3521,17 +2920,9 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
-  p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
-
-  p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
 
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -3620,18 +3011,10 @@ packages:
       preact-render-to-string:
         optional: true
 
-  prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
-
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-
-  prompts@2.4.2:
-    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
-    engines: {node: '>= 6'}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -3651,11 +3034,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  react-doctor@0.9.12:
-    resolution: {integrity: sha512-H7RNg13RYKwpQvi3+O3IkSj8pAD1pGTxSetxu7aOwXX3wmF+BydCLDiWxkPT9Pq7bIMHjuJ0taSZLsxEjlNjcA==}
-    engines: {node: ^20.19.0 || >=22.13.0}
-    hasBin: true
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -3733,10 +3111,6 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  require-in-the-middle@8.0.1:
-    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
-    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -3796,13 +3170,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  semifies@1.0.0:
-    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -3864,10 +3231,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
@@ -3920,12 +3283,6 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
-  stubborn-fs@2.0.0:
-    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
-
-  stubborn-utils@1.0.2:
-    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
@@ -4072,10 +3429,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
-
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
@@ -4084,10 +3437,6 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
 
   ultracite@7.2.5:
     resolution: {integrity: sha512-Fw+V7P/gzTcVz6wmyYxaw8AGIOYDOilzwEiQq7pDGjrHwqdSzNrzevh1wxk0FTYfSHhk5a+wX02/Ayu8IK/x0A==}
@@ -4146,15 +3495,6 @@ packages:
     peerDependenciesMeta:
       synckit:
         optional: true
-
-  update-browserslist-db@1.3.1:
-    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -4264,9 +3604,6 @@ packages:
     resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
     hasBin: true
 
-  vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
-
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -4320,9 +3657,6 @@ packages:
     resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
     engines: {node: ^22.14.0 || >=24.0.0}
 
-  when-exit@2.1.5:
-    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -4336,10 +3670,6 @@ packages:
   widest-line@6.0.0:
     resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
     engines: {node: '>=20'}
-
-  word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -4364,9 +3694,6 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
@@ -4376,10 +3703,6 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
 
   yocto-spinner@1.2.2:
     resolution: {integrity: sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==}
@@ -4391,12 +3714,6 @@ packages:
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
-
-  zod-validation-error@4.0.2:
-    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -4428,30 +3745,6 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
-    dependencies:
-      '@apm-js-collab/code-transformer': 0.18.1
-      es-module-lexer: 2.3.2
-      magic-string: 0.30.21
-      module-details-from-path: 1.0.4
-
-  '@apm-js-collab/code-transformer@0.18.1':
-    dependencies:
-      '@types/estree': 1.0.8
-      astring: 1.9.0
-      esquery: 1.7.0
-      meriyah: 6.1.4
-      semifies: 1.0.0
-      source-map: 0.6.1
-
-  '@apm-js-collab/tracing-hooks@0.13.0':
-    dependencies:
-      '@apm-js-collab/code-transformer': 0.18.1
-      debug: 4.4.3
-      module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -4477,44 +3770,6 @@ snapshots:
       lru-cache: 11.5.2
     optional: true
 
-  '@astrojs/compiler@4.0.0': {}
-
-  '@babel/code-frame@7.29.7':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
-  '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.8
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-      '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.8
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8
-      '@babel/types': 7.29.8
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.29.8':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
   '@babel/generator@8.0.0-rc.1':
     dependencies:
       '@babel/parser': 8.0.0-rc.1
@@ -4524,79 +3779,15 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.29.7':
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.8
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-globals@7.29.7': {}
-
-  '@babel/helper-module-imports@7.29.7':
-    dependencies:
-      '@babel/traverse': 7.29.8
-      '@babel/types': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-string-parser@7.29.7': {}
-
   '@babel/helper-string-parser@8.0.0-rc.2': {}
 
-  '@babel/helper-validator-identifier@7.29.7': {}
-
   '@babel/helper-validator-identifier@8.0.0-rc.1': {}
-
-  '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helpers@7.29.7':
-    dependencies:
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-
-  '@babel/parser@7.29.8':
-    dependencies:
-      '@babel/types': 7.29.8
 
   '@babel/parser@8.0.0-rc.1':
     dependencies:
       '@babel/types': 8.0.0-rc.1
 
   '@babel/runtime@7.28.6': {}
-
-  '@babel/template@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
-
-  '@babel/traverse@7.29.8':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.8
-      '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.8
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/types@7.29.8':
-    dependencies:
-      '@babel/helper-string-parser': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@8.0.0-rc.1':
     dependencies:
@@ -5029,56 +4220,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.9.0(jiti@2.7.0))':
-    dependencies:
-      eslint: 10.9.0(jiti@2.7.0)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/regexpp@4.12.2': {}
-
-  '@eslint/config-array@0.23.5':
-    dependencies:
-      '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
-      minimatch: 10.2.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/config-helpers@0.7.0':
-    dependencies:
-      '@eslint/core': 1.2.1
-
-  '@eslint/core@1.2.1':
-    dependencies:
-      '@types/json-schema': 7.0.15
-
-  '@eslint/object-schema@3.0.5': {}
-
-  '@eslint/plugin-kit@0.7.2':
-    dependencies:
-      '@eslint/core': 1.2.1
-      levn: 0.4.1
-
   '@exodus/bytes@1.15.1':
     optional: true
-
-  '@humanfs/core@0.19.2':
-    dependencies:
-      '@humanfs/types': 0.15.0
-
-  '@humanfs/node@0.16.8':
-    dependencies:
-      '@humanfs/core': 0.19.2
-      '@humanfs/types': 0.15.0
-      '@humanwhocodes/retry': 0.4.3
-
-  '@humanfs/types@0.15.0': {}
-
-  '@humanwhocodes/module-importer@1.0.1': {}
-
-  '@humanwhocodes/retry@0.4.3': {}
-
-  '@iarna/toml@2.2.5': {}
 
   '@img/colour@1.1.0':
     optional: true
@@ -5349,109 +4492,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opentelemetry/api-logs@0.220.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
-  '@opentelemetry/api@1.9.1': {}
-
-  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.220.0
-      import-in-the-middle: 3.3.3
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/semantic-conventions@1.43.0': {}
-
-  '@oxc-parser/binding-android-arm-eabi@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-android-arm64@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-arm64@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-x64@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-freebsd-x64@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.143.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.143.0':
+  '@opentelemetry/api@1.9.1':
     optional: true
 
   '@oxc-project/types@0.112.0': {}
-
-  '@oxc-project/types@0.143.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
@@ -5766,60 +4810,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@sentry/conventions@0.16.0': {}
-
-  '@sentry/core@10.70.0':
-    dependencies:
-      '@sentry/conventions': 0.16.0
-
-  '@sentry/node-core@10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.70.0
-      '@sentry/opentelemetry': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
-      import-in-the-middle: 3.3.3
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
-
-  '@sentry/node@10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
-      '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.70.0
-      '@sentry/node-core': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
-      '@sentry/opentelemetry': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
-      '@sentry/server-utils': 10.70.0
-      import-in-the-middle: 3.3.3
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
-
-  '@sentry/opentelemetry@10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
-      '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.70.0
-
-  '@sentry/server-utils@10.70.0':
-    dependencies:
-      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.4
-      '@apm-js-collab/tracing-hooks': 0.13.0
-      '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.70.0
-      meriyah: 6.1.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@shaderfrog/glsl-parser@7.0.1': {}
-
   '@shikijs/core@4.4.3':
     dependencies:
       '@shikijs/primitive': 4.4.3
@@ -5983,8 +4973,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/esrecurse@4.3.1': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -6000,8 +4988,6 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/jsesc@2.5.1': {}
-
-  '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -6034,18 +5020,16 @@ snapshots:
 
   '@types/vscode@1.109.0': {}
 
-  '@typescript-eslint/types@8.67.0': {}
-
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/analytics@2.0.1(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@2.0.1(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.3.2(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
-  '@vercel/speed-insights@2.0.0(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/speed-insights@2.0.0(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.3.2(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vitest/expect@3.2.4':
@@ -6121,33 +5105,6 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agent-install@0.0.5:
-    dependencies:
-      '@iarna/toml': 2.2.5
-      commander: 14.0.3
-      jsonc-parser: 3.3.1
-      picocolors: 1.1.1
-      prompts: 2.4.2
-      yaml: 2.9.0
-
-  ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
-  ajv@6.15.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
-  ajv@8.20.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
   ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
@@ -6180,11 +5137,6 @@ snapshots:
 
   astring@1.9.0: {}
 
-  atomically@2.1.1:
-    dependencies:
-      stubborn-fs: 2.0.0
-      when-exit: 2.1.5
-
   auto-bind@5.0.1: {}
 
   bail@2.0.2: {}
@@ -6214,21 +5166,9 @@ snapshots:
     dependencies:
       balanced-match: 4.0.3
 
-  brace-expansion@5.0.9:
-    dependencies:
-      balanced-match: 4.0.3
-
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  browserslist@4.28.8:
-    dependencies:
-      baseline-browser-mapping: 2.11.17
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.412
-      node-releases: 2.0.53
-      update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
   cac@6.7.14: {}
 
@@ -6261,8 +5201,6 @@ snapshots:
   ci-info@3.9.0: {}
 
   citty@0.2.2: {}
-
-  cjs-module-lexer@2.2.1: {}
 
   classcat@5.0.5: {}
 
@@ -6300,22 +5238,6 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@14.0.3: {}
-
-  conf@15.1.0:
-    dependencies:
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      atomically: 2.1.1
-      debounce-fn: 6.0.0
-      dot-prop: 10.2.0
-      env-paths: 3.0.0
-      json-schema-typed: 8.0.2
-      semver: 7.7.4
-      uint8array-extras: 1.5.0
-
-  confbox@0.2.4: {}
-
-  convert-source-map@2.0.0: {}
 
   convert-to-spaces@2.0.1: {}
 
@@ -6396,10 +5318,6 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  debounce-fn@6.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -6412,22 +5330,11 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
-  deep-is@0.1.4: {}
-
   deepmerge@4.3.1: {}
 
   defu@6.1.4: {}
 
   dequal@2.0.3: {}
-
-  deslop-js@0.9.12:
-    dependencies:
-      '@oxc-project/types': 0.143.0
-      fast-glob: 3.3.3
-      minimatch: 10.2.6
-      oxc-parser: 0.143.0
-      oxc-resolver: 11.24.2
-      typescript: 5.9.3
 
   detect-indent@6.1.0: {}
 
@@ -6445,15 +5352,9 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dot-prop@10.2.0:
-    dependencies:
-      type-fest: 5.8.0
-
   dts-resolver@2.1.3(oxc-resolver@11.24.2):
     optionalDependencies:
       oxc-resolver: 11.24.2
-
-  electron-to-chromium@1.5.412: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6474,13 +5375,9 @@ snapshots:
   entities@8.0.0:
     optional: true
 
-  env-paths@3.0.0: {}
-
   environment@1.1.0: {}
 
   es-module-lexer@1.7.0: {}
-
-  es-module-lexer@2.3.2: {}
 
   es-toolkit@1.51.0: {}
 
@@ -6527,90 +5424,11 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
-  escalade@3.2.0: {}
-
   escape-string-regexp@2.0.0: {}
-
-  escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.9.0(jiti@2.7.0)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/parser': 7.29.8
-      eslint: 10.9.0(jiti@2.7.0)
-      hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-scope@9.1.2:
-    dependencies:
-      '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
-  eslint-visitor-keys@3.4.3: {}
-
-  eslint-visitor-keys@5.0.1: {}
-
-  eslint@10.9.0(jiti@2.7.0):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.0(jiti@2.7.0))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.7.0
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.2
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.15.0
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.6
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.7.0
-    transitivePeerDependencies:
-      - supports-color
-
-  espree@11.2.0:
-    dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
-      eslint-visitor-keys: 5.0.1
-
   esprima@4.0.1: {}
-
-  esquery@1.7.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  esrecurse@4.3.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  estraverse@5.3.0: {}
 
   estree-util-attach-comments@3.0.0:
     dependencies:
@@ -6645,15 +5463,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  esutils@2.0.3: {}
-
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
-
-  fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -6662,12 +5476,6 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
-
-  fast-json-stable-stringify@2.1.0: {}
-
-  fast-levenshtein@2.0.6: {}
-
-  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6683,10 +5491,6 @@ snapshots:
 
   fflate@0.4.9: {}
 
-  file-entry-cache@8.0.0:
-    dependencies:
-      flat-cache: 4.0.1
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -6695,18 +5499,6 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-
-  find-up@5.0.0:
-    dependencies:
-      locate-path: 6.0.0
-      path-exists: 4.0.0
-
-  flat-cache@4.0.1:
-    dependencies:
-      flatted: 3.4.4
-      keyv: 4.5.4
-
-  flatted@3.4.4: {}
 
   formatly@0.3.0:
     dependencies:
@@ -6727,8 +5519,6 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  gensync@1.0.0-beta.2: {}
-
   get-east-asian-width@1.5.0: {}
 
   get-tsconfig@4.13.6:
@@ -6738,10 +5528,6 @@ snapshots:
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
-  glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
@@ -6865,12 +5651,6 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  hermes-estree@0.25.1: {}
-
-  hermes-parser@0.25.1:
-    dependencies:
-      hermes-estree: 0.25.1
-
   hookable@6.0.1: {}
 
   html-encoding-sniffer@4.0.0:
@@ -6914,15 +5694,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  import-in-the-middle@3.3.3:
-    dependencies:
-      cjs-module-lexer: 2.2.1
-      es-module-lexer: 2.3.2
-      module-details-from-path: 1.0.4
-
   import-without-cache@0.2.5: {}
-
-  imurmurhash@0.1.4: {}
 
   indent-string@5.0.0: {}
 
@@ -7001,8 +5773,6 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  js-tokens@4.0.0: {}
-
   js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
@@ -7070,29 +5840,11 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-buffer@3.0.1: {}
-
-  json-schema-traverse@0.4.1: {}
-
-  json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
-
-  json-stable-stringify-without-jsonify@1.0.1: {}
-
-  json5@2.2.3: {}
-
   jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  keyv@4.5.4:
-    dependencies:
-      json-buffer: 3.0.1
-
-  kleur@3.0.3: {}
 
   knip@5.86.0(@types/node@20.19.33)(typescript@5.9.3):
     dependencies:
@@ -7111,11 +5863,6 @@ snapshots:
       unbash: 2.2.0
       yaml: 2.8.2
       zod: 4.3.6
-
-  levn@0.4.1:
-    dependencies:
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -7214,14 +5961,11 @@ snapshots:
       lightningcss-linux-x64-musl: 1.33.0
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
+    optional: true
 
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
-
-  locate-path@6.0.0:
-    dependencies:
-      p-locate: 5.0.0
 
   lodash.startcase@4.4.0: {}
 
@@ -7238,10 +5982,6 @@ snapshots:
   lru-cache@11.5.2:
     optional: true
 
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
-
   lucide-react@1.27.0(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -7249,12 +5989,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  magicast@0.5.4:
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
-      source-map-js: 1.2.1
 
   markdown-extensions@2.0.0: {}
 
@@ -7427,8 +6161,6 @@ snapshots:
     optional: true
 
   merge2@1.4.1: {}
-
-  meriyah@6.1.4: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -7701,15 +6433,9 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-function@5.0.1: {}
-
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.2
-
-  minimatch@10.2.6:
-    dependencies:
-      brace-expansion: 5.0.9
 
   minimatch@5.1.9:
     dependencies:
@@ -7719,8 +6445,6 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  module-details-from-path@1.0.4: {}
-
   mri@1.2.0: {}
 
   ms@2.1.3: {}
@@ -7729,9 +6453,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  natural-compare@1.4.0: {}
-
-  next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@20.19.33)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.3.2
       '@swc/helpers': 0.5.23
@@ -7740,7 +6462,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.2
       '@next/swc-darwin-x64': 16.3.2
@@ -7756,8 +6478,6 @@ snapshots:
       - '@babel/core'
       - '@types/node'
       - babel-plugin-macros
-
-  node-releases@2.0.53: {}
 
   nwsapi@2.2.24: {}
 
@@ -7781,40 +6501,7 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  optionator@0.9.4:
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.4.1
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
-      word-wrap: 1.2.5
-
   outdent@0.5.0: {}
-
-  oxc-parser@0.143.0:
-    dependencies:
-      '@oxc-project/types': 0.143.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.143.0
-      '@oxc-parser/binding-android-arm64': 0.143.0
-      '@oxc-parser/binding-darwin-arm64': 0.143.0
-      '@oxc-parser/binding-darwin-x64': 0.143.0
-      '@oxc-parser/binding-freebsd-x64': 0.143.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.143.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.143.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.143.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.143.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.143.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.143.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.143.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.143.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.143.0
-      '@oxc-parser/binding-linux-x64-musl': 0.143.0
-      '@oxc-parser/binding-openharmony-arm64': 0.143.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.143.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.143.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.143.0
 
   oxc-resolver@11.19.1:
     optionalDependencies:
@@ -7860,15 +6547,7 @@ snapshots:
       '@oxc-resolver/binding-wasm32-wasi': 11.24.2
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
-
-  oxlint-plugin-react-doctor@0.9.12:
-    dependencies:
-      '@shaderfrog/glsl-parser': 7.0.1
-      '@typescript-eslint/types': 8.67.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      lightningcss: 1.33.0
-      oxc-parser: 0.143.0
+    optional: true
 
   oxlint@1.77.0:
     optionalDependencies:
@@ -7891,6 +6570,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.77.0
       '@oxlint/binding-win32-ia32-msvc': 1.77.0
       '@oxlint/binding-win32-x64-msvc': 1.77.0
+    optional: true
 
   p-filter@2.1.0:
     dependencies:
@@ -7900,17 +6580,9 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
-  p-limit@3.1.0:
-    dependencies:
-      yocto-queue: 0.1.0
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
-
-  p-locate@5.0.0:
-    dependencies:
-      p-limit: 3.1.0
 
   p-map@2.1.0: {}
 
@@ -7997,14 +6669,7 @@ snapshots:
 
   preact@10.29.8: {}
 
-  prelude-ls@1.2.1: {}
-
   prettier@2.8.8: {}
-
-  prompts@2.4.2:
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
 
   property-information@7.1.0: {}
 
@@ -8017,35 +6682,6 @@ snapshots:
   query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
-
-  react-doctor@0.9.12(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.9.0(jiti@2.7.0)):
-    dependencies:
-      '@astrojs/compiler': 4.0.0
-      '@sentry/node': 10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
-      agent-install: 0.0.5
-      conf: 15.1.0
-      confbox: 0.2.4
-      deslop-js: 0.9.12
-      eslint-plugin-react-hooks: 7.1.1(eslint@10.9.0(jiti@2.7.0))
-      jiti: 2.7.0
-      magicast: 0.5.4
-      oxc-resolver: 11.24.2
-      oxlint: 1.77.0
-      oxlint-plugin-react-doctor: 0.9.12
-      prompts: 2.4.2
-      typescript: 5.9.3
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
-      yaml: 2.9.0
-      yoga-layout: 3.2.1
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - eslint
-      - oxlint-tsgolint
-      - supports-color
-      - vite-plus
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:
@@ -8178,14 +6814,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  require-from-string@2.0.2: {}
-
-  require-in-the-middle@8.0.1:
-    dependencies:
-      debug: 4.4.3
-      module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
+  require-from-string@2.0.2:
+    optional: true
 
   resolve-from@5.0.0: {}
 
@@ -8279,10 +6909,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  semifies@1.0.0: {}
-
-  semver@6.3.1: {}
-
   semver@7.7.4: {}
 
   semver@7.8.5:
@@ -8358,8 +6984,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.6.1: {}
-
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
@@ -8411,12 +7035,6 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stubborn-fs@2.0.0:
-    dependencies:
-      stubborn-utils: 1.0.2
-
-  stubborn-utils@1.0.2: {}
-
   style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
@@ -8427,12 +7045,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.3):
+  styled-jsx@5.1.6(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
-    optionalDependencies:
-      '@babel/core': 7.29.7
 
   symbol-tree@3.2.4: {}
 
@@ -8539,17 +7155,11 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  type-check@0.4.0:
-    dependencies:
-      prelude-ls: 1.2.1
-
   type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
-
-  uint8array-extras@1.5.0: {}
 
   ultracite@7.2.5(oxlint@1.77.0):
     dependencies:
@@ -8616,16 +7226,6 @@ snapshots:
   unrun@0.2.27:
     dependencies:
       rolldown: 1.0.0-rc.3
-
-  update-browserslist-db@1.3.1(browserslist@4.28.8):
-    dependencies:
-      browserslist: 4.28.8
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
 
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
@@ -8789,8 +7389,6 @@ snapshots:
     dependencies:
       vscode-languageserver-protocol: 3.17.5
 
-  vscode-uri@3.1.0: {}
-
   w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
@@ -8842,8 +7440,6 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  when-exit@2.1.5: {}
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -8857,8 +7453,6 @@ snapshots:
     dependencies:
       string-width: 8.2.0
 
-  word-wrap@1.2.5: {}
-
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -8871,13 +7465,10 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
-  yallist@3.1.1: {}
-
   yaml@2.8.2: {}
 
-  yaml@2.9.0: {}
-
-  yocto-queue@0.1.0: {}
+  yaml@2.9.0:
+    optional: true
 
   yocto-spinner@1.2.2:
     dependencies:
@@ -8886,10 +7477,6 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   yoga-layout@3.2.1: {}
-
-  zod-validation-error@4.0.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Context

The Modules Graph and Relational Schema tabs are the report's two canvas views. Both have a tree sidebar, a canvas, and (on Modules) a bottom drawer with problems and the boot trace. This PR grew from one sidebar fix into the interaction-polish batch for those two tabs; every change landed after being reproduced in the browser against the demo report.

## Problem

Seven distinct paper cuts, worst first:

- Selecting a module appended the detail panel below the full projects list, so on any real project it started off-screen.
- Opening or closing the bottom drawer left the canvas painted at the wrong height (cut graph) and shifted every node vertically by `(Δheight/2)·(zoom−1)`.
- The legend ⓘ button never opened: the click that opened the popover bubbled to the document-level outside-click closer and shut it in the same instant.
- The trace badge in the detail panel switched to the Boot tab instead of the drawer next to the graph.
- In the schema's focused view, selecting a second table replaced the first; in the show-all view the highlight did the same.
- The share dialog and the viewer's open-a-report window were two unrelated modal implementations with different backdrops.
- The legend popover had its own rounded translucent styling matching nothing else.

## Possible flows

| Path | Affected |
| --- | --- |
| Selecting a module (canvas, tree, `REPORT_APP.openModule`) | detail covers the sidebar, animated |
| Dock open/close (header click, trace badge) | canvas resizes after commit, camera anchored |
| Legend ⓘ (open, second click, outside click) | opens, toggles, closes |
| Schema selection (sidebar, drawer, canvas click) in both view modes | groups accumulate; toggle-off removes one, empty click clears all |
| Share dialog and viewer open-report window | one `Modal` molecule |
| Window resize on the Modules canvas | same camera anchoring, no drift |

## Solution

- `mg-detail-open` on the sidebar hides the header/search/tree while a module is selected (the CSS hook existed but nothing applied it); a 160ms fade covers the swap both ways, `prefers-reduced-motion` disables it.
- Dock resize moved into a layout effect keyed on the dock state; `resize()` compensates the camera by `(Δ/2)(1−1/zoom)` so world points keep their screen position.
- The outside-click closer ignores clicks on `#mg-info`; the popover panel reuses `.modal-panel`.
- The trace badge sets the dock state instead of calling `switchTab("boot")`.
- `SchemaCanvas` keeps a set of focus roots: focused mode shows the union of each root's related tables (star for one, overview layout for more); show-all mode dims against the same union. Deselecting a table removes its group; empty-canvas click clears all.
- New `Modal` molecule (dim + blur backdrop, surface panel, Escape/backdrop close), exported from `nestjs-doctor/report-ui`; React stays external in that build so the website renders it with its own React.
- Hover indent guides on the modules and schema trees, one continuous 1px line per depth, same look as the findings file tree.

Deliberately not done: no `Popover` molecule (one consumer), no guides on the endpoints tree (not asked), arrow-direction fix stays in PR #367.

## Before vs after

| Interaction | Before | After |
| --- | --- | --- |
| Select `OrdersModule` | detail below the tree, scroll to find it | detail takes the sidebar, fades in |
| Close the drawer at 125% zoom | graph cut at drawer height, nodes shifted ~35px | full height, nodes pixel-stable |
| Click ⓘ | nothing visible | legend opens, panel-styled |
| Select `orders` then `products` (schema) | products replaces orders | both groups visible |
| Share button | flat dark backdrop | same blurred, shadowed modal as the viewer |
| Idle edges on the graph | importer → imported | unchanged |

## Example

Open the demo report, Modules Graph, click `OrdersModule`: the sidebar swaps to the detail panel. Click the purple `36ms init · trace ▸` badge: the drawer opens on Boot trace with `api/OrdersModule` focused, still on the graph. Close the drawer: `AppModule` stays at exactly the same pixel. Relational Schema, select `orders` then `products`: Order's star and Product's group render together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAT9c3kq2cDxg6DRSiV8b1
