### PR TITLE
fix(website): report styles load with the page, not with the demo

### DIFF
--- a/packages/website/src/app/opengraph-image.tsx
+++ b/packages/website/src/app/opengraph-image.tsx
@@ -14,9 +14,13 @@ const FONT_URL_RE = /url\((https:[^)]+)\)/;
 /** Downloads one weight of IBM Plex Mono through the same host next/font uses. */
 async function plexMono(weight: number): Promise<ArrayBuffer | null> {
 	try {
-		const css = await (
-			await fetch(`${FONT_CSS}`, { headers: { "User-Agent": "Mozilla/5.0" } })
-		).text();
+		const cssRes = await fetch(FONT_CSS, {
+			headers: { "User-Agent": "Mozilla/5.0" },
+		});
+		if (!cssRes.ok) {
+			return null;
+		}
+		const css = await cssRes.text();
 		const block = css
 			.split("@font-face")
 			.find((part) => part.includes(`font-weight: ${weight}`));
@@ -24,7 +28,11 @@ async function plexMono(weight: number): Promise<ArrayBuffer | null> {
 		if (!url) {
 			return null;
 		}
-		return await (await fetch(url)).arrayBuffer();
+		const fontRes = await fetch(url);
+		if (!fontRes.ok) {
+			return null;
+		}
+		return await fontRes.arrayBuffer();
 	} catch {
 		return null;
 	}

--- a/packages/website/src/app/report/report-viewer.tsx
+++ b/packages/website/src/app/report/report-viewer.tsx
@@ -193,19 +193,8 @@ function LoadedReport({
 	}, [artifact, hiddenTabs, shared, demo, onLoadAnother]);
 
 	return (
-		<>
-			<link href="https://fonts.googleapis.com" rel="preconnect" />
-			<link crossOrigin="" href="https://fonts.gstatic.com" rel="preconnect" />
-			<link
-				href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@200;400;500;600;700&display=swap"
-				precedence="default"
-				rel="stylesheet"
-			/>
-			{/* biome-ignore lint/security/noDangerouslySetInnerHtml: the report's own stylesheet */}
-			<style dangerouslySetInnerHTML={{ __html: getReportStyles() }} />
-			{/* biome-ignore lint/security/noDangerouslySetInnerHtml: the report's static mount skeleton */}
-			<div dangerouslySetInnerHTML={{ __html: getReportHtml() }} />
-		</>
+		// biome-ignore lint/security/noDangerouslySetInnerHtml: the report's static mount skeleton
+		<div dangerouslySetInnerHTML={{ __html: getReportHtml() }} />
 	);
 }
 
@@ -416,6 +405,15 @@ export function ReportViewer() {
 
 	return (
 		<div className="min-h-dvh bg-black">
+			<link href="https://fonts.googleapis.com" rel="preconnect" />
+			<link crossOrigin="" href="https://fonts.gstatic.com" rel="preconnect" />
+			<link
+				href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@200;400;500;600;700&display=swap"
+				precedence="default"
+				rel="stylesheet"
+			/>
+			{/* biome-ignore lint/security/noDangerouslySetInnerHtml: the report's own stylesheet */}
+			<style dangerouslySetInnerHTML={{ __html: getReportStyles() }} />
 			{state.phase === "loaded" ? (
 				<LoadedReport
 					artifact={state.artifact}


### PR DESCRIPTION
## Context

The `/report` page's picker modal renders through the shared `Modal` styled by the report stylesheet, which `getReportStyles()` injects into the page.

## Problem

The stylesheet was injected inside `LoadedReport`, which only mounts once the demo JSON fetch resolves. On first paint the modal's markup existed with no CSS, so it flashed as unstyled text on black before snapping into the styled overlay — the flicker on clicking "open report" on the deployed site. Before the shared-Modal refactor the picker was inline-styled, which is why this never flickered.

## Possible flows

| Path | Before |
| --- | --- |
| Visiting /report cold | unstyled flash until the demo fetch lands |
| /report?demo | same flash |
| Loading a shared file after the page is up | no flash (styles already in) |

## Solution

The report stylesheet and the font links moved from `LoadedReport` to the `ReportViewer` root, so they are part of the pre-rendered static HTML and apply on the very first frame. `LoadedReport` keeps only the mount skeleton.

## Before vs after

| | Before | After |
| --- | --- | --- |
| First paint of /report | unstyled modal text | styled modal |
| Style injection point | LoadedReport (after demo fetch) | viewer root (static HTML) |

## Example

`out/report.html` from `next build` now begins the page with `<div class="min-h-dvh bg-black"><style>` — stylesheet ahead of the modal markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAT9c3kq2cDxg6DRSiV8b1
