### PR TITLE
feat(cli): summarize repeated duplicate-module warnings

### DIFF
--- a/.changeset/duplicate-module-warning-summary.md
+++ b/.changeset/duplicate-module-warning-summary.md
@@ -1,0 +1,7 @@
+---
+"nestjs-doctor": patch
+---
+
+### Changed
+
+- **One line instead of twelve for duplicate module names.** When several `@Module` class names are each declared in more than one file, the console prints a single summary; `--verbose` restores the per-module lines with the file lists. The Node API's warnings keep the full detail.

--- a/packages/nestjs-doctor/src/cli/formatters/warning-summary.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/warning-summary.ts
@@ -1,0 +1,17 @@
+const DUPLICATE_MODULE_RE = /^@Module class .+ is declared in \d+ files /;
+
+/** Console warning lines, with repeated duplicate-module warnings collapsed. */
+export function summarizeWarnings(
+	warnings: string[],
+	verbose: boolean
+): string[] {
+	const duplicates = warnings.filter((w) => DUPLICATE_MODULE_RE.test(w));
+	if (verbose || duplicates.length <= 1) {
+		return warnings;
+	}
+	const rest = warnings.filter((w) => !DUPLICATE_MODULE_RE.test(w));
+	return [
+		...rest,
+		`${duplicates.length} @Module class names are declared in more than one file each; each name's declarations are analyzed as one module (--verbose lists them)`,
+	];
+}

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -38,6 +38,7 @@ import {
 	printConsoleReport,
 	printMonorepoReport,
 } from "./formatters/console-reporter.js";
+import { summarizeWarnings } from "./formatters/warning-summary.js";
 import { resolveMinScore } from "./min-score.js";
 import {
 	getCliVersion,
@@ -88,12 +89,13 @@ export interface InteractiveArtifacts {
 
 const displayCustomRuleWarnings = (
 	warnings: string[],
-	isMachineReadable: boolean
+	isMachineReadable: boolean,
+	verbose: boolean
 ): void => {
 	if (isMachineReadable) {
 		return;
 	}
-	for (const warning of warnings) {
+	for (const warning of summarizeWarnings(warnings, verbose)) {
 		logger.warn(warning);
 	}
 };
@@ -183,7 +185,8 @@ abstract class ScanPipeline {
 			this.stopProgress();
 			displayCustomRuleWarnings(
 				this.scanConfig.customRuleWarnings,
-				this.options.isMachineReadable
+				this.options.isMachineReadable,
+				this.options.verbose
 			);
 		});
 		return this;
@@ -336,7 +339,8 @@ abstract class ScanPipeline {
 				this.stopProgress();
 				displayCustomRuleWarnings(
 					this.workerWarnings,
-					this.options.isMachineReadable
+					this.options.isMachineReadable,
+					this.options.verbose
 				);
 				await this.outputStep?.();
 				return;

--- a/packages/nestjs-doctor/tests/unit/warning-summary.test.ts
+++ b/packages/nestjs-doctor/tests/unit/warning-summary.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from "vitest";
+import { summarizeWarnings } from "../../src/cli/formatters/warning-summary.js";
+
+const dup = (name: string) =>
+	`@Module class ${name} is declared in 2 files (a.ts, b.ts); their imports, providers, and exports are analyzed as one module`;
+
+it("collapses repeated duplicate-module warnings into one line", () => {
+	const warnings = [dup("A"), dup("B"), dup("C"), "custom rule x failed"];
+	const lines = summarizeWarnings(warnings, false);
+	expect(lines).toHaveLength(2);
+	expect(lines[0]).toBe("custom rule x failed");
+	expect(lines[1]).toContain("3 @Module class names are declared");
+	expect(lines[1]).toContain("--verbose");
+});
+
+it("prints everything verbatim under --verbose", () => {
+	const warnings = [dup("A"), dup("B"), "custom rule x failed"];
+	expect(summarizeWarnings(warnings, true)).toEqual(warnings);
+});
+
+it("keeps a single duplicate-module warning verbatim", () => {
+	const warnings = [dup("A")];
+	expect(summarizeWarnings(warnings, false)).toEqual(warnings);
+});


### PR DESCRIPTION
## Context

When several `@Module` classes share a name across files, `buildAnalysisContext` pushes one warning per merged module into the scan's warning channel, and the CLI prints them after the scan line.

## Problem

A monorepo using the lambda/standalone dual-entry pattern prints the same sentence once per app: a real scan of a 12-app workspace showed twelve near-identical `@Module class BootstrapModule is declared in 2 files (…)` lines. Repetition at that volume trains people to ignore the channel, and the pattern being warned about is idiomatic, not a mistake.

## Possible flows

| Path | Affected |
| --- | --- |
| Console scan, 2+ duplicate-name modules | collapsed to one line |
| Console scan with `--verbose` | full per-module lines, unchanged |
| Console scan, exactly one duplicate | unchanged, prints verbatim |
| `--json` / `--score` (machine readable) | unchanged, warnings never print |
| Node API `customRuleWarnings` | unchanged, full detail |

## Solution

A pure `summarizeWarnings(warnings, verbose)` in `cli/formatters` collapses the duplicate-module lines into `N @Module class names are declared in more than one file each; each name's declarations are analyzed as one module (--verbose lists them)` and leaves every other warning untouched. The engine still records full detail; only the console print is summarized, so the API and report artifacts keep everything.

## Before vs after

| Scan | Before | After |
| --- | --- | --- |
| 12-app dual-entry workspace | 12 repeated lines | 1 summary line |
| Same scan with `--verbose` | 12 lines | 12 lines |
| Single collision | 1 line | 1 line |

## Example

`nestjs-doctor ~/compass` used to print twelve `@Module class BootstrapModule is declared in 2 files …` lines; it now prints `12 @Module class names are declared in more than one file each; each name's declarations are analyzed as one module (--verbose lists them)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAT9c3kq2cDxg6DRSiV8b1
