### PR TITLE
chore(website): deploy production only on a changesets release

### DIFF
--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "if [ \"$VERCEL_ENV\" != \"production\" ]; then exit 1; fi; printf '%s' \"$VERCEL_GIT_COMMIT_MESSAGE\" | grep -qE 'changeset-release/main|Version Packages' && exit 1 || exit 0"
+}


### PR DESCRIPTION
## Context

nestjs.doctor deploys through Vercel's Git integration: every merge to main that touches `packages/website` triggers a production build. There is no `vercel.json` in the repo; all behavior comes from dashboard settings.

## Problem

Production redeploys on every merge, so the site can ship ahead of the npm package — the demo report and docs describe a CLI version nobody can install yet. Today's session had the report viewer deployed ahead of the published artifact format twice.

## Possible flows

| Deployment | Before | After |
| --- | --- | --- |
| PR preview | builds | builds (unchanged) |
| Merge to main (feature/fix) | production deploy | skipped |
| Merge of the changesets "Version Packages" PR | production deploy | production deploy |
| Manual redeploy from the Vercel dashboard | works | works (unchanged) |

## Solution

`packages/website/vercel.json` gains an `ignoreCommand` (it takes precedence over the dashboard's Ignored Build Step): non-production builds always proceed, and production builds proceed only when the commit message carries `changeset-release/main` or `Version Packages` — the shape of a changesets release merge, whether merged or squashed. Everything else about the project stays in the dashboard.

## Before vs after

Covered by the flow table above; the one behavior change is that a website-only hotfix now waits for the next release or a manual dashboard deploy.

## Example

Merging a feature PR after this lands leaves the last production deployment untouched; merging the open `Version Packages` PR (#363) builds and ships the site together with `nestjs-doctor@0.9.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAT9c3kq2cDxg6DRSiV8b1
