### PR TITLE
fix(ci): changesets action v2 renamed its script inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
         id: changesets
         uses: changesets/action@v2
         with:
-          publish: pnpm run release
-          version: pnpm run version
+          publish-script: pnpm run release
+          version-script: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Context

The Release workflow runs `changesets/action@v2` on every push to main; on the Version Packages merge it publishes to npm. PR #369 bumped the github-actions group, which moved the action to a v2 release that renamed its inputs.

## Problem

The action now rejects the old input names before doing anything: `The following inputs have been renamed: "publish" -> "publish-script", "version" -> "version-script"`. Every Release run since the bump fails in ~20s, including the 0.9.4 release merge — nothing was published, nothing half-done.

## Possible flows

| Trigger | Before | After |
| --- | --- | --- |
| Push to main with pending changesets | fails at input validation | opens/updates the Version Packages PR |
| Push of a Version Packages merge | fails, no publish | publishes to npm, tags, GitHub releases |
| `steps.changesets.outputs.published` consumers | never reached | unchanged output names, still work |

## Solution

Rename the two inputs. Nothing else in the workflow changes; the action's outputs kept their names.

## Before vs after

`publish:` / `version:` → `publish-script:` / `version-script:`, same values.

## Example

Run 33455807264 (the #363 merge) failed with the rename error; merging this re-triggers Release on main, which finds nestjs-doctor@0.9.4 unpublished and ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAT9c3kq2cDxg6DRSiV8b1
