### PR TITLE
fix(vscode): pin @types/vscode to the engines.vscode floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # Must not exceed the extension's engines.vscode; vsce rejects the publish.
+      - dependency-name: "@types/vscode"
     groups:
       dev-dependencies:
         dependency-type: development

--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -69,7 +69,7 @@
     "vscode-languageclient": "^9.0.0"
   },
   "devDependencies": {
-    "@types/vscode": "^1.134.0",
+    "@types/vscode": "~1.85.0",
     "nestjs-doctor-lsp": "workspace:*",
     "tsdown": "^0.20.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@types/vscode':
-        specifier: ^1.134.0
-        version: 1.134.0
+        specifier: ~1.85.0
+        version: 1.85.0
       nestjs-doctor-lsp:
         specifier: workspace:*
         version: link:../nestjs-doctor-lsp
@@ -1631,8 +1631,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/vscode@1.134.0':
-    resolution: {integrity: sha512-NDEu0hg4sF7+vvFsADsktqUJ6f80LHSZvVK2Ovo1XiQ0/VHck1O3zst+ZZyVA/uvz6vo6LcuoqU2q48YMqOwWw==}
+  '@types/vscode@1.85.0':
+    resolution: {integrity: sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -4794,7 +4794,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/vscode@1.134.0': {}
+  '@types/vscode@1.85.0': {}
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
## Context

The extension declares `engines.vscode: ^1.85.0`, and vsce enforces that `@types/vscode` never exceeds that floor — types describe APIs the minimum supported VS Code must actually have.

## Problem

The dev-dependencies bump (#370) raised `@types/vscode` to `^1.134.0`. The next release's `Publish VS Code Extension` job failed on run 33456926629: `@types/vscode ^1.134.0 greater than engines.vscode ^1.85.0`. The npm publish of 0.9.5 was unaffected.

## Possible flows

| Path | Affected |
| --- | --- |
| Release run's vscode job | fails today; green after this |
| Extension build/typecheck | verified against the 1.85 types |
| Future dependabot runs | `@types/vscode` ignored, cannot regress |

## Solution

`@types/vscode` pinned to `~1.85.0` to match the engine floor, and a dependabot ignore stops it from being bumped past the engine again. Raising `engines.vscode` instead would drop users on older VS Code for no feature need.

## Before vs after

| | Before | After |
| --- | --- | --- |
| `@types/vscode` | `^1.134.0` | `~1.85.0` |
| vsce publish | rejected | accepted |
| dependabot | re-bumps it | ignores it |

## Example

`pnpm --filter nestjs-doctor-vscode build && tsc --noEmit` passes against the 1.85 types; the next release's vscode job will build and skip the upload as a duplicate until the extension's own version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAT9c3kq2cDxg6DRSiV8b1
