### PR TITLE
fix(cli): honour telemetry opt-outs in the menu report and add a NestJS 12 fixture

### DIFF
--- a/.changeset/interactive-report-telemetry-gate.md
+++ b/.changeset/interactive-report-telemetry-gate.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+A report generated from the post-scan menu now honours `--no-telemetry`, `DO_NOT_TRACK`, and the `telemetry` and `report.telemetry` config keys. Before, the interactive path always embedded the report beacon; `--report` and the Node API already respected them. Also adds a NestJS 12 ESM fixture to the integration suite and documents a clean scan as an expected result.

--- a/packages/nestjs-doctor/README.md
+++ b/packages/nestjs-doctor/README.md
@@ -40,6 +40,10 @@ npx nestjs-doctor@latest .
 
 ![nestjs-doctor scoring a project 35 out of 100, an agent fixing the findings, and a rescan scoring 100](https://nestjs.doctor/demo.gif)
 
+A clean scan prints the score and nothing else. That is the expected result on
+a project the rules already agree with, and `--report` still draws the module
+graph, the traced endpoints and the schema diagram.
+
 Add `--verbose` for file paths and line numbers.
 
 ### 2. Open the report

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -33,6 +33,7 @@ import {
 import { buildReportArtifact, collectScanFacts } from "../report/artifact.js";
 import { buildHtmlReport } from "../report/html-report.js";
 import { resetEcosystem } from "../telemetry/ecosystem.js";
+import { reportTelemetryEnabled } from "../telemetry/send.js";
 import { logger } from "../ui/logger.js";
 import {
 	printConsoleReport,
@@ -122,6 +123,8 @@ abstract class ScanPipeline {
 	protected workerWarnings: string[] = [];
 	/** Set when any scanned sub-project declares its own opt-out. */
 	protected subProjectOptOut = false;
+	/** Whether a report built from the menu may embed its beacon; decided with the config. */
+	protected reportTelemetry = false;
 	/** Warnings raised while narrowing the scope; surfaced alongside the report. */
 	protected scopeWarnings: string[] = [];
 	protected readonly steps: PipelineStep[] = [];
@@ -154,6 +157,9 @@ abstract class ScanPipeline {
 			subProjectOptOut: this.subProjectOptOut,
 			targetPath: this.targetPath,
 		});
+		this.reportTelemetry =
+			reportTelemetryEnabled(this.options.telemetry, this.scanConfig.config) &&
+			!this.subProjectOptOut;
 	}
 
 	abstract applyScope(): this;
@@ -408,7 +414,10 @@ export class MonorepoPipeline extends ScanPipeline {
 	/** What the post-scan menu needs, without re-scanning. */
 	get interactiveArtifacts(): InteractiveArtifacts {
 		return {
-			buildReportHtml: () => buildHtmlReport(this.reportArtifact),
+			buildReportHtml: () =>
+				buildHtmlReport(this.reportArtifact, {
+					telemetry: this.reportTelemetry,
+				}),
 			moduleGraph: () => this.reportArtifact.graph,
 			printSummary: () => {
 				printMonorepoReport(this.result.result, this.options.verbose, true);
@@ -521,6 +530,7 @@ export class MonorepoPipeline extends ScanPipeline {
 				this.allProviders.push(...outcome.reportProviders);
 				this.bootstrapRoots.push(...outcome.bootstrapRoots);
 				this.subProjectOptOut = outcome.subProjectOptOut;
+				this.reportTelemetry = outcome.reportTelemetry;
 				this.scopeWarnings.push(...outcome.scopeWarnings);
 				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
 			}
@@ -538,6 +548,7 @@ export class MonorepoPipeline extends ScanPipeline {
 			bootstrapRoots: this.bootstrapRoots,
 			allFiles: this.allFiles,
 			subProjectOptOut: this.subProjectOptOut,
+			reportTelemetry: this.reportTelemetry,
 			scopeWarnings: this.scopeWarnings,
 			resolvedMinimumScore: this.resolvedMinimumScore,
 		};
@@ -621,7 +632,10 @@ export class SingleProjectPipeline extends ScanPipeline {
 	/** What the post-scan menu needs, without re-scanning. */
 	get interactiveArtifacts(): InteractiveArtifacts {
 		return {
-			buildReportHtml: () => buildHtmlReport(this.reportArtifact),
+			buildReportHtml: () =>
+				buildHtmlReport(this.reportArtifact, {
+					telemetry: this.reportTelemetry,
+				}),
 			moduleGraph: () => this.reportArtifact.graph,
 			printSummary: () => {
 				printConsoleReport(this.result.result, this.options.verbose, true);
@@ -654,6 +668,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 				};
 				this.reportProviders = outcome.reportProviders;
 				this.bootstrapRoots = outcome.bootstrapRoots;
+				this.reportTelemetry = outcome.reportTelemetry;
 				this.scopeWarnings.push(...outcome.scopeWarnings);
 				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
 			}
@@ -670,6 +685,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 			reportProviders: this.reportProviders,
 			bootstrapRoots: this.bootstrapRoots,
 			result: this.result.result,
+			reportTelemetry: this.reportTelemetry,
 			schemaGraph: this.result.schemaGraph,
 			scopeWarnings: this.scopeWarnings,
 			resolvedMinimumScore: this.resolvedMinimumScore,

--- a/packages/nestjs-doctor/src/cli/worker-delegate.ts
+++ b/packages/nestjs-doctor/src/cli/worker-delegate.ts
@@ -32,6 +32,7 @@ export type ScanOutcome =
 			bootstrapRoots: string[];
 			allFiles: string[];
 			subProjectOptOut: boolean;
+			reportTelemetry: boolean;
 			scopeWarnings: string[];
 			resolvedMinimumScore?: number;
 	  }
@@ -43,6 +44,7 @@ export type ScanOutcome =
 			reportProviders: ReportProvider[];
 			bootstrapRoots: string[];
 			result: DiagnoseResult;
+			reportTelemetry: boolean;
 			schemaGraph: EngineResult["schemaGraph"];
 			scopeWarnings: string[];
 			resolvedMinimumScore?: number;

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -20,7 +20,7 @@ import {
 	resolveScanConfig,
 	type ScanConfig,
 } from "../engine/scanner.js";
-import { scanTelemetryEnabled } from "../telemetry/send.js";
+import { reportTelemetryEnabled } from "../telemetry/send.js";
 import { spinner } from "../ui/spinner.js";
 import { buildReportArtifact, collectScanFacts } from "./artifact.js";
 import { buildHtmlReport } from "./html-report.js";
@@ -62,11 +62,7 @@ abstract class ReportPipeline {
 	 * each disable the beacon on their own.
 	 */
 	protected get telemetryEnabled(): boolean {
-		const config = this.scanConfig?.config;
-		return (
-			scanTelemetryEnabled(this.telemetry, config, process.env, "always") &&
-			config?.report?.telemetry !== false
-		);
+		return reportTelemetryEnabled(this.telemetry, this.scanConfig?.config);
 	}
 
 	abstract buildContext(): this;

--- a/packages/nestjs-doctor/src/telemetry/send.ts
+++ b/packages/nestjs-doctor/src/telemetry/send.ts
@@ -27,6 +27,18 @@ export function scanTelemetryEnabled(
 	return config?.telemetry !== false;
 }
 
+/** Whether a generated report may embed its beacon: the scan gate plus `report.telemetry`. */
+export function reportTelemetryEnabled(
+	flag: boolean,
+	config: NestjsDoctorConfig | undefined,
+	env: NodeJS.ProcessEnv = process.env
+): boolean {
+	return (
+		scanTelemetryEnabled(flag, config, env, "always") &&
+		config?.report?.telemetry !== false
+	);
+}
+
 /** Runs in a detached child, so a stalled network cannot hold the scan open. */
 const CHILD_SCRIPT = `
 const body = process.argv[1];

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nest12-esm-app",
+  "version": "1.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "dependencies": {
+    "@nestjs/common": "^12.0.1",
+    "@nestjs/core": "^12.0.1",
+    "@nestjs/observe": "^12.0.1",
+    "@nestjs/platform-express": "^12.0.1",
+    "zod": "^4.1.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { CoreModule } from "./core/core.module.js";
+import { ObserveModule } from "./observe.js";
+import { OrdersModule } from "./orders/orders.module.js";
+import { UsersModule } from "./users/users.module.js";
+
+@Module({
+  imports: [ObserveModule, CoreModule, UsersModule, OrdersModule],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/auth/auth.guard.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/auth/auth.guard.ts
@@ -1,0 +1,17 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  Injectable,
+} from "@nestjs/common";
+
+interface AuthorizedRequest {
+  headers: Record<string, string | undefined>;
+}
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<AuthorizedRequest>();
+    return typeof request.headers.authorization === "string";
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/core/config.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/core/config.ts
@@ -1,0 +1,10 @@
+export const APP_CONFIG = Symbol("APP_CONFIG");
+
+export interface AppConfig {
+  readonly currency: string;
+  readonly maxOrderLines: number;
+}
+
+export function loadConfig(): AppConfig {
+  return { currency: "USD", maxOrderLines: 50 };
+}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/core/core.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/core/core.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from "@nestjs/common";
+import { APP_CONFIG, loadConfig } from "./config.js";
+
+@Global()
+@Module({
+  providers: [{ provide: APP_CONFIG, useFactory: loadConfig }],
+  exports: [APP_CONFIG],
+})
+export class CoreModule {}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/main.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/main.ts
@@ -1,0 +1,17 @@
+import { StandardSchemaValidationPipe } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module.js";
+import { ObserveInstrument } from "./observe.js";
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule, {
+    instrument: ObserveInstrument,
+    routeConflictPolicy: { duplicate: "error", shadow: "warn" },
+    routeResolutionStrategy: "specificity",
+  });
+  app.useGlobalPipes(new StandardSchemaValidationPipe());
+  app.enableShutdownHooks();
+  await app.listen(3000);
+}
+
+await bootstrap();

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/observe.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/observe.ts
@@ -1,0 +1,3 @@
+import { createObserveModule } from "@nestjs/observe";
+
+export const { ObserveModule, ObserveInstrument } = createObserveModule();

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/orders/orders.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/orders/orders.controller.ts
@@ -1,0 +1,32 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { AuthGuard } from "../auth/auth.guard.js";
+import {
+  type CreateOrder,
+  createOrderSchema,
+  type ListOrdersQuery,
+  listOrdersQuerySchema,
+} from "./orders.schemas.js";
+import { OrdersService } from "./orders.service.js";
+
+@Controller("orders")
+@UseGuards(AuthGuard)
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Get()
+  list(@Query({ schema: listOrdersQuerySchema }) query: ListOrdersQuery) {
+    return this.ordersService.list(query);
+  }
+
+  @Post()
+  create(@Body({ schema: createOrderSchema }) body: CreateOrder) {
+    return this.ordersService.create(body);
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/orders/orders.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/orders/orders.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { UsersModule } from "../users/users.module.js";
+import { OrdersController } from "./orders.controller.js";
+import { OrdersService } from "./orders.service.js";
+
+@Module({
+  imports: [UsersModule],
+  controllers: [OrdersController],
+  providers: [OrdersService],
+})
+export class OrdersModule {}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/orders/orders.schemas.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/orders/orders.schemas.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const listOrdersQuerySchema = z.object({
+  userId: z.coerce.number().int().positive(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export const createOrderSchema = z.object({
+  userId: z.number().int().positive(),
+  lines: z
+    .array(
+      z.object({
+        sku: z.string().min(1),
+        quantity: z.number().int().positive(),
+      })
+    )
+    .min(1),
+});
+
+export type ListOrdersQuery = z.infer<typeof listOrdersQuerySchema>;
+export type CreateOrder = z.infer<typeof createOrderSchema>;

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/orders/orders.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/orders/orders.service.ts
@@ -1,0 +1,60 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  type OnApplicationShutdown,
+  type OnModuleInit,
+} from "@nestjs/common";
+import { APP_CONFIG, type AppConfig } from "../core/config.js";
+import { UsersService } from "../users/users.service.js";
+import type { CreateOrder, ListOrdersQuery } from "./orders.schemas.js";
+
+export interface OrderRecord {
+  id: number;
+  userId: number;
+  currency: string;
+  lines: CreateOrder["lines"];
+}
+
+@Injectable()
+export class OrdersService implements OnModuleInit, OnApplicationShutdown {
+  private readonly orders: OrderRecord[] = [];
+  private accepting = false;
+
+  constructor(
+    private readonly usersService: UsersService,
+    @Inject(APP_CONFIG) private readonly config: AppConfig
+  ) {}
+
+  onModuleInit(): void {
+    this.accepting = true;
+  }
+
+  onApplicationShutdown(): void {
+    this.accepting = false;
+  }
+
+  async create(input: CreateOrder): Promise<OrderRecord> {
+    if (!this.accepting) {
+      throw new BadRequestException("Orders are not being accepted");
+    }
+    if (input.lines.length > this.config.maxOrderLines) {
+      throw new BadRequestException("Too many order lines");
+    }
+    const user = await this.usersService.findOne(input.userId);
+    const order: OrderRecord = {
+      id: this.orders.length + 1,
+      userId: user.id,
+      currency: this.config.currency,
+      lines: input.lines,
+    };
+    this.orders.push(order);
+    return order;
+  }
+
+  list(query: ListOrdersQuery): OrderRecord[] {
+    return this.orders
+      .filter((order) => order.userId === query.userId)
+      .slice(0, query.limit);
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "../auth/auth.guard.js";
+import {
+  type CreateUser,
+  createUserSchema,
+  userIdSchema,
+} from "./users.schemas.js";
+import { UsersService } from "./users.service.js";
+
+@Controller("users")
+@UseGuards(AuthGuard)
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post()
+  create(@Body({ schema: createUserSchema }) body: CreateUser) {
+    return this.usersService.create(body);
+  }
+
+  @Get(":id")
+  findOne(@Param("id", { schema: userIdSchema }) id: number) {
+    return this.usersService.findOne(id);
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.module.ts
@@ -1,0 +1,17 @@
+import { Module } from "@nestjs/common";
+import { UsersController } from "./users.controller.js";
+import {
+  InMemoryUsersRepository,
+  USERS_REPOSITORY,
+} from "./users.repository.js";
+import { UsersService } from "./users.service.js";
+
+@Module({
+  controllers: [UsersController],
+  providers: [
+    UsersService,
+    { provide: USERS_REPOSITORY, useClass: InMemoryUsersRepository },
+  ],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.repository.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.repository.ts
@@ -1,0 +1,29 @@
+import { Injectable } from "@nestjs/common";
+
+export const USERS_REPOSITORY = Symbol("USERS_REPOSITORY");
+
+export interface UserRecord {
+  id: number;
+  email: string;
+  displayName: string;
+}
+
+export interface UsersRepository {
+  findById(id: number): Promise<UserRecord | undefined>;
+  insert(user: Omit<UserRecord, "id">): Promise<UserRecord>;
+}
+
+@Injectable()
+export class InMemoryUsersRepository implements UsersRepository {
+  private readonly rows = new Map<number, UserRecord>();
+
+  findById(id: number): Promise<UserRecord | undefined> {
+    return Promise.resolve(this.rows.get(id));
+  }
+
+  insert(user: Omit<UserRecord, "id">): Promise<UserRecord> {
+    const record = { id: this.rows.size + 1, ...user };
+    this.rows.set(record.id, record);
+    return Promise.resolve(record);
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.schemas.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.schemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  displayName: z.string().min(2).max(80),
+});
+
+export const userIdSchema = z.coerce.number().int().positive();
+
+export type CreateUser = z.infer<typeof createUserSchema>;

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/src/users/users.service.ts
@@ -1,0 +1,26 @@
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
+import {
+  USERS_REPOSITORY,
+  type UserRecord,
+  type UsersRepository,
+} from "./users.repository.js";
+import type { CreateUser } from "./users.schemas.js";
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @Inject(USERS_REPOSITORY) private readonly users: UsersRepository
+  ) {}
+
+  async create(input: CreateUser): Promise<UserRecord> {
+    return await this.users.insert(input);
+  }
+
+  async findOne(id: number): Promise<UserRecord> {
+    const user = await this.users.findById(id);
+    if (!user) {
+      throw new NotFoundException(`User ${id} not found`);
+    }
+    return user;
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/tsconfig.json
+++ b/packages/nestjs-doctor/tests/fixtures/nest12-esm-app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2023",
+    "strict": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "verbatimModuleSyntax": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/nestjs-doctor/tests/integration/nest12-esm-app.test.ts
+++ b/packages/nestjs-doctor/tests/integration/nest12-esm-app.test.ts
@@ -1,0 +1,60 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	buildAnalysisContext,
+	diagnose,
+	resolveScanConfig,
+} from "../../src/engine/scanner.js";
+
+const FIXTURE = resolve(import.meta.dirname, "../fixtures/nest12-esm-app");
+const NEST_12 = /^12\./;
+
+async function scan() {
+	const scanConfig = await resolveScanConfig(FIXTURE);
+	const context = await buildAnalysisContext(FIXTURE, scanConfig);
+	return { context, output: await diagnose(context) };
+}
+
+describe("NestJS 12 ESM app", () => {
+	it("reads the framework major from package.json", async () => {
+		const { context } = await scan();
+		expect(context.project.nestVersion).toMatch(NEST_12);
+	});
+
+	it("resolves .js relative imports to the TypeScript modules", async () => {
+		const { context } = await scan();
+		const modules = context.moduleGraph.modules;
+		expect([...modules.keys()].sort()).toEqual([
+			"AppModule",
+			"CoreModule",
+			"OrdersModule",
+			"UsersModule",
+		]);
+		expect(modules.get("AppModule")?.imports).toEqual(
+			expect.arrayContaining(["CoreModule", "UsersModule", "OrdersModule"])
+		);
+		expect(modules.get("OrdersModule")?.imports).toContain("UsersModule");
+		expect(modules.get("UsersModule")?.exports).toContain("UsersService");
+	});
+
+	it("traces the schema-validated routes", async () => {
+		const { context } = await scan();
+		const routes = context.endpointGraph.endpoints
+			.map((endpoint) => `${endpoint.httpMethod} ${endpoint.routePath}`)
+			.sort();
+		expect(routes).toEqual([
+			"GET /orders",
+			"GET /users/:id",
+			"POST /orders",
+			"POST /users",
+		]);
+	});
+
+	it("reports nothing on Nest 12 idioms it should accept", async () => {
+		const { output } = await scan();
+		const findings = output.diagnostics.map(
+			(diagnostic) => `${diagnostic.rule}: ${diagnostic.message}`
+		);
+		expect(findings).toEqual([]);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/interactive-report-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/interactive-report-telemetry.test.ts
@@ -1,0 +1,85 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	MonorepoPipeline,
+	SingleProjectPipeline,
+} from "../../src/cli/pipeline.js";
+import type { PipelineOptions } from "../../src/cli/setup.js";
+import { detectMonorepo } from "../../src/engine/project-detector.js";
+
+const FIXTURES = resolve(import.meta.dirname, "../fixtures");
+
+/** A scan with every output and the spinner suppressed, telemetry declined. */
+const declinedOptions = (): PipelineOptions => ({
+	base: undefined,
+	blocking: "none",
+	changedFilesFrom: undefined,
+	configPath: undefined,
+	format: "console",
+	interactive: false,
+	isMachineReadable: true,
+	jsonCompact: false,
+	minScore: undefined,
+	outputPath: undefined,
+	scope: "full",
+	score: false,
+	shareCode: false,
+	shareSections: undefined,
+	skipOutput: true,
+	sources: "all",
+	staged: false,
+	telemetry: false,
+	verbose: false,
+});
+
+const BEACON_MARKERS = ["posthog", "report_opened", "window.__ndTrack ="];
+
+describe("interactive report telemetry", () => {
+	it("omits the beacon from a single-project menu report under --no-telemetry", async () => {
+		const pipeline = new SingleProjectPipeline(
+			resolve(FIXTURES, "basic-app"),
+			declinedOptions()
+		);
+		await pipeline
+			.resolveConfig()
+			.buildContext()
+			.runRules()
+			.buildResult()
+			.applyScope()
+			.output()
+			.run();
+
+		const html = pipeline.interactiveArtifacts.buildReportHtml();
+		expect(html).toContain("<html");
+		for (const marker of BEACON_MARKERS) {
+			expect(html).not.toContain(marker);
+		}
+	});
+
+	it("omits the beacon from a monorepo menu report under --no-telemetry", async () => {
+		const targetPath = resolve(FIXTURES, "monorepo-app");
+		const monorepo = await detectMonorepo(targetPath);
+		if (!monorepo) {
+			throw new Error("monorepo-app fixture was not detected as a monorepo");
+		}
+		const pipeline = new MonorepoPipeline(
+			targetPath,
+			monorepo,
+			declinedOptions()
+		);
+		await pipeline
+			.resolveConfig()
+			.buildContext()
+			.runRules()
+			.buildResult()
+			.applyScope()
+			.output()
+			.run();
+
+		const html = pipeline.interactiveArtifacts.buildReportHtml();
+		expect(html).toContain("<html");
+		for (const marker of BEACON_MARKERS) {
+			expect(html).not.toContain(marker);
+		}
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
@@ -7,7 +7,10 @@ import {
 	buildScanPayload,
 	type ScanFacts,
 } from "../../src/telemetry/scan-telemetry.js";
-import { scanTelemetryEnabled } from "../../src/telemetry/send.js";
+import {
+	reportTelemetryEnabled,
+	scanTelemetryEnabled,
+} from "../../src/telemetry/send.js";
 
 const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
 	rule: "performance/no-unused-providers",
@@ -320,5 +323,23 @@ describe("scan telemetry gating", () => {
 		expect(on(true, undefined, { DO_NOT_TRACK: "1" })).toBe(false);
 		// Set-but-off is not a request to stop.
 		expect(on(true, undefined, { DO_NOT_TRACK: "0" })).toBe(true);
+	});
+});
+
+describe("report telemetry gating", () => {
+	it("follows the scan gate and adds the report.telemetry key", () => {
+		expect(reportTelemetryEnabled(true, undefined, {})).toBe(true);
+		expect(reportTelemetryEnabled(false, undefined, {})).toBe(false);
+		expect(reportTelemetryEnabled(true, { telemetry: false }, {})).toBe(false);
+		expect(
+			reportTelemetryEnabled(true, { report: { telemetry: false } }, {})
+		).toBe(false);
+		expect(reportTelemetryEnabled(true, undefined, { DO_NOT_TRACK: "1" })).toBe(
+			false
+		);
+	});
+
+	it("does not need a compiled key: the beacon has its own", () => {
+		expect(reportTelemetryEnabled(true, { telemetry: true }, {})).toBe(true);
 	});
 });

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -16,6 +16,10 @@ No config file, nothing to set up. It reads your TypeScript, runs 52 rules, and
 prints a score out of 100. Your code never leaves the machine; the scan reports
 only anonymous rule counts.
 
+A clean scan prints the score and nothing else. That is the expected result on
+a project the rules already agree with, and [the report](/docs/report) still
+draws the module graph, the traced endpoints and the schema diagram.
+
 ![CLI output](/cli-output.png)
 
 ## Reading the output


### PR DESCRIPTION

## Problem

`buildReportHtml` called `buildHtmlReport(this.reportArtifact)` with no options in both pipelines (`src/cli/pipeline.ts`, the two `interactiveArtifacts` getters). `buildHtmlReport` embeds the beacon unless `options.telemetry === false`. So a report generated from the menu carried the PostHog beacon under every opt-out, while the same report generated with `--report` did not.

The decision could not be made where the call sits: in worker mode the main thread never holds `scanConfig`, so the sub-project opt-out and the config keys were out of reach.


| Case | Before | After |
|---|---|---|
| Menu report, `--no-telemetry` | beacon embedded | no beacon |
| Menu report, `DO_NOT_TRACK=1` | beacon embedded | no beacon |
| Menu report, `report.telemetry: false` in config | beacon embedded | no beacon |
| Menu report, telemetry allowed | beacon embedded | beacon embedded |
| `--report` flag or API, any of the above | correct | correct, same code path |
| Scan of `nest12-esm-app` | no fixture | 4 modules, 4 routes, `nestVersion` `12.0.1`, 0 findings |

