### PR TITLE
feat(telemetry): per-repo CI identity, first-run notice, debug switch, docs page, one tagline

### DIFF
--- a/.changeset/tagline-one-string.md
+++ b/.changeset/tagline-one-string.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+One tagline everywhere the package describes itself. The npm description, the `--help` header and the agent skill's opening line now all lead with "The deterministic NestJS devtool that catches AI mistakes." The `--help` header also loses its em dash.

--- a/.changeset/tagline-vscode.md
+++ b/.changeset/tagline-vscode.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor-vscode": patch
+---
+
+Extension description matches the tagline the rest of the project uses.

--- a/.changeset/tagline-vscode.md
+++ b/.changeset/tagline-vscode.md
@@ -2,4 +2,4 @@
 "nestjs-doctor-vscode": patch
 ---
 
-Extension description matches the tagline the rest of the project uses.
+The extension's marketplace description and its README both lead with the tagline the rest of the project uses.

--- a/.changeset/telemetry-norm-engine.md
+++ b/.changeset/telemetry-norm-engine.md
@@ -1,0 +1,13 @@
+---
+"nestjs-doctor": minor
+---
+
+Bring scan telemetry up to the norm other JS CLIs follow.
+
+A scan run in CI now reports as `ci.<provider>.<hash>`, where the hash is a one-way digest of the numeric repository id the runner provides (`GITHUB_REPOSITORY_ID`, falling back to the repository name, or `CI_PROJECT_ID` on GitLab). Every run of one repository counted as one anonymous install before, and every repository in CI shared a single id per provider. The salt ships in the package, so this id is pseudonymous rather than anonymous: it is derived from an opaque number, never from the repository name, the checkout path, a remote URL, or a commit sha, and no project id is sent from CI.
+
+The first scan that reports now prints one line on stderr naming what is sent and the three ways to turn it off: `--no-telemetry`, `"telemetry": false` in the config, and `DO_NOT_TRACK=1`. It is never printed in CI or in a machine-readable format.
+
+`NESTJS_DOCTOR_TELEMETRY_DEBUG=1` prints the exact payload to stderr and sends nothing, so what a scan reports can be read before it leaves the machine.
+
+The `--telemetry` help text and the GitHub Action's `telemetry` input now name all three opt-outs, the debug variable, and the repository hash.

--- a/.changeset/telemetry-norm-engine.md
+++ b/.changeset/telemetry-norm-engine.md
@@ -4,7 +4,7 @@
 
 Bring scan telemetry up to the norm other JS CLIs follow.
 
-A scan run in CI now reports as `ci.<provider>.<hash>`, where the hash is a one-way digest of the numeric repository id the runner provides (`GITHUB_REPOSITORY_ID`, falling back to the repository name, or `CI_PROJECT_ID` on GitLab). Every run of one repository counted as one anonymous install before, and every repository in CI shared a single id per provider. The salt ships in the package, so this id is pseudonymous rather than anonymous: it is derived from an opaque number, never from the repository name, the checkout path, a remote URL, or a commit sha, and no project id is sent from CI.
+A scan run in CI now reports as `ci.<provider>.<hash>`, where the hash is a one-way digest of the numeric repository id the runner provides (`GITHUB_REPOSITORY_ID`, or `CI_PROJECT_ID` on GitLab). Every run of one repository counted as one anonymous install before, and every repository in CI shared a single id per provider. The salt ships in the package, so this id is pseudonymous rather than anonymous: it is derived from an opaque number, never from the repository name, the checkout path, a remote URL, or a commit sha, and no project id is sent from CI.
 
 The first scan that reports now prints one line on stderr naming what it reported and the three ways to turn it off: `--no-telemetry`, `"telemetry": false` in the config, and `DO_NOT_TRACK=1`. An interactive run prints it beside the summary the menu leaves behind, so the alternate screen cannot swallow it. It is never printed in CI, in a machine-readable format, or on a machine where the install id could not be written — that id is regenerated per run, so the line would otherwise repeat forever.
 

--- a/.changeset/telemetry-norm-engine.md
+++ b/.changeset/telemetry-norm-engine.md
@@ -6,8 +6,8 @@ Bring scan telemetry up to the norm other JS CLIs follow.
 
 A scan run in CI now reports as `ci.<provider>.<hash>`, where the hash is a one-way digest of the numeric repository id the runner provides (`GITHUB_REPOSITORY_ID`, falling back to the repository name, or `CI_PROJECT_ID` on GitLab). Every run of one repository counted as one anonymous install before, and every repository in CI shared a single id per provider. The salt ships in the package, so this id is pseudonymous rather than anonymous: it is derived from an opaque number, never from the repository name, the checkout path, a remote URL, or a commit sha, and no project id is sent from CI.
 
-The first scan that reports now prints one line on stderr naming what is sent and the three ways to turn it off: `--no-telemetry`, `"telemetry": false` in the config, and `DO_NOT_TRACK=1`. It is never printed in CI or in a machine-readable format.
+The first scan that reports now prints one line on stderr naming what it reported and the three ways to turn it off: `--no-telemetry`, `"telemetry": false` in the config, and `DO_NOT_TRACK=1`. An interactive run prints it beside the summary the menu leaves behind, so the alternate screen cannot swallow it. It is never printed in CI, in a machine-readable format, or on a machine where the install id could not be written — that id is regenerated per run, so the line would otherwise repeat forever.
 
-`NESTJS_DOCTOR_TELEMETRY_DEBUG=1` prints the exact payload to stderr and sends nothing, so what a scan reports can be read before it leaves the machine.
+`NESTJS_DOCTOR_TELEMETRY_DEBUG=1` prints the exact scan payload to stderr and sends nothing, so what a scan reports can be read before it leaves the machine.
 
 The `--telemetry` help text and the GitHub Action's `telemetry` input now name all three opt-outs, the debug variable, and the repository hash.

--- a/.changeset/telemetry-norm-lsp.md
+++ b/.changeset/telemetry-norm-lsp.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor-lsp": patch
+---
+
+`NESTJS_DOCTOR_TELEMETRY_DEBUG=1` prints the language server's telemetry payload to stderr and sends nothing.

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     description: "Token used to comment and set the commit status. The default posts as github-actions[bot], with GitHub's own avatar; a GitHub App installation token or a bot account's PAT posts under that identity's name and picture instead."
     default: ${{ github.token }}
   telemetry:
-    description: "Report anonymously after the scan: which built-in rules fired, the score, well-known dependencies, the config's shape, the scope and blocking level used, and how this run was triggered (the event, and which of this action's own inputs are on). Never your code, paths, repository, or organization. Set to false, or set `DO_NOT_TRACK: \"1\"` on the job, to turn it off."
+    description: "Report anonymously after the scan: which built-in rules fired, the score, well-known dependencies, the config's shape, the scope and blocking level used, how this run was triggered (the event, and which of this action's own inputs are on), and a one-way hash of your repository id so repeated runs count as one repository. Never your code, paths, repository name, or organization. Set to false, or set `DO_NOT_TRACK: \"1\"` on the job, to turn it off. Set `NESTJS_DOCTOR_TELEMETRY_DEBUG: \"1\"` to print the payload instead of sending it. https://nestjs.doctor/docs/telemetry"
     default: "true"
   node-version:
     description: "Node.js version to use"

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     description: "Token used to comment and set the commit status. The default posts as github-actions[bot], with GitHub's own avatar; a GitHub App installation token or a bot account's PAT posts under that identity's name and picture instead."
     default: ${{ github.token }}
   telemetry:
-    description: "Report anonymously after the scan: which built-in rules fired, the score, well-known dependencies, the config's shape, the scope and blocking level used, how this run was triggered (the event, and which of this action's own inputs are on), and a one-way hash of your repository id so repeated runs count as one repository. Never your code, paths, repository name, or organization. Set to false, or set `DO_NOT_TRACK: \"1\"` on the job, to turn it off. Set `NESTJS_DOCTOR_TELEMETRY_DEBUG: \"1\"` to print the payload instead of sending it. https://nestjs.doctor/docs/telemetry"
+    description: "Report anonymously after the scan: which built-in rules fired, the score, well-known dependencies, the config's shape, the scope and blocking level used, how this run was triggered (the event, and which of this action's own inputs are on), and a one-way hash of your repository id so repeated runs count as one repository. Never your code, paths, repository name, or organization. Set to false, or set `DO_NOT_TRACK: \"1\"` on the job, to turn it off. Set `NESTJS_DOCTOR_TELEMETRY_DEBUG: \"1\"` to print the scan payload instead of sending it. https://nestjs.doctor/docs/telemetry"
     default: "true"
   node-version:
     description: "Node.js version to use"

--- a/packages/nestjs-doctor-lsp/src/telemetry.ts
+++ b/packages/nestjs-doctor-lsp/src/telemetry.ts
@@ -135,11 +135,14 @@ export function resolveIdentity(
 		anonymousId: randomUUID(),
 		salt: randomUUID(),
 	};
-	try {
-		mkdirSync(dirname(file), { recursive: true });
-		writeFileSync(file, `${JSON.stringify(created, null, 2)}\n`, "utf-8");
-	} catch {
-		// A read-only home reports a per-run id.
+	// A debug run sends nothing, so it leaves no store behind either.
+	if (!isSet(env.NESTJS_DOCTOR_TELEMETRY_DEBUG)) {
+		try {
+			mkdirSync(dirname(file), { recursive: true });
+			writeFileSync(file, `${JSON.stringify(created, null, 2)}\n`, "utf-8");
+		} catch {
+			// A read-only home reports a per-run id.
+		}
 	}
 
 	return {

--- a/packages/nestjs-doctor-lsp/src/telemetry.ts
+++ b/packages/nestjs-doctor-lsp/src/telemetry.ts
@@ -206,24 +206,21 @@ req.end(body);
 export function sendLspEvent(
 	event: string,
 	distinctId: string,
-	properties: Record<string, unknown>
+	properties: Record<string, unknown>,
+	env: NodeJS.ProcessEnv = process.env
 ): void {
 	if (!POSTHOG_KEY) {
+		return;
+	}
+	const body = { event, distinct_id: distinctId, properties };
+	if (isSet(env.NESTJS_DOCTOR_TELEMETRY_DEBUG)) {
+		process.stderr.write(`${JSON.stringify(body, null, 2)}\n`);
 		return;
 	}
 	try {
 		const child = spawn(
 			process.execPath,
-			[
-				"-e",
-				CHILD_SCRIPT,
-				JSON.stringify({
-					api_key: POSTHOG_KEY,
-					event,
-					distinct_id: distinctId,
-					properties,
-				}),
-			],
+			["-e", CHILD_SCRIPT, JSON.stringify({ api_key: POSTHOG_KEY, ...body })],
 			{ detached: true, stdio: "ignore", windowsHide: true }
 		);
 		child.on("error", () => {

--- a/packages/nestjs-doctor-lsp/tests/telemetry.test.ts
+++ b/packages/nestjs-doctor-lsp/tests/telemetry.test.ts
@@ -30,10 +30,10 @@ const workspace = (config?: Record<string, unknown>): string => {
 	return dir;
 };
 
-const home = (): NodeJS.ProcessEnv => {
+const home = (extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => {
 	const dir = mkdtempSync(join(tmpdir(), "nd-lsp-home-"));
 	dirs.push(dir);
-	return { NESTJS_DOCTOR_CONFIG_DIR: dir };
+	return { NESTJS_DOCTOR_CONFIG_DIR: dir, ...extra };
 };
 
 afterAll(() => {
@@ -98,6 +98,14 @@ describe("lsp identity", () => {
 
 		expect(resolveIdentity("/repo/a", env).anonymousId).toBe(
 			resolveIdentity("/repo/b", env).anonymousId
+		);
+	});
+
+	it("stores nothing under the debug switch", () => {
+		const env = home({ NESTJS_DOCTOR_TELEMETRY_DEBUG: "1" });
+
+		expect(resolveIdentity("/repo/a", env).anonymousId).not.toBe(
+			resolveIdentity("/repo/a", env).anonymousId
 		);
 	});
 

--- a/packages/nestjs-doctor-lsp/tests/telemetry.test.ts
+++ b/packages/nestjs-doctor-lsp/tests/telemetry.test.ts
@@ -1,8 +1,17 @@
+import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
-import { lspTelemetryEnabled, resolveIdentity } from "../src/telemetry.js";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	lspTelemetryEnabled,
+	resolveIdentity,
+	sendLspEvent,
+} from "../src/telemetry.js";
+
+vi.mock("node:child_process", () => ({
+	spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+}));
 
 const dirs: string[] = [];
 
@@ -124,5 +133,45 @@ describe("lsp identity", () => {
 		expect(first.anonymousId).not.toMatch(CI_PREFIX);
 		expect(again.anonymousId).toBe(first.anonymousId);
 		expect(again.projectId).toBe(first.projectId);
+	});
+});
+
+describe("lsp telemetry debug switch", () => {
+	const written: string[] = [];
+
+	const captureStderr = () =>
+		vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+			written.push(String(chunk));
+			return true;
+		});
+
+	beforeEach(() => {
+		written.length = 0;
+		vi.mocked(spawn).mockClear();
+	});
+
+	it("prints the payload instead of spawning a sender", () => {
+		const stderr = captureStderr();
+
+		sendLspEvent(
+			"lsp_session",
+			"anon-1",
+			{ files_open: 2 },
+			{ NESTJS_DOCTOR_TELEMETRY_DEBUG: "1" }
+		);
+		stderr.mockRestore();
+
+		expect(spawn).not.toHaveBeenCalled();
+		expect(JSON.parse(written.join(""))).toEqual({
+			event: "lsp_session",
+			distinct_id: "anon-1",
+			properties: { files_open: 2 },
+		});
+	});
+
+	it("spawns the sender when the switch is off", () => {
+		sendLspEvent("lsp_session", "anon-1", { files_open: 2 }, {});
+
+		expect(spawn).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/nestjs-doctor-vscode/README.md
+++ b/packages/nestjs-doctor-vscode/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <b>Static analysis for NestJS — inline diagnostics and health score, right in your editor.</b>
+  <b>The deterministic NestJS devtool that catches AI mistakes.</b>
 </p>
 
 <p align="center">

--- a/packages/nestjs-doctor-vscode/package.json
+++ b/packages/nestjs-doctor-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "NestJS Doctor",
   "version": "0.1.4",
   "private": true,
-  "description": "Static analysis for NestJS — inline diagnostics and health score",
+  "description": "The deterministic NestJS devtool that catches AI mistakes. Inline diagnostics and a health score in your editor.",
   "categories": [
     "Linters"
   ],

--- a/packages/nestjs-doctor/package.json
+++ b/packages/nestjs-doctor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestjs-doctor",
   "version": "0.9.5",
-  "description": "Static analysis tool for NestJS that produces a health score with actionable diagnostics and an interactive report",
+  "description": "The deterministic NestJS devtool that catches AI mistakes. Static analysis for NestJS with a health score, diagnostics and an interactive report.",
   "keywords": [
     "nestjs",
     "nest",

--- a/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
+++ b/packages/nestjs-doctor/skills/nestjs-doctor/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: Bash, Read, Edit, Glob, Grep, Write
 
 > v0.0.0
 
+The deterministic NestJS devtool that catches AI mistakes.
+
 52 rules over security, correctness, architecture, performance, and database
 schema, scored 0-100. No model at scan time and nothing about your code leaves
 the machine, so the same

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -76,7 +76,7 @@ export const flags = {
 		description:
 			"Report anonymously after a scan: which built-in rules fired, the score, well-known dependencies, the config's shape, the scope and blocking level you ran with, and in CI how the run was triggered plus a one-way hash of the repository id. Never your code, paths, project name, or custom rule names. See https://nestjs.doctor/docs/telemetry",
 		negativeDescription:
-			'Scan and generate the report without reporting anything; DO_NOT_TRACK=1 and "telemetry": false in the config do the same, and NESTJS_DOCTOR_TELEMETRY_DEBUG=1 prints the payload instead of sending it',
+			'Scan and generate the report without reporting anything; DO_NOT_TRACK=1 and "telemetry": false in the config do the same, and NESTJS_DOCTOR_TELEMETRY_DEBUG=1 prints the scan payload instead of sending it',
 		default: true,
 	},
 	timings: {

--- a/packages/nestjs-doctor/src/cli/flags.ts
+++ b/packages/nestjs-doctor/src/cli/flags.ts
@@ -74,9 +74,9 @@ export const flags = {
 	telemetry: {
 		type: "boolean",
 		description:
-			"Report anonymously after a scan: which built-in rules fired, the score, well-known dependencies, the config's shape, the scope and blocking level you ran with, and in CI how the run was triggered. Never your code, paths, project name, or custom rule names",
+			"Report anonymously after a scan: which built-in rules fired, the score, well-known dependencies, the config's shape, the scope and blocking level you ran with, and in CI how the run was triggered plus a one-way hash of the repository id. Never your code, paths, project name, or custom rule names. See https://nestjs.doctor/docs/telemetry",
 		negativeDescription:
-			"Scan and generate the report without reporting anything",
+			'Scan and generate the report without reporting anything; DO_NOT_TRACK=1 and "telemetry": false in the config do the same, and NESTJS_DOCTOR_TELEMETRY_DEBUG=1 prints the payload instead of sending it',
 		default: true,
 	},
 	timings: {

--- a/packages/nestjs-doctor/src/cli/index.ts
+++ b/packages/nestjs-doctor/src/cli/index.ts
@@ -29,7 +29,7 @@ const main = defineCommand({
 		name: "nestjs-doctor",
 		version,
 		description:
-			"Static analysis tool for NestJS — health score, diagnostics, and interactive HTML report.\nCommands: ci install (scaffold .github/workflows/nestjs-doctor.yml)",
+			"The deterministic NestJS devtool that catches AI mistakes.\nCommands: ci install (scaffold .github/workflows/nestjs-doctor.yml)",
 	},
 	args: {
 		path: {

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -76,7 +76,7 @@ export const telemetryNoticeSite = (input: {
 	interactive: boolean;
 	isMachineReadable: boolean;
 }): "menu" | "none" | "run" => {
-	if (!(input.firstSend && !input.isMachineReadable)) {
+	if (!input.firstSend || input.isMachineReadable) {
 		return "none";
 	}
 	return input.interactive ? "menu" : "run";

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -66,6 +66,9 @@ import { createAnimatedProgress } from "./ui/animated-progress.js";
 
 type PipelineStep = () => void | Promise<void>;
 
+const TELEMETRY_NOTICE =
+	'nestjs-doctor reports each scan anonymously: which built-in rules fired, the score, well-known dependencies, and the shape of your config — never your code, paths, or project name. Turn it off with --no-telemetry, "telemetry": false in your config, or DO_NOT_TRACK=1. https://nestjs.doctor/docs/telemetry';
+
 const analysisLabel = (phase: AnalysisPhase): string => {
 	if (phase === "collecting") {
 		return "Collecting files";
@@ -123,6 +126,8 @@ abstract class ScanPipeline {
 	protected workerWarnings: string[] = [];
 	/** Set when any scanned sub-project declares its own opt-out. */
 	protected subProjectOptOut = false;
+	/** Set when this scan was the first telemetry send from this install. */
+	protected firstTelemetrySend = false;
 	/** Whether a report built from the menu may embed its beacon; decided with the config. */
 	protected reportTelemetry = false;
 	/** Warnings raised while narrowing the scope; surfaced alongside the report. */
@@ -145,7 +150,7 @@ abstract class ScanPipeline {
 		fileCount: number,
 		monorepo: boolean
 	): void {
-		reportScanTelemetry({
+		this.firstTelemetrySend = reportScanTelemetry({
 			blocking: this.options.blocking,
 			diagnostics,
 			fileCount,
@@ -250,6 +255,13 @@ abstract class ScanPipeline {
 			delta.introduced,
 			buildScopeInfo(scope, { baselineAvailable: true, fixed: delta.fixed })
 		);
+	}
+
+	/** One line, once per install, saying what a scan reports and how to stop it. */
+	protected printTelemetryNotice(): void {
+		if (this.firstTelemetrySend && !this.options.isMachineReadable) {
+			logger.warn(TELEMETRY_NOTICE);
+		}
 	}
 
 	/** Ends the spinner so nothing prints through an active frame. */
@@ -361,6 +373,7 @@ abstract class ScanPipeline {
 		} finally {
 			stopWatching();
 			this.stopProgress();
+			this.printTelemetryNotice();
 		}
 	}
 }
@@ -530,6 +543,7 @@ export class MonorepoPipeline extends ScanPipeline {
 				this.allProviders.push(...outcome.reportProviders);
 				this.bootstrapRoots.push(...outcome.bootstrapRoots);
 				this.subProjectOptOut = outcome.subProjectOptOut;
+				this.firstTelemetrySend = outcome.firstTelemetrySend;
 				this.reportTelemetry = outcome.reportTelemetry;
 				this.scopeWarnings.push(...outcome.scopeWarnings);
 				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
@@ -547,6 +561,7 @@ export class MonorepoPipeline extends ScanPipeline {
 			reportProviders: this.allProviders,
 			bootstrapRoots: this.bootstrapRoots,
 			allFiles: this.allFiles,
+			firstTelemetrySend: this.firstTelemetrySend,
 			subProjectOptOut: this.subProjectOptOut,
 			reportTelemetry: this.reportTelemetry,
 			scopeWarnings: this.scopeWarnings,
@@ -668,6 +683,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 				};
 				this.reportProviders = outcome.reportProviders;
 				this.bootstrapRoots = outcome.bootstrapRoots;
+				this.firstTelemetrySend = outcome.firstTelemetrySend;
 				this.reportTelemetry = outcome.reportTelemetry;
 				this.scopeWarnings.push(...outcome.scopeWarnings);
 				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
@@ -684,6 +700,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 			moduleGraph: this.result.moduleGraph,
 			reportProviders: this.reportProviders,
 			bootstrapRoots: this.bootstrapRoots,
+			firstTelemetrySend: this.firstTelemetrySend,
 			result: this.result.result,
 			reportTelemetry: this.reportTelemetry,
 			schemaGraph: this.result.schemaGraph,

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -67,7 +67,20 @@ import { createAnimatedProgress } from "./ui/animated-progress.js";
 type PipelineStep = () => void | Promise<void>;
 
 const TELEMETRY_NOTICE =
-	'nestjs-doctor reports each scan anonymously: which built-in rules fired, the score, well-known dependencies, and the shape of your config — never your code, paths, or project name. Turn it off with --no-telemetry, "telemetry": false in your config, or DO_NOT_TRACK=1. https://nestjs.doctor/docs/telemetry';
+	'nestjs-doctor reported this scan anonymously: which built-in rules fired, the score, well-known dependencies, and the shape of your config — never your code, paths, or project name. Turn it off with --no-telemetry, "telemetry": false in your config, or DO_NOT_TRACK=1. https://nestjs.doctor/docs/telemetry';
+
+/** Where the one-per-install notice prints. A menu draws in the alternate
+ * screen, so an interactive run waits for it to close. */
+export const telemetryNoticeSite = (input: {
+	firstSend: boolean;
+	interactive: boolean;
+	isMachineReadable: boolean;
+}): "menu" | "none" | "run" => {
+	if (!(input.firstSend && !input.isMachineReadable)) {
+		return "none";
+	}
+	return input.interactive ? "menu" : "run";
+};
 
 const analysisLabel = (phase: AnalysisPhase): string => {
 	if (phase === "collecting") {
@@ -257,9 +270,14 @@ abstract class ScanPipeline {
 		);
 	}
 
-	/** One line, once per install, saying what a scan reports and how to stop it. */
-	protected printTelemetryNotice(): void {
-		if (this.firstTelemetrySend && !this.options.isMachineReadable) {
+	/** One line, once per install, saying what this scan reported and how to stop it. */
+	protected printTelemetryNotice(site: "menu" | "run"): void {
+		const target = telemetryNoticeSite({
+			firstSend: this.firstTelemetrySend,
+			interactive: this.options.interactive,
+			isMachineReadable: this.options.isMachineReadable,
+		});
+		if (target === site) {
 			logger.warn(TELEMETRY_NOTICE);
 		}
 	}
@@ -373,7 +391,7 @@ abstract class ScanPipeline {
 		} finally {
 			stopWatching();
 			this.stopProgress();
-			this.printTelemetryNotice();
+			this.printTelemetryNotice("run");
 		}
 	}
 }
@@ -434,6 +452,7 @@ export class MonorepoPipeline extends ScanPipeline {
 			moduleGraph: () => this.reportArtifact.graph,
 			printSummary: () => {
 				printMonorepoReport(this.result.result, this.options.verbose, true);
+				this.printTelemetryNotice("menu");
 			},
 			result: this.result.result.combined,
 			subProjects: this.result.result.subProjects.map(({ name, result }) => ({
@@ -654,6 +673,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 			moduleGraph: () => this.reportArtifact.graph,
 			printSummary: () => {
 				printConsoleReport(this.result.result, this.options.verbose, true);
+				this.printTelemetryNotice("menu");
 			},
 			result: this.result.result,
 		};

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -69,8 +69,8 @@ type PipelineStep = () => void | Promise<void>;
 const TELEMETRY_NOTICE =
 	'nestjs-doctor reported this scan anonymously: which built-in rules fired, the score, well-known dependencies, and the shape of your config — never your code, paths, or project name. Turn it off with --no-telemetry, "telemetry": false in your config, or DO_NOT_TRACK=1. https://nestjs.doctor/docs/telemetry';
 
-/** Where the one-per-install notice prints. A menu draws in the alternate
- * screen, so an interactive run waits for it to close. */
+/** Where the one-per-install notice prints: after the menu closes on an
+ * interactive run, after the run otherwise. */
 export const telemetryNoticeSite = (input: {
 	firstSend: boolean;
 	interactive: boolean;

--- a/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
@@ -38,9 +38,8 @@ export interface ScanTelemetryInput {
 }
 
 /**
- * Reports the scan anonymously and returns whether that was this install's
- * first send. A failure here leaves the scan untouched, and the network call
- * runs in a detached child.
+ * Reports the scan anonymously from a detached child and returns whether that
+ * was this install's first send. A failure here leaves the scan untouched.
  */
 export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 	const isEnabled = input.isEnabled ?? scanTelemetryEnabled;
@@ -54,9 +53,11 @@ export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 	const env = input.env ?? process.env;
 	const hadStore = (input.hasStoredIdentityFn ?? hasStoredIdentity)(env);
 	let stored = false;
+	let sent = false;
 	try {
 		const identity = (input.resolveIdentityFn ?? resolveIdentity)(
-			input.targetPath
+			input.targetPath,
+			env
 		);
 		stored = identity.stored;
 		const scanConfig = input.scanConfig as ScanConfig;
@@ -67,7 +68,7 @@ export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 				...scanConfig.schemaRules,
 			].map((rule) => rule.meta.id)
 		);
-		(input.send ?? sendScanTelemetry)(
+		sent = (input.send ?? sendScanTelemetry)(
 			buildScanPayload({
 				action: actionContext(),
 				blocking: input.blocking,
@@ -99,5 +100,5 @@ export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 		// Reporting never breaks a scan.
 		return false;
 	}
-	return generatedIn(env) === "cli" && !hadStore && stored;
+	return generatedIn(env) === "cli" && !hadStore && stored && sent;
 };

--- a/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
@@ -50,16 +50,15 @@ export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 	) {
 		return false;
 	}
-	// Read the store before resolveIdentity writes one. CI keeps no store, so
-	// every run there would otherwise read as the first.
+	// Read before resolveIdentity, which writes the store.
 	const env = input.env ?? process.env;
-	const firstSend =
-		generatedIn(env) === "cli" &&
-		!(input.hasStoredIdentityFn ?? hasStoredIdentity)(env);
+	const hadStore = (input.hasStoredIdentityFn ?? hasStoredIdentity)(env);
+	let stored = false;
 	try {
 		const identity = (input.resolveIdentityFn ?? resolveIdentity)(
 			input.targetPath
 		);
+		stored = identity.stored;
 		const scanConfig = input.scanConfig as ScanConfig;
 		const enabled = new Set(
 			[
@@ -100,5 +99,5 @@ export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 		// Reporting never breaks a scan.
 		return false;
 	}
-	return firstSend;
+	return generatedIn(env) === "cli" && !hadStore && stored;
 };

--- a/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
@@ -5,7 +5,7 @@ import { allRules } from "../engine/rules/index.js";
 import type { ScanConfig } from "../engine/scanner.js";
 import { getEcosystem } from "../telemetry/ecosystem.js";
 import { actionContext, generatedIn } from "../telemetry/environment.js";
-import { resolveIdentity } from "../telemetry/install-id.js";
+import { hasStoredIdentity, resolveIdentity } from "../telemetry/install-id.js";
 import {
 	buildScanPayload,
 	readConfigFacts,
@@ -17,7 +17,11 @@ import { getCliVersion } from "./output.js";
 export interface ScanTelemetryInput {
 	blocking: BlockingLevel;
 	diagnostics: Diagnostic[];
+	/** Injectable for tests; defaults to the real environment. */
+	env?: NodeJS.ProcessEnv;
 	fileCount: number;
+	/** Injectable for tests; defaults to the read-only store check. */
+	hasStoredIdentityFn?: typeof hasStoredIdentity;
 	/** Injectable for tests; defaults to the compiled-in gating. */
 	isEnabled?: typeof scanTelemetryEnabled;
 	monorepo: boolean;
@@ -34,17 +38,24 @@ export interface ScanTelemetryInput {
 }
 
 /**
- * Reports the scan anonymously. A failure here leaves the scan untouched,
- * and the network call runs in a detached child.
+ * Reports the scan anonymously and returns whether that was this install's
+ * first send. A failure here leaves the scan untouched, and the network call
+ * runs in a detached child.
  */
-export const reportScanTelemetry = (input: ScanTelemetryInput): void => {
+export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 	const isEnabled = input.isEnabled ?? scanTelemetryEnabled;
 	if (
 		input.subProjectOptOut ||
 		!isEnabled(input.optionsTelemetry, input.scanConfig?.config)
 	) {
-		return;
+		return false;
 	}
+	// Read the store before resolveIdentity writes one. CI keeps no store, so
+	// every run there would otherwise read as the first.
+	const env = input.env ?? process.env;
+	const firstSend =
+		generatedIn(env) === "cli" &&
+		!(input.hasStoredIdentityFn ?? hasStoredIdentity)(env);
 	try {
 		const identity = (input.resolveIdentityFn ?? resolveIdentity)(
 			input.targetPath
@@ -87,5 +98,7 @@ export const reportScanTelemetry = (input: ScanTelemetryInput): void => {
 		);
 	} catch {
 		// Reporting never breaks a scan.
+		return false;
 	}
+	return firstSend;
 };

--- a/packages/nestjs-doctor/src/cli/worker-delegate.ts
+++ b/packages/nestjs-doctor/src/cli/worker-delegate.ts
@@ -31,6 +31,7 @@ export type ScanOutcome =
 			reportProviders: ReportProvider[];
 			bootstrapRoots: string[];
 			allFiles: string[];
+			firstTelemetrySend: boolean;
 			subProjectOptOut: boolean;
 			reportTelemetry: boolean;
 			scopeWarnings: string[];
@@ -43,6 +44,7 @@ export type ScanOutcome =
 			moduleGraph: EngineResult["moduleGraph"];
 			reportProviders: ReportProvider[];
 			bootstrapRoots: string[];
+			firstTelemetrySend: boolean;
 			result: DiagnoseResult;
 			reportTelemetry: boolean;
 			schemaGraph: EngineResult["schemaGraph"];

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -38,12 +38,34 @@ export function configDir(env: NodeJS.ProcessEnv = process.env): string {
 	);
 }
 
+// Shipped in the package, so a CI id is pseudonymous rather than anonymous.
+const CI_REPO_SALT = "nestjs-doctor.ci.v1";
+
+/** The repository the runner was given, preferring the id that survives a rename. */
+function repoKey(env: NodeJS.ProcessEnv): string | undefined {
+	const raw =
+		env.GITHUB_REPOSITORY_ID ?? env.GITHUB_REPOSITORY ?? env.CI_PROJECT_ID;
+	return raw?.trim().toLowerCase() || undefined;
+}
+
 /**
- * One id per CI provider, shared by every runner.
+ * One id per repository, or one per provider where none is named. Never
+ * derived from a path: a runner spells its checkout differently per platform.
  */
 function ciIdentity(env: NodeJS.ProcessEnv): string | undefined {
 	const provider = detectKnownCiProvider(env);
-	return provider ? `ci.${provider}` : undefined;
+	if (!provider) {
+		return undefined;
+	}
+	const repo = repoKey(env);
+	if (!repo) {
+		return `ci.${provider}`;
+	}
+	const hash = createHash("sha256")
+		.update(`${CI_REPO_SALT}:${repo}`)
+		.digest("hex")
+		.slice(0, 16);
+	return `ci.${provider}.${hash}`;
 }
 
 const readConfig = (file: string): StoredConfig | undefined => {
@@ -54,6 +76,13 @@ const readConfig = (file: string): StoredConfig | undefined => {
 		// A missing or corrupt store means no stored id.
 	}
 };
+
+/** Whether this install has stored an id, without creating one. */
+export function hasStoredIdentity(
+	env: NodeJS.ProcessEnv = process.env
+): boolean {
+	return readConfig(join(configDir(env), "telemetry.json")) !== undefined;
+}
 
 /** Reads the install id and salt, creating them on first run. */
 export function resolveIdentity(

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -42,9 +42,9 @@ export function configDir(env: NodeJS.ProcessEnv = process.env): string {
 
 const CI_REPO_SALT = "nestjs-doctor.ci.v1";
 
-/** The variables each provider uses to name a repository, in priority order. */
+/** The variables each provider uses for its numeric repository id. */
 const CI_REPO_VARS: Record<string, readonly string[]> = {
-	github: ["GITHUB_REPOSITORY_ID", "GITHUB_REPOSITORY"],
+	github: ["GITHUB_REPOSITORY_ID"],
 	gitlab: ["CI_PROJECT_ID"],
 };
 

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { dirname, join } from "node:path";
-import { detectKnownCiProvider } from "./environment.js";
+import { detectKnownCiProvider, isSet } from "./environment.js";
 
 interface TelemetryIdentity {
 	/** Stable per-install id, or a shared one per provider in CI. */
@@ -132,12 +132,15 @@ export function resolveIdentity(
 	};
 
 	let stored = false;
-	try {
-		mkdirSync(dirname(file), { recursive: true });
-		writeFileSync(file, `${JSON.stringify(created, null, 2)}\n`, "utf-8");
-		stored = true;
-	} catch {
-		// A read-only home reports a per-run id.
+	// A debug run sends nothing, so it leaves no store behind either.
+	if (!isSet(env.NESTJS_DOCTOR_TELEMETRY_DEBUG)) {
+		try {
+			mkdirSync(dirname(file), { recursive: true });
+			writeFileSync(file, `${JSON.stringify(created, null, 2)}\n`, "utf-8");
+			stored = true;
+		} catch {
+			// A read-only home reports a per-run id.
+		}
 	}
 
 	return {

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -9,6 +9,8 @@ interface TelemetryIdentity {
 	anonymousId: string;
 	/** Per-project, salted with a value that never leaves the machine. Absent under a known CI provider. */
 	projectId?: string;
+	/** Whether the id is the one on disk. False in CI and when the home is unwritable. */
+	stored: boolean;
 }
 
 interface StoredConfig {
@@ -38,26 +40,31 @@ export function configDir(env: NodeJS.ProcessEnv = process.env): string {
 	);
 }
 
-// Shipped in the package, so a CI id is pseudonymous rather than anonymous.
 const CI_REPO_SALT = "nestjs-doctor.ci.v1";
 
-/** The repository the runner was given, preferring the id that survives a rename. */
-function repoKey(env: NodeJS.ProcessEnv): string | undefined {
-	const raw =
-		env.GITHUB_REPOSITORY_ID ?? env.GITHUB_REPOSITORY ?? env.CI_PROJECT_ID;
-	return raw?.trim().toLowerCase() || undefined;
+/** The variables each provider uses to name a repository, in priority order. */
+const CI_REPO_VARS: Record<string, readonly string[]> = {
+	github: ["GITHUB_REPOSITORY_ID", "GITHUB_REPOSITORY"],
+	gitlab: ["CI_PROJECT_ID"],
+};
+
+function repoKey(provider: string, env: NodeJS.ProcessEnv): string | undefined {
+	for (const name of CI_REPO_VARS[provider] ?? []) {
+		const raw = env[name]?.trim().toLowerCase();
+		if (raw) {
+			return raw;
+		}
+	}
+	return undefined;
 }
 
-/**
- * One id per repository, or one per provider where none is named. Never
- * derived from a path: a runner spells its checkout differently per platform.
- */
+/** One id per repository, or one per provider that names none. */
 function ciIdentity(env: NodeJS.ProcessEnv): string | undefined {
 	const provider = detectKnownCiProvider(env);
 	if (!provider) {
 		return undefined;
 	}
-	const repo = repoKey(env);
+	const repo = repoKey(provider, env);
 	if (!repo) {
 		return `ci.${provider}`;
 	}
@@ -105,7 +112,7 @@ export function resolveIdentity(
 	if (ci) {
 		// No project id in CI: any salt shipped in the package makes a
 		// runner's checkout path guessable.
-		return { anonymousId: ci };
+		return { anonymousId: ci, stored: false };
 	}
 
 	const file = join(configDir(env), "telemetry.json");
@@ -115,6 +122,7 @@ export function resolveIdentity(
 		return {
 			anonymousId: existing.anonymousId,
 			projectId: salted(existing.salt),
+			stored: true,
 		};
 	}
 
@@ -123,9 +131,11 @@ export function resolveIdentity(
 		salt: randomUUID(),
 	};
 
+	let stored = false;
 	try {
 		mkdirSync(dirname(file), { recursive: true });
 		writeFileSync(file, `${JSON.stringify(created, null, 2)}\n`, "utf-8");
+		stored = true;
 	} catch {
 		// A read-only home reports a per-run id.
 	}
@@ -133,5 +143,6 @@ export function resolveIdentity(
 	return {
 		anonymousId: created.anonymousId,
 		projectId: salted(created.salt),
+		stored,
 	};
 }

--- a/packages/nestjs-doctor/src/telemetry/send.ts
+++ b/packages/nestjs-doctor/src/telemetry/send.ts
@@ -55,25 +55,27 @@ req.end(body);
 /** Hands the payload to a detached child, so the scan never waits on the network. */
 export function sendScanTelemetry(
 	payload: ScanPayload,
-	distinctId: string
+	distinctId: string,
+	env: NodeJS.ProcessEnv = process.env
 ): void {
 	if (!POSTHOG_KEY) {
+		return;
+	}
+
+	const body = {
+		event: "scan_completed",
+		distinct_id: distinctId,
+		properties: payload,
+	};
+	if (isSet(env.NESTJS_DOCTOR_TELEMETRY_DEBUG)) {
+		process.stderr.write(`${JSON.stringify(body, null, 2)}\n`);
 		return;
 	}
 
 	try {
 		const child = spawn(
 			process.execPath,
-			[
-				"-e",
-				CHILD_SCRIPT,
-				JSON.stringify({
-					api_key: POSTHOG_KEY,
-					event: "scan_completed",
-					distinct_id: distinctId,
-					properties: payload,
-				}),
-			],
+			["-e", CHILD_SCRIPT, JSON.stringify({ api_key: POSTHOG_KEY, ...body })],
 			{ detached: true, stdio: "ignore", windowsHide: true }
 		);
 		child.on("error", () => {

--- a/packages/nestjs-doctor/src/telemetry/send.ts
+++ b/packages/nestjs-doctor/src/telemetry/send.ts
@@ -52,14 +52,14 @@ req.on("timeout", () => req.destroy());
 req.end(body);
 `;
 
-/** Hands the payload to a detached child, so the scan never waits on the network. */
+/** Hands the payload to a detached child and returns whether one was started. */
 export function sendScanTelemetry(
 	payload: ScanPayload,
 	distinctId: string,
 	env: NodeJS.ProcessEnv = process.env
-): void {
+): boolean {
 	if (!POSTHOG_KEY) {
-		return;
+		return false;
 	}
 
 	const body = {
@@ -69,7 +69,7 @@ export function sendScanTelemetry(
 	};
 	if (isSet(env.NESTJS_DOCTOR_TELEMETRY_DEBUG)) {
 		process.stderr.write(`${JSON.stringify(body, null, 2)}\n`);
-		return;
+		return false;
 	}
 
 	try {
@@ -82,7 +82,9 @@ export function sendScanTelemetry(
 			// Best-effort; a scan never fails because of it.
 		});
 		child.unref();
+		return true;
 	} catch {
 		// Same for an environment that cannot spawn.
+		return false;
 	}
 }

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
@@ -28,7 +28,9 @@ const buildInput = (
 ): ScanTelemetryInput => ({
 	blocking: "error",
 	diagnostics: [],
+	env: {},
 	fileCount: 4,
+	hasStoredIdentityFn: () => false,
 	isEnabled: () => true,
 	monorepo: false,
 	optionsTelemetry: true,
@@ -123,7 +125,53 @@ describe("scan telemetry reporter", () => {
 			}),
 		});
 
-		expect(() => reportScanTelemetry(input)).not.toThrow();
+		expect(reportScanTelemetry(input)).toBe(false);
+	});
+
+	it("reports the first send an install ever makes", () => {
+		expect(reportScanTelemetry(buildInput())).toBe(true);
+	});
+
+	it("reports nothing new once the install has a stored id", () => {
+		expect(
+			reportScanTelemetry(buildInput({ hasStoredIdentityFn: () => true }))
+		).toBe(false);
+	});
+
+	it("reads the store before the identity resolver writes one", () => {
+		const order: string[] = [];
+		const input = buildInput({
+			hasStoredIdentityFn: vi.fn(() => {
+				order.push("read");
+				return false;
+			}),
+			resolveIdentityFn: vi.fn(() => {
+				order.push("resolve");
+				return { anonymousId: "anon-123" };
+			}),
+		});
+
+		reportScanTelemetry(input);
+
+		expect(order).toEqual(["read", "resolve"]);
+	});
+
+	it("announces no first send when nothing was sent", () => {
+		expect(reportScanTelemetry(buildInput({ isEnabled: () => false }))).toBe(
+			false
+		);
+		expect(reportScanTelemetry(buildInput({ subProjectOptOut: true }))).toBe(
+			false
+		);
+	});
+
+	it("announces no first send from CI, which stores no id", () => {
+		expect(reportScanTelemetry(buildInput({ env: { CI: "true" } }))).toBe(
+			false
+		);
+		expect(
+			reportScanTelemetry(buildInput({ env: { GITHUB_ACTIONS: "true" } }))
+		).toBe(false);
 	});
 
 	it("swallows a throw from resolving the identity", () => {
@@ -133,7 +181,7 @@ describe("scan telemetry reporter", () => {
 			}),
 		});
 
-		expect(() => reportScanTelemetry(input)).not.toThrow();
+		expect(reportScanTelemetry(input)).toBe(false);
 		expect(input.send).not.toHaveBeenCalled();
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { getCliVersion } from "../../src/cli/output.js";
+import { telemetryNoticeSite } from "../../src/cli/pipeline.js";
 import {
 	reportScanTelemetry,
 	type ScanTelemetryInput,
@@ -37,6 +38,7 @@ const buildInput = (
 	resolveIdentityFn: vi.fn(() => ({
 		anonymousId: "anon-123",
 		projectId: "proj-hash",
+		stored: true,
 	})),
 	result: { ...emptyResult(), elapsedMs: 12.7 },
 	scanConfig: scanConfigFixture(),
@@ -147,13 +149,25 @@ describe("scan telemetry reporter", () => {
 			}),
 			resolveIdentityFn: vi.fn(() => {
 				order.push("resolve");
-				return { anonymousId: "anon-123" };
+				return { anonymousId: "anon-123", stored: true };
 			}),
 		});
 
 		reportScanTelemetry(input);
 
 		expect(order).toEqual(["read", "resolve"]);
+	});
+
+	it("announces no first send when the id could not be stored", () => {
+		const input = buildInput({
+			resolveIdentityFn: vi.fn(() => ({
+				anonymousId: "anon-123",
+				stored: false,
+			})),
+		});
+
+		expect(reportScanTelemetry(input)).toBe(false);
+		expect(input.send).toHaveBeenCalledTimes(1);
 	});
 
 	it("announces no first send when nothing was sent", () => {
@@ -183,5 +197,32 @@ describe("scan telemetry reporter", () => {
 
 		expect(reportScanTelemetry(input)).toBe(false);
 		expect(input.send).not.toHaveBeenCalled();
+	});
+});
+
+describe("where the first-run notice prints", () => {
+	const site = (overrides: Parameters<typeof telemetryNoticeSite>[0]) =>
+		telemetryNoticeSite(overrides);
+
+	it("waits for the menu to close on an interactive run", () => {
+		// A line printed before the TUI is lost with the alternate screen.
+		expect(
+			site({ firstSend: true, interactive: true, isMachineReadable: false })
+		).toBe("menu");
+	});
+
+	it("prints at the end of a run with no menu", () => {
+		expect(
+			site({ firstSend: true, interactive: false, isMachineReadable: false })
+		).toBe("run");
+	});
+
+	it("prints nowhere for a machine-readable run or a later scan", () => {
+		expect(
+			site({ firstSend: true, interactive: true, isMachineReadable: true })
+		).toBe("none");
+		expect(
+			site({ firstSend: false, interactive: false, isMachineReadable: false })
+		).toBe("none");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
@@ -43,7 +43,7 @@ const buildInput = (
 	result: { ...emptyResult(), elapsedMs: 12.7 },
 	scanConfig: scanConfigFixture(),
 	scopeRequested: "full",
-	send: vi.fn(),
+	send: vi.fn(() => true),
 	subProjectOptOut: false,
 	targetPath: "/repo/app",
 	...overrides,
@@ -55,7 +55,10 @@ describe("scan telemetry reporter", () => {
 
 		reportScanTelemetry(input);
 
-		expect(input.resolveIdentityFn).toHaveBeenCalledWith("/repo/app");
+		expect(input.resolveIdentityFn).toHaveBeenCalledWith(
+			"/repo/app",
+			input.env ?? process.env
+		);
 		expect(input.send).toHaveBeenCalledTimes(1);
 		expect(input.send).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -140,6 +143,15 @@ describe("scan telemetry reporter", () => {
 		).toBe(false);
 	});
 
+	it("hands the identity resolver the same environment it read the store from", () => {
+		const env = { NESTJS_DOCTOR_CONFIG_DIR: "/nowhere" };
+		const input = buildInput({ env });
+
+		reportScanTelemetry(input);
+
+		expect(input.resolveIdentityFn).toHaveBeenCalledWith("/repo/app", env);
+	});
+
 	it("reads the store before the identity resolver writes one", () => {
 		const order: string[] = [];
 		const input = buildInput({
@@ -177,6 +189,13 @@ describe("scan telemetry reporter", () => {
 		expect(reportScanTelemetry(buildInput({ subProjectOptOut: true }))).toBe(
 			false
 		);
+	});
+
+	it("announces no first send when the sender only printed the payload", () => {
+		const input = buildInput({ send: vi.fn(() => false) });
+
+		expect(reportScanTelemetry(input)).toBe(false);
+		expect(input.send).toHaveBeenCalledTimes(1);
 	});
 
 	it("announces no first send from CI, which stores no id", () => {

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
@@ -388,11 +388,12 @@ describe("telemetry debug switch", () => {
 	it("prints the payload instead of spawning a sender", () => {
 		const stderr = captureStderr();
 
-		sendScanTelemetry(payload, "anon-1", {
+		const sent = sendScanTelemetry(payload, "anon-1", {
 			NESTJS_DOCTOR_TELEMETRY_DEBUG: "1",
 		});
 		stderr.mockRestore();
 
+		expect(sent).toBe(false);
 		expect(spawn).not.toHaveBeenCalled();
 		expect(JSON.parse(written.join(""))).toEqual({
 			event: "scan_completed",
@@ -420,10 +421,11 @@ describe("telemetry debug switch", () => {
 	});
 
 	it("treats the shell's own off spellings as off", () => {
-		sendScanTelemetry(payload, "anon-1", {
+		const sent = sendScanTelemetry(payload, "anon-1", {
 			NESTJS_DOCTOR_TELEMETRY_DEBUG: "0",
 		});
 
+		expect(sent).toBe(true);
 		expect(spawn).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
@@ -1,16 +1,26 @@
+import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodeDiagnostic } from "../../src/common/diagnostic.js";
 import type { Score } from "../../src/common/result.js";
 import { ACTION_ENV, actionContext } from "../../src/telemetry/environment.js";
 import {
 	buildScanPayload,
 	type ScanFacts,
+	type ScanPayload,
 } from "../../src/telemetry/scan-telemetry.js";
 import {
 	reportTelemetryEnabled,
 	scanTelemetryEnabled,
+	sendScanTelemetry,
 } from "../../src/telemetry/send.js";
+
+vi.mock("node:child_process", () => ({
+	spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+}));
+
+const TELEMETRY_INPUT = /^ {2}telemetry:$/m;
+const NEXT_INPUT = /^ {2}\S/m;
 
 const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
 	rule: "performance/no-unused-providers",
@@ -298,6 +308,22 @@ describe("scan telemetry payload", () => {
 			expect(actionYml).toMatch(new RegExp(`^ {2}${input}:$`, "m"));
 		}
 	});
+
+	it("describes the CI identity the code actually sends", () => {
+		// The input promised "never your repository" while the id in CI is now
+		// derived from the repository id.
+		const actionYml = readFileSync(
+			new URL("../../../../action.yml", import.meta.url),
+			"utf8"
+		);
+		const description = actionYml
+			.split(TELEMETRY_INPUT)[1]
+			?.split(NEXT_INPUT)[0];
+
+		expect(description).toBeTruthy();
+		expect(description).not.toContain("repository, or organization");
+		expect(description).toContain("one-way hash of your repository id");
+	});
 });
 
 describe("scan telemetry gating", () => {
@@ -341,5 +367,63 @@ describe("report telemetry gating", () => {
 
 	it("does not need a compiled key: the beacon has its own", () => {
 		expect(reportTelemetryEnabled(true, { telemetry: true }, {})).toBe(true);
+	});
+});
+
+describe("telemetry debug switch", () => {
+	const payload = { score: 90, file_count: 4 } as unknown as ScanPayload;
+	const written: string[] = [];
+
+	const captureStderr = () =>
+		vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+			written.push(String(chunk));
+			return true;
+		});
+
+	beforeEach(() => {
+		written.length = 0;
+		vi.mocked(spawn).mockClear();
+	});
+
+	it("prints the payload instead of spawning a sender", () => {
+		const stderr = captureStderr();
+
+		sendScanTelemetry(payload, "anon-1", {
+			NESTJS_DOCTOR_TELEMETRY_DEBUG: "1",
+		});
+		stderr.mockRestore();
+
+		expect(spawn).not.toHaveBeenCalled();
+		expect(JSON.parse(written.join(""))).toEqual({
+			event: "scan_completed",
+			distinct_id: "anon-1",
+			properties: payload,
+		});
+	});
+
+	it("prints exactly what it would have sent", () => {
+		sendScanTelemetry(payload, "anon-1", {});
+		const args = vi.mocked(spawn).mock.calls[0]?.[1] as string[];
+		const { api_key, ...sent } = JSON.parse(args[2] as string) as Record<
+			string,
+			unknown
+		>;
+
+		const stderr = captureStderr();
+		sendScanTelemetry(payload, "anon-1", {
+			NESTJS_DOCTOR_TELEMETRY_DEBUG: "1",
+		});
+		stderr.mockRestore();
+
+		expect(api_key).toBeTruthy();
+		expect(JSON.parse(written.join(""))).toEqual(sent);
+	});
+
+	it("treats the shell's own off spellings as off", () => {
+		sendScanTelemetry(payload, "anon-1", {
+			NESTJS_DOCTOR_TELEMETRY_DEBUG: "0",
+		});
+
+		expect(spawn).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
@@ -310,8 +310,6 @@ describe("scan telemetry payload", () => {
 	});
 
 	it("describes the CI identity the code actually sends", () => {
-		// The input promised "never your repository" while the id in CI is now
-		// derived from the repository id.
 		const actionYml = readFileSync(
 			new URL("../../../../action.yml", import.meta.url),
 			"utf8"

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry.test.ts
@@ -21,6 +21,8 @@ vi.mock("node:child_process", () => ({
 
 const TELEMETRY_INPUT = /^ {2}telemetry:$/m;
 const NEXT_INPUT = /^ {2}\S/m;
+/** The retired promise that no part of the repository is sent. */
+const NEVER_THE_REPOSITORY = /Never[^.]*\brepository\b(?! name)/;
 
 const code = (overrides: Partial<CodeDiagnostic>): CodeDiagnostic => ({
 	rule: "performance/no-unused-providers",
@@ -319,7 +321,7 @@ describe("scan telemetry payload", () => {
 			?.split(NEXT_INPUT)[0];
 
 		expect(description).toBeTruthy();
-		expect(description).not.toContain("repository, or organization");
+		expect(description).not.toMatch(NEVER_THE_REPOSITORY);
 		expect(description).toContain("one-way hash of your repository id");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
+++ b/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
@@ -232,6 +232,13 @@ describe("install identity", () => {
 		expect(resolveIdentity("/repo/a", env).stored).toBe(false);
 	});
 
+	it("stores nothing under the debug switch", () => {
+		const env = isolated({ NESTJS_DOCTOR_TELEMETRY_DEBUG: "1" });
+
+		expect(resolveIdentity("/repo/a", env).stored).toBe(false);
+		expect(hasStoredIdentity(env)).toBe(false);
+	});
+
 	it("stores nothing in CI", () => {
 		expect(
 			resolveIdentity(

--- a/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
+++ b/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
@@ -2,11 +2,17 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { configDir, resolveIdentity } from "../../src/telemetry/install-id.js";
+import {
+	configDir,
+	hasStoredIdentity,
+	resolveIdentity,
+} from "../../src/telemetry/install-id.js";
 import { scanTelemetryEnabled } from "../../src/telemetry/send.js";
 
 const SHA256_HEX = /^[a-f0-9]{64}$/;
 const CI_PREFIX = /^ci\./;
+const CI_GITHUB_REPO = /^ci\.github\.[a-f0-9]{16}$/;
+const CI_GITLAB_REPO = /^ci\.gitlab\.[a-f0-9]{16}$/;
 
 const homes: string[] = [];
 
@@ -16,6 +22,10 @@ const isolated = (extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => {
 	homes.push(home);
 	return { NESTJS_DOCTOR_CONFIG_DIR: home, ...extra };
 };
+
+/** A GitHub runner's env, with whatever repository variables the case needs. */
+const runnerEnv = (extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv =>
+	isolated({ CI: "true", GITHUB_ACTIONS: "true", ...extra });
 
 afterAll(() => {
 	for (const home of homes) {
@@ -64,21 +74,109 @@ describe("install identity", () => {
 		expect(identity.anonymousId).not.toContain(stored.salt);
 	});
 
-	it("collapses a CI fleet to one id per provider", () => {
-		const runner = () =>
+	it("gives one id per repository in CI, stable across runs", () => {
+		const acme = () =>
 			resolveIdentity(
 				"/repo/a",
-				isolated({ CI: "true", GITHUB_ACTIONS: "true" })
-			);
+				runnerEnv({ GITHUB_REPOSITORY_ID: "918273645" })
+			).anonymousId;
 
-		expect(runner().anonymousId).toBe("ci.github");
-		expect(runner().anonymousId).toBe("ci.github");
+		expect(acme()).toMatch(CI_GITHUB_REPO);
+		expect(acme()).toBe(acme());
+		expect(
+			resolveIdentity(
+				"/repo/a",
+				runnerEnv({ GITHUB_REPOSITORY_ID: "555000111" })
+			).anonymousId
+		).not.toBe(acme());
+	});
+
+	it("hashes one repository the same from a push and a pull request", () => {
+		const repo = {
+			GITHUB_REPOSITORY_ID: "918273645",
+			GITHUB_REPOSITORY: "acme/api",
+		};
+		const push = resolveIdentity(
+			"/home/runner/work/api/api",
+			runnerEnv({
+				...repo,
+				GITHUB_EVENT_NAME: "push",
+				GITHUB_REF: "refs/heads/main",
+			})
+		);
+		const pull = resolveIdentity(
+			"/home/runner/work/api/api",
+			runnerEnv({
+				...repo,
+				GITHUB_EVENT_NAME: "pull_request",
+				GITHUB_REF: "refs/pull/7/merge",
+			})
+		);
+
+		expect(pull.anonymousId).toBe(push.anonymousId);
+	});
+
+	it("falls back to the repository name, spelled either way", () => {
+		const upper = resolveIdentity(
+			"/repo/a",
+			runnerEnv({ GITHUB_REPOSITORY: "Acme/API" })
+		).anonymousId;
+		const lower = resolveIdentity(
+			"/repo/a",
+			runnerEnv({ GITHUB_REPOSITORY: " acme/api " })
+		).anonymousId;
+
+		expect(upper).toMatch(CI_GITHUB_REPO);
+		expect(lower).toBe(upper);
+	});
+
+	it("keeps the repository, the id and the checkout path out of the CI id", () => {
+		const id = resolveIdentity(
+			"/home/runner/work/acme-api/acme-api",
+			runnerEnv({
+				GITHUB_REPOSITORY_ID: "918273645",
+				GITHUB_REPOSITORY: "acme/acme-api",
+			})
+		).anonymousId;
+
+		expect(id).not.toContain("acme");
+		expect(id).not.toContain("runner");
+		expect(id).not.toContain("918273645");
+	});
+
+	it("gives one CI id whatever spelling the runner uses for its checkout", () => {
+		const repo = { GITHUB_REPOSITORY_ID: "918273645" };
+		const linux = resolveIdentity(
+			"/home/runner/work/api/api",
+			runnerEnv(repo)
+		).anonymousId;
+		const windows = resolveIdentity(
+			"D:/a/api/api",
+			runnerEnv(repo)
+		).anonymousId;
+
+		expect(windows).toBe(linux);
+	});
+
+	it("hashes the GitLab project id too", () => {
+		expect(
+			resolveIdentity(
+				"/repo/a",
+				isolated({ GITLAB_CI: "true", CI_PROJECT_ID: "918273645" })
+			).anonymousId
+		).toMatch(CI_GITLAB_REPO);
+	});
+
+	it("keeps a shared id for a provider that names no repository", () => {
 		expect(
 			resolveIdentity(
 				"/repo/a",
 				isolated({ JENKINS_URL: "https://ci.example.com" })
 			).anonymousId
 		).toBe("ci.jenkins");
+		expect(resolveIdentity("/repo/a", runnerEnv({})).anonymousId).toBe(
+			"ci.github"
+		);
 	});
 
 	it("treats a bare CI variable as a machine, not a named provider", () => {
@@ -97,10 +195,10 @@ describe("install identity", () => {
 		// the package would make the hash reversible to the repository name.
 		const runner = resolveIdentity(
 			"/home/runner/work/acme-api/acme-api",
-			isolated({ GITHUB_ACTIONS: "1" })
+			runnerEnv({ GITHUB_REPOSITORY_ID: "918273645" })
 		);
 
-		expect(runner.anonymousId).toBe("ci.github");
+		expect(runner.anonymousId).toMatch(CI_GITHUB_REPO);
 		expect(runner.projectId).toBeUndefined();
 	});
 
@@ -121,6 +219,22 @@ describe("install identity", () => {
 		const second = resolveIdentity("/repo/a", env);
 
 		expect(first.anonymousId).not.toBe(second.anonymousId);
+	});
+
+	it("knows whether this install has ever stored an id", () => {
+		const env = isolated();
+
+		expect(hasStoredIdentity(env)).toBe(false);
+		resolveIdentity("/repo/a", env);
+		expect(hasStoredIdentity(env)).toBe(true);
+	});
+
+	it("reads the store without creating one", () => {
+		const env = isolated();
+
+		hasStoredIdentity(env);
+
+		expect(hasStoredIdentity(env)).toBe(false);
 	});
 });
 

--- a/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
+++ b/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
@@ -116,18 +116,12 @@ describe("install identity", () => {
 		expect(pull.anonymousId).toBe(push.anonymousId);
 	});
 
-	it("falls back to the repository name, spelled either way", () => {
-		const upper = resolveIdentity(
-			"/repo/a",
-			runnerEnv({ GITHUB_REPOSITORY: "Acme/API" })
-		).anonymousId;
-		const lower = resolveIdentity(
-			"/repo/a",
-			runnerEnv({ GITHUB_REPOSITORY: " acme/api " })
-		).anonymousId;
-
-		expect(upper).toMatch(CI_GITHUB_REPO);
-		expect(lower).toBe(upper);
+	it("keeps the shared id when the runner names only the repository", () => {
+		// The repository name is an enumerable dictionary, so it is never hashed.
+		expect(
+			resolveIdentity("/repo/a", runnerEnv({ GITHUB_REPOSITORY: "acme/api" }))
+				.anonymousId
+		).toBe("ci.github");
 	});
 
 	it("keeps the repository, the id and the checkout path out of the CI id", () => {

--- a/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
+++ b/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
@@ -221,6 +221,42 @@ describe("install identity", () => {
 		expect(first.anonymousId).not.toBe(second.anonymousId);
 	});
 
+	it("says whether the id it returned was persisted", () => {
+		const env = isolated();
+
+		expect(resolveIdentity("/repo/a", env).stored).toBe(true);
+		expect(resolveIdentity("/repo/a", env).stored).toBe(true);
+	});
+
+	it("says a per-run id was never stored", () => {
+		const blocker = join(mkdtempSync(join(tmpdir(), "nd-blocked-")), "file");
+		homes.push(dirname(blocker));
+		writeFileSync(blocker, "", "utf-8");
+		const env = { NESTJS_DOCTOR_CONFIG_DIR: join(blocker, "nope") };
+
+		expect(resolveIdentity("/repo/a", env).stored).toBe(false);
+		expect(resolveIdentity("/repo/a", env).stored).toBe(false);
+	});
+
+	it("stores nothing in CI", () => {
+		expect(
+			resolveIdentity(
+				"/repo/a",
+				runnerEnv({ GITHUB_REPOSITORY_ID: "918273645" })
+			).stored
+		).toBe(false);
+	});
+
+	it("reads each provider only its own repository variables", () => {
+		// A GitHub variable left in a GitLab job must not identify the project.
+		const gitlab = resolveIdentity(
+			"/repo/a",
+			isolated({ GITLAB_CI: "true", GITHUB_REPOSITORY: "acme/api" })
+		);
+
+		expect(gitlab.anonymousId).toBe("ci.gitlab");
+	});
+
 	it("knows whether this install has ever stored an id", () => {
 		const env = isolated();
 

--- a/packages/nestjs-doctor/tests/unit/worker-delegate.test.ts
+++ b/packages/nestjs-doctor/tests/unit/worker-delegate.test.ts
@@ -53,7 +53,15 @@ const requestFixture = (): ScanWorkerRequest =>
 	}) as unknown as ScanWorkerRequest;
 
 const outcomeFixture = (): ScanOutcome =>
-	({ kind: "single", customRuleWarnings: [] }) as unknown as ScanOutcome;
+	({
+		kind: "single",
+		customRuleWarnings: [],
+		firstTelemetrySend: true,
+	}) as unknown as ScanOutcome;
+
+/** Fails to compile if the outcome stops carrying the notice decision. */
+const firstSendOf = (outcome: ScanOutcome): boolean =>
+	outcome.firstTelemetrySend;
 
 const delegateInput = (
 	overrides: Partial<CanDelegateInput> = {}
@@ -151,6 +159,8 @@ describe("worker delegate — runInWorker", () => {
 		await expect(promise).resolves.toBeUndefined();
 		expect(createWorker).toHaveBeenCalledWith(workerUrl, requestFixture());
 		expect(apply).toHaveBeenCalledWith(outcome);
+		// The reporter runs in the worker; the notice is printed on main.
+		expect(firstSendOf(apply.mock.calls[0]?.[0] as ScanOutcome)).toBe(true);
 		expect(worker.terminateCalls).toBe(1);
 	});
 

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -1,6 +1,6 @@
 # NestJS Doctor
 
-> Diagnose and fix your NestJS code in one command. 52 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics. An interactive HTML report visualizes the module dependency graph with circular imports highlighted, traced HTTP endpoints, and an ER diagram of the database schema. Zero config. Monorepo support. Ships an official GitHub Action that reports only what a pull request introduced.
+> The deterministic NestJS devtool that catches AI mistakes. 52 built-in rules across security, performance, correctness, architecture, and schema. Outputs a 0-100 score with actionable diagnostics. An interactive HTML report visualizes the module dependency graph with circular imports highlighted, traced HTTP endpoints, and an ER diagram of the database schema. Zero config. Monorepo support. Ships an official GitHub Action that reports only what a pull request introduced.
 
 ## Quick Start
 

--- a/packages/website/src/app/docs/configuration/page.mdx
+++ b/packages/website/src/app/docs/configuration/page.mdx
@@ -67,6 +67,8 @@ See [Config loading](/docs/pipeline/config-loading) for implementation details.
 | `rules` | `Record<string, RuleOverride \| boolean>` | Enable/disable individual rules, and pass rule options |
 | `categories` | `Record<string, boolean>` | Enable/disable entire categories |
 | `customRulesDir` | `string` | Path to a directory of custom `.ts` rule files |
+| `telemetry` | `boolean` | Set to `false` to send nothing (see [Telemetry](/docs/telemetry)) |
+| `report.telemetry` | `boolean` | Set to `false` to drop the beacon from a generated HTML report |
 
 Set a rule to `false` to disable it. The object form does the same through `enabled`, and `surfaces` decides where the rule may appear (see [Surfaces](/docs/custom-rules#surfaces)):
 

--- a/packages/website/src/app/docs/language-server/page.mdx
+++ b/packages/website/src/app/docs/language-server/page.mdx
@@ -86,6 +86,12 @@ A client that never answers the `workspace/configuration` request leaves the
 server waiting, and no scan runs. Answering with `null` is fine and the defaults
 apply.
 
+## Telemetry
+
+A started session reports one `lsp_session_started` event, under the same
+install id the CLI uses and with the same opt-outs. See
+[Telemetry](/docs/telemetry#the-language-server).
+
 ## Troubleshooting
 
 When `nestjs-doctor` is missing from the project you opened, the server sends

--- a/packages/website/src/app/docs/reference/cli/page.mdx
+++ b/packages/website/src/app/docs/reference/cli/page.mdx
@@ -129,8 +129,8 @@ screen.
 Handing off detects Claude Code, Codex, and Cursor on your PATH and starts the
 one you pick with the top findings as its first prompt, plainly: no
 permission-skipping flags are passed. Copy the prompt instead to use any other
-agent. The prompt never leaves your machine; the scan itself reports only
-anonymous rule counts.
+agent. The prompt never leaves your machine; what the scan itself reports is
+listed on [Telemetry](/docs/telemetry).
 
 The menu never appears where it could hang a machine. It is skipped in CI,
 inside coding agents, in pipes, in `dumb` terminals, and in every mode other

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -13,8 +13,8 @@ npx nestjs-doctor@latest .
 ```
 
 No config file, nothing to set up. It reads your TypeScript, runs 52 rules, and
-prints a score out of 100. Your code never leaves the machine; the scan reports
-only anonymous rule counts.
+prints a score out of 100. Your code never leaves the machine; what the scan
+itself reports is listed on [Telemetry](/docs/telemetry).
 
 A clean scan prints the score and nothing else. That is the expected result on
 a project the rules already agree with, and [the report](/docs/report) still

--- a/packages/website/src/app/docs/telemetry/page.mdx
+++ b/packages/website/src/app/docs/telemetry/page.mdx
@@ -104,7 +104,7 @@ Outside CI the event carries two ids. `telemetry.json` holds an install id and a
 - **`distinct_id`:** a random UUID, stable for this install.
 - **`project_id`:** a SHA-256 over a second random UUID and the resolved project path.
 
-The salt never leaves the machine. A hash built with it cannot be reversed against a constant shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing.
+The salt never leaves the machine, so neither hash can be rebuilt from anything shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing.
 
 The store lives where the platform expects a CLI to keep its own config:
 
@@ -116,7 +116,7 @@ The store lives where the platform expects a CLI to keep its own config:
 
 Under a recognized CI provider nothing is written and `project_id` is absent. `distinct_id` becomes `ci.<provider>.<hash>` instead, where the hash is the first 16 hex characters of a SHA-256 over a constant salt and the repository id. GitHub supplies `GITHUB_REPOSITORY_ID`, GitLab supplies `CI_PROJECT_ID`, and a provider that supplies no repository id keeps a shared `ci.<provider>`. The repository name is never read: it is a short enumerable string, and the salt ships in the package.
 
-The CI id is pseudonymous rather than anonymous. It is a one-way hash, so it groups repeated runs of one repository without naming it. It is not reversible to a repository name, and no path, remote URL or commit sha goes into it.
+The CI id is pseudonymous rather than anonymous. Repository ids are sequential integers and the salt ships in the package, so anyone holding both the package and the data can hash every id and match one back to a repository. No path, remote URL or commit sha goes into it.
 
 ## Turning it off
 
@@ -204,7 +204,9 @@ The payload goes to stderr and no child process is spawned, so nothing is sent. 
 }
 ```
 
-The printed body and the sent body are built from the same values, so what is printed is what would have been sent. It prints only when the scan would otherwise have reported: with `--no-telemetry`, `"telemetry": false`, `DO_NOT_TRACK` set, or a build with no compiled key, there is no payload to print. The variable covers the scan event only. A generated report's own beacon is not affected by it.
+The printed body and the sent body are built from the same values, so what is printed is what would have been sent. It prints only when the scan would otherwise have reported. With `--no-telemetry`, `"telemetry": false`, `DO_NOT_TRACK` set, or a build with no compiled key, there is no payload to print.
+
+A debug run sends nothing and stores no id, so it never counts as the first send and never prints the notice below. The variable covers the scan event only. A generated report's own beacon is not affected by it.
 
 ## The first-run notice
 

--- a/packages/website/src/app/docs/telemetry/page.mdx
+++ b/packages/website/src/app/docs/telemetry/page.mdx
@@ -1,0 +1,221 @@
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { docsMetadata } from "@/lib/docs-metadata";
+export const metadata = docsMetadata["/docs/telemetry"];
+
+<BreadcrumbJsonLd path="/docs/telemetry" />
+
+# Telemetry
+
+A finished scan reports one `scan_completed` event. It is posted to `https://us.i.posthog.com/e/` by a detached child process with a three second timeout, so a stalled network never holds the scan open.
+
+Sending is best effort. A failed request, a blocked host, or an environment that cannot spawn all leave the scan and its exit code untouched.
+
+## What is sent
+
+The payload is built from rule metadata, counts, and a fixed set of environment values. Nothing in it is read out of your source files.
+
+### The run
+
+| Field | Value |
+|---|---|
+| `version` | The nestjs-doctor version that ran |
+| `generated_in` | `cli` or `ci` |
+| `platform` | The Node platform string, such as `darwin` |
+| `node_major` | The Node major version, such as `24` |
+| `duration_ms` | How long the scan took, rounded |
+| `score` | The 0-100 health score |
+| `scope_requested` | The `--scope` mode asked for: `full`, `files`, `lines` or `changed` |
+| `blocking` | The `--blocking` level: `none`, `warning` or `error` |
+| `findings` | Built-in rule id, then severity, then a count |
+| `rules_with_findings` | How many rule ids that map holds |
+| `rule_errors` | Built-in rule ids that threw during the scan |
+
+### The project
+
+| Field | Value |
+|---|---|
+| `file_count` | How many files the scan collected |
+| `monorepo` | Whether more than one project was scanned |
+| `framework` | `express`, `fastify`, or null |
+| `orm` | The detected ORM, or null |
+| `nest_version` | The `@nestjs/core` version the project depends on |
+
+### The config
+
+| Field | Value |
+|---|---|
+| `config_include_count` | How many `include` globs the project declared |
+| `config_exclude_count` | How many `exclude` globs it added past the defaults |
+| `config_min_score` | The `minScore` value, or null |
+| `categories_disabled` | Which of the five categories are turned off |
+| `rules_turned_off` | Built-in rule ids set to `false` |
+| `rule_overrides` | Built-in rule ids carrying any entry under `rules` |
+| `rules_disabled` | Built-in rule ids that did not run |
+| `ignored_rules` | Built-in rule ids under `ignore.rules` |
+| `ignored_file_count` | How many `ignore.files` globs there are |
+| `custom_rules_dir` | Whether `customRulesDir` is set, as a boolean |
+| `custom_rules_loaded` | How many custom rules loaded |
+
+### The ecosystem
+
+| Field | Value |
+|---|---|
+| `nestjs_packages` | Packages from the `@nestjs` scope and a tracked third-party list |
+| `frontend` | Frontend framework packages the project depends on |
+| `databases` | Database driver packages |
+| `cloud` | Cloud vendor names, from package names and scope prefixes |
+| `cloud_services` | `vendor:service` pairs, such as `aws:client-s3` |
+| `messaging` | Queue and broker packages |
+
+Each of these is an intersection with a list compiled into the CLI. A package outside the lists is never named, and the dependency list itself never travels.
+
+### The CI context
+
+| Field | Value |
+|---|---|
+| `ci_provider` | A slug from a fixed provider list, or `unknown` on a runner that only sets `CI` |
+| `ci_event` | The workflow trigger, or `other` |
+| `via_action` | Whether the official GitHub Action ran the scan |
+| `action_ref` | `v<major>`, `sha`, or `branch` |
+| `action_version_pin` | `latest`, `local`, or `pinned` |
+| `actor_association` | GitHub's own term for the author's tie to the repository |
+| `action_comment` | Whether the action was asked to comment |
+| `action_commit_status` | Whether it was asked to write a commit status |
+| `action_review_comments` | Whether it was asked to leave review comments |
+| `action_sarif` | Whether it was asked to upload SARIF |
+
+Every CI field is a boolean or a value from a fixed list. An unrecognized value is dropped rather than forwarded, so no environment variable can put an unbounded string in the payload.
+
+## What is never sent
+
+Six things the payload has no field for, each decided in code rather than by convention:
+
+- **No source text:** `findings` maps a rule id to a severity to a count, built from the rule id and severity of each finding and nothing else.
+- **No file paths:** only `file_count` and `ignored_file_count` travel. `rule_errors` carries rule ids, never the error message, which quotes the file that broke the rule.
+- **No project name:** `project_id` is a SHA-256 over a random per-install salt and the resolved project path.
+- **No globs:** the config reader returns counts. `config_exclude_count` subtracts the built-in defaults, so it counts only what the project declared.
+- **No custom rule names:** every rule-id array is filtered against the built-in ids. A count and a boolean are all that describe custom rules.
+- **No branch names:** a ref is reduced to `v<major>`, `sha` or `branch`, because a fork's branch name has no bound.
+
+## Identity
+
+Outside CI the event carries two ids, both generated on first run and stored in `telemetry.json`:
+
+- **`distinct_id`:** a random UUID, stable for this install.
+- **`project_id`:** a SHA-256 over a second random UUID and the resolved project path.
+
+That second UUID is the salt, and it never leaves the machine. A hash built with it cannot be reversed against a constant shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing.
+
+The store lives where the platform expects a CLI to keep its own config:
+
+| Platform | Location |
+|---|---|
+| macOS | `~/Library/Preferences/nestjs-doctor/telemetry.json` |
+| Linux | `$XDG_CONFIG_HOME/nestjs-doctor/telemetry.json`, or `~/.config` when unset |
+| Windows | `%APPDATA%\nestjs-doctor\telemetry.json` |
+
+Under a recognized CI provider nothing is written and `project_id` is absent. `distinct_id` becomes `ci.<provider>.<hash>` instead, where the hash is the first 16 hex characters of a SHA-256 over a constant salt and the repository id. GitHub supplies `GITHUB_REPOSITORY_ID` or `GITHUB_REPOSITORY`, GitLab supplies `CI_PROJECT_ID`, and a provider that names no repository keeps a shared `ci.<provider>`.
+
+The CI id is pseudonymous rather than anonymous. It is a one-way hash, so it groups repeated runs of one repository without naming it. It is not reversible to a repository name, and no path, remote URL or commit sha goes into it.
+
+## Turning it off
+
+| Control | Effect |
+|---|---|
+| `--no-telemetry` | Scans and writes the report, sends nothing |
+| `"telemetry": false` in the config file | The same, for everyone on the project |
+| `DO_NOT_TRACK` set to anything but empty, `0` or `false` | The same, honored across tools |
+
+Two consequences of how those checks are written:
+
+- **`DO_NOT_TRACK=0` and `DO_NOT_TRACK=false`:** neither opts out. One helper reads every switch on this page, and it treats an empty value, `0` and `false` as unset.
+- **A monorepo sub-project:** a sub-project config with `telemetry: false` opts out the whole scan, not its own package. The report returns before any payload is built.
+
+A generated HTML report carries its own beacon for how the report itself is used. All three controls above disable it, and so does `report.telemetry` set to `false`.
+
+## Printing the payload
+
+Set `NESTJS_DOCTOR_TELEMETRY_DEBUG` to read what a scan would report:
+
+```bash
+NESTJS_DOCTOR_TELEMETRY_DEBUG=1 npx nestjs-doctor@latest .
+```
+
+The payload goes to stderr and no child process is spawned, so nothing is sent. One real scan of a two-file project prints:
+
+```json
+{
+  "event": "scan_completed",
+  "distinct_id": "c85d0fac-31ed-4155-b997-facdabb0b595",
+  "properties": {
+    "action_commit_status": null,
+    "action_comment": null,
+    "action_ref": null,
+    "action_review_comments": null,
+    "action_sarif": null,
+    "action_version_pin": null,
+    "actor_association": null,
+    "blocking": "error",
+    "categories_disabled": [],
+    "ci_event": null,
+    "ci_provider": null,
+    "cloud": [],
+    "cloud_services": [],
+    "config_exclude_count": 0,
+    "config_include_count": 0,
+    "config_min_score": null,
+    "custom_rules_dir": false,
+    "custom_rules_loaded": 0,
+    "databases": [],
+    "duration_ms": 10,
+    "file_count": 2,
+    "findings": {
+      "security/require-guards-on-endpoints": {
+        "warning": 3
+      }
+    },
+    "framework": "express",
+    "frontend": [],
+    "generated_in": "cli",
+    "ignored_file_count": 0,
+    "ignored_rules": [],
+    "messaging": [],
+    "monorepo": false,
+    "nest_version": "11.1.18",
+    "nestjs_packages": [
+      "@nestjs/common",
+      "@nestjs/core",
+      "@nestjs/platform-express"
+    ],
+    "orm": null,
+    "node_major": 24,
+    "platform": "darwin",
+    "project_id": "fdc2d61ea612d5ffebaef4d9b5ff98299e21df9abff7f61ba1bc53fd10a062b7",
+    "rule_errors": [],
+    "rule_overrides": [],
+    "rules_turned_off": [],
+    "rules_disabled": [],
+    "rules_with_findings": 1,
+    "scope_requested": "full",
+    "score": 66,
+    "version": "0.9.5",
+    "via_action": false
+  }
+}
+```
+
+The printed body and the sent body are built from the same values, so what is printed is what would have been sent. The variable covers the scan event only. A generated report's own beacon is not affected by it.
+
+## The first-run notice
+
+The first scan that reports on a machine prints one line to stderr, then never again:
+
+```text
+nestjs-doctor reported this scan anonymously: which built-in rules fired, the score, well-known dependencies, and the shape of your config — never your code, paths, or project name. Turn it off with --no-telemetry, "telemetry": false in your config, or DO_NOT_TRACK=1. https://nestjs.doctor/docs/telemetry
+```
+
+It prints once the scan has finished, and once the interactive menu has closed when one opened. Machine-readable runs never print it, and neither does CI, which stores no id to remember the run by. A machine whose config directory cannot be written stores nothing either, so it stays quiet rather than repeating the notice on every scan.
+
+## What it is used for
+
+The data answers which rules fire in real projects, which ones teams turn off, and whether a first scan is followed by a second. That decides which rules ship on by default, which ones need better messages, and which parts of the CLI are worth building on.

--- a/packages/website/src/app/docs/telemetry/page.mdx
+++ b/packages/website/src/app/docs/telemetry/page.mdx
@@ -114,7 +114,7 @@ The store lives where the platform expects a CLI to keep its own config:
 | Linux | `$XDG_CONFIG_HOME/nestjs-doctor/telemetry.json`, or `~/.config` when unset |
 | Windows | `%APPDATA%\nestjs-doctor\telemetry.json` |
 
-Under a recognized CI provider nothing is written and `project_id` is absent. `distinct_id` becomes `ci.<provider>.<hash>` instead, where the hash is the first 16 hex characters of a SHA-256 over a constant salt and the repository id. GitHub supplies `GITHUB_REPOSITORY_ID` or `GITHUB_REPOSITORY`, GitLab supplies `CI_PROJECT_ID`, and a provider that names no repository keeps a shared `ci.<provider>`.
+Under a recognized CI provider nothing is written and `project_id` is absent. `distinct_id` becomes `ci.<provider>.<hash>` instead, where the hash is the first 16 hex characters of a SHA-256 over a constant salt and the repository id. GitHub supplies `GITHUB_REPOSITORY_ID`, GitLab supplies `CI_PROJECT_ID`, and a provider that supplies no repository id keeps a shared `ci.<provider>`. The repository name is never read: it is a short enumerable string, and the salt ships in the package.
 
 The CI id is pseudonymous rather than anonymous. It is a one-way hash, so it groups repeated runs of one repository without naming it. It is not reversible to a repository name, and no path, remote URL or commit sha goes into it.
 
@@ -204,7 +204,7 @@ The payload goes to stderr and no child process is spawned, so nothing is sent. 
 }
 ```
 
-The printed body and the sent body are built from the same values, so what is printed is what would have been sent. The variable covers the scan event only. A generated report's own beacon is not affected by it.
+The printed body and the sent body are built from the same values, so what is printed is what would have been sent. It prints only when the scan would otherwise have reported: with `--no-telemetry`, `"telemetry": false`, `DO_NOT_TRACK` set, or a build with no compiled key, there is no payload to print. The variable covers the scan event only. A generated report's own beacon is not affected by it.
 
 ## The first-run notice
 
@@ -215,6 +215,10 @@ nestjs-doctor reported this scan anonymously: which built-in rules fired, the sc
 ```
 
 It prints once the scan has finished, and once the interactive menu has closed when one opened. Machine-readable runs never print it, and neither does CI, which stores no id to remember the run by. A machine whose config directory cannot be written stores nothing either, so it stays quiet rather than repeating the notice on every scan.
+
+## The language server
+
+The language server behind the VS Code extension reports separately: one `lsp_session_started` event per session, carrying the editor name and version, the platform, the Node major, and the same `project_id`. It reads the same `telemetry.json`, so a machine reports under one install id, and it honors `DO_NOT_TRACK`, `"telemetry": false` in the project config, and `NESTJS_DOCTOR_TELEMETRY_DEBUG`. See [Language server](/docs/language-server).
 
 ## What it is used for
 

--- a/packages/website/src/app/docs/telemetry/page.mdx
+++ b/packages/website/src/app/docs/telemetry/page.mdx
@@ -99,12 +99,12 @@ Six things the payload has no field for, each decided in code rather than by con
 
 ## Identity
 
-Outside CI the event carries two ids, both generated on first run and stored in `telemetry.json`:
+Outside CI the event carries two ids. `telemetry.json` holds an install id and a salt, both created on first run. The project id is derived from that salt on every run and never stored:
 
 - **`distinct_id`:** a random UUID, stable for this install.
 - **`project_id`:** a SHA-256 over a second random UUID and the resolved project path.
 
-That second UUID is the salt, and it never leaves the machine. A hash built with it cannot be reversed against a constant shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing.
+The salt never leaves the machine. A hash built with it cannot be reversed against a constant shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing.
 
 The store lives where the platform expects a CLI to keep its own config:
 
@@ -128,7 +128,7 @@ The CI id is pseudonymous rather than anonymous. It is a one-way hash, so it gro
 
 Two consequences of how those checks are written:
 
-- **`DO_NOT_TRACK=0` and `DO_NOT_TRACK=false`:** neither opts out. One helper reads every switch on this page, and it treats an empty value, `0` and `false` as unset.
+- **`DO_NOT_TRACK=0` and `DO_NOT_TRACK=false`:** neither opts out. One helper reads the environment switches, and it treats an empty value, `0` and `false` as unset.
 - **A monorepo sub-project:** a sub-project config with `telemetry: false` opts out the whole scan, not its own package. The report returns before any payload is built.
 
 A generated HTML report carries its own beacon for how the report itself is used. All three controls above disable it, and so does `report.telemetry` set to `false`.

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -10,8 +10,10 @@ const ibmPlexMono = IBM_Plex_Mono({
 	weight: ["200", "400", "500", "700"],
 });
 
-const HOME_TITLE = "NestJS Doctor - Diagnose and Fix Your NestJS Code";
-const HOME_DESCRIPTION = "Diagnose and fix your NestJS code in one command.";
+const HOME_TITLE =
+	"NestJS Doctor - The deterministic NestJS devtool that catches AI mistakes";
+const HOME_DESCRIPTION =
+	"The deterministic NestJS devtool that catches AI mistakes. Static analysis for NestJS with a health score, diagnostics and a CI gate.";
 
 export const metadata: Metadata = {
 	metadataBase: new URL(SITE_URL),

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -10,8 +10,7 @@ const ibmPlexMono = IBM_Plex_Mono({
 	weight: ["200", "400", "500", "700"],
 });
 
-const HOME_TITLE =
-	"NestJS Doctor - The deterministic NestJS devtool that catches AI mistakes";
+const HOME_TITLE = "NestJS Doctor - Deterministic static analysis for NestJS";
 const HOME_DESCRIPTION =
 	"The deterministic NestJS devtool that catches AI mistakes. Static analysis for NestJS with a health score, diagnostics and a CI gate.";
 

--- a/packages/website/src/app/opengraph-image.tsx
+++ b/packages/website/src/app/opengraph-image.tsx
@@ -3,7 +3,8 @@ import { join } from "node:path";
 import { ImageResponse } from "next/og";
 
 export const dynamic = "force-static";
-export const alt = "NestJS Doctor - Diagnose and fix your NestJS code";
+export const alt =
+	"NestJS Doctor - The deterministic NestJS devtool that catches AI mistakes";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -98,7 +99,7 @@ export default async function Image() {
 					maxWidth: 900,
 				}}
 			>
-				{"Diagnose and fix your NestJS code in one command."}
+				{"The deterministic NestJS devtool that catches AI mistakes."}
 			</div>
 
 			<div

--- a/packages/website/src/components/json-ld.tsx
+++ b/packages/website/src/components/json-ld.tsx
@@ -18,7 +18,8 @@ const SOFTWARE_APPLICATION = {
 	"@context": "https://schema.org",
 	"@type": "SoftwareApplication",
 	name: "nestjs-doctor",
-	description: "Diagnose and fix your NestJS code in one command.",
+	description:
+		"The deterministic NestJS devtool that catches AI mistakes. Static analysis for NestJS with a health score, diagnostics and a CI gate.",
 	url: SITE_URL,
 	applicationCategory: "DeveloperApplication",
 	operatingSystem: "Cross-platform",

--- a/packages/website/src/components/landing/hero.tsx
+++ b/packages/website/src/components/landing/hero.tsx
@@ -54,9 +54,9 @@ export const Hero = () => (
 	<section className="grid min-h-0 flex-1 gap-12 border-white/15 border-b py-6 lg:grid-cols-[52fr_48fr]">
 		<div className="self-center">
 			<h1 className="mt-0 mb-4 text-balance font-extralight text-[#f2f1ef] text-[clamp(30px,3.4vw,46px)] leading-[1.08] tracking-[-0.02em]">
-				The deterministic,{" "}
+				The deterministic{" "}
 				<span className="font-normal text-nest-red">NestJS</span> devtool that{" "}
-				<span className="font-normal text-nest-red">catches AI mistakes</span>
+				<span className="font-normal text-nest-red">catches AI mistakes</span>.
 			</h1>
 			<div className="mb-5 max-w-[66ch] space-y-1 text-[13px] text-white/[0.92] leading-relaxed">
 				{POINTS.map((point) => (

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -5,7 +5,7 @@ export const DOCS_PAGES: Record<string, PageCopy> = {
 	"/docs": {
 		title: "What is nestjs-doctor?",
 		description:
-			"Diagnostic CLI tool that scans NestJS codebases and produces a health score across security, correctness, architecture, performance, and schema.",
+			"The deterministic NestJS devtool that catches AI mistakes. Static analysis that scans a NestJS codebase and produces a health score across security, correctness, architecture, performance, and schema.",
 	},
 	"/docs/nest-devtools-alternative": {
 		title: "NestJS Doctor vs Nest Devtools",

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -72,6 +72,11 @@ export const DOCS_PAGES: Record<string, PageCopy> = {
 		description:
 			"Wire custom rules into a nestjs-doctor scan: customRulesDir, how rule files load, custom/ id prefixing, and the surfaces a rule's findings appear on.",
 	},
+	"/docs/telemetry": {
+		title: "Telemetry",
+		description:
+			"Every field a nestjs-doctor scan reports, what it never sends, how the install and CI ids are built, the three ways to turn it off, and how to print the payload instead of sending it.",
+	},
 	"/docs/ci": {
 		title: "GitHub Actions setup",
 		description:

--- a/packages/website/src/lib/docs-navigation.ts
+++ b/packages/website/src/lib/docs-navigation.ts
@@ -50,6 +50,7 @@ export const DOCS_NAV: NavSection[] = [
 		items: [
 			{ title: "Config files", href: "/docs/configuration" },
 			{ title: "Custom rule configuration", href: "/docs/custom-rules" },
+			{ title: "Telemetry", href: "/docs/telemetry" },
 		],
 	},
 	{


### PR DESCRIPTION
## Context

Scan telemetry sends one `scan_completed` event per scan (rule ids that fired, score, well-known dependencies, config shape, CI context) and honours `--no-telemetry`, `DO_NOT_TRACK` and the `telemetry` config key. The norm the JS ecosystem holds a CLI to (Next.js, Astro, Homebrew, GitHub CLI) has five parts: a notice before or with the first send, nothing that identifies code or paths, an env var and a config key to disable, a debug print of the exact payload, and `DO_NOT_TRACK`. Three of the five held. Separately, ten days of PostHog data showed every GitHub Action run reporting as one `distinct_id` (`ci.github`), so CI adoption could not be counted, and three different taglines were live across the README, the GitHub description and `package.json`.

## Problem

- No notice: a first-time user's scan reported before any text told them what leaves the machine or how to stop it.
- No way to see the payload: `--help` described it in prose, nothing printed it.
- `ci.github` for every Action run: 665 CI scans in one week from one id, could be three repositories or two hundred.
- No `/docs/telemetry` page; the setup and CLI reference pages said the scan reports "only anonymous rule counts", which understates the payload.
- Three taglines, and the two that Google renders (`HOME_TITLE`, `HOME_DESCRIPTION` in `layout.tsx`) said "Diagnose and fix", which the CLI alone does not do.

## Possible flows

| Flow | Before | After |
|---|---|---|
| First local scan on a machine, TTY, menu follows | payload sent, nothing said | payload sent; after the menu closes, one stderr line says what was reported and names the three opt-outs |
| First local scan, non-interactive (`--json`, piped, `--score`) | payload sent, nothing said | payload sent; the notice prints once unless the output is machine-readable |
| Second and later scans | payload sent | payload sent, no notice |
| Config home not writable (read-only `HOME`, no CI variable) | per-run id, payload sent | same, and no notice, since it could not be remembered |
| GitHub Action run | `distinct_id = "ci.github"`, no `project_id` | `distinct_id = "ci.github.<16 hex>"` from a salted hash of the numeric `GITHUB_REPOSITORY_ID`, still no `project_id`; a runner without that variable keeps `ci.github` |
| GitLab CI run | `ci.gitlab` | `ci.gitlab.<16 hex>` from `CI_PROJECT_ID`; a stray `GITHUB_REPOSITORY` is ignored |
| Any other CI | `ci.<provider>` | unchanged |
| `NESTJS_DOCTOR_TELEMETRY_DEBUG=1` | no such switch | the exact `{event, distinct_id, properties}` printed to stderr, nothing spawned, no id stored, no first-run notice; also in the LSP |
| `--no-telemetry`, `DO_NOT_TRACK=1`, `"telemetry": false`, `report.telemetry: false` | honoured | honoured, unchanged; `DO_NOT_TRACK=0` still does not opt out, now documented |
| `--help`, `action.yml` telemetry input | prose that omitted `DO_NOT_TRACK`, the config key, and promised "never your repository" | name all three opt-outs and the debug variable, and say a one-way hash of the repository id is sent |
| Reader of `/docs/setup` or the CLI reference | "reports only anonymous rule counts" | first half of the sentence kept, the clause replaced by a link to `/docs/telemetry` |

## Solution

**Engine** (`feat(telemetry)` and its fix commit):
- `install-id.ts`: `ciIdentity()` hashes the provider's numeric repository id (`GITHUB_REPOSITORY_ID`; `CI_PROJECT_ID` on GitLab) with the shipped salt, sixteen hex characters. Pseudonymous, not anonymous: anyone with the package can hash a candidate id and test membership, which is why the repository name is never hashed (a name is an enumerable dictionary). Never `GITHUB_WORKSPACE`, a remote URL or a sha. Identical across runners and across `pull_request` and `push`.
- `TelemetryIdentity.stored` says whether the local store was written; the reporter reports a first send only when no store existed and one was written.
- `send.ts` and the LSP sender: `NESTJS_DOCTOR_TELEMETRY_DEBUG` (any value but empty, `0`, `false`) prints the body and returns before spawning; the printed object is the same one the child would post.
- `ScanOutcome.firstTelemetrySend` carries the decision out of the worker; `telemetryNoticeSite()` prints the notice after the menu on an interactive run and in `run()`'s `finally` otherwise, never when machine-readable, never in CI.

**Docs and positioning** (`docs(telemetry)`, `docs(tagline)`):
- `/docs/telemetry`: what is sent, grouped; what is never sent, with the six deciding checks; identity including the CI pseudonym; turning it off as a table; the debug variable with a real captured payload; the notice; what the data is used for. Two facts published nowhere before: `DO_NOT_TRACK=0` does not opt out, and one sub-project's `telemetry: false` opts out the whole monorepo scan.
- The tagline `The deterministic NestJS devtool that catches AI mistakes.` in every place the project describes itself: README, hero, `layout.tsx` title and description, `package.json`, `llms.txt`, `cli/index.ts` help header, GitHub description, the VS Code extension manifest, `docs-metadata.ts`, the skill file, plus `opengraph-image.tsx` and `json-ld.tsx` found by grep. Positioning, never phrased as detection.

Deliberately not done: the first run still sends (the Homebrew shape, notify and send nothing until the next run, would drop every install that never runs twice, 25 of 67 in the baseline, from telemetry); no `trigger` enum, `scan_id` or suppression counts yet (weeks 2 to 3); the LSP's own CI identity still uses the shared id; `init.ts` keeps "Diagnose and fix" because the skill it describes does edit files.

## Before vs after

| Case | Before | After |
|---|---|---|
| Distinct CI ids in a week with N repositories running the Action | 1 | N (one per repository id) |
| CI payload fields | no `project_id` | no `project_id`, unchanged |
| First local scan | silent | payload plus one notice line, once per install |
| `NESTJS_DOCTOR_TELEMETRY_DEBUG=1 npx nestjs-doctor .` | scans and sends | scans, prints the payload, sends nothing, stores nothing, so the next real run is still the first |
| `DO_NOT_TRACK=1`, `--no-telemetry`, config keys | honoured | honoured |
| Score, findings, exit codes | unchanged | unchanged |
| Taglines live | three | one |

The dashboard tile "CI identities per week" steps up on the first release with this change; the old `ci.github` rows do not join the new ones.

## Example

A fresh config dir, built CLI at this branch's head, debug on:

```
$ NESTJS_DOCTOR_CONFIG_DIR=/tmp/cfg NESTJS_DOCTOR_TELEMETRY_DEBUG=1 nestjs-doctor tests/fixtures/basic-app
{
  "event": "scan_completed",
  "distinct_id": "1b0035d2-6786-4406-b3a6-1e6eb1fda250",
  "properties": {
    "blocking": "error",
    "duration_ms": 14,
    "file_count": 4,
    "findings": {},
    "generated_in": "cli",
    "nest_version": "11.1.18",
    …

$ ls /tmp/cfg
ls: /tmp/cfg: No such file or directory

$ GITHUB_ACTIONS=true CI=true GITHUB_REPOSITORY_ID=123456789 NESTJS_DOCTOR_TELEMETRY_DEBUG=1 nestjs-doctor tests/fixtures/basic-app
  "distinct_id": "ci.github.feccf872380c3b3b",
  "generated_in": "ci",
```

The notice itself prints once, on the first run that really sends, after the summary (or after the menu closes). A debug run prints the payload only, sends nothing and stores nothing, so it never spends the notice.

Before this branch the same runs printed nothing, and the CI run's `distinct_id` was `ci.github`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjSReP4FCbUcwjtdgWn4iV
