### PR TITLE
fix(rules): require-timestamps at info, join tables skipped, Prisma recipe accepted

### DIFF
--- a/.changeset/rules-timestamps-orm-narrowed.md
+++ b/.changeset/rules-timestamps-orm-narrowed.md
@@ -4,6 +4,6 @@
 
 ### Changed
 
-`schema/require-timestamps` drops from `warning` to `info`. Each entity it reports now costs `0.5 × 1.1 = 0.55` penalty points instead of `1.5 × 1.1 = 1.65`, so schema-heavy projects' scores rise. Join tables, entities whose every column is a primary key or a relation's own column, are no longer reported at all.
+`schema/require-timestamps` drops from `warning` to `info`. Each entity it reports now costs `0.5 × 1.1 = 0.55` penalty points instead of `1.5 × 1.1 = 1.65`, so schema-heavy projects' scores rise. Runs gated with `--blocking warning` no longer fail on this rule. Join tables, entities whose every column is a primary key or a relation's own column, are no longer reported at all.
 
 `architecture/no-orm-in-services` no longer reports `PrismaService`/`PrismaClient`, so the official NestJS Prisma recipe is quiet. The "you can disable this rule" sentence is gone from its `help`.

--- a/.changeset/rules-timestamps-orm-narrowed.md
+++ b/.changeset/rules-timestamps-orm-narrowed.md
@@ -1,0 +1,9 @@
+---
+"nestjs-doctor": patch
+---
+
+### Changed
+
+`schema/require-timestamps` drops from `warning` to `info`. Each entity it reports now costs `0.5 × 1.1 = 0.55` penalty points instead of `1.5 × 1.1 = 1.65`, so schema-heavy projects' scores rise. Join tables, entities whose every column is a primary key or a relation's own column, are no longer reported at all.
+
+`architecture/no-orm-in-services` no longer reports `PrismaService`/`PrismaClient`, so the official NestJS Prisma recipe is quiet. The "you can disable this rule" sentence is gone from its `help`.

--- a/.rules-rationale.md
+++ b/.rules-rationale.md
@@ -488,7 +488,7 @@
 ### `architecture/no-orm-in-services`
 | Severity | Scope | Description |
 |----------|-------|-------------|
-| warning | file | Services should use repository abstractions instead of ORM directly |
+| info | file | Services should use repository abstractions instead of ORM directly |
 
 **Rationale:** The repository pattern adds a layer of abstraction between services and the ORM, making services testable with mock repositories and allowing ORM changes without modifying business logic. This is a well-established pattern in enterprise application architecture.
 
@@ -661,7 +661,7 @@
 ### `schema/require-timestamps`
 | Severity | Scope | Description |
 |----------|-------|-------------|
-| warning | schema | Entities should have timestamp columns (createdAt/updatedAt) |
+| info | schema | Entities should have timestamp columns (createdAt/updatedAt) |
 
 **Rationale:** Timestamp columns (`createdAt`, `updatedAt`) provide a built-in audit trail for every record. They're essential for debugging data issues ("when did this change?"), building incremental sync/ETL pipelines, implementing cache invalidation, and meeting compliance requirements. Adding them retroactively requires a migration and backfill.
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/architecture/no-orm-in-services.ts
@@ -10,8 +10,6 @@ import type { Rule } from "../../types.js";
 // injecting ORM types either. Both rules above and below should remain
 // symmetric for the two ORMs' typed repository classes.
 const ORM_TYPES = new Set([
-	"PrismaService",
-	"PrismaClient",
 	"EntityManager",
 	"DataSource",
 	"Connection",
@@ -27,7 +25,7 @@ export const noOrmInServices: Rule = {
 		severity: "info",
 		description:
 			"Services should use repository abstractions instead of ORM directly",
-		help: "Create a repository class that wraps ORM calls and inject that instead. Note: If your project follows the official NestJS Prisma recipe (injecting PrismaService directly), you can disable this rule.",
+		help: "Create a repository class that wraps ORM calls and inject that instead.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/schema/require-timestamps.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/schema/require-timestamps.ts
@@ -62,18 +62,27 @@ function hasTimestampColumns(entity: SchemaEntity, orm: string): boolean {
 	return false;
 }
 
+// Every column is a primary key or a relation's own column.
+function isKeyOnlyEntity(entity: SchemaEntity): boolean {
+	const relationProps = new Set(entity.relations.map((r) => r.propertyName));
+	return entity.columns.every((c) => c.isPrimary || relationProps.has(c.name));
+}
+
 export const requireTimestamps: SchemaRule = {
 	meta: {
 		id: "schema/require-timestamps",
 		category: "schema",
 		scope: "schema",
-		severity: "warning",
+		severity: "info",
 		description: "Entities should have timestamp columns (createdAt/updatedAt)",
 		help: "Add createdAt/updatedAt columns to track when records are created and modified.",
 	},
 
 	check(context) {
 		for (const entity of context.schemaGraph.entities.values()) {
+			if (isKeyOnlyEntity(entity)) {
+				continue;
+			}
 			if (!hasTimestampColumns(entity, context.orm)) {
 				context.report({
 					filePath: entity.filePath,

--- a/packages/nestjs-doctor/src/report/data/examples.ts
+++ b/packages/nestjs-doctor/src/report/data/examples.ts
@@ -507,7 +507,7 @@ export class OrderService {
 		"architecture/no-orm-in-services": {
 			bad: `@Injectable()
 export class UserService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly em: EntityManager) {}
 }`,
 			good: `@Injectable()
 export class UserService {

--- a/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/architecture-rules.test.ts
@@ -609,7 +609,7 @@ describe("no-orm-in-services", () => {
 		expect(diags).toHaveLength(0);
 	});
 
-	it("flags PrismaService injection in services", () => {
+	it("stays quiet on PrismaService injection — the official Nest recipe", () => {
 		const diags = runRule(
 			noOrmInServices,
 			`
@@ -620,7 +620,56 @@ describe("no-orm-in-services", () => {
       }
     `
 		);
-		expect(diags.length).toBeGreaterThan(0);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("stays quiet on PrismaClient injection", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class UsersService {
+        constructor(private readonly prisma: PrismaClient) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(0);
+	});
+
+	it("still flags EntityManager injection", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class UsersService {
+        constructor(private readonly em: EntityManager) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("EntityManager");
+	});
+
+	it("still flags @InjectRepository() in a service using a TypeORM Repository", () => {
+		const diags = runRule(
+			noOrmInServices,
+			`
+      import { Injectable } from '@nestjs/common';
+      import { InjectRepository } from '@nestjs/typeorm';
+      import { Repository } from 'typeorm';
+      @Injectable()
+      export class UsersService {
+        constructor(
+          @InjectRepository(User)
+          private readonly users: Repository<User>,
+        ) {}
+      }
+    `
+		);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("@InjectRepository");
 	});
 
 	it("skips classes named *Repository", () => {
@@ -630,7 +679,7 @@ describe("no-orm-in-services", () => {
       import { Injectable } from '@nestjs/common';
       @Injectable()
       export class UsersRepository {
-        constructor(private readonly prisma: PrismaService) {}
+        constructor(private readonly em: EntityManager) {}
       }
     `
 		);
@@ -1596,8 +1645,8 @@ describe("no-orm-in-services duplicates", () => {
       @Injectable()
       export class ReportService {
         constructor(
-          private readonly primary: PrismaService,
-          private readonly replica: PrismaService,
+          private readonly primary: EntityManager,
+          private readonly replica: EntityManager,
         ) {}
       }
     `
@@ -1613,7 +1662,7 @@ describe("no-orm-in-services duplicates", () => {
       @Injectable()
       export class ReportService {
         constructor(
-          private readonly prisma: PrismaService,
+          private readonly em: EntityManager,
           private readonly source: DataSource,
         ) {}
       }
@@ -1633,7 +1682,7 @@ describe("no-orm-in-services duplicates", () => {
           @InjectRepository(User) private a: Repository<User>,
           @InjectRepository(Role) private b: Repository<Role>,
           @InjectModel(Doc.name) private c: Model<Doc>,
-          private d: PrismaService,
+          private d: EntityManager,
         ) {}
       }
     `

--- a/packages/nestjs-doctor/tests/unit/schema/schema-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/schema/schema-rules.test.ts
@@ -211,7 +211,10 @@ describe("require-primary-key with MikroORM relation primary keys (issue #294)",
 describe("schema/require-timestamps", () => {
 	it("should report entity without timestamp columns", () => {
 		const entity = makeEntity({
-			columns: [makeColumn({ name: "id", isPrimary: true })],
+			columns: [
+				makeColumn({ name: "id", isPrimary: true }),
+				makeColumn({ name: "email" }),
+			],
 		});
 		const graph = makeGraph([entity]);
 		const diagnostics = runSchemaRule(requireTimestamps, graph);
@@ -393,6 +396,122 @@ describe("schema/require-timestamps", () => {
 		const diagnostics = runSchemaRule(requireTimestamps, graph);
 
 		expect(diagnostics).toHaveLength(1);
+	});
+
+	it("skips a Prisma join table whose columns are all composite-@@id FKs", () => {
+		const entity = makeEntity({
+			name: "PostTag",
+			columns: [
+				makeColumn({ name: "postId", isPrimary: true }),
+				makeColumn({ name: "tagId", isPrimary: true }),
+			],
+			relations: [
+				makeRelation({ propertyName: "post", toEntity: "Post" }),
+				makeRelation({ propertyName: "tag", toEntity: "Tag" }),
+			],
+		});
+		const graph = makeGraph([entity], "prisma");
+		const diagnostics = runSchemaRule(requireTimestamps, graph);
+
+		expect(diagnostics).toHaveLength(0);
+	});
+
+	it("skips a TypeORM join entity with only @PrimaryColumn FKs", () => {
+		const entity = makeEntity({
+			name: "PostTag",
+			columns: [
+				makeColumn({ name: "postId", isPrimary: true }),
+				makeColumn({ name: "tagId", isPrimary: true }),
+			],
+			relations: [
+				makeRelation({ propertyName: "post", toEntity: "Post" }),
+				makeRelation({ propertyName: "tag", toEntity: "Tag" }),
+			],
+		});
+		const graph = makeGraph([entity], "typeorm");
+		const diagnostics = runSchemaRule(requireTimestamps, graph);
+
+		expect(diagnostics).toHaveLength(0);
+	});
+
+	it("skips a Drizzle join table whose only columns are references()", () => {
+		const entity = makeEntity({
+			name: "PostTag",
+			columns: [
+				makeColumn({ name: "postId", isPrimary: false }),
+				makeColumn({ name: "tagId", isPrimary: false }),
+			],
+			relations: [
+				makeRelation({ propertyName: "postId", toEntity: "Post" }),
+				makeRelation({ propertyName: "tagId", toEntity: "Tag" }),
+			],
+		});
+		const graph = makeGraph([entity], "drizzle");
+		const diagnostics = runSchemaRule(requireTimestamps, graph);
+
+		expect(diagnostics).toHaveLength(0);
+	});
+
+	it("skips a MikroORM entity whose only column is a primary: true relation FK", () => {
+		const entity = makeEntity({
+			name: "PostTag",
+			columns: [makeColumn({ name: "user", isPrimary: true })],
+			relations: [makeRelation({ propertyName: "user", toEntity: "User" })],
+		});
+		const graph = makeGraph([entity], "mikro-orm");
+		const diagnostics = runSchemaRule(requireTimestamps, graph);
+
+		expect(diagnostics).toHaveLength(0);
+	});
+
+	it("still reports a join table that carries a payload column", () => {
+		const entity = makeEntity({
+			name: "PostTag",
+			columns: [
+				makeColumn({ name: "postId", isPrimary: false }),
+				makeColumn({ name: "tagId", isPrimary: false }),
+				makeColumn({ name: "role", type: "text" }),
+			],
+			relations: [
+				makeRelation({ propertyName: "postId", toEntity: "Post" }),
+				makeRelation({ propertyName: "tagId", toEntity: "Tag" }),
+			],
+		});
+		const graph = makeGraph([entity], "drizzle");
+		const diagnostics = runSchemaRule(requireTimestamps, graph);
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].entity).toBe("PostTag");
+	});
+
+	it("still reports an ordinary entity with a FK and a data column", () => {
+		const entity = makeEntity({
+			name: "Post",
+			columns: [
+				makeColumn({ name: "id", isPrimary: true }),
+				makeColumn({ name: "title", type: "text" }),
+				makeColumn({ name: "authorId" }),
+			],
+			relations: [makeRelation({ propertyName: "author", toEntity: "User" })],
+		});
+		const graph = makeGraph([entity], "typeorm");
+		const diagnostics = runSchemaRule(requireTimestamps, graph);
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].entity).toBe("Post");
+	});
+
+	it("reports at info severity", () => {
+		const entity = makeEntity({
+			columns: [
+				makeColumn({ name: "id", isPrimary: true }),
+				makeColumn({ name: "email" }),
+			],
+		});
+		const graph = makeGraph([entity]);
+		const diagnostics = runSchemaRule(requireTimestamps, graph);
+
+		expect(diagnostics[0].severity).toBe("info");
 	});
 });
 

--- a/packages/website/public/demo-report.json
+++ b/packages/website/public/demo-report.json
@@ -21,8 +21,8 @@
   "summary": {
     "total": 26,
     "errors": 4,
-    "warnings": 15,
-    "info": 7,
+    "warnings": 13,
+    "info": 9,
     "byCategory": {
       "security": 6,
       "performance": 6,
@@ -818,7 +818,7 @@
       "rule": "schema/require-timestamps",
       "category": "schema",
       "scope": "schema",
-      "severity": "warning"
+      "severity": "info"
     },
     {
       "filePath": "/demo/nest-shop/apps/api/src/payments/invoice.entity.ts",
@@ -828,7 +828,7 @@
       "rule": "schema/require-timestamps",
       "category": "schema",
       "scope": "schema",
-      "severity": "warning"
+      "severity": "info"
     },
     {
       "filePath": "/demo/nest-shop/apps/api/src/catalog/product.entity.ts",
@@ -8129,7 +8129,7 @@
             "rule": "schema/require-timestamps",
             "category": "schema",
             "scope": "schema",
-            "severity": "warning"
+            "severity": "info"
           },
           {
             "filePath": "apps/api/src/payments/invoice.entity.ts",
@@ -8139,7 +8139,7 @@
             "rule": "schema/require-timestamps",
             "category": "schema",
             "scope": "schema",
-            "severity": "warning"
+            "severity": "info"
           },
           {
             "filePath": "apps/api/src/catalog/product.entity.ts",
@@ -8165,8 +8165,8 @@
         "summary": {
           "total": 4,
           "errors": 0,
-          "warnings": 2,
-          "info": 2,
+          "warnings": 0,
+          "info": 4,
           "byCategory": {
             "security": 0,
             "performance": 0,

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -340,7 +340,7 @@ Docs: https://nestjs.doctor/docs/language-server
 ### Schema (3)
 
 - `require-primary-key` (error) — Entity with no primary key column
-- `require-timestamps` (warning) — Entity missing createdAt/updatedAt columns
+- `require-timestamps` (info) — Entity missing createdAt/updatedAt columns
 - `require-cascade-rule` (info) — Relation with no explicit onDelete behavior
 
 Schema rules run against entities extracted from Prisma, TypeORM, Drizzle, or MikroORM. They report against an entity, so their findings carry no line number.

--- a/packages/website/src/app/docs/rules/architecture/page.mdx
+++ b/packages/website/src/app/docs/rules/architecture/page.mdx
@@ -317,20 +317,20 @@ export class UserService {
 
 Detects services that reach the ORM directly instead of going through a repository layer. Two shapes count:
 
-- **ORM types:** `PrismaService`, `PrismaClient`, `EntityManager`, `DataSource`, `Connection`, `MongooseModel`, `MikroORM`, `DrizzleService`.
+- **ORM types:** `EntityManager`, `DataSource`, `Connection`, `MongooseModel`, `MikroORM`, `DrizzleService`.
 - **ORM-binding decorators:** `@InjectRepository`, `@InjectModel`, `@InjectEntityManager`.
 
 **Why:** When services depend on ORM types directly, switching ORMs or data sources requires changing every service. A repository layer provides a clean abstraction boundary.
 
 **Note:** TypeORM's `Repository<T>` and MikroORM's `EntityRepository<T>` are allowed in services. They are the repository abstraction the rule asks for. Classes named `*Repository` or `*Repo` are skipped as well, so a custom repository can inject whatever it needs.
 
-Two official setups inject these types on purpose. The [NestJS Prisma recipe](https://docs.nestjs.com/recipes/prisma) injects `PrismaService`, and the [@mikro-orm/nestjs setup](https://mikro-orm.io/docs/usage-with-nestjs) injects `EntityManager` or uses `@InjectRepository`. Disable this rule if the project follows either.
+The [@mikro-orm/nestjs setup](https://mikro-orm.io/docs/usage-with-nestjs) injects `EntityManager` or uses `@InjectRepository` on purpose.
 
 <CodeGroup labels={["Bad", "Good"]}>
 ```typescript
 @Injectable()
 export class UserService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly em: EntityManager) {}
 }
 ```
 ```typescript

--- a/packages/website/src/app/docs/rules/schema/page.mdx
+++ b/packages/website/src/app/docs/rules/schema/page.mdx
@@ -49,7 +49,7 @@ model Product {
 
 Detects entities missing `createdAt`/`updatedAt` timestamp columns.
 
-Entities whose every column is a primary key or a relation's own column are skipped. A join table has no data of its own to timestamp.
+Entities whose every column is a primary key or a relation's own column are skipped.
 
 **Why:** Timestamp columns are essential for auditing, debugging, and data integrity. Without them, there is no way to know when a record was created or last modified.
 

--- a/packages/website/src/app/docs/rules/schema/page.mdx
+++ b/packages/website/src/app/docs/rules/schema/page.mdx
@@ -12,7 +12,7 @@ export const metadata = docsMetadata["/docs/rules/schema"];
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
 | `require-primary-key` | error | Entity without a primary key column |
-| `require-timestamps` | warning | Entity missing createdAt/updatedAt columns |
+| `require-timestamps` | info | Entity missing createdAt/updatedAt columns |
 | `require-cascade-rule` | info | Relation missing explicit onDelete behavior |
 
 ---
@@ -48,6 +48,8 @@ model Product {
 **Scope:** Schema
 
 Detects entities missing `createdAt`/`updatedAt` timestamp columns.
+
+Entities whose every column is a primary key or a relation's own column are skipped. A join table has no data of its own to timestamp.
 
 **Why:** Timestamp columns are essential for auditing, debugging, and data integrity. Without them, there is no way to know when a record was created or last modified.
 

--- a/packages/website/src/components/landing/graph-and-schema.tsx
+++ b/packages/website/src/components/landing/graph-and-schema.tsx
@@ -160,7 +160,7 @@ const SCHEMA_FINDINGS = [
 		text: "Entity 'Payment' has no primary key column.",
 	},
 	{
-		level: "warning" as const,
+		level: "info" as const,
 		rule: "schema/require-timestamps",
 		text: "Entity 'Order' has no timestamp columns.",
 	},


### PR DESCRIPTION

## Problem

- A join table (`PostTag { postId, tagId }`) has nothing to timestamp, yet `require-timestamps` reports it like any other entity.
- The official NestJS Prisma recipe injects `PrismaService` into services. `no-orm-in-services` reports every service that follows the framework's own docs.

## Possible flows

| Flow | Before | After |
|---|---|---|
| Entity with data columns and no timestamps | warning, 1.65 points | info, 0.55 points |
| Join table: every column a primary key (Prisma `@@id`, TypeORM `@PrimaryColumn`, MikroORM `primary: true`) | reported | skipped |
| Drizzle join table: columns are `references()` with no `primaryKey()` | reported | skipped (a relation's own column counts as a key column; Drizzle is the one extractor where a relation is also a column) |
| Join table with a payload column (`role`) | reported | still reported |
| Service injecting `PrismaService` or `PrismaClient` | info finding | quiet |
| Service injecting `EntityManager`, `DataSource`, `@InjectRepository()` | info finding | unchanged |
| `require-primary-key` on a keyless entity | reported | unchanged |

## Solution

- `require-timestamps`: `meta.severity` to `info`; `isKeyOnlyEntity` skips an entity whose every column is `isPrimary` or matches a relation's `propertyName`. An entity with zero columns is skipped too (nothing to timestamp; `require-primary-key` still covers it).
- `no-orm-in-services`: `PrismaService` and `PrismaClient` removed from `ORM_TYPES`; the "you can disable this rule" sentence removed from `help`. The `@InjectRepository()` and `EntityManager` paths are untouched.
- Docs: severity cell, the join-table sentence, the ORM-type list, the Bad sample now injects `EntityManager` (the Prisma one no longer fires; `rule-examples.test.ts` enforces that Bad fires and Good does not). `llms.txt`, the landing mock, `.rules-rationale.md` and the committed demo report updated (the demo report is hand-curated, so its severities and summary counts were edited by the scorer's own arithmetic).

Not done: no rule id changes, no other severity changes, no composite-key work. No fixture entity is key-only, so the join-table skip changes zero existing findings; it is proven by new unit tests only.

## Before vs after

`--score --no-telemetry` on the shipped 0.9.5 versus this branch:

| Fixture | Before | After | Why |
|---|---|---|---|
| `tests/fixtures/typeorm-app` (11 files, 2 entities without timestamps) | 86 | 88 | 2 × (1.65 − 0.55) / 11 files |
| `tests/fixtures/mikro-orm-app` (11 files, 2) | 80 | 82 | same |
| `tests/fixtures/drizzle-app` (16 files, 2) | 86 | 88 | same |
| A service following the Prisma recipe | 1 `no-orm-in-services` finding | 0 | type removed |
| `tests/fixtures/basic-app` | 100 | 100 | unchanged |
| `packages/website/public/demo-report.json` (hand-curated, 58 files) | 93, 15 warnings / 7 info | 93, 13 warnings / 9 info | penalty 41.35 → 39.15 does not cross a rounding boundary |
