### PR TITLE
feat(cli): not-scored findings print last under their own heading, plus four search-landing edits

### DIFF
--- a/.changeset/console-not-scored-heading.md
+++ b/.changeset/console-not-scored-heading.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Console reports now print findings from rules that do not carry the `score` surface under a `Not scored` heading, after every finding that moves the score. The interactive view lists those rules last too. No score, exit code, or machine-readable output changes.

--- a/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
@@ -189,10 +189,7 @@ const collectAffectedFiles = (diagnostics: Diagnostic[]): Set<string> =>
 
 // --- Print functions ---
 
-const printDiagnostics = (
-	diagnostics: Diagnostic[],
-	verbose: boolean
-): void => {
+const printRuleGroups = (diagnostics: Diagnostic[], verbose: boolean): void => {
 	const ruleGroups = groupByRule(diagnostics);
 	const sortedGroups = sortBySeverity([...ruleGroups.entries()]);
 
@@ -206,11 +203,7 @@ const printDiagnostics = (
 		const countLabel =
 			count > 1 ? colorizeBySeverity(` (${count})`, first.severity) : "";
 
-		const notScored = onSurface(first, "score")
-			? ""
-			: highlighter.dim(" · not scored");
-
-		logger.log(`  ${icon} ${first.message}${countLabel}${notScored}`);
+		logger.log(`  ${icon} ${first.message}${countLabel}`);
 
 		if (first.help) {
 			logger.dim(`    ${first.help}`);
@@ -226,6 +219,27 @@ const printDiagnostics = (
 
 		logger.break();
 	}
+};
+
+// Findings off the score surface print last, under one heading that carries
+// the tag the per-finding line used to.
+const printDiagnostics = (
+	diagnostics: Diagnostic[],
+	verbose: boolean
+): void => {
+	const scored = diagnostics.filter((d) => onSurface(d, "score"));
+	const notScored = diagnostics.filter((d) => !onSurface(d, "score"));
+
+	printRuleGroups(scored, verbose);
+
+	if (notScored.length === 0) {
+		return;
+	}
+
+	logger.dim(`  Not scored (${notScored.length})`);
+	logger.dim("    Reported only. These do not move the score.");
+	logger.break();
+	printRuleGroups(notScored, verbose);
 };
 
 // --- Main reporter ---

--- a/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/formatters/console-reporter.ts
@@ -221,8 +221,7 @@ const printRuleGroups = (diagnostics: Diagnostic[], verbose: boolean): void => {
 	}
 };
 
-// Findings off the score surface print last, under one heading that carries
-// the tag the per-finding line used to.
+// Findings off the score surface print last, under their own heading.
 const printDiagnostics = (
 	diagnostics: Diagnostic[],
 	verbose: boolean

--- a/packages/nestjs-doctor/src/cli/interactive/agents.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/agents.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import type { Diagnostic } from "../../common/diagnostic.js";
 import { logger } from "../../ui/logger.js";
 import { isCommandAvailable } from "../ui/commands.js";
-import { buildFixPrompt, groupFindings } from "./findings.js";
+import { buildFixPrompt, groupFindings, SEVERITY_RANK } from "./findings.js";
 
 export interface LaunchableAgent {
 	binary: string;
@@ -29,7 +29,9 @@ export const buildHandoffPrompt = (
 	targetPath: string
 ): string => {
 	const groups = groupFindings(diagnostics);
-	const top = groups.slice(0, 3);
+	const top = [...groups]
+		.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity])
+		.slice(0, 3);
 
 	const sections = top.map((group) => buildFixPrompt(group, targetPath));
 	const remaining = groups.length - top.length;

--- a/packages/nestjs-doctor/src/cli/interactive/findings.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/findings.ts
@@ -12,7 +12,7 @@ export interface RuleGroup {
 	severity: Severity;
 }
 
-const SEVERITY_RANK: Record<Severity, number> = {
+export const SEVERITY_RANK: Record<Severity, number> = {
 	error: 0,
 	warning: 1,
 	info: 2,

--- a/packages/nestjs-doctor/src/cli/interactive/findings.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/findings.ts
@@ -1,12 +1,14 @@
 import {
 	type Diagnostic,
 	isCodeDiagnostic,
+	onSurface,
 	type Severity,
 } from "../../common/diagnostic.js";
 
 export interface RuleGroup {
 	diagnostics: Diagnostic[];
 	rule: string;
+	scored: boolean;
 	severity: Severity;
 }
 
@@ -16,7 +18,10 @@ const SEVERITY_RANK: Record<Severity, number> = {
 	info: 2,
 };
 
-/** Groups by rule, worst severity first, then by how often the rule fired. */
+/**
+ * Groups by rule: scored rules first, then worst severity, then by how often
+ * the rule fired.
+ */
 export const groupFindings = (diagnostics: Diagnostic[]): RuleGroup[] => {
 	const groups = new Map<string, RuleGroup>();
 	for (const diagnostic of diagnostics) {
@@ -27,12 +32,14 @@ export const groupFindings = (diagnostics: Diagnostic[]): RuleGroup[] => {
 			groups.set(diagnostic.rule, {
 				diagnostics: [diagnostic],
 				rule: diagnostic.rule,
+				scored: onSurface(diagnostic, "score"),
 				severity: diagnostic.severity,
 			});
 		}
 	}
 	return [...groups.values()].sort(
 		(a, b) =>
+			Number(b.scored) - Number(a.scored) ||
 			SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] ||
 			b.diagnostics.length - a.diagnostics.length ||
 			a.rule.localeCompare(b.rule)

--- a/packages/nestjs-doctor/src/cli/interactive/tui/navigate.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/navigate.ts
@@ -10,11 +10,20 @@ type ListRow =
 	| { kind: "category"; label: string }
 	| { groupIndex: number; kind: "group" };
 
-/** One caption per category, wherever the category first appears. */
+/**
+ * One caption per category, wherever the category first appears. The first
+ * not-scored group opens its own block and categories caption again inside it.
+ */
 export const buildListRows = (groups: RuleGroup[]): ListRow[] => {
 	const rows: ListRow[] = [];
-	const seen = new Set<string>();
+	let seen = new Set<string>();
+	let inScored = true;
 	for (const [groupIndex, group] of groups.entries()) {
+		if (inScored && !group.scored) {
+			inScored = false;
+			seen = new Set<string>();
+			rows.push({ kind: "category", label: "not scored" });
+		}
 		const category = group.rule.split("/")[0];
 		if (!(group.rule.startsWith("custom/") || seen.has(category))) {
 			seen.add(category);

--- a/packages/nestjs-doctor/src/cli/interactive/tui/navigate.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/navigate.ts
@@ -10,10 +10,7 @@ type ListRow =
 	| { kind: "category"; label: string }
 	| { groupIndex: number; kind: "group" };
 
-/**
- * One caption per category, wherever the category first appears. The first
- * not-scored group opens its own block and categories caption again inside it.
- */
+/** One caption per category; the not-scored block opens its own caption and re-captions inside. */
 export const buildListRows = (groups: RuleGroup[]): ListRow[] => {
 	const rows: ListRow[] = [];
 	let seen = new Set<string>();

--- a/packages/nestjs-doctor/src/cli/interactive/tui/review-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/review-screen.tsx
@@ -13,7 +13,7 @@ import {
 	scrollWindow,
 } from "./navigate.js";
 import { buildPanelLines } from "./panel.js";
-import { NOT_SCORED_TAG, ruleNameBudget, truncate } from "./text.js";
+import { truncate } from "./text.js";
 import { palette, SEVERITY_MARK, severityColor } from "./theme.js";
 import type { Toast } from "./types.js";
 
@@ -186,14 +186,9 @@ export const ReviewScreen = ({
 							current !== undefined && row.groupIndex === current.groupIndex;
 						const count = entry.diagnostics.length;
 						const suffix = count > 1 ? ` (${count})` : "";
-						// The tag keeps its full width; a row too narrow for both drops it.
-						const budget = ruleNameBudget(
-							leftContent - 3,
-							entry.scored ? 0 : NOT_SCORED_TAG.length
-						);
 						const name = truncate(
 							`${shortRule(entry.rule)}${suffix}`,
-							budget.width
+							leftContent - 3
 						);
 						return (
 							<Box flexDirection="row" key={entry.rule}>
@@ -217,9 +212,6 @@ export const ReviewScreen = ({
 										>
 											{name}
 										</Text>
-										{budget.tag ? (
-											<Text color={palette.dim}>{NOT_SCORED_TAG}</Text>
-										) : null}
 									</Text>
 								</Box>
 							</Box>

--- a/packages/nestjs-doctor/src/cli/interactive/tui/review-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/review-screen.tsx
@@ -19,6 +19,8 @@ import type { Toast } from "./types.js";
 
 const MIN_VISIBLE_ROWS = 8;
 const CHROME_ROWS = 7;
+const NOT_SCORED_TAG = " · not scored";
+const MIN_RULE_NAME_WIDTH = 8;
 
 interface ReviewScreenProps {
 	deferPrint: (text: string) => void;
@@ -186,9 +188,11 @@ export const ReviewScreen = ({
 							current !== undefined && row.groupIndex === current.groupIndex;
 						const count = entry.diagnostics.length;
 						const suffix = count > 1 ? ` (${count})` : "";
+						// The tag keeps its full width; the rule name gives way to it.
+						const tag = entry.scored ? "" : NOT_SCORED_TAG;
 						const name = truncate(
 							`${shortRule(entry.rule)}${suffix}`,
-							leftContent - 3
+							Math.max(MIN_RULE_NAME_WIDTH, leftContent - 3 - tag.length)
 						);
 						return (
 							<Box flexDirection="row" key={entry.rule}>
@@ -212,6 +216,7 @@ export const ReviewScreen = ({
 										>
 											{name}
 										</Text>
+										{tag ? <Text color={palette.dim}>{tag}</Text> : null}
 									</Text>
 								</Box>
 							</Box>

--- a/packages/nestjs-doctor/src/cli/interactive/tui/review-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/review-screen.tsx
@@ -13,14 +13,12 @@ import {
 	scrollWindow,
 } from "./navigate.js";
 import { buildPanelLines } from "./panel.js";
-import { truncate } from "./text.js";
+import { NOT_SCORED_TAG, ruleNameBudget, truncate } from "./text.js";
 import { palette, SEVERITY_MARK, severityColor } from "./theme.js";
 import type { Toast } from "./types.js";
 
 const MIN_VISIBLE_ROWS = 8;
 const CHROME_ROWS = 7;
-const NOT_SCORED_TAG = " · not scored";
-const MIN_RULE_NAME_WIDTH = 8;
 
 interface ReviewScreenProps {
 	deferPrint: (text: string) => void;
@@ -175,10 +173,10 @@ export const ReviewScreen = ({
 		<Box flexDirection="column" gap={1}>
 			<Box borderColor={palette.border} borderStyle="single">
 				<Box flexDirection="column" flexShrink={0} width={leftWidth}>
-					{visibleSlice.map((row) => {
+					{visibleSlice.map((row, index) => {
 						if (row.kind === "category") {
 							return (
-								<Text color={palette.muted} key={row.label}>
+								<Text color={palette.muted} key={`caption-${offset + index}`}>
 									{` ${truncate(row.label.toUpperCase(), leftContent - 1)}`}
 								</Text>
 							);
@@ -188,11 +186,14 @@ export const ReviewScreen = ({
 							current !== undefined && row.groupIndex === current.groupIndex;
 						const count = entry.diagnostics.length;
 						const suffix = count > 1 ? ` (${count})` : "";
-						// The tag keeps its full width; the rule name gives way to it.
-						const tag = entry.scored ? "" : NOT_SCORED_TAG;
+						// The tag keeps its full width; a row too narrow for both drops it.
+						const budget = ruleNameBudget(
+							leftContent - 3,
+							entry.scored ? 0 : NOT_SCORED_TAG.length
+						);
 						const name = truncate(
 							`${shortRule(entry.rule)}${suffix}`,
-							Math.max(MIN_RULE_NAME_WIDTH, leftContent - 3 - tag.length)
+							budget.width
 						);
 						return (
 							<Box flexDirection="row" key={entry.rule}>
@@ -216,7 +217,9 @@ export const ReviewScreen = ({
 										>
 											{name}
 										</Text>
-										{tag ? <Text color={palette.dim}>{tag}</Text> : null}
+										{budget.tag ? (
+											<Text color={palette.dim}>{NOT_SCORED_TAG}</Text>
+										) : null}
 									</Text>
 								</Box>
 							</Box>

--- a/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/score-screen.tsx
@@ -5,7 +5,7 @@ import { usableColumns, usableRows } from "../../../ui/terminal.js";
 import { formatElapsedTime } from "../../formatters/console-reporter.js";
 import { groupFindings } from "../findings.js";
 import { clampOffset, listCapacity, scrollWindow } from "./navigate.js";
-import { padEnd, truncate } from "./text.js";
+import { NOT_SCORED_TAG, padEnd, ruleNameBudget, truncate } from "./text.js";
 import {
 	getNestBirds,
 	getStarRating,
@@ -430,19 +430,28 @@ export const ScoreScreen = ({
 								{selectedRules.length > 0 ? (
 									<Box flexDirection="column" paddingTop={0}>
 										<Text color={palette.muted}>{" TOP RULES"}</Text>
-										{shownRules.map((group) => (
-											<Text key={group.rule}>
-												<Text color={severityColor(group.severity)}>
-													{` ${SEVERITY_MARK[group.severity]} `}
+										{shownRules.map((group) => {
+											const budget = ruleNameBudget(
+												panelWidth - 8,
+												group.scored ? 0 : NOT_SCORED_TAG.length
+											);
+											return (
+												<Text key={group.rule}>
+													<Text color={severityColor(group.severity)}>
+														{` ${SEVERITY_MARK[group.severity]} `}
+													</Text>
+													<Text color={palette.text}>
+														{truncate(shortRule(group.rule), budget.width)}
+													</Text>
+													{budget.tag ? (
+														<Text color={palette.dim}>{NOT_SCORED_TAG}</Text>
+													) : null}
+													<Text color={palette.dim}>
+														{` ${group.diagnostics.length}`}
+													</Text>
 												</Text>
-												<Text color={palette.text}>
-													{truncate(shortRule(group.rule), panelWidth - 8)}
-												</Text>
-												<Text color={palette.dim}>
-													{` ${group.diagnostics.length}`}
-												</Text>
-											</Text>
-										))}
+											);
+										})}
 										{rulesTruncated ? (
 											<Text color={palette.dim}>
 												{` … +${selectedRules.length - shownRules.length} more rules`}

--- a/packages/nestjs-doctor/src/cli/interactive/tui/text.ts
+++ b/packages/nestjs-doctor/src/cli/interactive/tui/text.ts
@@ -1,5 +1,21 @@
 const WHITESPACE = /\s+/;
 
+const MIN_RULE_NAME_WIDTH = 8;
+
+export const NOT_SCORED_TAG = " · not scored";
+
+/**
+ * Splits the room left for a rule row between its name and its tag. A tag that
+ * would squeeze the name below the minimum is dropped instead.
+ */
+export const ruleNameBudget = (
+	available: number,
+	tagLength: number
+): { tag: boolean; width: number } =>
+	tagLength > 0 && available - tagLength >= MIN_RULE_NAME_WIDTH
+		? { tag: true, width: available - tagLength }
+		: { tag: false, width: available };
+
 export const truncate = (text: string, width: number): string =>
 	text.length <= width ? text : `${text.slice(0, Math.max(0, width - 1))}…`;
 

--- a/packages/nestjs-doctor/tests/unit/console-reporter.test.ts
+++ b/packages/nestjs-doctor/tests/unit/console-reporter.test.ts
@@ -435,8 +435,95 @@ describe("printConsoleReport surfaces", () => {
 		const output = lines.join("\n");
 
 		expect(output).toContain("should be readonly");
-		expect(output).toContain("not scored");
+		expect(output).toContain("Not scored (1)");
 		expect(output).toContain("Provider is never injected");
+	});
+
+	it("prints not-scored findings after every scored one", () => {
+		const { lines, restore } = capture();
+		printConsoleReport(
+			makeResult({
+				diagnostics: [
+					{ ...scored, severity: "info" },
+					{ ...reportOnly, severity: "warning" },
+				],
+			}),
+			true
+		);
+		restore();
+		const output = lines.join("\n");
+
+		expect(output.indexOf("Provider is never injected")).toBeLessThan(
+			output.indexOf("should be readonly")
+		);
+	});
+
+	it("heads the not-scored block with its own line", () => {
+		const { lines, restore } = capture();
+		printConsoleReport(makeResult({ diagnostics: [reportOnly, scored] }), true);
+		restore();
+		const output = lines.join("\n");
+
+		expect(output).toContain("Not scored (1)");
+		expect(output).toContain("do not move the score");
+	});
+
+	it("drops the per-line not-scored tag under the heading", () => {
+		const { lines, restore } = capture();
+		printConsoleReport(makeResult({ diagnostics: [reportOnly, scored] }), true);
+		restore();
+		const output = lines.join("\n");
+
+		expect(output.match(/not scored/gi)).toHaveLength(1);
+		expect(
+			lines.find((line) => line.toLowerCase().includes("not scored"))?.trim()
+		).toBe("Not scored (1)");
+	});
+
+	it("prints no heading when every finding is scored", () => {
+		const { lines, restore } = capture();
+		printConsoleReport(makeResult({ diagnostics: [scored] }), true);
+		restore();
+
+		expect(lines.join("\n")).not.toContain("Not scored");
+	});
+
+	it("counts diagnostics, not groups, in the heading", () => {
+		const { lines, restore } = capture();
+		printConsoleReport(
+			makeResult({
+				diagnostics: [
+					reportOnly,
+					{ ...reportOnly, line: 2 },
+					{ ...reportOnly, line: 3 },
+				],
+			}),
+			false
+		);
+		restore();
+		const output = lines.join("\n");
+
+		expect(output).toContain("Not scored (3)");
+		expect(output.match(/should be readonly/g)).toHaveLength(1);
+	});
+
+	it("collapses a not-scored error below a scored info", () => {
+		const { lines, restore } = capture();
+		printConsoleReport(
+			makeResult({
+				diagnostics: [
+					{ ...reportOnly, severity: "error" },
+					{ ...scored, severity: "info" },
+				],
+			}),
+			true
+		);
+		restore();
+		const output = lines.join("\n");
+
+		expect(output.indexOf("Provider is never injected")).toBeLessThan(
+			output.indexOf("should be readonly")
+		);
 	});
 
 	it("leaves out a finding that never reaches the cli surface", () => {

--- a/packages/nestjs-doctor/tests/unit/interactive-detail.test.ts
+++ b/packages/nestjs-doctor/tests/unit/interactive-detail.test.ts
@@ -38,6 +38,49 @@ describe("groupFindings", () => {
 		]);
 		expect(groups[1].diagnostics).toHaveLength(2);
 	});
+
+	it("keeps severity order inside the scored groups", () => {
+		const groups = groupFindings([
+			code({ rule: "security/b", severity: "warning" }),
+			code({ rule: "correctness/a", severity: "error" }),
+		]);
+		expect(groups.map((group) => group.rule)).toEqual([
+			"correctness/a",
+			"security/b",
+		]);
+	});
+
+	it("lists a not-scored warning group after a scored info group", () => {
+		const groups = groupFindings([
+			code({
+				rule: "correctness/prefer-readonly-injection",
+				severity: "warning",
+				surfaces: ["cli"],
+			}),
+			code({ rule: "performance/no-unused-providers", severity: "info" }),
+		]);
+		expect(groups[0].rule).toBe("performance/no-unused-providers");
+		expect(groups[1].rule).toBe("correctness/prefer-readonly-injection");
+	});
+
+	it("marks the group as not scored", () => {
+		const groups = groupFindings([
+			code({
+				rule: "correctness/prefer-readonly-injection",
+				surfaces: ["cli"],
+			}),
+			code({ rule: "performance/no-unused-providers" }),
+		]);
+		expect(
+			groups.find(
+				(group) => group.rule === "correctness/prefer-readonly-injection"
+			)?.scored
+		).toBe(false);
+		expect(
+			groups.find((group) => group.rule === "performance/no-unused-providers")
+				?.scored
+		).toBe(true);
+	});
 });
 
 describe("buildFixPrompt", () => {
@@ -46,6 +89,7 @@ describe("buildFixPrompt", () => {
 			{
 				diagnostics: [code({}), code({ line: 40, column: 1 })],
 				rule: "security/require-auth-guards",
+				scored: true,
 				severity: "warning",
 			},
 			"/app"
@@ -62,7 +106,7 @@ describe("buildFixPrompt", () => {
 			code({ line: index + 1 })
 		);
 		const prompt = buildFixPrompt(
-			{ diagnostics: many, rule: "r/x", severity: "info" },
+			{ diagnostics: many, rule: "r/x", scored: true, severity: "info" },
 			"/app"
 		);
 		expect(prompt.match(/^- \//gm)).toHaveLength(10);

--- a/packages/nestjs-doctor/tests/unit/interactive-handoff.test.ts
+++ b/packages/nestjs-doctor/tests/unit/interactive-handoff.test.ts
@@ -32,6 +32,26 @@ describe("buildHandoffPrompt", () => {
 		expect(prompt).toContain("npx nestjs-doctor@latest . --json");
 	});
 
+	it("leads with a not-scored error over scored infos", () => {
+		const prompt = buildHandoffPrompt(
+			[
+				finding({ rule: "performance/one", severity: "info" }),
+				finding({ rule: "performance/two", severity: "info" }),
+				finding({ rule: "performance/three", severity: "info" }),
+				finding({
+					rule: "security/no-vulnerable-nestjs-packages",
+					severity: "error",
+					surfaces: ["cli"],
+				}),
+			],
+			"/app"
+		);
+		expect(
+			prompt.indexOf("security/no-vulnerable-nestjs-packages")
+		).toBeLessThan(prompt.indexOf("performance/"));
+		expect(prompt).toContain("1 more rule reported");
+	});
+
 	it("orders the sections worst first", () => {
 		const prompt = buildHandoffPrompt(
 			[

--- a/packages/nestjs-doctor/tests/unit/tui-navigate.test.ts
+++ b/packages/nestjs-doctor/tests/unit/tui-navigate.test.ts
@@ -8,6 +8,7 @@ import {
 	moveSelection,
 	scrollWindow,
 } from "../../src/cli/interactive/tui/navigate.js";
+import { ruleNameBudget } from "../../src/cli/interactive/tui/text.js";
 import type { Diagnostic } from "../../src/common/diagnostic.js";
 
 const diagnostic = (
@@ -121,5 +122,42 @@ describe("buildListRows", () => {
 	it("does not caption custom rules", () => {
 		const custom = groupFindings([diagnostic("custom/team-rule", "info")]);
 		expect(buildListRows(custom)).toEqual([{ groupIndex: 0, kind: "group" }]);
+	});
+
+	it("opens a not-scored block and captions categories again inside it", () => {
+		const mixed = groupFindings([
+			diagnostic("correctness/awaited", "error"),
+			diagnostic("performance/nested-controller", "warning"),
+			{
+				...diagnostic("correctness/no-async-without-await", "info"),
+				surfaces: ["cli"],
+			},
+		]);
+		expect(buildListRows(mixed)).toEqual([
+			{ kind: "category", label: "correctness" },
+			{ groupIndex: 0, kind: "group" },
+			{ kind: "category", label: "performance" },
+			{ groupIndex: 1, kind: "group" },
+			{ kind: "category", label: "not scored" },
+			{ kind: "category", label: "correctness" },
+			{ groupIndex: 2, kind: "group" },
+		]);
+	});
+});
+
+describe("ruleNameBudget", () => {
+	const tag = " · not scored".length;
+
+	it("drops the tag when the name would fall below the minimum", () => {
+		expect(ruleNameBudget(17, tag)).toEqual({ tag: false, width: 17 });
+	});
+
+	it("keeps the tag once the name still gets the minimum", () => {
+		expect(ruleNameBudget(21, tag)).toEqual({ tag: true, width: 8 });
+		expect(ruleNameBudget(24, tag)).toEqual({ tag: true, width: 11 });
+	});
+
+	it("gives an untagged row the whole width", () => {
+		expect(ruleNameBudget(17, 0)).toEqual({ tag: false, width: 17 });
 	});
 });

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -223,7 +223,7 @@ surfaces: `cli`, `prComment`, `score`, `ciFailure`, all four by default. Only
 rules whose surfaces include `score` are counted; a rule set to `["cli"]` still
 reports every finding in the console and the HTML report, and weighs nothing.
 `correctness/no-async-without-await` and `correctness/prefer-readonly-injection`
-are `["cli"]`, so they never comment on a pull request and never fail a build. Override per rule with `"rules": { "<id>": { "surfaces": [...] } }`.
+are `["cli"]`, so they never comment on a pull request and never fail a build. The console prints those findings last, under a "Not scored" heading. Override per rule with `"rules": { "<id>": { "surfaces": [...] } }`.
 
 Severity weights: error = 3.0, warning = 1.5, info = 0.5
 Category multipliers: security = 1.5x, correctness = 1.3x, schema = 1.1x, architecture = 1.0x, performance = 0.8x

--- a/packages/website/src/app/docs/coding-agents/page.mdx
+++ b/packages/website/src/app/docs/coding-agents/page.mdx
@@ -24,6 +24,15 @@ The first one is the everyday skill. Its description tells the agent to reach
 for it after writing Nest code and before committing, so it runs without being
 asked.
 
+The everyday skill runs this after a change:
+
+```bash
+npx nestjs-doctor@latest . --scope changed --base origin/main --verbose
+```
+
+It needs a git repository with the base commit fetched; without one the scan
+reports everything and says why.
+
 It installs for Claude Code, Cursor, Codex, OpenCode, Windsurf, Amp,
 Antigravity, and Gemini CLI. Detection looks for each one's config directory or
 binary. Windsurf is the exception: it has no skills directory, so the content goes into

--- a/packages/website/src/app/docs/nest-devtools-alternative/page.mdx
+++ b/packages/website/src/app/docs/nest-devtools-alternative/page.mdx
@@ -10,15 +10,9 @@ Both tools draw a NestJS module graph. They get there from opposite ends.
 
 Nest Devtools boots your application and introspects the graph Nest built.
 nestjs-doctor reads the `@Module()` decorators in your source and never runs
-anything. Neither approach contains the other, so this page covers what each
-one can see.
+anything. It is [free under MIT](#everything-is-free).
 
-## How each one gets the graph
-
-Nest Devtools takes a `DevtoolsModule` import plus a `snapshot` flag on
-`NestFactory.create`. The running app then exposes an extra HTTP server, on
-port 8000 by default, and the dashboard at devtools.nestjs.com reads the graph
-from it. Nest's own documentation says not to enable the module in production.
+Neither approach contains the other, so this page covers what each one can see.
 
 nestjs-doctor takes one command:
 
@@ -29,6 +23,13 @@ npx nestjs-doctor@latest . --report
 That writes a single HTML file and opens it. Nothing boots, so a module that
 cannot start, because a provider is missing, still shows up in the graph with
 the problem named.
+
+## How each one gets the graph
+
+Nest Devtools takes a `DevtoolsModule` import plus a `snapshot` flag on
+`NestFactory.create`. The running app then exposes an extra HTTP server, on
+port 8000 by default, and the dashboard at devtools.nestjs.com reads the graph
+from it. Nest's own documentation says not to enable the module in production.
 
 | | Nest Devtools | nestjs-doctor |
 |---|---|---|

--- a/packages/website/src/app/docs/rules/architecture/page.mdx
+++ b/packages/website/src/app/docs/rules/architecture/page.mdx
@@ -9,18 +9,24 @@ export const metadata = docsMetadata["/docs/rules/architecture"];
 
 10 rules that enforce clean layering, dependency injection patterns, and module boundaries.
 
+Run every rule on this page against a project:
+
+```bash
+npx nestjs-doctor@latest . --verbose
+```
+
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
-| `no-business-logic-in-controllers` | error | Loops, `switch`, a second branch, or repeated array ops in handlers |
-| `no-repository-in-controllers` | error | Repository injection in controllers |
-| `no-orm-in-controllers` | error | ORM types or ORM-binding decorators injected into controllers |
-| `no-circular-module-deps` | error | Cycles in the `@Module()` import graph |
-| `no-manual-instantiation` | error | `new SomeService()` for a class registered as a provider |
-| `no-service-locator` | warning | `ModuleRef.get()`/`resolve()` usage |
-| `prefer-constructor-injection` | warning | `@Inject()` property injection |
-| `no-orm-in-services` | info | Services using ORM directly (should use repositories) |
-| `require-module-boundaries` | info | Relative imports into another module's internal directories |
-| `no-barrel-export-internals` | info | Re-exporting repositories from barrel files |
+| [`no-business-logic-in-controllers`](#no-business-logic-in-controllers) | error | Loops, `switch`, a second branch, or repeated array ops in handlers |
+| [`no-repository-in-controllers`](#no-repository-in-controllers) | error | Repository injection in controllers |
+| [`no-orm-in-controllers`](#no-orm-in-controllers) | error | ORM types or ORM-binding decorators injected into controllers |
+| [`no-circular-module-deps`](#no-circular-module-deps) | error | Cycles in the `@Module()` import graph |
+| [`no-manual-instantiation`](#no-manual-instantiation) | error | `new SomeService()` for a class registered as a provider |
+| [`no-service-locator`](#no-service-locator) | warning | `ModuleRef.get()`/`resolve()` usage |
+| [`prefer-constructor-injection`](#prefer-constructor-injection) | warning | `@Inject()` property injection |
+| [`no-orm-in-services`](#no-orm-in-services) | info | Services using ORM directly (should use repositories) |
+| [`require-module-boundaries`](#require-module-boundaries) | info | Relative imports into another module's internal directories |
+| [`no-barrel-export-internals`](#no-barrel-export-internals) | info | Re-exporting repositories from barrel files |
 
 ---
 

--- a/packages/website/src/app/docs/rules/architecture/page.mdx
+++ b/packages/website/src/app/docs/rules/architecture/page.mdx
@@ -15,6 +15,8 @@ Run every rule on this page against a project:
 npx nestjs-doctor@latest . --verbose
 ```
 
+Without `--verbose` the console prints one line per rule; with it, every file and line.
+
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
 | [`no-business-logic-in-controllers`](#no-business-logic-in-controllers) | error | Loops, `switch`, a second branch, or repeated array ops in handlers |

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -28,8 +28,10 @@ The score is weighted by severity and category, then normalized by project
 size. A small project with three errors scores worse than a large one with three.
 It always covers the whole project, whatever you scope the report to.
 
-Findings are grouped by rule, worst first. Add `--verbose` for the file and line
-behind each one:
+Findings are grouped by rule, worst first. Rules that do not move the score
+print last, under a `Not scored` heading.
+
+Add `--verbose` for the file and line behind each one:
 
 ```bash
 npx nestjs-doctor@latest . --verbose


### PR DESCRIPTION
## Context

Three rules carry no `score` surface: `correctness/no-async-without-await` and `correctness/prefer-readonly-injection` (`["cli"]`) and `security/no-vulnerable-nestjs-packages` (`["cli", "prComment"]`). They print like every other finding, with a small `· not scored` tag at the end of the line. Telemetry says `no-async-without-await` fires in 51 of 84 installs and, with `prefer-readonly-injection`, is 52% of everything printed. Improvement plan rows 2.8 and 2.7.

## Problem

- A reader sees a wall of warnings that do not move the score, interleaved by severity with the ones that do, and reads the tool as noisy. The turn-off rate for those two rules is the metric.
- On a TTY the human never sees the console printer at all: `canPrompt` sends them into the interactive list, which sorts by severity only. The spec row named only the console.
- Four search-landing pages put the command a visitor came for below the fold.

## Possible flows

| Flow | Before | After |
|---|---|---|
| `nestjs-doctor .` in CI, non-TTY, or `--verbose` | not-scored findings interleaved by severity, `· not scored` per line | scored findings first, then a dim `Not scored (n)` heading with `Reported only. These do not move the score.`, then that group sorted by severity |
| Interactive TTY run | list sorted by severity | scored rule groups first, not-scored groups last under their own `not scored` caption; the score screen's top rules carry a ` · not scored` tag when the row has room |
| `--format github` | console report plus annotations | annotations byte-identical; the console half moves as above |
| `--format json`, `sarif`, `gitlab`, `markdown`, `--score` | unchanged | byte-identical (checked against a `b67449e` build) |
| Agent handoff prompt (top three groups, "worst first") | severity order | still severity order: it sorts on its own, so a not-scored CVE error stays first |
| A user who configured `surfaces` for a rule | the configured surfaces decide | same: the predicate is per diagnostic, `!onSurface(d, "score")`, never a rule-id list |
| Score, exit code, `--blocking` | as before | untouched |

## Solution

- `printDiagnostics` partitions on the `score` surface, prints the scored partition exactly as before, then the heading and the rest. The per-line tag is gone; the heading carries it.
- `groupFindings` gains `scored` and a leading sort key; `buildListRows` emits a `not scored` caption at the boundary; the review row carries no tag (the caption says it, and a tag cost ten characters of rule name at 80 columns); the score screen's top rules keep the tag when the row has room; `buildHandoffPrompt` keeps its own severity sort.
- Docs: a run command and anchored rule names on `/docs/rules/architecture`; the `--report` command and the MIT fact in the first screen of `/docs/nest-devtools-alternative`; the everyday skill command on `/docs/coding-agents`, byte-identical to the shipped skill; one sentence on `/docs/setup` about the heading. `llms.txt` gains one sentence.

Not done: no change to which rules carry which surfaces (giving the CVE rule the `score` surface is a scoring change with its own entry), no scoring or gate change.

## Before vs after

`node packages/nestjs-doctor/dist/cli/index.mjs packages/nestjs-doctor/tests/fixtures/bad-practices --no-telemetry`, colour stripped, help lines elided.

Before (`b67449e`):

```
  ✗ Possible hardcoded Secret key detected. (3)
  ✗ Controller injects repository 'UsersRepository' directly. Use a service layer instead.
  ⚠ Constructor parameter 'usersService' should be readonly. (3) · not scored
  ⚠ Endpoint 'findAll' has no @UseGuards() at class or method level. (2)
  ⚠ Provider 'ConfigService' is never injected by any other provider or controller.
```

After:

```
  ✗ Possible hardcoded Secret key detected. (3)
  ✗ Controller injects repository 'UsersRepository' directly. Use a service layer instead.
  ⚠ Endpoint 'findAll' has no @UseGuards() at class or method level. (2)
  ⚠ Provider 'ConfigService' is never injected by any other provider or controller.

  Not scored (3)
    Reported only. These do not move the score.

  ⚠ Constructor parameter 'usersService' should be readonly. (3)
```

| Output | Before | After |
|---|---|---|
| `--format json` on the same fixture | 5 rules, score 56 | identical bytes |
| `--score` | 56 | 56 |
| Exit code with `--blocking warning` | 1 | 1 |

## Example

Real command and output above. `security/no-vulnerable-nestjs-packages` lands under the same heading by design: the line already said `· not scored`, and inside the group its errors sort first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjSReP4FCbUcwjtdgWn4iV
