### PR TITLE
feat(cli): one line, once, pointing at the extension and the LSP; the telemetry notice goes

### DIFF
--- a/.changeset/quiet-moons-jump.md
+++ b/.changeset/quiet-moons-jump.md
@@ -3,4 +3,6 @@
 "nestjs-doctor-lsp": patch
 ---
 
-Point CLI users at the VS Code extension once per install
+The first console scan on a machine now prints one line pointing at the VS Code extension and the `nestjs-doctor-lsp` language server, then never again. It is never printed in CI, inside a coding agent, in a machine-readable format, when stderr is not a TTY, once the language server has already run, or on a machine where the marker could not be written.
+
+The first-run telemetry notice is gone. It printed the same once-per-install line budget on a message nobody had asked for; [the telemetry page](https://nestjs.doctor/docs/telemetry) still documents every field and every opt-out.

--- a/.changeset/quiet-moons-jump.md
+++ b/.changeset/quiet-moons-jump.md
@@ -1,0 +1,6 @@
+---
+"nestjs-doctor": patch
+"nestjs-doctor-lsp": patch
+---
+
+Point CLI users at the VS Code extension once per install

--- a/.changeset/telemetry-norm-engine.md
+++ b/.changeset/telemetry-norm-engine.md
@@ -6,8 +6,6 @@ Bring scan telemetry up to the norm other JS CLIs follow.
 
 A scan run in CI now reports as `ci.<provider>.<hash>`, where the hash is a one-way digest of the numeric repository id the runner provides (`GITHUB_REPOSITORY_ID`, or `CI_PROJECT_ID` on GitLab). Every run of one repository counted as one anonymous install before, and every repository in CI shared a single id per provider. The salt ships in the package, so this id is pseudonymous rather than anonymous: it is derived from an opaque number, never from the repository name, the checkout path, a remote URL, or a commit sha, and no project id is sent from CI.
 
-The first scan that reports now prints one line on stderr naming what it reported and the three ways to turn it off: `--no-telemetry`, `"telemetry": false` in the config, and `DO_NOT_TRACK=1`. An interactive run prints it beside the summary the menu leaves behind, so the alternate screen cannot swallow it. It is never printed in CI, in a machine-readable format, or on a machine where the install id could not be written — that id is regenerated per run, so the line would otherwise repeat forever.
-
 `NESTJS_DOCTOR_TELEMETRY_DEBUG=1` prints the exact scan payload to stderr and sends nothing, so what a scan reports can be read before it leaves the machine.
 
 The `--telemetry` help text and the GitHub Action's `telemetry` input now name all three opt-outs, the debug variable, and the repository hash.

--- a/.changeset/telemetry-scan-shape.md
+++ b/.changeset/telemetry-scan-shape.md
@@ -15,4 +15,4 @@ Six fields on the `scan_completed` payload:
 | `total_ms` | Wall time for the whole run; `duration_ms` still covers the rules on a single project and the whole scan on a monorepo |
 | `suppressed_inline` | Built-in rule id to a count of findings silenced by an inline comment |
 
-A `--report` run now reports `scan_completed`, where it previously sent nothing, and prints the first-run notice after the path to the written report.
+A `--report` run now reports `scan_completed`, where it previously sent nothing.

--- a/packages/nestjs-doctor-lsp/src/server.ts
+++ b/packages/nestjs-doctor-lsp/src/server.ts
@@ -16,6 +16,7 @@ import { groupByFile } from "./convert.js";
 import { publishDiagnostics } from "./publish.js";
 import {
 	lspTelemetryEnabled,
+	markLspSeen,
 	resolveIdentity,
 	sendLspEvent,
 } from "./telemetry.js";
@@ -161,6 +162,7 @@ function terminateWorker() {
  * One event per session, naming the editor.
  */
 function reportSession(params: InitializeParams): void {
+	markLspSeen();
 	const options = params.initializationOptions as
 		| { telemetry?: boolean }
 		| undefined;

--- a/packages/nestjs-doctor-lsp/src/telemetry.ts
+++ b/packages/nestjs-doctor-lsp/src/telemetry.ts
@@ -105,7 +105,11 @@ export function markLspSeen(env: NodeJS.ProcessEnv = process.env): void {
 	let existing: Record<string, string> = {};
 	try {
 		const parsed: unknown = JSON.parse(readFileSync(file, "utf-8"));
-		if (typeof parsed === "object" && parsed !== null) {
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			!Array.isArray(parsed)
+		) {
 			existing = parsed as Record<string, string>;
 		}
 	} catch {

--- a/packages/nestjs-doctor-lsp/src/telemetry.ts
+++ b/packages/nestjs-doctor-lsp/src/telemetry.ts
@@ -99,6 +99,30 @@ export interface LspIdentity {
 	projectId?: string;
 }
 
+/** Records that the extension has run, so the CLI stops pointing at it. */
+export function markLspSeen(env: NodeJS.ProcessEnv = process.env): void {
+	const file = join(configDir(env), "hints.json");
+	let existing: Record<string, string> = {};
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(file, "utf-8"));
+		if (typeof parsed === "object" && parsed !== null) {
+			existing = parsed as Record<string, string>;
+		}
+	} catch {
+		// A missing or corrupt store means no hints.
+	}
+	try {
+		mkdirSync(dirname(file), { recursive: true });
+		writeFileSync(
+			file,
+			`${JSON.stringify({ ...existing, lsp: new Date().toISOString().slice(0, 10) }, null, 2)}\n`,
+			"utf-8"
+		);
+	} catch {
+		// A read-only home keeps no hints.
+	}
+}
+
 /** Reads the id the CLI wrote, creating it when this is the first tool to run. */
 export function resolveIdentity(
 	projectRoot: string,

--- a/packages/nestjs-doctor-lsp/tests/telemetry.test.ts
+++ b/packages/nestjs-doctor-lsp/tests/telemetry.test.ts
@@ -1,10 +1,17 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	lspTelemetryEnabled,
+	markLspSeen,
 	resolveIdentity,
 	sendLspEvent,
 } from "../src/telemetry.js";
@@ -16,6 +23,7 @@ vi.mock("node:child_process", () => ({
 const dirs: string[] = [];
 
 const CI_PREFIX = /^ci\./;
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
 
 const workspace = (config?: Record<string, unknown>): string => {
 	const dir = mkdtempSync(join(tmpdir(), "nd-lsp-"));
@@ -141,6 +149,21 @@ describe("lsp identity", () => {
 		expect(first.anonymousId).not.toMatch(CI_PREFIX);
 		expect(again.anonymousId).toBe(first.anonymousId);
 		expect(again.projectId).toBe(first.projectId);
+	});
+});
+
+describe("lsp hints", () => {
+	it("marks the extension seen without creating the identity store", () => {
+		const env = home();
+		const configDir = env.NESTJS_DOCTOR_CONFIG_DIR as string;
+
+		markLspSeen(env);
+
+		const hints = JSON.parse(
+			readFileSync(join(configDir, "hints.json"), "utf-8")
+		);
+		expect(hints.lsp).toMatch(ISO_DAY);
+		expect(existsSync(join(configDir, "telemetry.json"))).toBe(false);
 	});
 });
 

--- a/packages/nestjs-doctor/src/cli/extension-hint.ts
+++ b/packages/nestjs-doctor/src/cli/extension-hint.ts
@@ -1,19 +1,18 @@
 import { isNonInteractiveEnvironment } from "./ui/environment.js";
 
 export const EXTENSION_HINT =
-	"These findings can appear as you type: the VS Code extension rolobits.nestjs-doctor-vscode";
+	"Get these as you type: VS Code extension rolobits.nestjs-doctor-vscode, or nestjs-doctor-lsp.";
 
-/** Where the one-per-install extension line prints, mirroring `telemetryNoticeSite`. */
+/** Where the one-per-install extension line prints: after the menu closes on an
+ * interactive run, after the run otherwise. */
 export const extensionHintSite = (input: {
 	env?: NodeJS.ProcessEnv;
-	firstSend: boolean;
 	hints: Record<string, string>;
 	interactive: boolean;
 	isMachineReadable: boolean;
 	tty: boolean;
 }): "menu" | "none" | "run" => {
 	if (
-		input.firstSend ||
 		input.isMachineReadable ||
 		!input.tty ||
 		input.hints.extension ||

--- a/packages/nestjs-doctor/src/cli/extension-hint.ts
+++ b/packages/nestjs-doctor/src/cli/extension-hint.ts
@@ -1,0 +1,26 @@
+import { isNonInteractiveEnvironment } from "./ui/environment.js";
+
+export const EXTENSION_HINT =
+	"These findings can appear as you type: the VS Code extension rolobits.nestjs-doctor-vscode";
+
+/** Where the one-per-install extension line prints, mirroring `telemetryNoticeSite`. */
+export const extensionHintSite = (input: {
+	env?: NodeJS.ProcessEnv;
+	firstSend: boolean;
+	hints: Record<string, string>;
+	interactive: boolean;
+	isMachineReadable: boolean;
+	tty: boolean;
+}): "menu" | "none" | "run" => {
+	if (
+		input.firstSend ||
+		input.isMachineReadable ||
+		!input.tty ||
+		input.hints.extension ||
+		input.hints.lsp ||
+		isNonInteractiveEnvironment(input.env)
+	) {
+		return "none";
+	}
+	return input.interactive ? "menu" : "run";
+};

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -34,11 +34,7 @@ import { buildReportArtifact, collectScanFacts } from "../report/artifact.js";
 import { buildHtmlReport } from "../report/html-report.js";
 import { resetEcosystem } from "../telemetry/ecosystem.js";
 import { markHint, readHints } from "../telemetry/install-id.js";
-import {
-	reportTelemetryEnabled,
-	TELEMETRY_NOTICE,
-	telemetryNoticeSite,
-} from "../telemetry/send.js";
+import { reportTelemetryEnabled } from "../telemetry/send.js";
 import { highlighter } from "../ui/highlighter.js";
 import { logger } from "../ui/logger.js";
 import { EXTENSION_HINT, extensionHintSite } from "./extension-hint.js";
@@ -130,8 +126,6 @@ abstract class ScanPipeline {
 	protected workerWarnings: string[] = [];
 	/** Set when any scanned sub-project declares its own opt-out. */
 	protected subProjectOptOut = false;
-	/** Set when this scan was the first telemetry send from this install. */
-	protected firstTelemetrySend = false;
 	/** Whether a report built from the menu may embed its beacon; decided with the config. */
 	protected reportTelemetry = false;
 	/** Warnings raised while narrowing the scope; surfaced alongside the report. */
@@ -158,7 +152,7 @@ abstract class ScanPipeline {
 		totalMs: number,
 		suppressed: Record<string, number>
 	): void {
-		this.firstTelemetrySend = reportScanTelemetry({
+		reportScanTelemetry({
 			blocking: this.options.blocking,
 			diagnostics,
 			fileCount,
@@ -269,22 +263,9 @@ abstract class ScanPipeline {
 		);
 	}
 
-	/** One line, once per install, saying what this scan reported and how to stop it. */
-	protected printTelemetryNotice(site: "menu" | "run"): void {
-		const target = telemetryNoticeSite({
-			firstSend: this.firstTelemetrySend,
-			interactive: this.options.interactive,
-			isMachineReadable: this.options.isMachineReadable,
-		});
-		if (target === site) {
-			logger.warn(TELEMETRY_NOTICE);
-		}
-	}
-
 	/** One line, once per install, pointing at the editor extension. */
 	protected printExtensionHint(site: "menu" | "run"): void {
 		const target = extensionHintSite({
-			firstSend: this.firstTelemetrySend,
 			hints: readHints(),
 			interactive: this.options.interactive,
 			isMachineReadable: this.options.isMachineReadable,
@@ -404,7 +385,6 @@ abstract class ScanPipeline {
 		} finally {
 			stopWatching();
 			this.stopProgress();
-			this.printTelemetryNotice("run");
 			this.printExtensionHint("run");
 		}
 	}
@@ -469,7 +449,6 @@ export class MonorepoPipeline extends ScanPipeline {
 			moduleGraph: () => this.reportArtifact.graph,
 			printSummary: () => {
 				printMonorepoReport(this.result.result, this.options.verbose, true);
-				this.printTelemetryNotice("menu");
 				this.printExtensionHint("menu");
 			},
 			result: this.result.result.combined,
@@ -585,7 +564,6 @@ export class MonorepoPipeline extends ScanPipeline {
 				this.allProviders.push(...outcome.reportProviders);
 				this.bootstrapRoots.push(...outcome.bootstrapRoots);
 				this.subProjectOptOut = outcome.subProjectOptOut;
-				this.firstTelemetrySend = outcome.firstTelemetrySend;
 				this.reportTelemetry = outcome.reportTelemetry;
 				this.scopeWarnings.push(...outcome.scopeWarnings);
 				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
@@ -603,7 +581,6 @@ export class MonorepoPipeline extends ScanPipeline {
 			reportProviders: this.allProviders,
 			bootstrapRoots: this.bootstrapRoots,
 			allFiles: this.allFiles,
-			firstTelemetrySend: this.firstTelemetrySend,
 			subProjectOptOut: this.subProjectOptOut,
 			reportTelemetry: this.reportTelemetry,
 			scopeWarnings: this.scopeWarnings,
@@ -697,7 +674,6 @@ export class SingleProjectPipeline extends ScanPipeline {
 			moduleGraph: () => this.reportArtifact.graph,
 			printSummary: () => {
 				printConsoleReport(this.result.result, this.options.verbose, true);
-				this.printTelemetryNotice("menu");
 				this.printExtensionHint("menu");
 			},
 			result: this.result.result,
@@ -728,7 +704,6 @@ export class SingleProjectPipeline extends ScanPipeline {
 				};
 				this.reportProviders = outcome.reportProviders;
 				this.bootstrapRoots = outcome.bootstrapRoots;
-				this.firstTelemetrySend = outcome.firstTelemetrySend;
 				this.reportTelemetry = outcome.reportTelemetry;
 				this.scopeWarnings.push(...outcome.scopeWarnings);
 				this.resolvedMinimumScore = outcome.resolvedMinimumScore;
@@ -745,7 +720,6 @@ export class SingleProjectPipeline extends ScanPipeline {
 			moduleGraph: this.result.moduleGraph,
 			reportProviders: this.reportProviders,
 			bootstrapRoots: this.bootstrapRoots,
-			firstTelemetrySend: this.firstTelemetrySend,
 			result: this.result.result,
 			reportTelemetry: this.reportTelemetry,
 			schemaGraph: this.result.schemaGraph,

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -290,9 +290,8 @@ abstract class ScanPipeline {
 			isMachineReadable: this.options.isMachineReadable,
 			tty: process.stderr.isTTY === true,
 		});
-		if (target === site) {
+		if (target === site && markHint("extension")) {
 			console.error(highlighter.dim(EXTENSION_HINT));
-			markHint("extension");
 		}
 	}
 

--- a/packages/nestjs-doctor/src/cli/pipeline.ts
+++ b/packages/nestjs-doctor/src/cli/pipeline.ts
@@ -33,12 +33,15 @@ import {
 import { buildReportArtifact, collectScanFacts } from "../report/artifact.js";
 import { buildHtmlReport } from "../report/html-report.js";
 import { resetEcosystem } from "../telemetry/ecosystem.js";
+import { markHint, readHints } from "../telemetry/install-id.js";
 import {
 	reportTelemetryEnabled,
 	TELEMETRY_NOTICE,
 	telemetryNoticeSite,
 } from "../telemetry/send.js";
+import { highlighter } from "../ui/highlighter.js";
 import { logger } from "../ui/logger.js";
+import { EXTENSION_HINT, extensionHintSite } from "./extension-hint.js";
 import {
 	printConsoleReport,
 	printMonorepoReport,
@@ -278,6 +281,21 @@ abstract class ScanPipeline {
 		}
 	}
 
+	/** One line, once per install, pointing at the editor extension. */
+	protected printExtensionHint(site: "menu" | "run"): void {
+		const target = extensionHintSite({
+			firstSend: this.firstTelemetrySend,
+			hints: readHints(),
+			interactive: this.options.interactive,
+			isMachineReadable: this.options.isMachineReadable,
+			tty: process.stderr.isTTY === true,
+		});
+		if (target === site) {
+			console.error(highlighter.dim(EXTENSION_HINT));
+			markHint("extension");
+		}
+	}
+
 	/** Ends the spinner so nothing prints through an active frame. */
 	protected stopProgress(): void {
 		this.progress?.succeed("Scan complete");
@@ -388,6 +406,7 @@ abstract class ScanPipeline {
 			stopWatching();
 			this.stopProgress();
 			this.printTelemetryNotice("run");
+			this.printExtensionHint("run");
 		}
 	}
 }
@@ -452,6 +471,7 @@ export class MonorepoPipeline extends ScanPipeline {
 			printSummary: () => {
 				printMonorepoReport(this.result.result, this.options.verbose, true);
 				this.printTelemetryNotice("menu");
+				this.printExtensionHint("menu");
 			},
 			result: this.result.result.combined,
 			subProjects: this.result.result.subProjects.map(({ name, result }) => ({
@@ -679,6 +699,7 @@ export class SingleProjectPipeline extends ScanPipeline {
 			printSummary: () => {
 				printConsoleReport(this.result.result, this.options.verbose, true);
 				this.printTelemetryNotice("menu");
+				this.printExtensionHint("menu");
 			},
 			result: this.result.result,
 		};

--- a/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
+++ b/packages/nestjs-doctor/src/cli/scan-telemetry-reporter.ts
@@ -5,7 +5,7 @@ import { allRules } from "../engine/rules/index.js";
 import type { ScanConfig } from "../engine/scanner.js";
 import { getEcosystem } from "../telemetry/ecosystem.js";
 import { actionContext, generatedIn } from "../telemetry/environment.js";
-import { hasStoredIdentity, resolveIdentity } from "../telemetry/install-id.js";
+import { resolveIdentity } from "../telemetry/install-id.js";
 import {
 	buildScanPayload,
 	type PayloadOutputFormat,
@@ -21,8 +21,6 @@ export interface ScanTelemetryInput {
 	/** Injectable for tests; defaults to the real environment. */
 	env?: NodeJS.ProcessEnv;
 	fileCount: number;
-	/** Injectable for tests; defaults to the read-only store check. */
-	hasStoredIdentityFn?: typeof hasStoredIdentity;
 	/** Injectable for tests; defaults to the compiled-in gating. */
 	isEnabled?: typeof scanTelemetryEnabled;
 	monorepo: boolean;
@@ -44,28 +42,23 @@ export interface ScanTelemetryInput {
 }
 
 /**
- * Reports the scan anonymously from a detached child and returns whether that
- * was this install's first send. A failure here leaves the scan untouched.
+ * Reports the scan anonymously from a detached child. A failure here leaves the
+ * scan untouched.
  */
-export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
+export const reportScanTelemetry = (input: ScanTelemetryInput): void => {
 	const isEnabled = input.isEnabled ?? scanTelemetryEnabled;
 	if (
 		input.subProjectOptOut ||
 		!isEnabled(input.optionsTelemetry, input.scanConfig?.config)
 	) {
-		return false;
+		return;
 	}
-	// Read before resolveIdentity, which writes the store.
 	const env = input.env ?? process.env;
-	const hadStore = (input.hasStoredIdentityFn ?? hasStoredIdentity)(env);
-	let stored = false;
-	let sent = false;
 	try {
 		const identity = (input.resolveIdentityFn ?? resolveIdentity)(
 			input.targetPath,
 			env
 		);
-		stored = identity.stored;
 		const scanConfig = input.scanConfig as ScanConfig;
 		const enabled = new Set(
 			[
@@ -74,7 +67,7 @@ export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 				...scanConfig.schemaRules,
 			].map((rule) => rule.meta.id)
 		);
-		sent = (input.send ?? sendScanTelemetry)(
+		(input.send ?? sendScanTelemetry)(
 			buildScanPayload({
 				action: actionContext(env),
 				blocking: input.blocking,
@@ -108,7 +101,5 @@ export const reportScanTelemetry = (input: ScanTelemetryInput): boolean => {
 		);
 	} catch {
 		// Reporting never breaks a scan.
-		return false;
 	}
-	return generatedIn(env) === "cli" && !hadStore && stored && sent;
 };

--- a/packages/nestjs-doctor/src/cli/worker-delegate.ts
+++ b/packages/nestjs-doctor/src/cli/worker-delegate.ts
@@ -31,7 +31,6 @@ export type ScanOutcome =
 			reportProviders: ReportProvider[];
 			bootstrapRoots: string[];
 			allFiles: string[];
-			firstTelemetrySend: boolean;
 			subProjectOptOut: boolean;
 			reportTelemetry: boolean;
 			scopeWarnings: string[];
@@ -44,7 +43,6 @@ export type ScanOutcome =
 			moduleGraph: EngineResult["moduleGraph"];
 			reportProviders: ReportProvider[];
 			bootstrapRoots: string[];
-			firstTelemetrySend: boolean;
 			result: DiagnoseResult;
 			reportTelemetry: boolean;
 			schemaGraph: EngineResult["schemaGraph"];

--- a/packages/nestjs-doctor/src/report/pipeline.ts
+++ b/packages/nestjs-doctor/src/report/pipeline.ts
@@ -38,8 +38,6 @@ type PipelineStep = () => void | Promise<void>;
 /** Abstract base for report pipelines — shared step queue and config */
 abstract class ReportPipeline {
 	protected _html!: string;
-	/** Set when this scan was the first telemetry send from this install. */
-	protected firstTelemetrySend = false;
 	protected scanConfig!: ScanConfig;
 	/** One id per report, shared by the artifact and the beacon it embeds. */
 	protected readonly scanId = randomUUID();
@@ -97,7 +95,7 @@ abstract class ReportPipeline {
 		totalMs: number,
 		suppressed: Record<string, number>
 	): void {
-		this.firstTelemetrySend = reportScanTelemetry({
+		reportScanTelemetry({
 			blocking: "error",
 			diagnostics,
 			fileCount,
@@ -120,10 +118,6 @@ abstract class ReportPipeline {
 	abstract runRules(): this;
 	abstract buildResult(): this;
 	abstract generateHtml(): this;
-
-	get firstSend(): boolean {
-		return this.firstTelemetrySend;
-	}
 
 	get generatedHtml(): string {
 		return this._html;

--- a/packages/nestjs-doctor/src/report/setup.ts
+++ b/packages/nestjs-doctor/src/report/setup.ts
@@ -1,6 +1,5 @@
 import type { SourceInclusion } from "../common/artifact.js";
 import { detectMonorepo } from "../engine/project-detector.js";
-import { TELEMETRY_NOTICE, telemetryNoticeSite } from "../telemetry/send.js";
 import { highlighter } from "../ui/highlighter.js";
 import { logger } from "../ui/logger.js";
 import {
@@ -28,20 +27,9 @@ export const runReport = async (
 ): Promise<void> => {
 	const monorepo = await detectMonorepo(targetPath);
 
-	const writeAndOpen = async (
-		html: string,
-		firstSend: boolean
-	): Promise<void> => {
+	const writeAndOpen = async (html: string): Promise<void> => {
 		const outPath = await writeReportFile(targetPath, html, outputPath);
 		logger.info(`Report written to ${highlighter.info(outPath)}`);
-		const site = telemetryNoticeSite({
-			firstSend,
-			interactive: false,
-			isMachineReadable: false,
-		});
-		if (site === "run") {
-			logger.warn(TELEMETRY_NOTICE);
-		}
 		openReportInBrowser(outPath);
 	};
 
@@ -72,7 +60,7 @@ export const runReport = async (
 			.generateHtml()
 			.run();
 		logMonorepoSummary(pipeline.monoResult, pipeline.mergedGraph);
-		await writeAndOpen(pipeline.generatedHtml, pipeline.firstSend);
+		await writeAndOpen(pipeline.generatedHtml);
 		return;
 	}
 
@@ -92,5 +80,5 @@ export const runReport = async (
 		.generateHtml()
 		.run();
 	logSingleProjectSummary(pipeline.scanResult);
-	await writeAndOpen(pipeline.generatedHtml, pipeline.firstSend);
+	await writeAndOpen(pipeline.generatedHtml);
 };

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -123,13 +123,6 @@ export function markHint(
 	}
 }
 
-/** Whether this install has stored an id, without creating one. */
-export function hasStoredIdentity(
-	env: NodeJS.ProcessEnv = process.env
-): boolean {
-	return readConfig(join(configDir(env), "telemetry.json")) !== undefined;
-}
-
 /** Reads the install id and salt, creating them on first run. */
 export function resolveIdentity(
 	projectRoot: string,

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -84,6 +84,41 @@ const readConfig = (file: string): StoredConfig | undefined => {
 	}
 };
 
+/** One-time notices this install has already seen, keyed by name. */
+export function readHints(
+	env: NodeJS.ProcessEnv = process.env
+): Record<string, string> {
+	try {
+		const parsed: unknown = JSON.parse(
+			readFileSync(join(configDir(env), "hints.json"), "utf-8")
+		);
+		return typeof parsed === "object" && parsed !== null
+			? (parsed as Record<string, string>)
+			: {};
+	} catch {
+		// A missing or corrupt store means no hints.
+		return {};
+	}
+}
+
+/** Records a one-time notice. Best effort: a read-only home shows it again. */
+export function markHint(
+	name: "extension" | "lsp",
+	env: NodeJS.ProcessEnv = process.env
+): void {
+	const file = join(configDir(env), "hints.json");
+	const hints = {
+		...readHints(env),
+		[name]: new Date().toISOString().slice(0, 10),
+	};
+	try {
+		mkdirSync(dirname(file), { recursive: true });
+		writeFileSync(file, `${JSON.stringify(hints, null, 2)}\n`, "utf-8");
+	} catch {
+		// A read-only home keeps no hints.
+	}
+}
+
 /** Whether this install has stored an id, without creating one. */
 export function hasStoredIdentity(
 	env: NodeJS.ProcessEnv = process.env

--- a/packages/nestjs-doctor/src/telemetry/install-id.ts
+++ b/packages/nestjs-doctor/src/telemetry/install-id.ts
@@ -92,7 +92,9 @@ export function readHints(
 		const parsed: unknown = JSON.parse(
 			readFileSync(join(configDir(env), "hints.json"), "utf-8")
 		);
-		return typeof parsed === "object" && parsed !== null
+		return typeof parsed === "object" &&
+			parsed !== null &&
+			!Array.isArray(parsed)
 			? (parsed as Record<string, string>)
 			: {};
 	} catch {
@@ -101,11 +103,11 @@ export function readHints(
 	}
 }
 
-/** Records a one-time notice. Best effort: a read-only home shows it again. */
+/** Records a one-time notice. Returns whether the write landed: false on a read-only home. */
 export function markHint(
 	name: "extension" | "lsp",
 	env: NodeJS.ProcessEnv = process.env
-): void {
+): boolean {
 	const file = join(configDir(env), "hints.json");
 	const hints = {
 		...readHints(env),
@@ -114,8 +116,10 @@ export function markHint(
 	try {
 		mkdirSync(dirname(file), { recursive: true });
 		writeFileSync(file, `${JSON.stringify(hints, null, 2)}\n`, "utf-8");
+		return true;
 	} catch {
 		// A read-only home keeps no hints.
+		return false;
 	}
 }
 

--- a/packages/nestjs-doctor/src/telemetry/send.ts
+++ b/packages/nestjs-doctor/src/telemetry/send.ts
@@ -39,22 +39,6 @@ export function reportTelemetryEnabled(
 	);
 }
 
-export const TELEMETRY_NOTICE =
-	'nestjs-doctor reported this scan anonymously: which built-in rules fired, the score, well-known dependencies, and the shape of your config — never your code, paths, or project name. Turn it off with --no-telemetry, "telemetry": false in your config, or DO_NOT_TRACK=1. https://nestjs.doctor/docs/telemetry';
-
-/** Where the one-per-install notice prints: after the menu closes on an
- * interactive run, after the run otherwise. */
-export const telemetryNoticeSite = (input: {
-	firstSend: boolean;
-	interactive: boolean;
-	isMachineReadable: boolean;
-}): "menu" | "none" | "run" => {
-	if (!input.firstSend || input.isMachineReadable) {
-		return "none";
-	}
-	return input.interactive ? "menu" : "run";
-};
-
 /** Runs in a detached child, so a stalled network cannot hold the scan open. */
 const CHILD_SCRIPT = `
 const body = process.argv[1];

--- a/packages/nestjs-doctor/tests/integration/inline-suppressions.test.ts
+++ b/packages/nestjs-doctor/tests/integration/inline-suppressions.test.ts
@@ -150,7 +150,6 @@ describe("inline suppression (integration)", () => {
 				diagnostics: scanResult.result.diagnostics,
 				env: {},
 				fileCount: context.files.length,
-				hasStoredIdentityFn: () => true,
 				isEnabled: () => true,
 				monorepo: false,
 				optionsTelemetry: true,

--- a/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
+++ b/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
@@ -137,13 +137,6 @@ describe("the hints store", () => {
 		expect(readFileSync(join(home, "telemetry.json"), "utf-8")).toBe(identity);
 	});
 
-	it("survives an unwritable config directory", () => {
-		const env = { NESTJS_DOCTOR_CONFIG_DIR: "/dev/null/nestjs-doctor" };
-
-		expect(() => markHint("extension", env)).not.toThrow();
-		expect(readHints(env)).toEqual({});
-	});
-
 	it("returns false, so the hint stays quiet, when the config directory can't be written", () => {
 		const home = mkdtempSync(join(tmpdir(), "nd-hints-blocked-"));
 		homes.push(home);

--- a/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
+++ b/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
@@ -95,6 +95,12 @@ describe("where the extension hint prints", () => {
 		}
 	});
 
+	it("lands on the first --no-telemetry run, since firstSend never turns true", () => {
+		// --no-telemetry keeps firstSend false forever; the hint can't wait on a
+		// signal that will never come.
+		expect(site({ firstSend: false, hints: {} })).toBe("run");
+	});
+
 	it("prints on run 2 and nowhere on run 3", () => {
 		const env = isolated();
 
@@ -136,5 +142,16 @@ describe("the hints store", () => {
 
 		expect(() => markHint("extension", env)).not.toThrow();
 		expect(readHints(env)).toEqual({});
+	});
+
+	it("returns false, so the hint stays quiet, when the config directory can't be written", () => {
+		const home = mkdtempSync(join(tmpdir(), "nd-hints-blocked-"));
+		homes.push(home);
+		const blocker = join(home, "file");
+		writeFileSync(blocker, "", "utf-8");
+		const env = { NESTJS_DOCTOR_CONFIG_DIR: join(blocker, "nope") };
+
+		expect(() => markHint("extension", env)).not.toThrow();
+		expect(markHint("extension", env)).toBe(false);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
+++ b/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { extensionHintSite } from "../../src/cli/extension-hint.js";
+import { AGENT_ENV_VARS } from "../../src/telemetry/environment.js";
+import { markHint, readHints } from "../../src/telemetry/install-id.js";
+import { telemetryNoticeSite } from "../../src/telemetry/send.js";
+
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+const homes: string[] = [];
+
+/** A throwaway config home, set through the override honoured on every platform. */
+const isolated = (): NodeJS.ProcessEnv => {
+	const home = mkdtempSync(join(tmpdir(), "nd-hints-"));
+	homes.push(home);
+	return { NESTJS_DOCTOR_CONFIG_DIR: home };
+};
+
+/** A plain interactive console run with nothing recorded yet. */
+const site = (
+	overrides: Partial<Parameters<typeof extensionHintSite>[0]> = {}
+): "menu" | "none" | "run" =>
+	extensionHintSite({
+		env: {},
+		firstSend: false,
+		hints: {},
+		interactive: false,
+		isMachineReadable: false,
+		tty: true,
+		...overrides,
+	});
+
+afterAll(() => {
+	for (const home of homes) {
+		rmSync(home, { force: true, recursive: true });
+	}
+});
+
+describe("where the extension hint prints", () => {
+	it("prints at the end of a run with no menu", () => {
+		expect(site()).toBe("run");
+	});
+
+	it("waits for the menu to close on an interactive run", () => {
+		// A line printed before the TUI is lost with the alternate screen.
+		expect(site({ interactive: true })).toBe("menu");
+	});
+
+	it("prints nowhere on the run that sends telemetry first", () => {
+		expect(site({ firstSend: true })).toBe("none");
+	});
+
+	it("prints nowhere for a machine-readable run", () => {
+		expect(site({ isMachineReadable: true })).toBe("none");
+	});
+
+	it("prints nowhere in the scan worker", () => {
+		// The worker is constructed machine-readable even for an interactive scan.
+		expect(site({ interactive: true, isMachineReadable: true })).toBe("none");
+	});
+
+	it("prints nowhere when stderr is not a TTY", () => {
+		expect(site({ tty: false })).toBe("none");
+	});
+
+	it("prints nowhere in CI", () => {
+		expect(site({ env: { CI: "1" } })).toBe("none");
+	});
+
+	it("prints nowhere inside a coding agent", () => {
+		for (const name of AGENT_ENV_VARS) {
+			expect(site({ env: { [name]: "1" } })).toBe("none");
+		}
+	});
+
+	it("prints nowhere once it has printed", () => {
+		expect(site({ hints: { extension: "2026-09-02" } })).toBe("none");
+	});
+
+	it("prints nowhere when the extension has already run", () => {
+		expect(site({ hints: { lsp: "2026-09-02" } })).toBe("none");
+	});
+
+	it("uses the same two sites as the telemetry notice", () => {
+		for (const interactive of [true, false]) {
+			expect(site({ interactive })).toBe(
+				telemetryNoticeSite({
+					firstSend: true,
+					interactive,
+					isMachineReadable: false,
+				})
+			);
+		}
+	});
+
+	it("prints on run 2 and nowhere on run 3", () => {
+		const env = isolated();
+
+		// Run 1 sends telemetry for the first time and marks nothing.
+		expect(site({ firstSend: true })).toBe("none");
+		expect(readHints(env)).toEqual({});
+
+		expect(site({ hints: readHints(env) })).toBe("run");
+		markHint("extension", env);
+
+		expect(site({ hints: readHints(env) })).toBe("none");
+	});
+});
+
+describe("the hints store", () => {
+	it("records the day the notice printed", () => {
+		const env = isolated();
+
+		markHint("extension", env);
+
+		expect(readHints(env).extension).toMatch(ISO_DAY);
+	});
+
+	it("keeps the other hints and leaves telemetry.json alone", () => {
+		const env = isolated();
+		const home = env.NESTJS_DOCTOR_CONFIG_DIR as string;
+		const identity = `${JSON.stringify({ anonymousId: "a", salt: "s" })}\n`;
+		writeFileSync(join(home, "telemetry.json"), identity, "utf-8");
+
+		markHint("lsp", env);
+		markHint("extension", env);
+
+		expect(Object.keys(readHints(env)).sort()).toEqual(["extension", "lsp"]);
+		expect(readFileSync(join(home, "telemetry.json"), "utf-8")).toBe(identity);
+	});
+
+	it("survives an unwritable config directory", () => {
+		const env = { NESTJS_DOCTOR_CONFIG_DIR: "/dev/null/nestjs-doctor" };
+
+		expect(() => markHint("extension", env)).not.toThrow();
+		expect(readHints(env)).toEqual({});
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
+++ b/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
@@ -77,13 +77,6 @@ describe("where the extension hint prints", () => {
 		expect(site({ hints: { lsp: "2026-09-02" } })).toBe("none");
 	});
 
-	it("prints on the first qualifying run", () => {
-		const env = isolated();
-
-		expect(readHints(env)).toEqual({});
-		expect(site({ hints: readHints(env) })).toBe("run");
-	});
-
 	it("prints on run 1 and nowhere on run 2", () => {
 		const env = isolated();
 

--- a/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
+++ b/packages/nestjs-doctor/tests/unit/extension-hint.test.ts
@@ -5,7 +5,6 @@ import { afterAll, describe, expect, it } from "vitest";
 import { extensionHintSite } from "../../src/cli/extension-hint.js";
 import { AGENT_ENV_VARS } from "../../src/telemetry/environment.js";
 import { markHint, readHints } from "../../src/telemetry/install-id.js";
-import { telemetryNoticeSite } from "../../src/telemetry/send.js";
 
 const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -24,7 +23,6 @@ const site = (
 ): "menu" | "none" | "run" =>
 	extensionHintSite({
 		env: {},
-		firstSend: false,
 		hints: {},
 		interactive: false,
 		isMachineReadable: false,
@@ -46,10 +44,6 @@ describe("where the extension hint prints", () => {
 	it("waits for the menu to close on an interactive run", () => {
 		// A line printed before the TUI is lost with the alternate screen.
 		expect(site({ interactive: true })).toBe("menu");
-	});
-
-	it("prints nowhere on the run that sends telemetry first", () => {
-		expect(site({ firstSend: true })).toBe("none");
 	});
 
 	it("prints nowhere for a machine-readable run", () => {
@@ -83,30 +77,15 @@ describe("where the extension hint prints", () => {
 		expect(site({ hints: { lsp: "2026-09-02" } })).toBe("none");
 	});
 
-	it("uses the same two sites as the telemetry notice", () => {
-		for (const interactive of [true, false]) {
-			expect(site({ interactive })).toBe(
-				telemetryNoticeSite({
-					firstSend: true,
-					interactive,
-					isMachineReadable: false,
-				})
-			);
-		}
-	});
-
-	it("lands on the first --no-telemetry run, since firstSend never turns true", () => {
-		// --no-telemetry keeps firstSend false forever; the hint can't wait on a
-		// signal that will never come.
-		expect(site({ firstSend: false, hints: {} })).toBe("run");
-	});
-
-	it("prints on run 2 and nowhere on run 3", () => {
+	it("prints on the first qualifying run", () => {
 		const env = isolated();
 
-		// Run 1 sends telemetry for the first time and marks nothing.
-		expect(site({ firstSend: true })).toBe("none");
 		expect(readHints(env)).toEqual({});
+		expect(site({ hints: readHints(env) })).toBe("run");
+	});
+
+	it("prints on run 1 and nowhere on run 2", () => {
+		const env = isolated();
 
 		expect(site({ hints: readHints(env) })).toBe("run");
 		markHint("extension", env);

--- a/packages/nestjs-doctor/tests/unit/report-scan-telemetry.test.ts
+++ b/packages/nestjs-doctor/tests/unit/report-scan-telemetry.test.ts
@@ -34,7 +34,6 @@ const injected = (
 	extra: Partial<ScanTelemetryInput> = {}
 ): Partial<ScanTelemetryInput> => ({
 	env: {},
-	hasStoredIdentityFn: () => false,
 	isEnabled: (flag, config) => scanTelemetryEnabled(flag, config, {}),
 	resolveIdentityFn: () => ({
 		anonymousId: "anon-123",
@@ -214,87 +213,5 @@ describe("report scan telemetry", () => {
 
 		expect(send).not.toHaveBeenCalled();
 		expect(pipeline.generatedHtml).not.toContain("var SCAN");
-	});
-});
-
-describe("report first-run notice", () => {
-	const runWithFirstSend = async (
-		firstSend: boolean
-	): Promise<{ lines: string[] }> => {
-		vi.resetModules();
-		const lines: string[] = [];
-		vi.doMock("../../src/engine/project-detector.js", () => ({
-			detectMonorepo: () => Promise.resolve(null),
-		}));
-		vi.doMock("../../src/report/output.js", () => ({
-			logMonorepoSummary: () => undefined,
-			logSingleProjectSummary: () => undefined,
-			openReportInBrowser: () => lines.push("opened"),
-			writeReportFile: () => Promise.resolve("/repo/report.html"),
-		}));
-		vi.doMock("../../src/report/pipeline.js", () => ({
-			MonorepoReportPipeline: class {},
-			SingleProjectReportPipeline: class {
-				firstSend = firstSend;
-				generatedHtml = "<html>";
-				scanResult = {};
-				resolveConfig() {
-					return this;
-				}
-				buildContext() {
-					return this;
-				}
-				runRules() {
-					return this;
-				}
-				buildResult() {
-					return this;
-				}
-				generateHtml() {
-					return this;
-				}
-				run() {
-					return Promise.resolve();
-				}
-			},
-		}));
-
-		const { logger } = await import("../../src/ui/logger.js");
-		vi.spyOn(logger, "info").mockImplementation((...args) => {
-			lines.push(`info:${args.join(" ")}`);
-		});
-		vi.spyOn(logger, "warn").mockImplementation((...args) => {
-			lines.push(`warn:${args.join(" ")}`);
-		});
-
-		const { runReport } = await import("../../src/report/setup.js");
-		await runReport(
-			"/repo",
-			undefined,
-			undefined,
-			undefined,
-			true,
-			"all",
-			"9.9.9"
-		);
-		vi.doUnmock("../../src/engine/project-detector.js");
-		vi.doUnmock("../../src/report/output.js");
-		vi.doUnmock("../../src/report/pipeline.js");
-		return { lines };
-	};
-
-	it("prints the first-run notice after the report is written", async () => {
-		const { lines } = await runWithFirstSend(true);
-
-		expect(lines[0]).toContain("Report written to");
-		expect(lines[1]).toContain("reported this scan anonymously");
-		expect(lines[2]).toBe("opened");
-	});
-
-	it("prints nothing on a later run", async () => {
-		const { lines } = await runWithFirstSend(false);
-
-		expect(lines[0]).toContain("Report written to");
-		expect(lines.some((line) => line.startsWith("warn:"))).toBe(false);
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
+++ b/packages/nestjs-doctor/tests/unit/scan-telemetry-reporter.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../src/cli/scan-telemetry-reporter.js";
 import type { Rule } from "../../src/engine/rules/types.js";
 import type { ScanConfig } from "../../src/engine/scanner.js";
-import { telemetryNoticeSite } from "../../src/telemetry/send.js";
 import { emptyResult } from "./report-artifact-fixture.js";
 
 const ruleWithId = (id: string): Rule => ({ meta: { id } }) as unknown as Rule;
@@ -31,7 +30,6 @@ const buildInput = (
 	diagnostics: [],
 	env: {},
 	fileCount: 4,
-	hasStoredIdentityFn: () => false,
 	isEnabled: () => true,
 	monorepo: false,
 	optionsTelemetry: true,
@@ -149,20 +147,10 @@ describe("scan telemetry reporter", () => {
 			}),
 		});
 
-		expect(reportScanTelemetry(input)).toBe(false);
+		expect(() => reportScanTelemetry(input)).not.toThrow();
 	});
 
-	it("reports the first send an install ever makes", () => {
-		expect(reportScanTelemetry(buildInput())).toBe(true);
-	});
-
-	it("reports nothing new once the install has a stored id", () => {
-		expect(
-			reportScanTelemetry(buildInput({ hasStoredIdentityFn: () => true }))
-		).toBe(false);
-	});
-
-	it("hands the identity resolver the same environment it read the store from", () => {
+	it("hands the identity resolver the environment it was given", () => {
 		const env = { NESTJS_DOCTOR_CONFIG_DIR: "/nowhere" };
 		const input = buildInput({ env });
 
@@ -171,59 +159,67 @@ describe("scan telemetry reporter", () => {
 		expect(input.resolveIdentityFn).toHaveBeenCalledWith("/repo/app", env);
 	});
 
-	it("reads the store before the identity resolver writes one", () => {
-		const order: string[] = [];
-		const input = buildInput({
-			hasStoredIdentityFn: vi.fn(() => {
-				order.push("read");
-				return false;
-			}),
-			resolveIdentityFn: vi.fn(() => {
-				order.push("resolve");
-				return { anonymousId: "anon-123", stored: true };
-			}),
-		});
+	it("sends one payload carrying every field, on a run that stores its first id", () => {
+		// Pins the payload against the removal of the first-run notice: the same
+		// 50 fields go out, in one send, on the run that used to print it.
+		const input = buildInput();
 
 		reportScanTelemetry(input);
 
-		expect(order).toEqual(["read", "resolve"]);
-	});
-
-	it("announces no first send when the id could not be stored", () => {
-		const input = buildInput({
-			resolveIdentityFn: vi.fn(() => ({
-				anonymousId: "anon-123",
-				stored: false,
-			})),
-		});
-
-		expect(reportScanTelemetry(input)).toBe(false);
 		expect(input.send).toHaveBeenCalledTimes(1);
-	});
-
-	it("announces no first send when nothing was sent", () => {
-		expect(reportScanTelemetry(buildInput({ isEnabled: () => false }))).toBe(
-			false
-		);
-		expect(reportScanTelemetry(buildInput({ subProjectOptOut: true }))).toBe(
-			false
-		);
-	});
-
-	it("announces no first send when the sender only printed the payload", () => {
-		const input = buildInput({ send: vi.fn(() => false) });
-
-		expect(reportScanTelemetry(input)).toBe(false);
-		expect(input.send).toHaveBeenCalledTimes(1);
-	});
-
-	it("announces no first send from CI, which stores no id", () => {
-		expect(reportScanTelemetry(buildInput({ env: { CI: "true" } }))).toBe(
-			false
-		);
-		expect(
-			reportScanTelemetry(buildInput({ env: { GITHUB_ACTIONS: "true" } }))
-		).toBe(false);
+		expect(input.send).toHaveBeenCalledWith(expect.anything(), "anon-123");
+		expect(Object.keys(input.send.mock.calls[0]?.[0] ?? {}).sort()).toEqual([
+			"action_comment",
+			"action_commit_status",
+			"action_ref",
+			"action_review_comments",
+			"action_sarif",
+			"action_version_pin",
+			"actor_association",
+			"blocking",
+			"categories_disabled",
+			"ci_event",
+			"ci_provider",
+			"cloud",
+			"cloud_services",
+			"config_exclude_count",
+			"config_include_count",
+			"config_min_score",
+			"custom_rules_dir",
+			"custom_rules_loaded",
+			"databases",
+			"duration_ms",
+			"file_count",
+			"findings",
+			"framework",
+			"frontend",
+			"generated_in",
+			"ignored_file_count",
+			"ignored_rules",
+			"messaging",
+			"monorepo",
+			"nest_version",
+			"nestjs_packages",
+			"node_major",
+			"orm",
+			"output_format",
+			"platform",
+			"project_id",
+			"report_requested",
+			"rule_errors",
+			"rule_overrides",
+			"rules_disabled",
+			"rules_turned_off",
+			"rules_with_findings",
+			"scan_id",
+			"scope_requested",
+			"score",
+			"suppressed_inline",
+			"total_ms",
+			"trigger",
+			"version",
+			"via_action",
+		]);
 	});
 
 	it("swallows a throw from resolving the identity", () => {
@@ -233,34 +229,7 @@ describe("scan telemetry reporter", () => {
 			}),
 		});
 
-		expect(reportScanTelemetry(input)).toBe(false);
+		expect(() => reportScanTelemetry(input)).not.toThrow();
 		expect(input.send).not.toHaveBeenCalled();
-	});
-});
-
-describe("where the first-run notice prints", () => {
-	const site = (overrides: Parameters<typeof telemetryNoticeSite>[0]) =>
-		telemetryNoticeSite(overrides);
-
-	it("waits for the menu to close on an interactive run", () => {
-		// A line printed before the TUI is lost with the alternate screen.
-		expect(
-			site({ firstSend: true, interactive: true, isMachineReadable: false })
-		).toBe("menu");
-	});
-
-	it("prints at the end of a run with no menu", () => {
-		expect(
-			site({ firstSend: true, interactive: false, isMachineReadable: false })
-		).toBe("run");
-	});
-
-	it("prints nowhere for a machine-readable run or a later scan", () => {
-		expect(
-			site({ firstSend: true, interactive: true, isMachineReadable: true })
-		).toBe("none");
-		expect(
-			site({ firstSend: false, interactive: false, isMachineReadable: false })
-		).toBe("none");
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
+++ b/packages/nestjs-doctor/tests/unit/telemetry-identity.test.ts
@@ -1,12 +1,14 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import {
-	configDir,
-	hasStoredIdentity,
-	resolveIdentity,
-} from "../../src/telemetry/install-id.js";
+import { configDir, resolveIdentity } from "../../src/telemetry/install-id.js";
 import { scanTelemetryEnabled } from "../../src/telemetry/send.js";
 
 const SHA256_HEX = /^[a-f0-9]{64}$/;
@@ -236,7 +238,9 @@ describe("install identity", () => {
 		const env = isolated({ NESTJS_DOCTOR_TELEMETRY_DEBUG: "1" });
 
 		expect(resolveIdentity("/repo/a", env).stored).toBe(false);
-		expect(hasStoredIdentity(env)).toBe(false);
+		expect(
+			existsSync(join(env.NESTJS_DOCTOR_CONFIG_DIR as string, "telemetry.json"))
+		).toBe(false);
 	});
 
 	it("stores nothing in CI", () => {
@@ -256,22 +260,6 @@ describe("install identity", () => {
 		);
 
 		expect(gitlab.anonymousId).toBe("ci.gitlab");
-	});
-
-	it("knows whether this install has ever stored an id", () => {
-		const env = isolated();
-
-		expect(hasStoredIdentity(env)).toBe(false);
-		resolveIdentity("/repo/a", env);
-		expect(hasStoredIdentity(env)).toBe(true);
-	});
-
-	it("reads the store without creating one", () => {
-		const env = isolated();
-
-		hasStoredIdentity(env);
-
-		expect(hasStoredIdentity(env)).toBe(false);
 	});
 });
 

--- a/packages/nestjs-doctor/tests/unit/worker-delegate.test.ts
+++ b/packages/nestjs-doctor/tests/unit/worker-delegate.test.ts
@@ -56,12 +56,7 @@ const outcomeFixture = (): ScanOutcome =>
 	({
 		kind: "single",
 		customRuleWarnings: [],
-		firstTelemetrySend: true,
 	}) as unknown as ScanOutcome;
-
-/** Fails to compile if the outcome stops carrying the notice decision. */
-const firstSendOf = (outcome: ScanOutcome): boolean =>
-	outcome.firstTelemetrySend;
 
 const delegateInput = (
 	overrides: Partial<CanDelegateInput> = {}
@@ -159,8 +154,6 @@ describe("worker delegate — runInWorker", () => {
 		await expect(promise).resolves.toBeUndefined();
 		expect(createWorker).toHaveBeenCalledWith(workerUrl, requestFixture());
 		expect(apply).toHaveBeenCalledWith(outcome);
-		// The reporter runs in the worker; the notice is printed on main.
-		expect(firstSendOf(apply.mock.calls[0]?.[0] as ScanOutcome)).toBe(true);
 		expect(worker.terminateCalls).toBe(1);
 	});
 

--- a/packages/website/src/app/docs/telemetry/page.mdx
+++ b/packages/website/src/app/docs/telemetry/page.mdx
@@ -115,7 +115,7 @@ Outside CI the event carries two ids. `telemetry.json` holds an install id and a
 - **`distinct_id`:** a random UUID, stable for this install.
 - **`project_id`:** a SHA-256 over a second random UUID and the resolved project path.
 
-The salt never leaves the machine, so neither hash can be rebuilt from anything shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing. A local `hints.json` next to it records which one-time notices have already printed; it is never sent.
+The salt never leaves the machine, so neither hash can be rebuilt from anything shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing. A local `hints.json` next to it records whether the one-time editor line has printed; it is never sent.
 
 The store lives where the platform expects a CLI to keep its own config:
 
@@ -239,19 +239,7 @@ The payload goes to stderr and no child process is spawned, so nothing is sent. 
 
 The printed body and the sent body are built from the same values, so what is printed is what would have been sent. It prints only when the scan would otherwise have reported. With `--no-telemetry`, `"telemetry": false`, `DO_NOT_TRACK` set, or a build with no compiled key, there is no payload to print.
 
-A debug run sends nothing and stores no id, so it never counts as the first send and never prints the notice below. The variable covers the scan event only. A generated report's own beacon is not affected by it.
-
-## The first-run notice
-
-The first scan that reports on a machine prints one line to stderr, then never again:
-
-```text
-nestjs-doctor reported this scan anonymously: which built-in rules fired, the score, well-known dependencies, and the shape of your config — never your code, paths, or project name. Turn it off with --no-telemetry, "telemetry": false in your config, or DO_NOT_TRACK=1. https://nestjs.doctor/docs/telemetry
-```
-
-It prints once the scan has finished, and once the interactive menu has closed when one opened. A `--report` run prints it after the path to the written report.
-
-Machine-readable runs never print it, and neither does CI, which stores no id to remember the run by. A machine whose config directory cannot be written stores nothing either, so it stays quiet rather than repeating the notice on every scan.
+A debug run sends nothing and stores no id. The variable covers the scan event only. A generated report's own beacon is not affected by it.
 
 ## The language server
 

--- a/packages/website/src/app/docs/telemetry/page.mdx
+++ b/packages/website/src/app/docs/telemetry/page.mdx
@@ -115,7 +115,7 @@ Outside CI the event carries two ids. `telemetry.json` holds an install id and a
 - **`distinct_id`:** a random UUID, stable for this install.
 - **`project_id`:** a SHA-256 over a second random UUID and the resolved project path.
 
-The salt never leaves the machine, so neither hash can be rebuilt from anything shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing.
+The salt never leaves the machine, so neither hash can be rebuilt from anything shipped in the package. If the config directory cannot be written, the scan reports a fresh id and stores nothing. A local `hints.json` next to it records which one-time notices have already printed; it is never sent.
 
 The store lives where the platform expects a CLI to keep its own config:
 

--- a/packages/website/src/app/docs/vscode-extension/page.mdx
+++ b/packages/website/src/app/docs/vscode-extension/page.mdx
@@ -19,6 +19,8 @@ npm install -D nestjs-doctor
 
 The extension's LSP server loads `nestjs-doctor` from your workspace `node_modules`, so the dev dependency is required.
 
+The CLI mentions the extension on one scan per machine, never in CI, and stops for good once the extension has run.
+
 ## How it works
 
 The extension activates automatically when your workspace contains `@nestjs/core` in `node_modules` or when you open a TypeScript file. It starts a Language Server (LSP) that runs nestjs-doctor's analysis in the background using the [incremental scanning API](/docs/reference/node-api#incremental-scanning). That server also runs on its own, in [any other editor that speaks LSP](/docs/language-server).

--- a/packages/website/src/app/docs/vscode-extension/page.mdx
+++ b/packages/website/src/app/docs/vscode-extension/page.mdx
@@ -19,7 +19,7 @@ npm install -D nestjs-doctor
 
 The extension's LSP server loads `nestjs-doctor` from your workspace `node_modules`, so the dev dependency is required.
 
-The CLI prints one line pointing at the extension and the language server on its first scan on a machine, never in CI, and never again after that.
+The CLI prints one line pointing at the extension and the language server on the first console scan in a terminal on a machine, never in CI, and never again after that.
 
 ## How it works
 

--- a/packages/website/src/app/docs/vscode-extension/page.mdx
+++ b/packages/website/src/app/docs/vscode-extension/page.mdx
@@ -19,7 +19,7 @@ npm install -D nestjs-doctor
 
 The extension's LSP server loads `nestjs-doctor` from your workspace `node_modules`, so the dev dependency is required.
 
-The CLI mentions the extension on one scan per machine, never in CI, and stops for good once the extension has run.
+The CLI prints one line pointing at the extension and the language server on its first scan on a machine, never in CI, and never again after that.
 
 ## How it works
 


### PR DESCRIPTION
## Context

One CLI install in thirty also runs the VS Code extension. SonarLint and ESLint got their editor installs from CLI users who were told the editor version existed. Improvement plan row 3.5: one line, once, after a scan.

This PR also removes the first-run telemetry notice from PR #385 (unreleased). Two one-time lines on consecutive runs read as nagging; the telemetry disclosure stays in `--help` and on `/docs/telemetry`.

## Problem

Nothing in the CLI mentioned the extension or the language server. A user who runs `npx nestjs-doctor .` every week never learns the same findings can appear in the editor as they type.

## Possible flows

| Flow | Before (main) | After |
|---|---|---|
| First console scan on a machine | telemetry notice | `Get these as you type: VS Code extension rolobits.nestjs-doctor-vscode, or nestjs-doctor-lsp.` |
| Second and later scans | nothing | nothing: `hints.json` in the config dir records that it printed |
| `--format json`, `sarif`, `gitlab`, `markdown`, `github`, `--score` | nothing | nothing; stdout untouched |
| CI (`CI` or `GITHUB_ACTIONS` set), a coding agent, the scan worker | nothing | nothing |
| Interactive run | nothing | after the menu closes, never inside the alt screen |
| A machine where the extension's language server already ran | nothing | nothing: the LSP writes `hints.lsp` on `initialize`, before its own telemetry gate |
| Unwritable config dir | nothing | nothing: the line prints only when its once-marker persisted |
| `--report` run | telemetry notice after "Report written to" | nothing extra |
| `telemetry.json` | id and salt | byte-for-byte untouched by this feature |


