### PR TITLE
docs(website): which TypeScript versions scan, and why not an oxlint rule

### DIFF
--- a/packages/website/src/app/docs/nestjs-eslint-plugins/page.mdx
+++ b/packages/website/src/app/docs/nestjs-eslint-plugins/page.mdx
@@ -6,19 +6,20 @@ export const metadata = docsMetadata["/docs/nestjs-eslint-plugins"];
 
 # NestJS Doctor vs ESLint plugins
 
-A linter is the better tool for most of what a linter does. It runs on save in
-milliseconds, and the three NestJS plugins below ship 36 rules between them.
-oxlint is what the Nest 12 CLI now scaffolds. Swagger decorator hygiene,
-throttled routes, permissive CORS and unsafe upload filenames are checked there
-and nowhere in nestjs-doctor.
+For most of what a linter checks, a linter is the better tool. It runs on save
+in milliseconds, and the three NestJS plugins ship 36 rules between them.
+oxlint is what the Nest 12 CLI now scaffolds.
 
-The difference is what each tool is handed. A lint rule is handed one file and
-asked a question about that file. nestjs-doctor is handed the application: every
-`@Module()` at once, the provider graph, the endpoint graph and the ORM schema.
+The plugins cover Swagger decorator hygiene, throttled routes, permissive CORS
+and unsafe upload filenames. nestjs-doctor covers none of those four.
+
+The difference is what each tool reads. A lint rule reads one file and answers
+one question about that file. nestjs-doctor reads the whole application: every
+`@Module()` at once, the provider map, the endpoint graph and the ORM schema.
 
 ## What each plugin covers
 
-Every row was read from the installed package on 2026-09-02, not from a README.
+Each row comes from the installed package on 2026-09-02, not from a README.
 
 | Plugin | Version | NestJS rules | Roughly about |
 |---|---|---|---|
@@ -33,57 +34,61 @@ Counting a plugin's rules takes one command against the package itself:
 node -e "console.log(Object.keys(require('eslint-plugin-nestjs-security').rules).length)"
 ```
 
-Rule sets move. Re-run that against the version you have installed rather than
-trusting the number in the table.
+Rule sets move. Run that command against the version you have installed rather
+than trusting the number in the table.
 
 ## What only a project-scoped scan sees
 
 nestjs-doctor builds one module graph from every `@Module()` decorator in the
 project before any rule runs. Eight of its 52 rules run once over the whole
-project instead of once per file, so they can answer questions no single file
+project instead of once per file. Those eight answer questions no single file
 contains.
 
-Running all 36 plugin rules over a fixture with a two-module import cycle and an
-unused module export reported neither. On the same files nestjs-doctor reported
-both:
+All 36 plugin rules ran over a fixture with a two-module import cycle and an
+unused module export. They reported neither. nestjs-doctor reported both on the
+same files:
 
 - `architecture/no-circular-module-deps`, an `error`, on the cycle.
 - `performance/no-unused-module-exports`, an `info`, on the export nobody imports.
 - `performance/no-unused-providers` and `performance/no-orphan-modules` read the
-  same graph.
+  same module graph.
 
 The ORM schema is the second thing no plugin models. nestjs-doctor extracts
 entities and relations from Prisma, TypeORM, Drizzle and MikroORM into a schema
-graph, then reports `schema/require-primary-key`, `schema/require-timestamps`
-and `schema/require-cascade-rule` against the entity. None of the 36 rules
-models an entity or a relation.
+graph. `schema/require-primary-key`, `schema/require-timestamps` and
+`schema/require-cascade-rule` read that graph and report against the entity.
 
-The third is one number. Every finding is weighted by severity and category,
-normalized by file count, and reduced to a score out of 100 for the whole
-project. That score is comparable across repositories in a way that a count of
-lint errors is not, and `--min-score` gates a build on it.
+None of the 36 plugin rules models an entity or a relation.
 
-## Where they overlap
+The third thing is one number. nestjs-doctor weights every finding by severity
+and category, then normalizes by file count. The result is one score out of 100
+for the whole project.
 
-The overlaps below were produced by running both tools over the same fixture and
-comparing per file and line, on 2026-09-02.
+That score is comparable across repositories in a way that a count of lint
+errors is not. `--min-score` gates a build on it.
+
+## Where the plugins and nestjs-doctor overlap
+
+Each row comes from running both tools over the same fixture on 2026-09-02 and
+comparing the output file by file and line by line.
 
 | Case | nestjs-doctor | Plugin rule | Result |
 |---|---|---|---|
-| Endpoint with no guard | `security/require-guards-on-endpoints` | `nestjs-security/require-guards`, `@darraghor/nestjs-typed/api-methods-should-be-guarded` | All three flagged the same handler and no other. A guard at class level and a guard at method level both count everywhere |
+| Endpoint with no guard | `security/require-guards-on-endpoints` | `nestjs-security/require-guards`, `@darraghor/nestjs-typed/api-methods-should-be-guarded` | All three reported the same handler and no other. A guard at class level and a guard at method level both count everywhere |
 | Nested non-primitive without `@Type()` | `correctness/validated-non-primitive-needs-type` | `@darraghor/nestjs-typed/validated-non-primitive-property-needs-type-decorator` | Same two properties, same two lines |
 | `@ValidateNested()` on an array | `correctness/validate-nested-array-each` | `@darraghor/nestjs-typed/validate-nested-of-array-should-set-each` | Same property, same line |
 | Injectable no module provides | `correctness/injectable-must-be-provided` | `@darraghor/nestjs-typed/injectable-should-be-provided` | Same file. This rule does read the whole project, so provider registration is not a gap |
 
-Both validation rows are about class-validator metadata on a DTO. Whether a
-`ValidationPipe` is registered at all is a separate question, and it is
-`eslint-plugin-nestjs-security` and `eslint-plugin-nestjs` that ask it.
+Both validation rows cover class-validator metadata on a DTO. Whether the
+application registers a `ValidationPipe` at all is a separate question.
+`eslint-plugin-nestjs-security` and `eslint-plugin-nestjs` are the two that
+ask it.
 
 Any of the nestjs-doctor rules named on this page can fail a build. None of them
 restricts its surfaces, and `--blocking` gates on findings carrying the
 `ciFailure` surface. [Failing the build](/docs/ci/gates) covers the flags.
 
-## Running both
+## Running the plugins and nestjs-doctor together
 
 Nothing here requires a choice. The plugins stay in the editor, running per file
 on save. nestjs-doctor runs in CI over the whole project on every pull request.
@@ -93,7 +98,7 @@ That covers the 52 rules, the HTML report, the GitHub Action and the VS Code
 extension.
 
 Scan a project once and compare the output against what your linter already
-tells you:
+reports:
 
 ```bash
 npx nestjs-doctor@latest .

--- a/packages/website/src/app/docs/nestjs-eslint-plugins/page.mdx
+++ b/packages/website/src/app/docs/nestjs-eslint-plugins/page.mdx
@@ -1,0 +1,104 @@
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { docsMetadata } from "@/lib/docs-metadata";
+export const metadata = docsMetadata["/docs/nestjs-eslint-plugins"];
+
+<BreadcrumbJsonLd path="/docs/nestjs-eslint-plugins" />
+
+# NestJS Doctor vs ESLint plugins
+
+A linter is the better tool for most of what a linter does. It runs on save in
+milliseconds, the three NestJS plugins below ship 36 rules between them, and
+oxlint is what the Nest 12 CLI now scaffolds. Swagger decorator hygiene,
+throttled routes, permissive CORS and unsafe upload filenames are checked there
+and nowhere in nestjs-doctor.
+
+The difference is what each tool is handed. A lint rule is handed one file and
+asked a question about that file. nestjs-doctor is handed the application: every
+`@Module()` at once, the provider graph, the endpoint graph and the ORM schema.
+
+## What each plugin covers
+
+Every row was read from the installed package on 2026-09-02, not from a README.
+
+| Plugin | Version | Rules | Roughly about |
+|---|---|---|---|
+| `eslint-plugin-nestjs` | 1.2.3 | 4 | `ParseIntPipe`, deprecated API modules, injection, registering a validation pipe |
+| `@darraghor/eslint-plugin-nestjs-typed` | 7.3.4 | 22 | Swagger and OpenAPI decorators, class-validator DTO metadata, provider wiring |
+| `eslint-plugin-nestjs-security` | 3.1.1 | 10 | Guards, validation pipes, throttling, CORS, serialization, upload filenames |
+| `oxlint` | 1.81.0 | 0 | No NestJS plugin. Its plugin list is unicorn, oxc, typescript, import, react, jsdoc, jest, vitest, jsx-a11y, nextjs, react-perf, promise, node and vue |
+
+Counting a plugin's rules takes one command against the package itself:
+
+```bash
+node -e "console.log(Object.keys(require('eslint-plugin-nestjs-security').rules).length)"
+```
+
+Rule sets move. Re-run that against the version you have installed rather than
+trusting the number in the table.
+
+## What only a project-scoped scan sees
+
+nestjs-doctor builds one module graph from every `@Module()` decorator in the
+project before any rule runs. Eight of its 52 rules run once over the whole
+project instead of once per file, so they can answer questions no single file
+contains.
+
+Running all 36 plugin rules over a fixture with a two-module import cycle and an
+unused module export reported neither. On the same files nestjs-doctor reported
+both:
+
+- `architecture/no-circular-module-deps`, an `error`, on the cycle.
+- `performance/no-unused-module-exports`, an `info`, on the export nobody imports.
+- `performance/no-unused-providers` and `performance/no-orphan-modules` read the
+  same graph.
+
+The ORM schema is the second thing no plugin models. nestjs-doctor extracts
+entities and relations from Prisma, TypeORM, Drizzle and MikroORM into a schema
+graph, then reports `schema/require-primary-key`, `schema/require-timestamps`
+and `schema/require-cascade-rule` against the entity. None of the 36 rules
+models an entity or a relation.
+
+The third is one number. Every finding is weighted by severity and category,
+normalized by file count, and reduced to a score out of 100 for the whole
+project. That score is comparable across repositories in a way that a count of
+lint errors is not, and `--min-score` gates a build on it.
+
+## Where they overlap
+
+The overlaps below were produced by running both tools over the same fixture and
+comparing per file and line, on 2026-09-02.
+
+| Case | nestjs-doctor | Plugin rule | Result |
+|---|---|---|---|
+| Endpoint with no guard | `security/require-guards-on-endpoints` | `nestjs-security/require-guards`, `@darraghor/nestjs-typed/api-methods-should-be-guarded` | All three flagged the same handler and no other. A guard at class level and a guard at method level both count everywhere |
+| Nested non-primitive without `@Type()` | `correctness/validated-non-primitive-needs-type` | `@darraghor/nestjs-typed/validated-non-primitive-property-needs-type-decorator` | Same two properties, same two lines |
+| `@ValidateNested()` on an array | `correctness/validate-nested-array-each` | `@darraghor/nestjs-typed/validate-nested-of-array-should-set-each` | Same property, same line |
+| Injectable no module provides | `correctness/injectable-must-be-provided` | `@darraghor/nestjs-typed/injectable-should-be-provided` | Same file. This rule does read the whole project, so provider registration is not a gap |
+
+Both validation rows are about class-validator metadata on a DTO. Whether a
+`ValidationPipe` is registered at all is a separate question, and it is
+`eslint-plugin-nestjs-security` and `eslint-plugin-nestjs` that ask it.
+
+Any of the nestjs-doctor rules named on this page can fail a build. None of them
+restricts its surfaces, and `--blocking` gates on findings carrying the
+`ciFailure` surface. [Failing the build](/docs/ci/gates) covers the flags.
+
+## Running both
+
+Nothing here requires a choice. The plugins stay in the editor where they belong,
+running per file on save, and nestjs-doctor runs in CI over the whole project on
+every pull request.
+
+Both are free. nestjs-doctor ships under MIT with no paid tier and no seat count,
+including the 52 rules, the HTML report, the GitHub Action and the VS Code
+extension.
+
+Scan a project once and compare the output against what your linter already
+tells you:
+
+```bash
+npx nestjs-doctor@latest .
+```
+
+[Quickstart](/docs/setup) covers reading the score, and [Rules](/docs/rules)
+lists all 52.

--- a/packages/website/src/app/docs/nestjs-eslint-plugins/page.mdx
+++ b/packages/website/src/app/docs/nestjs-eslint-plugins/page.mdx
@@ -7,7 +7,7 @@ export const metadata = docsMetadata["/docs/nestjs-eslint-plugins"];
 # NestJS Doctor vs ESLint plugins
 
 A linter is the better tool for most of what a linter does. It runs on save in
-milliseconds, the three NestJS plugins below ship 36 rules between them, and
+milliseconds, and the three NestJS plugins below ship 36 rules between them.
 oxlint is what the Nest 12 CLI now scaffolds. Swagger decorator hygiene,
 throttled routes, permissive CORS and unsafe upload filenames are checked there
 and nowhere in nestjs-doctor.
@@ -20,12 +20,12 @@ asked a question about that file. nestjs-doctor is handed the application: every
 
 Every row was read from the installed package on 2026-09-02, not from a README.
 
-| Plugin | Version | Rules | Roughly about |
+| Plugin | Version | NestJS rules | Roughly about |
 |---|---|---|---|
 | `eslint-plugin-nestjs` | 1.2.3 | 4 | `ParseIntPipe`, deprecated API modules, injection, registering a validation pipe |
 | `@darraghor/eslint-plugin-nestjs-typed` | 7.3.4 | 22 | Swagger and OpenAPI decorators, class-validator DTO metadata, provider wiring |
 | `eslint-plugin-nestjs-security` | 3.1.1 | 10 | Guards, validation pipes, throttling, CORS, serialization, upload filenames |
-| `oxlint` | 1.81.0 | 0 | No NestJS plugin. Its plugin list is unicorn, oxc, typescript, import, react, jsdoc, jest, vitest, jsx-a11y, nextjs, react-perf, promise, node and vue |
+| `oxlint` | 1.81.0 | none | No NestJS plugin. Its plugin list is unicorn, oxc, typescript, import, react, jsdoc, jest, vitest, jsx-a11y, nextjs, react-perf, promise, node and vue |
 
 Counting a plugin's rules takes one command against the package itself:
 
@@ -85,12 +85,11 @@ restricts its surfaces, and `--blocking` gates on findings carrying the
 
 ## Running both
 
-Nothing here requires a choice. The plugins stay in the editor where they belong,
-running per file on save, and nestjs-doctor runs in CI over the whole project on
-every pull request.
+Nothing here requires a choice. The plugins stay in the editor, running per file
+on save. nestjs-doctor runs in CI over the whole project on every pull request.
 
-Both are free. nestjs-doctor ships under MIT with no paid tier and no seat count,
-including the 52 rules, the HTML report, the GitHub Action and the VS Code
+Both are free. nestjs-doctor ships under MIT with no paid tier and no seat count.
+That covers the 52 rules, the HTML report, the GitHub Action and the VS Code
 extension.
 
 Scan a project once and compare the output against what your linter already

--- a/packages/website/src/app/docs/page.mdx
+++ b/packages/website/src/app/docs/page.mdx
@@ -39,8 +39,7 @@ your laptop and in CI, which is what makes it usable as a gate.
 
 ## How it fits with ESLint
 
-ESLint reads a file. nestjs-doctor reads the application: which modules import
-which, which providers are actually injected, which endpoints have a guard,
-which entities the ORM defines. A lint rule cannot see that picture, so it
-cannot check it. Circular module dependencies and unused providers show up here
-and not there.
+A lint rule is handed one file. nestjs-doctor is handed the application, so
+module cycles, unused providers and the ORM schema show up here and not there.
+[NestJS Doctor vs ESLint plugins](/docs/nestjs-eslint-plugins) compares them
+rule for rule.

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -14,7 +14,7 @@ npx nestjs-doctor@latest .
 
 No config file, nothing to set up. It reads your TypeScript, runs 52 rules, and
 prints a score out of 100. Your code never leaves the machine; what the scan
-itself reports is listed on [Telemetry](/docs/telemetry).
+itself reports appears on [Telemetry](/docs/telemetry).
 
 A clean scan prints the score and nothing else. That is the expected result on
 a project the rules already agree with, and [the report](/docs/report) still
@@ -50,30 +50,34 @@ it loads nestjs-doctor from your workspace.
 
 ## Requirements
 
-nestjs-doctor does not use your project's TypeScript. It parses your source with
-the compiler bundled in `ts-morph`. It reads `tsconfig.json` only for `baseUrl`
-and `paths`, and adds no files from it. It resolves no dependencies, so a scan
-works on a checkout with no `node_modules` installed.
+nestjs-doctor needs Node 20.19 or newer, whatever version your project targets.
 
-| Your project's TypeScript | Scans | Notes |
+It does not use your project's TypeScript. It parses your source with the
+compiler bundled in `ts-morph`.
+
+It reads `tsconfig.json` only for `baseUrl` and `paths`, and adds no files from
+it. It resolves no dependencies, so a scan works on a checkout with no
+`node_modules` installed.
+
+These three TypeScript versions scan:
+
+| Your project's TypeScript | Scans | Version checked on 2026-09-02 |
 |---|---|---|
-| 5.x | Yes | Checked 2026-09-02 on 5.9.3 |
-| 6.x | Yes | Checked 2026-09-02 on 6.0.3, the release nestjs-doctor bundles |
-| 7.0 | Yes | Checked 2026-09-02 on 7.0.2, with `nodenext` and `verbatimModuleSyntax` |
+| 5.x | Yes | 5.9.3 |
+| 6.x | Yes | 6.0.3 |
+| 7.0 | Yes | 7.0.2, with `nodenext` and `verbatimModuleSyntax` |
 
-The same NestJS 11 app scored the same on all three, with the same file count,
-the same traced endpoints and no rule errors.
-
-The CLI itself needs Node 20.19 or newer, whatever version your project targets.
+The same NestJS 11 app scored the same on all three TypeScript versions, with
+the same file count, the same traced endpoints and no rule errors.
 
 The limit is syntax, not the version number. nestjs-doctor bundles TypeScript
-6.0.2 through `ts-morph` 28, and TypeScript 7.0 introduced no syntax that
-compiler cannot parse.
+6.0.2 through `ts-morph` 28. TypeScript 7.0 introduced no syntax that compiler
+cannot parse.
 
-Syntax it cannot parse does not fail the scan. The TypeScript parser recovers
-from the error and returns a partial tree, so the file is still counted and
-still analyzed. What the parser could not recover is not reported, and nothing
-marks the file as partly read.
+Syntax nestjs-doctor cannot parse does not fail the scan. The TypeScript parser
+recovers from the error and returns a partial tree, so nestjs-doctor still
+counts and analyzes the file. It reports nothing that the parser could not
+recover, and nothing marks the file as partly read.
 
 ## Exit codes
 

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -51,8 +51,9 @@ it loads nestjs-doctor from your workspace.
 ## Requirements
 
 nestjs-doctor does not use your project's TypeScript. It parses your source with
-the compiler bundled in `ts-morph`, reads no `tsconfig.json` and resolves no
-dependencies, so a scan works on a checkout with no `node_modules` installed.
+the compiler bundled in `ts-morph`. It reads `tsconfig.json` only for `baseUrl`
+and `paths`, and adds no files from it. It resolves no dependencies, so a scan
+works on a checkout with no `node_modules` installed.
 
 | Your project's TypeScript | Scans | Notes |
 |---|---|---|
@@ -61,8 +62,9 @@ dependencies, so a scan works on a checkout with no `node_modules` installed.
 | 7.0 | Yes | Checked 2026-09-02 on 7.0.2, with `nodenext` and `verbatimModuleSyntax` |
 
 The same NestJS 11 app scored the same on all three, with the same file count,
-the same traced endpoints and no rule errors. The CLI itself needs Node 20.19 or
-newer, whatever version your project targets.
+the same traced endpoints and no rule errors.
+
+The CLI itself needs Node 20.19 or newer, whatever version your project targets.
 
 The limit is syntax, not the version number. nestjs-doctor bundles TypeScript
 6.0.2 through `ts-morph` 28, and TypeScript 7.0 introduced no syntax that

--- a/packages/website/src/app/docs/setup/page.mdx
+++ b/packages/website/src/app/docs/setup/page.mdx
@@ -48,6 +48,31 @@ npm install -D nestjs-doctor
 `npx` is enough for a one-off. The VS Code extension needs the install, because
 it loads nestjs-doctor from your workspace.
 
+## Requirements
+
+nestjs-doctor does not use your project's TypeScript. It parses your source with
+the compiler bundled in `ts-morph`, reads no `tsconfig.json` and resolves no
+dependencies, so a scan works on a checkout with no `node_modules` installed.
+
+| Your project's TypeScript | Scans | Notes |
+|---|---|---|
+| 5.x | Yes | Checked 2026-09-02 on 5.9.3 |
+| 6.x | Yes | Checked 2026-09-02 on 6.0.3, the release nestjs-doctor bundles |
+| 7.0 | Yes | Checked 2026-09-02 on 7.0.2, with `nodenext` and `verbatimModuleSyntax` |
+
+The same NestJS 11 app scored the same on all three, with the same file count,
+the same traced endpoints and no rule errors. The CLI itself needs Node 20.19 or
+newer, whatever version your project targets.
+
+The limit is syntax, not the version number. nestjs-doctor bundles TypeScript
+6.0.2 through `ts-morph` 28, and TypeScript 7.0 introduced no syntax that
+compiler cannot parse.
+
+Syntax it cannot parse does not fail the scan. The TypeScript parser recovers
+from the error and returns a partial tree, so the file is still counted and
+still analyzed. What the parser could not recover is not reported, and nothing
+marks the file as partly read.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/packages/website/src/lib/docs-metadata.ts
+++ b/packages/website/src/lib/docs-metadata.ts
@@ -12,6 +12,11 @@ export const DOCS_PAGES: Record<string, PageCopy> = {
 		description:
 			"Both draw a NestJS module graph. Nest Devtools boots your app; nestjs-doctor reads your source, adds 52 rules, an ER diagram and a CI gate, and is MIT licensed.",
 	},
+	"/docs/nestjs-eslint-plugins": {
+		title: "NestJS Doctor vs ESLint plugins",
+		description:
+			"What the NestJS ESLint plugins and oxlint check, what a project-scoped scan sees that a file-scoped lint rule cannot, and where the two overlap rule for rule.",
+	},
 	"/docs/setup": {
 		title: "Quickstart",
 		description:

--- a/packages/website/src/lib/docs-navigation.ts
+++ b/packages/website/src/lib/docs-navigation.ts
@@ -35,6 +35,10 @@ export const DOCS_NAV: NavSection[] = [
 				title: "NestJS Doctor vs Nest Devtools",
 				href: "/docs/nest-devtools-alternative",
 			},
+			{
+				title: "NestJS Doctor vs ESLint plugins",
+				href: "/docs/nestjs-eslint-plugins",
+			},
 		],
 	},
 	{


### PR DESCRIPTION
## Problem

- The docs said nothing about which TypeScript versions scan. The plan flagged TS 7 as an unchecked product risk; it was checked today and it is not one.
- No page answered the lint-rule objection, and the two comparison claims the plan proposed would have shipped false (see Solution).

