### PR TITLE
feat(website): the leaderboard is the TUI score screen, with the fifteen most-starred apps built on NestJS

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -23,6 +23,7 @@
     "codemirror": "6.0.2",
     "dagre": "0.8.5",
     "lucide-react": "^1.35.0",
+    "motion": "12.23.24",
     "nestjs-doctor": "workspace:^",
     "next": "16.3.3",
     "posthog-js": "^1.422.5",

--- a/packages/website/src/app/leaderboard/leaderboard-entries.ts
+++ b/packages/website/src/app/leaderboard/leaderboard-entries.ts
@@ -1,13 +1,36 @@
+export interface TopRule {
+	count: number;
+	rule: string;
+	severity: "error" | "info" | "warning";
+}
+
 interface LeaderboardEntry {
+	commit: string;
 	errorCount: number;
 	fileCount: number;
 	githubUrl: string;
+	infoCount?: number;
+	kind?: "app" | "starter";
+	moduleCount?: number;
 	name: string;
+	nestMajor: number;
+	nestVersion?: string;
+	orm?: string;
 	packageName: string;
+	scannedAt: string;
 	score: number;
+	stars?: number;
+	topRules?: TopRule[];
+	upgradedTo?: 12;
 	warningCount: number;
 }
 
+export const SCANNED_WITH = "0.9.5";
+export const SCANNED_AT = "2026-09-02";
+
+const SHORT_COMMIT_LENGTH = 7;
+
+/** Builds the certificate URL from the scan facts and the scan stamp. */
 const buildShareUrl = (entry: LeaderboardEntry): string => {
 	const searchParams = new URLSearchParams({
 		p: entry.packageName,
@@ -15,64 +38,689 @@ const buildShareUrl = (entry: LeaderboardEntry): string => {
 		e: String(entry.errorCount),
 		w: String(entry.warningCount),
 		f: String(entry.fileCount),
+		d: entry.scannedAt,
+		v: SCANNED_WITH,
+		r: entry.name,
 	});
+	if (entry.infoCount !== undefined) {
+		searchParams.set("i", String(entry.infoCount));
+	}
+	if (entry.moduleCount !== undefined) {
+		searchParams.set("m", String(entry.moduleCount));
+	}
+	if (entry.nestVersion) {
+		searchParams.set("n", entry.nestVersion);
+	}
+	if (entry.orm) {
+		searchParams.set("o", entry.orm);
+	}
+	if (entry.commit) {
+		searchParams.set("c", entry.commit.slice(0, SHORT_COMMIT_LENGTH));
+	}
 	return `/share?${searchParams.toString()}`;
 };
 
 const RAW_ENTRIES: LeaderboardEntry[] = [
 	{
-		name: "nestjs/nest",
-		githubUrl: "https://github.com/nestjs/nest",
-		packageName: "@nestjs/core",
-		score: 91,
-		errorCount: 0,
-		warningCount: 12,
-		fileCount: 8,
+		name: "twentyhq/twenty",
+		githubUrl: "https://github.com/twentyhq/twenty",
+		packageName: "twenty-server",
+		kind: "app",
+		stars: 56_040,
+		score: 99,
+		errorCount: 53,
+		warningCount: 1105,
+		infoCount: 402,
+		fileCount: 6994,
+		moduleCount: 381,
+		nestMajor: 11,
+		nestVersion: "11.2.1",
+		orm: "typeorm",
+		topRules: [
+			{
+				rule: "architecture/no-orm-in-controllers",
+				severity: "error",
+				count: 20,
+			},
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 11 },
+			{
+				rule: "architecture/no-repository-in-controllers",
+				severity: "error",
+				count: 10,
+			},
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 8,
+			},
+			{
+				rule: "architecture/no-circular-module-deps",
+				severity: "error",
+				count: 2,
+			},
+			{
+				rule: "architecture/no-manual-instantiation",
+				severity: "error",
+				count: 1,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "57545214e58c8d181f7855da333de447f887e032",
+	},
+	{
+		name: "amplication/amplication",
+		githubUrl: "https://github.com/amplication/amplication",
+		packageName: "amplication",
+		kind: "app",
+		stars: 16_012,
+		score: 98,
+		errorCount: 22,
+		warningCount: 320,
+		infoCount: 244,
+		fileCount: 1655,
+		moduleCount: 124,
+		nestMajor: 9,
+		nestVersion: "9.3.12",
+		orm: "prisma",
+		topRules: [
+			{
+				rule: "architecture/no-circular-module-deps",
+				severity: "error",
+				count: 17,
+			},
+			{
+				rule: "correctness/param-decorator-matches-route",
+				severity: "error",
+				count: 4,
+			},
+			{
+				rule: "security/no-vulnerable-nestjs-packages",
+				severity: "error",
+				count: 1,
+			},
+			{
+				rule: "correctness/no-async-without-await",
+				severity: "warning",
+				count: 218,
+			},
+			{
+				rule: "security/require-guards-on-endpoints",
+				severity: "warning",
+				count: 37,
+			},
+			{
+				rule: "correctness/prefer-readonly-injection",
+				severity: "warning",
+				count: 24,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "7656495d27f0dceff89657590c3f14149e45c7a6",
 	},
 	{
 		name: "ever-co/ever-gauzy",
 		githubUrl: "https://github.com/ever-co/ever-gauzy",
 		packageName: "ever-gauzy",
-		score: 72,
-		errorCount: 18,
-		warningCount: 84,
-		fileCount: 52,
+		kind: "app",
+		stars: 4359,
+		score: 98,
+		errorCount: 77,
+		warningCount: 1193,
+		infoCount: 563,
+		fileCount: 3751,
+		moduleCount: 217,
+		nestMajor: 11,
+		nestVersion: "11.1.26",
+		orm: "typeorm",
+		topRules: [
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 35 },
+			{
+				rule: "architecture/no-circular-module-deps",
+				severity: "error",
+				count: 31,
+			},
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 4,
+			},
+			{
+				rule: "architecture/no-repository-in-controllers",
+				severity: "error",
+				count: 3,
+			},
+			{ rule: "security/no-eval", severity: "error", count: 2 },
+			{
+				rule: "security/no-synchronize-in-production",
+				severity: "error",
+				count: 1,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "fe004fe999272d495d7e33636d5b53495e2749be",
 	},
 	{
-		name: "rubiin/ultimate-nest",
-		githubUrl: "https://github.com/rubiin/ultimate-nest",
-		packageName: "ultimate-nest",
-		score: 85,
-		errorCount: 2,
-		warningCount: 21,
-		fileCount: 14,
+		name: "bookorbit/bookorbit",
+		githubUrl: "https://github.com/bookorbit/bookorbit",
+		packageName: "server",
+		kind: "app",
+		stars: 3736,
+		score: 98,
+		errorCount: 24,
+		warningCount: 403,
+		infoCount: 69,
+		fileCount: 1125,
+		moduleCount: 72,
+		nestMajor: 11,
+		nestVersion: "11.2.3",
+		orm: "drizzle",
+		topRules: [
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 11,
+			},
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 4 },
+			{
+				rule: "architecture/no-circular-module-deps",
+				severity: "error",
+				count: 4,
+			},
+			{
+				rule: "architecture/no-repository-in-controllers",
+				severity: "error",
+				count: 2,
+			},
+			{ rule: "security/no-eval", severity: "error", count: 1 },
+			{
+				rule: "architecture/no-manual-instantiation",
+				severity: "error",
+				count: 1,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "9165dbed1dd9b30b075d74c8a718a1a4673f7e95",
+	},
+	{
+		name: "immich-app/immich",
+		githubUrl: "https://github.com/immich-app/immich",
+		packageName: "immich",
+		kind: "app",
+		stars: 113_268,
+		score: 97,
+		errorCount: 27,
+		warningCount: 350,
+		infoCount: 1,
+		fileCount: 443,
+		moduleCount: 4,
+		nestMajor: 11,
+		nestVersion: "11.0.4",
+		topRules: [
+			{
+				rule: "architecture/no-repository-in-controllers",
+				severity: "error",
+				count: 19,
+			},
+			{
+				rule: "architecture/no-manual-instantiation",
+				severity: "error",
+				count: 6,
+			},
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 1,
+			},
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 1 },
+			{
+				rule: "correctness/prefer-readonly-injection",
+				severity: "warning",
+				count: 212,
+			},
+			{
+				rule: "correctness/no-async-without-await",
+				severity: "warning",
+				count: 95,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "2c53b76400e95c4e30571e87f85de83b0620ef01",
+	},
+	{
+		name: "ghostfolio/ghostfolio",
+		githubUrl: "https://github.com/ghostfolio/ghostfolio",
+		packageName: "ghostfolio",
+		kind: "app",
+		stars: 9232,
+		score: 97,
+		errorCount: 15,
+		warningCount: 105,
+		infoCount: 23,
+		fileCount: 292,
+		moduleCount: 63,
+		nestMajor: 11,
+		nestVersion: "11.1.28",
+		orm: "prisma",
+		topRules: [
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 10,
+			},
+			{
+				rule: "architecture/no-circular-module-deps",
+				severity: "error",
+				count: 3,
+			},
+			{ rule: "security/no-eval", severity: "error", count: 1 },
+			{
+				rule: "architecture/no-orm-in-controllers",
+				severity: "error",
+				count: 1,
+			},
+			{
+				rule: "correctness/no-async-without-await",
+				severity: "warning",
+				count: 83,
+			},
+			{ rule: "performance/no-sync-io", severity: "warning", count: 7 },
+		],
+		scannedAt: "2026-09-02",
+		commit: "73e4f0368de398d7b67c50fb2926351414e2044e",
 	},
 	{
 		name: "brocoders/nestjs-boilerplate",
 		githubUrl: "https://github.com/brocoders/nestjs-boilerplate",
 		packageName: "nestjs-boilerplate",
-		score: 78,
-		errorCount: 5,
-		warningCount: 34,
-		fileCount: 22,
+		kind: "starter",
+		stars: 4384,
+		score: 96,
+		errorCount: 1,
+		warningCount: 19,
+		infoCount: 48,
+		fileCount: 157,
+		moduleCount: 24,
+		nestMajor: 11,
+		nestVersion: "11.1.18",
+		orm: "typeorm",
+		upgradedTo: 12,
+		topRules: [
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 1 },
+			{
+				rule: "security/require-guards-on-endpoints",
+				severity: "warning",
+				count: 11,
+			},
+			{
+				rule: "correctness/no-async-without-await",
+				severity: "warning",
+				count: 3,
+			},
+			{
+				rule: "correctness/validated-non-primitive-needs-type",
+				severity: "warning",
+				count: 3,
+			},
+			{
+				rule: "performance/no-unused-providers",
+				severity: "warning",
+				count: 2,
+			},
+			{
+				rule: "architecture/require-module-boundaries",
+				severity: "info",
+				count: 17,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "9620f159eefe38f47747d02ab162852367c5472c",
 	},
 	{
-		name: "vendure-ecommerce/vendure",
-		githubUrl: "https://github.com/vendure-ecommerce/vendure",
+		name: "toeverything/AFFiNE",
+		githubUrl: "https://github.com/toeverything/AFFiNE",
+		packageName: "@affine/server",
+		kind: "app",
+		stars: 72_118,
+		score: 95,
+		errorCount: 17,
+		warningCount: 219,
+		infoCount: 130,
+		fileCount: 528,
+		moduleCount: 69,
+		nestMajor: 11,
+		nestVersion: "11.1.18",
+		orm: "prisma",
+		topRules: [
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 14,
+			},
+			{
+				rule: "architecture/no-orm-in-controllers",
+				severity: "error",
+				count: 2,
+			},
+			{ rule: "schema/require-primary-key", severity: "error", count: 1 },
+			{
+				rule: "correctness/no-async-without-await",
+				severity: "warning",
+				count: 125,
+			},
+			{
+				rule: "performance/no-unused-providers",
+				severity: "warning",
+				count: 53,
+			},
+			{ rule: "performance/no-sync-io", severity: "warning", count: 11 },
+		],
+		scannedAt: "2026-09-02",
+		commit: "f78e46f90e112f33df063b97cd38f636dfc5b212",
+	},
+	{
+		name: "nocodb/nocodb",
+		githubUrl: "https://github.com/nocodb/nocodb",
+		packageName: "nocodb",
+		kind: "app",
+		stars: 64_805,
+		score: 95,
+		errorCount: 55,
+		warningCount: 1005,
+		infoCount: 157,
+		fileCount: 1197,
+		moduleCount: 7,
+		nestMajor: 10,
+		nestVersion: "10.4.19",
+		topRules: [
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 27,
+			},
+			{
+				rule: "correctness/param-decorator-matches-route",
+				severity: "error",
+				count: 13,
+			},
+			{
+				rule: "correctness/require-inject-decorator",
+				severity: "error",
+				count: 11,
+			},
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 3 },
+			{
+				rule: "architecture/no-manual-instantiation",
+				severity: "error",
+				count: 1,
+			},
+			{
+				rule: "correctness/no-async-without-await",
+				severity: "warning",
+				count: 747,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "fb10b70be62c98ae90dd01af2d1ebbccf4f92cb9",
+	},
+	{
+		name: "novuhq/novu",
+		githubUrl: "https://github.com/novuhq/novu",
+		packageName: "@novu/api-service",
+		kind: "app",
+		stars: 39_710,
+		score: 95,
+		errorCount: 82,
+		warningCount: 2758,
+		infoCount: 691,
+		fileCount: 3454,
+		moduleCount: 81,
+		nestMajor: 11,
+		nestVersion: "11.1.27",
+		orm: "mongoose",
+		topRules: [
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 52 },
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 12,
+			},
+			{
+				rule: "architecture/no-repository-in-controllers",
+				severity: "error",
+				count: 11,
+			},
+			{
+				rule: "architecture/no-circular-module-deps",
+				severity: "error",
+				count: 4,
+			},
+			{
+				rule: "correctness/no-missing-interceptor-method",
+				severity: "error",
+				count: 2,
+			},
+			{ rule: "security/no-eval", severity: "error", count: 1 },
+		],
+		scannedAt: "2026-09-02",
+		commit: "cfc272c0dcb662badfe8d1f92225afb796280e98",
+	},
+	{
+		name: "vendurehq/vendure",
+		githubUrl: "https://github.com/vendurehq/vendure",
 		packageName: "@vendure/core",
-		score: 76,
-		errorCount: 12,
-		warningCount: 67,
-		fileCount: 45,
+		kind: "app",
+		stars: 8394,
+		score: 95,
+		errorCount: 79,
+		warningCount: 590,
+		infoCount: 107,
+		fileCount: 741,
+		moduleCount: 22,
+		nestMajor: 11,
+		nestVersion: "11.0.12",
+		orm: "typeorm",
+		topRules: [
+			{ rule: "schema/require-primary-key", severity: "error", count: 78 },
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 1,
+			},
+			{
+				rule: "correctness/prefer-readonly-injection",
+				severity: "warning",
+				count: 447,
+			},
+			{
+				rule: "correctness/no-async-without-await",
+				severity: "warning",
+				count: 105,
+			},
+			{ rule: "performance/no-sync-io", severity: "warning", count: 17 },
+			{
+				rule: "correctness/no-fire-and-forget-async",
+				severity: "warning",
+				count: 4,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "1ad4ba80d1d30060f459e74d95bd7faf6a1d14f2",
 	},
 	{
-		name: "medusajs/medusa",
-		githubUrl: "https://github.com/medusajs/medusa",
-		packageName: "@medusajs/medusa",
-		score: 74,
-		errorCount: 14,
-		warningCount: 89,
-		fileCount: 58,
+		name: "hoppscotch/hoppscotch",
+		githubUrl: "https://github.com/hoppscotch/hoppscotch",
+		packageName: "hoppscotch-backend",
+		kind: "app",
+		stars: 80_163,
+		score: 92,
+		errorCount: 11,
+		warningCount: 102,
+		infoCount: 21,
+		fileCount: 189,
+		moduleCount: 26,
+		nestMajor: 11,
+		nestVersion: "11.2.1",
+		orm: "prisma",
+		topRules: [
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 7,
+			},
+			{ rule: "schema/require-primary-key", severity: "error", count: 2 },
+			{
+				rule: "architecture/no-orm-in-controllers",
+				severity: "error",
+				count: 1,
+			},
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 1 },
+			{
+				rule: "correctness/no-fire-and-forget-async",
+				severity: "warning",
+				count: 53,
+			},
+			{
+				rule: "correctness/prefer-readonly-injection",
+				severity: "warning",
+				count: 23,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "ac145e7f758151b41fd46d3e5f513886ce9068ba",
+	},
+	{
+		name: "apitable/apitable",
+		githubUrl: "https://github.com/apitable/apitable",
+		packageName: "@apitable/room-server",
+		kind: "app",
+		stars: 15_584,
+		score: 91,
+		errorCount: 34,
+		warningCount: 218,
+		infoCount: 40,
+		fileCount: 535,
+		moduleCount: 47,
+		nestMajor: 8,
+		nestVersion: "8.1.2",
+		orm: "typeorm",
+		topRules: [
+			{
+				rule: "architecture/no-repository-in-controllers",
+				severity: "error",
+				count: 12,
+			},
+			{
+				rule: "architecture/no-circular-module-deps",
+				severity: "error",
+				count: 9,
+			},
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 6,
+			},
+			{
+				rule: "security/no-vulnerable-nestjs-packages",
+				severity: "error",
+				count: 4,
+			},
+			{
+				rule: "architecture/no-manual-instantiation",
+				severity: "error",
+				count: 2,
+			},
+			{ rule: "security/no-hardcoded-secrets", severity: "error", count: 1 },
+		],
+		scannedAt: "2026-09-02",
+		commit: "88b24ce9f359cc434778be75d03603182882dc76",
+	},
+	{
+		name: "gitroomhq/postiz-app",
+		githubUrl: "https://github.com/gitroomhq/postiz-app",
+		packageName: "gitroom",
+		kind: "app",
+		stars: 35_391,
+		score: 89,
+		errorCount: 28,
+		warningCount: 613,
+		infoCount: 69,
+		fileCount: 396,
+		moduleCount: 12,
+		nestMajor: 11,
+		nestVersion: "11.1.21",
+		orm: "prisma",
+		topRules: [
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 25,
+			},
+			{ rule: "schema/require-primary-key", severity: "error", count: 3 },
+			{
+				rule: "correctness/no-async-without-await",
+				severity: "warning",
+				count: 242,
+			},
+			{
+				rule: "correctness/prefer-readonly-injection",
+				severity: "warning",
+				count: 210,
+			},
+			{ rule: "security/no-exposed-env-vars", severity: "warning", count: 116 },
+			{
+				rule: "performance/no-unused-providers",
+				severity: "warning",
+				count: 26,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "ec162d2ac19f7ec736d2ead907369d4b8d12f274",
+	},
+	{
+		name: "teableio/teable",
+		githubUrl: "https://github.com/teableio/teable",
+		packageName: "@teable/backend",
+		kind: "app",
+		stars: 21_750,
+		score: 89,
+		errorCount: 32,
+		warningCount: 702,
+		infoCount: 178,
+		fileCount: 921,
+		moduleCount: 130,
+		nestMajor: 10,
+		nestVersion: "10.3.5",
+		orm: "prisma",
+		topRules: [
+			{
+				rule: "architecture/no-business-logic-in-controllers",
+				severity: "error",
+				count: 17,
+			},
+			{
+				rule: "architecture/no-orm-in-controllers",
+				severity: "error",
+				count: 4,
+			},
+			{
+				rule: "correctness/require-inject-decorator",
+				severity: "error",
+				count: 3,
+			},
+			{ rule: "schema/require-primary-key", severity: "error", count: 3 },
+			{
+				rule: "architecture/no-manual-instantiation",
+				severity: "error",
+				count: 2,
+			},
+			{
+				rule: "architecture/no-circular-module-deps",
+				severity: "error",
+				count: 2,
+			},
+		],
+		scannedAt: "2026-09-02",
+		commit: "5ef2238883cad7c3980084de9a9031135fb9734f",
 	},
 ];
 

--- a/packages/website/src/app/leaderboard/leaderboard-entries.ts
+++ b/packages/website/src/app/leaderboard/leaderboard-entries.ts
@@ -28,37 +28,9 @@ interface LeaderboardEntry {
 export const SCANNED_WITH = "0.9.5";
 export const SCANNED_AT = "2026-09-02";
 
-const SHORT_COMMIT_LENGTH = 7;
-
-/** Builds the certificate URL from the scan facts and the scan stamp. */
-const buildShareUrl = (entry: LeaderboardEntry): string => {
-	const searchParams = new URLSearchParams({
-		p: entry.packageName,
-		s: String(entry.score),
-		e: String(entry.errorCount),
-		w: String(entry.warningCount),
-		f: String(entry.fileCount),
-		d: entry.scannedAt,
-		v: SCANNED_WITH,
-		r: entry.name,
-	});
-	if (entry.infoCount !== undefined) {
-		searchParams.set("i", String(entry.infoCount));
-	}
-	if (entry.moduleCount !== undefined) {
-		searchParams.set("m", String(entry.moduleCount));
-	}
-	if (entry.nestVersion) {
-		searchParams.set("n", entry.nestVersion);
-	}
-	if (entry.orm) {
-		searchParams.set("o", entry.orm);
-	}
-	if (entry.commit) {
-		searchParams.set("c", entry.commit.slice(0, SHORT_COMMIT_LENGTH));
-	}
-	return `/share?${searchParams.toString()}`;
-};
+/** The certificate page each entry links to and shares. */
+const buildShareUrl = (entry: LeaderboardEntry): string =>
+	`/share/${entry.name}`;
 
 const RAW_ENTRIES: LeaderboardEntry[] = [
 	{

--- a/packages/website/src/app/leaderboard/leaderboard-screen.tsx
+++ b/packages/website/src/app/leaderboard/leaderboard-screen.tsx
@@ -1,0 +1,584 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ScoreBar } from "@/components/score-bar";
+import { track } from "@/lib/analytics";
+import {
+	isFocusInFrame,
+	isInteractiveTarget,
+	isTypingTarget,
+} from "@/lib/keyboard";
+import {
+	getNestBirds,
+	MENU_CLASS,
+	MENU_LIST_CLASS,
+	MENU_ROW_CLASS,
+	PERFECT_SCORE,
+	palette,
+	scoreColor,
+	scoreTier,
+} from "@/lib/tui-theme";
+import {
+	type ResolvedLeaderboardEntry,
+	SCANNED_AT,
+	SCANNED_WITH,
+	type TopRule,
+} from "./leaderboard-entries";
+
+const COMMAND = "npx -y nestjs-doctor@latest .";
+const CONTRIBUTE_URL =
+	"https://github.com/RoloBits/nestjs-doctor/edit/main/packages/website/src/app/leaderboard/leaderboard-entries.ts";
+const SCORE_GOOD_THRESHOLD = 75;
+const MARK_CLEAN_THRESHOLD = 90;
+const COPIED_RESET_MS = 1600;
+/** Rows the projects pane shows at once, the browser's answer to listCapacity. */
+const LIST_CAPACITY = 10;
+
+const SEVERITY_MARK: Record<TopRule["severity"], string> = {
+	error: "✗",
+	warning: "⚠",
+	info: "●",
+};
+
+const severityColor = (severity: TopRule["severity"]): string => {
+	if (severity === "error") {
+		return palette.error;
+	}
+	if (severity === "warning") {
+		return palette.warning;
+	}
+	return palette.info;
+};
+
+/** The row's mark: clean at 90, watch from 75, failing below. */
+const rankMark = (score: number): string => {
+	if (score >= MARK_CLEAN_THRESHOLD) {
+		return "✓";
+	}
+	if (score >= SCORE_GOOD_THRESHOLD) {
+		return "▲";
+	}
+	return "✗";
+};
+
+const nestTag = (entry: ResolvedLeaderboardEntry): string =>
+	entry.upgradedTo
+		? `Nest ${entry.nestMajor}, same on ${entry.upgradedTo}`
+		: `Nest ${entry.nestMajor}`;
+
+/** Nest version, star count, and whether the repo is an app or a starter. */
+const originLine = (entry: ResolvedLeaderboardEntry): string => {
+	const parts = [nestTag(entry)];
+	if (entry.stars) {
+		parts.push(`${entry.stars.toLocaleString("en-US")} stars`);
+	}
+	if (entry.kind) {
+		parts.push(entry.kind);
+	}
+	return parts.join(" · ");
+};
+
+/** Keeps a scroll offset inside [0, total - visible]. Ported from tui/navigate.ts. */
+const clampOffset = (offset: number, total: number, visible: number): number =>
+	Math.max(0, Math.min(offset, Math.max(0, total - visible)));
+
+/** Keeps the selection inside the visible window. Ported from tui/navigate.ts. */
+const scrollWindow = (
+	offset: number,
+	selected: number,
+	height: number
+): number => {
+	if (height <= 0) {
+		return 0;
+	}
+	if (selected < offset) {
+		return selected;
+	}
+	if (selected >= offset + height) {
+		return selected - height + 1;
+	}
+	return offset;
+};
+
+const optionId = (index: number): string => `leaderboard-project-${index}`;
+
+/** Pluralises like the TUI's countLabel. */
+const countLabel = (count: number, singular: string): string =>
+	`${count} ${singular}${count === 1 ? "" : "s"}`;
+
+const shortRule = (rule: string): string =>
+	rule.split("/").slice(1).join("/") || rule;
+
+const FRAME_CLASS = "flex flex-col gap-4 px-4 py-4 text-[13px] leading-[1.5]";
+const LIST_CLASS = "flex flex-col";
+const LISTBOX_CLASS =
+	"flex flex-col focus-visible:outline-2 focus-visible:outline-nest-red focus-visible:outline-offset-2";
+const PANEL_LABEL_CLASS = "font-bold text-[11px] uppercase tracking-[0.08em]";
+const ROW_CLASS =
+	"flex w-full items-center gap-3 py-0.5 pr-2 text-left transition-colors";
+
+const Separator = () => (
+	<span className="whitespace-pre" style={{ color: palette.dim }}>
+		{"  ·  "}
+	</span>
+);
+
+interface MenuItem {
+	copy?: string;
+	external?: boolean;
+	hint: string;
+	href?: string;
+	internal?: boolean;
+	label: string;
+}
+
+const buildMenuItems = (entry: ResolvedLeaderboardEntry): MenuItem[] => [
+	{ label: "Run it on your codebase", hint: COMMAND, copy: COMMAND },
+	{
+		label: "Open on GitHub",
+		hint: entry.name,
+		href: entry.githubUrl,
+		external: true,
+	},
+	{
+		label: "Share this score",
+		hint: `${entry.score}/100 as a page you can send`,
+		href: entry.shareUrl,
+		internal: true,
+	},
+	{
+		label: "Add your project",
+		hint: "Open a PR to leaderboard-entries.ts",
+		href: CONTRIBUTE_URL,
+		external: true,
+	},
+];
+
+export const LeaderboardScreen = ({
+	entries,
+}: {
+	entries: ResolvedLeaderboardEntry[];
+}) => {
+	const [selected, setSelected] = useState(0);
+	const [menuIndex, setMenuIndex] = useState(0);
+	const [focus, setFocus] = useState<"list" | "menu">("list");
+	const [offset, setOffset] = useState(0);
+	const [toast, setToast] = useState<string | null>(null);
+	const frameRef = useRef<HTMLDivElement>(null);
+	const listRef = useRef<HTMLDivElement>(null);
+	const menuRefs = useRef<(HTMLElement | null)[]>([]);
+
+	const entry = entries[Math.min(selected, entries.length - 1)];
+	const items = buildMenuItems(entry);
+	const tier = scoreTier(entry.score);
+	const birds = getNestBirds(entry.score);
+	const labelWidth = Math.max(...items.map((item) => item.label.length));
+	const nameWidth = Math.max(...entries.map((row) => row.name.length));
+
+	const handleCopy = useCallback(async (command: string) => {
+		try {
+			await navigator.clipboard.writeText(command);
+			track("command_copied", { command, surface: "leaderboard" });
+			setToast(`Copied ${command}`);
+			setTimeout(() => setToast(null), COPIED_RESET_MS);
+		} catch {
+			// Clipboard is unavailable outside a secure context.
+		}
+	}, []);
+
+	const projectCount = entries.length;
+	const menuCount = items.length;
+	const overflow = projectCount > LIST_CAPACITY;
+	const safeOffset = scrollWindow(
+		clampOffset(offset, projectCount, LIST_CAPACITY),
+		Math.min(selected, projectCount - 1),
+		LIST_CAPACITY
+	);
+	const visible = entries.slice(safeOffset, safeOffset + LIST_CAPACITY);
+
+	useEffect(() => {
+		setOffset(safeOffset);
+	}, [safeOffset]);
+
+	useEffect(() => {
+		const onKeyDown = (event: globalThis.KeyboardEvent) => {
+			if (event.metaKey || event.ctrlKey || event.altKey) {
+				return;
+			}
+			if (isTypingTarget(event.target)) {
+				return;
+			}
+			// Tab traversal is the browser's; onFocus tells the panes who has it.
+			const active = document.activeElement;
+			if (!isFocusInFrame(active, frameRef.current)) {
+				return;
+			}
+
+			if (event.key === "ArrowDown" || event.key === "j") {
+				event.preventDefault();
+				if (focus === "list") {
+					setSelected((current) => Math.min(current + 1, projectCount - 1));
+				} else {
+					const next = (menuIndex + 1) % menuCount;
+					setMenuIndex(next);
+					menuRefs.current[next]?.focus();
+				}
+				return;
+			}
+			if (event.key === "ArrowUp" || event.key === "k") {
+				event.preventDefault();
+				if (focus === "list") {
+					setSelected((current) => Math.max(current - 1, 0));
+				} else {
+					const next = menuIndex === 0 ? menuCount - 1 : menuIndex - 1;
+					setMenuIndex(next);
+					menuRefs.current[next]?.focus();
+				}
+				return;
+			}
+			// Left and right swap panes, as the TUI does; up and down move inside one.
+			if (
+				event.key === "ArrowRight" ||
+				event.key === "ArrowLeft" ||
+				event.key === "l" ||
+				event.key === "h"
+			) {
+				event.preventDefault();
+				if (focus === "list") {
+					setFocus("menu");
+					menuRefs.current[menuIndex]?.focus();
+				} else {
+					setFocus("list");
+					listRef.current?.focus();
+				}
+				return;
+			}
+			if (event.key === "Enter") {
+				const onMenuRow = menuRefs.current.some((node) => node === active);
+				if (!onMenuRow && isInteractiveTarget(active)) {
+					return;
+				}
+				const row = menuRefs.current[menuIndex];
+				if (row) {
+					event.preventDefault();
+					row.click();
+				}
+			}
+		};
+
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [focus, projectCount, menuCount, menuIndex]);
+
+	return (
+		<div className={FRAME_CLASS} ref={frameRef} style={{ color: palette.text }}>
+			<div className="flex flex-row gap-4">
+				<pre
+					className="m-0 leading-tight"
+					style={{ color: scoreColor(entry.score) }}
+				>
+					{`┌───────┐\n│ ${birds[0]} │\n│ ${birds[1]} │\n└───────┘`}
+				</pre>
+				<div className="flex flex-col justify-center">
+					<div className="font-bold" style={{ color: palette.bright }}>
+						{"NESTJS DOCTOR "}
+						<span style={{ color: palette.dim }}>{`v${SCANNED_WITH}`}</span>
+					</div>
+					<div style={{ color: palette.muted }}>
+						{`leaderboard · ${entries.length} projects · scanned ${SCANNED_AT} · nestjs-doctor ${SCANNED_WITH}`}
+					</div>
+				</div>
+			</div>
+
+			<div>
+				<div className="font-bold">
+					<span style={{ color: scoreColor(entry.score) }}>
+						{`${entry.score}/${PERFECT_SCORE} ${tier.stars}`}
+					</span>
+					<span
+						className="whitespace-pre"
+						style={{ color: palette.muted }}
+					>{`  ${tier.label}`}</span>
+				</div>
+				<ScoreBar score={entry.score} />
+				<div className="flex flex-wrap items-baseline">
+					<span style={{ color: palette.error }}>
+						{`✗ ${countLabel(entry.errorCount, "error")}`}
+					</span>
+					<Separator />
+					<span style={{ color: palette.warning }}>
+						{`⚠ ${countLabel(entry.warningCount, "warning")}`}
+					</span>
+					{entry.infoCount ? (
+						<>
+							<Separator />
+							<span style={{ color: palette.info }}>
+								{`● ${entry.infoCount} info`}
+							</span>
+						</>
+					) : null}
+					<Separator />
+					<span style={{ color: palette.dim }}>
+						{`${entry.fileCount} files`}
+					</span>
+					{entry.moduleCount ? (
+						<>
+							<Separator />
+							<span style={{ color: palette.dim }}>
+								{`${entry.moduleCount} modules`}
+							</span>
+						</>
+					) : null}
+				</div>
+			</div>
+
+			<div className="grid gap-4 sm:grid-cols-[max-content_1fr]">
+				<div className={LIST_CLASS}>
+					<div
+						className={PANEL_LABEL_CLASS}
+						style={{
+							color: focus === "list" ? palette.bright : palette.muted,
+						}}
+					>
+						{" PROJECTS"}
+					</div>
+					<div
+						aria-activedescendant={optionId(selected)}
+						aria-label="Projects"
+						className={LISTBOX_CLASS}
+						onFocus={() => setFocus("list")}
+						ref={listRef}
+						role="listbox"
+						tabIndex={0}
+					>
+						{visible.map((row, position) => {
+							const index = safeOffset + position;
+							const active = index === selected;
+							return (
+								<button
+									aria-selected={active}
+									className={ROW_CLASS}
+									id={optionId(index)}
+									key={row.name}
+									onClick={() => {
+										setSelected(index);
+										setFocus("list");
+										listRef.current?.focus();
+									}}
+									role="option"
+									style={{
+										backgroundColor: active ? palette.washRed : undefined,
+									}}
+									tabIndex={-1}
+									type="button"
+								>
+									<span
+										className="w-[3px] self-stretch"
+										style={{
+											backgroundColor: active ? palette.nestRed : "transparent",
+										}}
+									/>
+									<span
+										style={{
+											color: active ? palette.bright : palette.text,
+											fontWeight: active ? 700 : 400,
+											minWidth: `${nameWidth}ch`,
+										}}
+									>
+										{row.name}
+									</span>
+									<span
+										className="text-right"
+										style={{
+											color: active ? palette.bright : scoreColor(row.score),
+											minWidth: "7ch",
+										}}
+									>
+										{`${row.score}/${PERFECT_SCORE}`}
+									</span>
+									<span style={{ color: palette.dim }}>
+										{rankMark(row.score)}
+									</span>
+								</button>
+							);
+						})}
+					</div>
+					{overflow ? (
+						<div style={{ color: palette.dim }}>
+							{` … ${safeOffset + 1}–${Math.min(safeOffset + LIST_CAPACITY, projectCount)} of ${projectCount}`}
+						</div>
+					) : null}
+				</div>
+
+				<div
+					aria-live="polite"
+					className="flex flex-col sm:border-l sm:pl-4"
+					style={{ borderColor: palette.border }}
+				>
+					<div>
+						<span className="font-bold" style={{ color: palette.bright }}>
+							{entry.name}
+						</span>
+						<span
+							className="whitespace-pre"
+							style={{ color: scoreColor(entry.score) }}
+						>
+							{`  ${entry.score}/${PERFECT_SCORE}`}
+						</span>
+					</div>
+					<div style={{ color: palette.muted }}>{originLine(entry)}</div>
+					<div className="flex flex-wrap items-baseline">
+						<span
+							style={{ color: palette.error }}
+						>{`✗ ${entry.errorCount}`}</span>
+						<Separator />
+						<span style={{ color: palette.warning }}>
+							{`⚠ ${entry.warningCount}`}
+						</span>
+						{entry.infoCount ? (
+							<>
+								<Separator />
+								<span style={{ color: palette.dim }}>
+									{`${entry.infoCount} info`}
+								</span>
+							</>
+						) : null}
+						<Separator />
+						<span style={{ color: palette.dim }}>
+							{`${entry.fileCount} files`}
+						</span>
+					</div>
+					{entry.topRules?.length ? (
+						<div className="mt-2 flex flex-col">
+							<div
+								className={PANEL_LABEL_CLASS}
+								style={{ color: palette.muted }}
+							>
+								{" TOP RULES"}
+							</div>
+							{entry.topRules.map((rule) => (
+								<div className="flex items-baseline gap-2" key={rule.rule}>
+									<span style={{ color: severityColor(rule.severity) }}>
+										{` ${SEVERITY_MARK[rule.severity]}`}
+									</span>
+									<span style={{ color: palette.text }}>
+										{shortRule(rule.rule)}
+									</span>
+									<span style={{ color: palette.dim }}>{rule.count}</span>
+								</div>
+							))}
+						</div>
+					) : null}
+				</div>
+			</div>
+
+			<div
+				className={focus === "menu" ? MENU_CLASS : MENU_LIST_CLASS}
+				style={focus === "menu" ? { borderColor: palette.nestRed } : undefined}
+			>
+				{items.map((item, index) => {
+					const active = index === menuIndex;
+					const rowStyle = {
+						backgroundColor: active ? palette.washRed : undefined,
+					};
+					const labelStyle = {
+						color: active ? palette.bright : palette.text,
+						fontWeight: active ? 700 : 400,
+						minWidth: `${labelWidth}ch`,
+					};
+					const body = (
+						<>
+							<span
+								className="w-[3px] self-stretch"
+								style={{
+									backgroundColor: active ? palette.nestRed : "transparent",
+								}}
+							/>
+							<span style={labelStyle}>{item.label}</span>
+							<span style={{ color: active ? palette.muted : palette.dim }}>
+								{item.hint}
+							</span>
+						</>
+					);
+
+					if (item.internal && item.href) {
+						return (
+							<Link
+								className={MENU_ROW_CLASS}
+								href={item.href}
+								key={item.label}
+								onFocus={() => {
+									setMenuIndex(index);
+									setFocus("menu");
+								}}
+								onMouseEnter={() => setMenuIndex(index)}
+								ref={(node) => {
+									menuRefs.current[index] = node;
+								}}
+								style={rowStyle}
+							>
+								{body}
+							</Link>
+						);
+					}
+
+					if (item.href) {
+						return (
+							<a
+								className={MENU_ROW_CLASS}
+								href={item.href}
+								key={item.label}
+								onFocus={() => {
+									setMenuIndex(index);
+									setFocus("menu");
+								}}
+								onMouseEnter={() => setMenuIndex(index)}
+								ref={(node) => {
+									menuRefs.current[index] = node;
+								}}
+								rel="noreferrer"
+								style={rowStyle}
+								target="_blank"
+							>
+								{body}
+							</a>
+						);
+					}
+
+					return (
+						<button
+							className={MENU_ROW_CLASS}
+							key={item.label}
+							onClick={() => item.copy && handleCopy(item.copy)}
+							onFocus={() => {
+								setMenuIndex(index);
+								setFocus("menu");
+							}}
+							onMouseEnter={() => setMenuIndex(index)}
+							ref={(node) => {
+								menuRefs.current[index] = node;
+							}}
+							style={rowStyle}
+							type="button"
+						>
+							{body}
+						</button>
+					);
+				})}
+			</div>
+
+			<div className="flex flex-col">
+				{toast ? (
+					<div style={{ color: palette.success }}>{`✓ ${toast}`}</div>
+				) : null}
+				<div style={{ color: palette.dim }}>
+					{`nestjs-doctor ${SCANNED_WITH} scanned each repo at one pinned commit on ${SCANNED_AT}, with no dependencies installed.`}
+				</div>
+				<div style={{ color: palette.dim }}>
+					↑↓ move · ←→ switch pane · enter open
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/packages/website/src/app/leaderboard/page.tsx
+++ b/packages/website/src/app/leaderboard/page.tsx
@@ -1,164 +1,30 @@
 import type { Metadata } from "next";
-import Image from "next/image";
-import Link from "next/link";
+import { Desktop } from "@/components/macos/desktop";
 import { pageMetadata } from "@/lib/site";
-import {
-	LEADERBOARD_ENTRIES,
-	type ResolvedLeaderboardEntry,
-} from "./leaderboard-entries";
-
-const PERFECT_SCORE = 100;
-const SCORE_GOOD_THRESHOLD = 75;
-const SCORE_OK_THRESHOLD = 50;
-const SCORE_BAR_WIDTH = 20;
-const COMMAND = "npx -y nestjs-doctor@latest .";
-const CONTRIBUTE_URL =
-	"https://github.com/RoloBits/nestjs-doctor/edit/main/packages/website/src/app/leaderboard/leaderboard-entries.ts";
-
-const getScoreColorClass = (score: number): string => {
-	if (score >= SCORE_GOOD_THRESHOLD) {
-		return "text-green-400";
-	}
-	if (score >= SCORE_OK_THRESHOLD) {
-		return "text-yellow-500";
-	}
-	return "text-red-400";
-};
-
-const getNestBirds = (score: number): [string, string] => {
-	if (score >= SCORE_GOOD_THRESHOLD) {
-		return ["\u25E0 \u25E0 \u25E0", "\u2570\u2500\u2500\u2500\u256F"];
-	}
-	if (score >= SCORE_OK_THRESHOLD) {
-		return ["\u2022 \u2022 \u2022", "\u2570\u2500\u2500\u2500\u256F"];
-	}
-	return ["x x x", "\u2570\u2500\u2500\u2500\u256F"];
-};
-
-const ScoreBar = ({ score }: { score: number }) => {
-	const filledCount = Math.round((score / PERFECT_SCORE) * SCORE_BAR_WIDTH);
-	const emptyCount = SCORE_BAR_WIDTH - filledCount;
-	const colorClass = getScoreColorClass(score);
-
-	return (
-		<span className="text-xs sm:text-sm">
-			<span className={colorClass}>{"\u2588".repeat(filledCount)}</span>
-			<span className="text-neutral-700">{"\u2591".repeat(emptyCount)}</span>
-		</span>
-	);
-};
-
-const LeaderboardRow = ({
-	entry,
-	rank,
-}: {
-	entry: ResolvedLeaderboardEntry;
-	rank: number;
-}) => {
-	const colorClass = getScoreColorClass(entry.score);
-
-	return (
-		<div className="group grid grid-cols-[2rem_1fr_auto] items-center border-white/5 border-b py-2 transition-colors hover:bg-white/2 sm:grid-cols-[2.5rem_7rem_1fr_auto] sm:py-2.5">
-			<span className="text-right text-neutral-600">{rank}</span>
-
-			<a
-				className="ml-2 truncate text-white transition-colors hover:text-blue-400 sm:ml-4"
-				href={entry.githubUrl}
-				rel="noreferrer"
-				target="_blank"
-			>
-				{entry.name}
-			</a>
-
-			<span className="hidden sm:inline">
-				<ScoreBar score={entry.score} />
-			</span>
-
-			<Link
-				className="ml-4 text-right transition-colors hover:underline"
-				href={entry.shareUrl}
-			>
-				<span className={`${colorClass} font-medium`}>{entry.score}</span>
-				<span className="text-neutral-600">/{PERFECT_SCORE}</span>
-			</Link>
-		</div>
-	);
-};
+import { LEADERBOARD_ENTRIES } from "./leaderboard-entries";
+import { LeaderboardScreen } from "./leaderboard-screen";
 
 export const metadata: Metadata = pageMetadata("/leaderboard", {
 	title: "Leaderboard",
-	description:
-		"Scores for popular open-source NestJS projects, diagnosed by NestJS Doctor.",
+	description: `Health scores that nestjs-doctor measured for the ${LEADERBOARD_ENTRIES.length} most-starred open-source projects built on NestJS, one pinned commit each.`,
 });
 
-const LeaderboardPage = () => {
-	const topScore = LEADERBOARD_ENTRIES[0]?.score ?? 0;
-	const [eyes, mouth] = getNestBirds(topScore);
-	const topScoreColor = getScoreColorClass(topScore);
+const WINDOW_TITLE = "nestjs-doctor — leaderboard";
 
-	return (
-		<div className="mx-auto min-h-screen w-full max-w-3xl bg-[#0a0a0a] p-6 pb-32 font-mono text-base text-neutral-300 leading-relaxed sm:p-8 sm:pb-40 sm:text-lg">
-			<div className="mb-8">
-				<Link
-					className="inline-flex items-center gap-2 text-neutral-500 transition-colors hover:text-neutral-300"
-					href="/"
-				>
-					<Image
-						alt=""
-						className="rounded"
-						height={20}
-						src="/logo.png"
-						width={20}
-					/>
-					<span>nestjs-doctor</span>
-				</Link>
-			</div>
-
-			<div className="mb-2">
-				<pre className={`${topScoreColor} leading-tight`}>
-					{`  \u250C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n  \u2502 ${eyes} \u2502\n  \u2502 ${mouth} \u2502\n  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518`}
-				</pre>
-			</div>
-
-			<h1 className="mb-1 text-white text-xl">Leaderboard</h1>
-			<div className="mb-8 text-neutral-500">
-				Scores for popular open-source NestJS projects.
-			</div>
-
-			<div className="mb-8">
-				{LEADERBOARD_ENTRIES.map((entry, index) => (
-					<LeaderboardRow entry={entry} key={entry.name} rank={index + 1} />
-				))}
-			</div>
-
-			<div className="min-h-[1.4em]" />
-
-			<div className="text-neutral-500">Run it on your codebase:</div>
-			<div className="mt-2">
-				<span className="border border-white/20 px-3 py-1.5 text-white">
-					{COMMAND}
-				</span>
-			</div>
-
-			<div className="min-h-[1.4em]" />
-			<div className="min-h-[1.4em]" />
-
-			<div className="text-neutral-500">
-				{"+ "}
-				<a
-					className="text-green-400 transition-colors hover:text-green-300 hover:underline"
-					href={CONTRIBUTE_URL}
-					rel="noreferrer"
-					target="_blank"
-				>
-					Add your project
-				</a>
-				<span className="text-neutral-600">
-					{" \u2014 open a PR to leaderboard-entries.ts"}
-				</span>
-			</div>
-		</div>
-	);
-};
+const LeaderboardPage = () => (
+	<div className="h-dvh w-full bg-[#0a0a0a] font-mono text-base text-neutral-300 leading-relaxed">
+		<h1 className="sr-only">Leaderboard</h1>
+		<p className="sr-only">
+			{`Health scores for the ${LEADERBOARD_ENTRIES.length} most-starred open-source projects built on NestJS, each measured at one pinned commit.`}
+		</p>
+		<Desktop
+			reopenLabel="Open leaderboard"
+			section="Leaderboard"
+			title={WINDOW_TITLE}
+		>
+			<LeaderboardScreen entries={LEADERBOARD_ENTRIES} />
+		</Desktop>
+	</div>
+);
 
 export default LeaderboardPage;

--- a/packages/website/src/app/opengraph-image.tsx
+++ b/packages/website/src/app/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { ImageResponse } from "next/og";
+import { loadPlexMono } from "@/lib/og-font";
 
 export const dynamic = "force-static";
 export const alt =
@@ -8,51 +9,12 @@ export const alt =
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-const FONT_CSS =
-	"https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap";
-const FONT_URL_RE = /url\((https:[^)]+)\)/;
-
-/** Downloads one weight of IBM Plex Mono through the same host next/font uses. */
-async function plexMono(weight: number): Promise<ArrayBuffer | null> {
-	try {
-		const cssRes = await fetch(FONT_CSS, {
-			headers: { "User-Agent": "Mozilla/5.0" },
-		});
-		if (!cssRes.ok) {
-			return null;
-		}
-		const css = await cssRes.text();
-		const block = css
-			.split("@font-face")
-			.find((part) => part.includes(`font-weight: ${weight}`));
-		const url = block?.match(FONT_URL_RE)?.[1];
-		if (!url) {
-			return null;
-		}
-		const fontRes = await fetch(url);
-		if (!fontRes.ok) {
-			return null;
-		}
-		return await fontRes.arrayBuffer();
-	} catch {
-		return null;
-	}
-}
-
 export default async function Image() {
-	const [regular, semibold, logo] = await Promise.all([
-		plexMono(400),
-		plexMono(600),
+	const [fonts, logo] = await Promise.all([
+		loadPlexMono(),
 		readFile(join(process.cwd(), "public/logo.png")),
 	]);
 	const logoSrc = `data:image/png;base64,${logo.toString("base64")}`;
-	const fonts: { data: ArrayBuffer; name: string; weight: 400 | 600 }[] = [];
-	if (regular) {
-		fonts.push({ name: "IBM Plex Mono", data: regular, weight: 400 as const });
-	}
-	if (semibold) {
-		fonts.push({ name: "IBM Plex Mono", data: semibold, weight: 600 as const });
-	}
 
 	return new ImageResponse(
 		<div
@@ -146,6 +108,6 @@ export default async function Image() {
 				</div>
 			</div>
 		</div>,
-		{ ...size, fonts: fonts.length > 0 ? fonts : undefined }
+		{ ...size, fonts }
 	);
 }

--- a/packages/website/src/app/share/[owner]/[repo]/entry.ts
+++ b/packages/website/src/app/share/[owner]/[repo]/entry.ts
@@ -1,0 +1,15 @@
+import { LEADERBOARD_ENTRIES } from "@/app/leaderboard/leaderboard-entries";
+
+export interface EntryParams {
+	owner: string;
+	repo: string;
+}
+
+export const entryParams = (): EntryParams[] =>
+	LEADERBOARD_ENTRIES.map((entry) => {
+		const [owner, repo] = entry.name.split("/");
+		return { owner, repo };
+	});
+
+export const findEntry = ({ owner, repo }: EntryParams) =>
+	LEADERBOARD_ENTRIES.find((entry) => entry.name === `${owner}/${repo}`);

--- a/packages/website/src/app/share/[owner]/[repo]/opengraph-image.tsx
+++ b/packages/website/src/app/share/[owner]/[repo]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+import { certificateFromEntry } from "../../certificate";
+import {
+	CERTIFICATE_IMAGE_SIZE,
+	certificateImage,
+} from "../../certificate-image";
+import { type EntryParams, entryParams, findEntry } from "./entry";
+
+export const dynamic = "force-static";
+export const alt = "Certificate of health, issued by nestjs-doctor";
+export const size = CERTIFICATE_IMAGE_SIZE;
+export const contentType = "image/png";
+
+export const generateStaticParams = (): EntryParams[] => entryParams();
+
+export default async function Image({
+	params,
+}: {
+	params: Promise<EntryParams>;
+}) {
+	const entry = findEntry(await params);
+	if (!entry) {
+		notFound();
+	}
+	return certificateImage(certificateFromEntry(entry));
+}

--- a/packages/website/src/app/share/[owner]/[repo]/page.tsx
+++ b/packages/website/src/app/share/[owner]/[repo]/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Desktop } from "@/components/macos/desktop";
+import { pageMetadata } from "@/lib/site";
+import { PERFECT_SCORE } from "@/lib/tui-theme";
+import { certificateFromEntry } from "../../certificate";
+import { CertificateScreen } from "../../certificate-screen";
+import { type EntryParams, entryParams, findEntry } from "./entry";
+
+export const dynamicParams = false;
+
+export const generateStaticParams = (): EntryParams[] => entryParams();
+
+export async function generateMetadata({
+	params,
+}: {
+	params: Promise<EntryParams>;
+}): Promise<Metadata> {
+	const entry = findEntry(await params);
+	if (!entry) {
+		return {};
+	}
+	return {
+		...pageMetadata(entry.shareUrl, {
+			title: `${entry.name} scored ${entry.score}/${PERFECT_SCORE}`,
+			description: `Certificate of health for ${entry.name}: ${entry.errorCount} errors, ${entry.warningCount} warnings across ${entry.fileCount} files, measured by nestjs-doctor at commit ${entry.commit.slice(0, 7)}.`,
+		}),
+		robots: { index: true, follow: true },
+	};
+}
+
+const WINDOW_TITLE = "nestjs-doctor — certificate";
+
+export default async function EntryCertificatePage({
+	params,
+}: {
+	params: Promise<EntryParams>;
+}) {
+	const entry = findEntry(await params);
+	if (!entry) {
+		notFound();
+	}
+	return (
+		<div className="h-dvh w-full bg-[#0a0a0a] font-mono text-base text-neutral-300 leading-relaxed">
+			<h1 className="sr-only">{`Certificate of health for ${entry.name}`}</h1>
+			<p className="sr-only">
+				{`${entry.name} scored ${entry.score}/${PERFECT_SCORE} on nestjs-doctor.`}
+			</p>
+			<Desktop
+				reopenLabel="Open certificate"
+				section="Certificate"
+				title={WINDOW_TITLE}
+			>
+				<CertificateScreen certificate={certificateFromEntry(entry)} />
+			</Desktop>
+		</div>
+	);
+}

--- a/packages/website/src/app/share/animated-score.tsx
+++ b/packages/website/src/app/share/animated-score.tsx
@@ -1,53 +1,29 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ScoreBar } from "@/components/score-bar";
+import { PERFECT_SCORE, palette, scoreColor, scoreTier } from "@/lib/tui-theme";
 
-const PERFECT_SCORE = 100;
-const SCORE_GOOD_THRESHOLD = 75;
-const SCORE_OK_THRESHOLD = 50;
-const SCORE_BAR_WIDTH = 30;
 const SCORE_FRAME_COUNT = 20;
 const SCORE_FRAME_DELAY_MS = 30;
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
 const easeOutCubic = (progress: number) => 1 - (1 - progress) ** 3;
 
-const getScoreColorClass = (score: number): string => {
-	if (score >= SCORE_GOOD_THRESHOLD) {
-		return "text-green-400";
-	}
-	if (score >= SCORE_OK_THRESHOLD) {
-		return "text-yellow-500";
-	}
-	return "text-red-400";
-};
-
-const getScoreLabel = (score: number): string => {
-	if (score >= SCORE_GOOD_THRESHOLD) {
-		return "Great";
-	}
-	if (score >= SCORE_OK_THRESHOLD) {
-		return "Needs work";
-	}
-	return "Critical";
-};
-
-const ScoreBar = ({ score }: { score: number }) => {
-	const filledCount = Math.round((score / PERFECT_SCORE) * SCORE_BAR_WIDTH);
-	const emptyCount = SCORE_BAR_WIDTH - filledCount;
-	const colorClass = getScoreColorClass(score);
-
-	return (
-		<>
-			<span className={colorClass}>{"\u2588".repeat(filledCount)}</span>
-			<span className="text-neutral-600">{"\u2591".repeat(emptyCount)}</span>
-		</>
-	);
-};
-
-const AnimatedScore = ({ targetScore }: { targetScore: number }) => {
-	const [animatedScore, setAnimatedScore] = useState(0);
+/** The console reporter's score line, counted up unless motion is reduced.
+ * A null target means the link carried no usable score. */
+const AnimatedScore = ({ targetScore }: { targetScore: number | null }) => {
+	const [score, setScore] = useState(0);
 
 	useEffect(() => {
+		if (targetScore === null) {
+			return;
+		}
+		if (window.matchMedia(REDUCED_MOTION_QUERY).matches) {
+			setScore(targetScore);
+			return;
+		}
+
 		let cancelled = false;
 		let frame = 0;
 		let timer: ReturnType<typeof setTimeout>;
@@ -56,7 +32,7 @@ const AnimatedScore = ({ targetScore }: { targetScore: number }) => {
 			if (cancelled || frame > SCORE_FRAME_COUNT) {
 				return;
 			}
-			setAnimatedScore(
+			setScore(
 				Math.round(easeOutCubic(frame / SCORE_FRAME_COUNT) * targetScore)
 			);
 			frame++;
@@ -70,19 +46,32 @@ const AnimatedScore = ({ targetScore }: { targetScore: number }) => {
 		};
 	}, [targetScore]);
 
-	const colorClass = getScoreColorClass(animatedScore);
+	if (targetScore === null) {
+		return (
+			<div>
+				<div className="font-bold text-lg" style={{ color: palette.muted }}>
+					{`--/${PERFECT_SCORE}`}
+				</div>
+				<ScoreBar score={0} />
+			</div>
+		);
+	}
+
+	const tier = scoreTier(score);
 
 	return (
-		<>
-			<div className="mb-2 pl-2">
-				<span className={colorClass}>{animatedScore}</span>
-				{` / ${PERFECT_SCORE}  `}
-				<span className={colorClass}>{getScoreLabel(animatedScore)}</span>
+		<div>
+			<div className="font-bold text-lg">
+				<span style={{ color: scoreColor(score) }}>
+					{`${score}/${PERFECT_SCORE} ${tier.stars}`}
+				</span>
+				<span
+					className="whitespace-pre"
+					style={{ color: palette.muted }}
+				>{`  ${tier.label}`}</span>
 			</div>
-			<div className="mb-6 pl-2">
-				<ScoreBar score={animatedScore} />
-			</div>
-		</>
+			<ScoreBar score={score} />
+		</div>
 	);
 };
 

--- a/packages/website/src/app/share/certificate-image.tsx
+++ b/packages/website/src/app/share/certificate-image.tsx
@@ -1,0 +1,325 @@
+import { ImageResponse } from "next/og";
+import { loadPlexMono } from "@/lib/og-font";
+import { PERFECT_SCORE, palette, scoreColor, scoreTier } from "@/lib/tui-theme";
+import { type CertificateValues, certificateTitle } from "./certificate";
+
+export const CERTIFICATE_IMAGE_SIZE = { width: 1200, height: 630 };
+const BAR_WIDTH = 560;
+const STAR_COUNT = 5;
+
+const tone = (score: number | null): string =>
+	score === null ? palette.muted : scoreColor(score);
+
+const eyes = (score: number | null): string => {
+	if (score === null) {
+		return "- - -";
+	}
+	if (score >= 75) {
+		return "^ ^ ^";
+	}
+	return score >= 50 ? "• • •" : "x x x";
+};
+
+const Face = ({ score }: { score: number | null }) => (
+	<div
+		style={{
+			display: "flex",
+			flexDirection: "column",
+			alignItems: "center",
+			justifyContent: "center",
+			width: 132,
+			height: 100,
+			border: `3px solid ${tone(score)}`,
+			borderRadius: 10,
+			color: tone(score),
+			fontSize: 30,
+			fontWeight: 600,
+		}}
+	>
+		<div style={{ display: "flex" }}>{eyes(score)}</div>
+		<div
+			style={{
+				display: "flex",
+				width: 56,
+				height: 18,
+				borderBottom: `3px solid ${tone(score)}`,
+				borderBottomLeftRadius: 14,
+				borderBottomRightRadius: 14,
+			}}
+		/>
+	</div>
+);
+
+const Stars = ({ filled }: { filled: number }) => (
+	<div style={{ display: "flex", gap: 8 }}>
+		{Array.from({ length: STAR_COUNT }, (_, index) => (
+			<div
+				key={index}
+				style={{
+					display: "flex",
+					width: 16,
+					height: 16,
+					transform: "rotate(45deg)",
+					background: index < filled ? "currentColor" : "transparent",
+					border: "2px solid currentColor",
+				}}
+			/>
+		))}
+	</div>
+);
+
+const Seal = ({ score }: { score: number | null }) => (
+	<div
+		style={{
+			display: "flex",
+			alignItems: "center",
+			justifyContent: "center",
+			width: 150,
+			height: 150,
+			borderRadius: 75,
+			border: `3px solid ${tone(score)}`,
+			color: tone(score),
+			transform: "rotate(-8deg)",
+		}}
+	>
+		<div
+			style={{
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				width: 96,
+				height: 96,
+				borderRadius: 48,
+				border: `1.5px solid ${tone(score)}`,
+				fontSize: 26,
+				fontWeight: 600,
+			}}
+		>
+			{eyes(score)}
+		</div>
+	</div>
+);
+
+const Fact = ({
+	label,
+	value,
+	color,
+}: {
+	color?: string;
+	label: string;
+	value: string;
+}) => (
+	<div style={{ display: "flex", gap: 10, fontSize: 22 }}>
+		<div style={{ display: "flex", color: palette.dim }}>{label}</div>
+		<div style={{ display: "flex", color: color ?? palette.text }}>{value}</div>
+	</div>
+);
+
+/** The 1200x630 social card for one certificate; null renders the blank form. */
+export async function certificateImage(values: CertificateValues | null) {
+	const fonts = await loadPlexMono();
+	const score = values?.score ?? null;
+	const tier = score === null ? null : scoreTier(score);
+	const filledStars =
+		tier === null ? 0 : STAR_COUNT - (tier.stars.match(/☆/g)?.length ?? 0);
+	const facts: { color?: string; label: string; value: string }[] = [];
+	if (values?.errorCount !== null && values?.errorCount !== undefined) {
+		facts.push({
+			label: "Errors",
+			value: String(values.errorCount),
+			color: palette.error,
+		});
+	}
+	if (values?.warningCount !== null && values?.warningCount !== undefined) {
+		facts.push({
+			label: "Warnings",
+			value: String(values.warningCount),
+			color: palette.warning,
+		});
+	}
+	if (values?.infoCount !== null && values?.infoCount !== undefined) {
+		facts.push({
+			label: "Info",
+			value: String(values.infoCount),
+			color: palette.info,
+		});
+	}
+	if (values?.fileCount !== null && values?.fileCount !== undefined) {
+		facts.push({ label: "Files", value: String(values.fileCount) });
+	}
+	if (values?.nestVersion) {
+		facts.push({ label: "Nest", value: values.nestVersion });
+	}
+	if (values?.orm) {
+		facts.push({ label: "ORM", value: values.orm });
+	}
+	const signed = [
+		values?.toolVersion
+			? `Signed, nestjs-doctor ${values.toolVersion}`
+			: "Signed, nestjs-doctor",
+		values?.commit ? `commit ${values.commit}` : null,
+		values?.scanDate ?? null,
+	]
+		.filter((part) => part !== null)
+		.join(" · ");
+
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				background: "#0a0a0a",
+				padding: 28,
+				fontFamily: '"IBM Plex Mono", monospace',
+				color: palette.text,
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					flex: 1,
+					border: `4px solid ${tone(score)}`,
+					padding: 5,
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						flex: 1,
+						flexDirection: "column",
+						justifyContent: "space-between",
+						border: `2px solid ${tone(score)}`,
+						padding: "36px 56px",
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "center",
+							gap: 6,
+						}}
+					>
+						<div
+							style={{
+								display: "flex",
+								fontSize: 26,
+								fontWeight: 600,
+								letterSpacing: 10,
+								color: palette.bright,
+							}}
+						>
+							CERTIFICATE OF HEALTH
+						</div>
+						<div
+							style={{ display: "flex", fontSize: 20, color: palette.muted }}
+						>
+							Issued by nestjs-doctor, the deterministic NestJS analyzer
+						</div>
+					</div>
+
+					<div
+						style={{
+							display: "flex",
+							fontSize: 52,
+							fontWeight: 600,
+							color: palette.bright,
+						}}
+					>
+						{values ? certificateTitle(values) : "Your NestJS codebase"}
+					</div>
+
+					<div style={{ display: "flex", alignItems: "center", gap: 28 }}>
+						<Face score={score} />
+						<div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+							<div
+								style={{
+									display: "flex",
+									alignItems: "center",
+									gap: 20,
+									fontSize: 44,
+									fontWeight: 600,
+									color: tone(score),
+								}}
+							>
+								<div style={{ display: "flex" }}>
+									{score === null
+										? `--/${PERFECT_SCORE}`
+										: `${score}/${PERFECT_SCORE}`}
+								</div>
+								<Stars filled={filledStars} />
+								{tier ? (
+									<div
+										style={{
+											display: "flex",
+											fontSize: 30,
+											fontWeight: 400,
+											color: palette.muted,
+										}}
+									>
+										{tier.label}
+									</div>
+								) : null}
+							</div>
+							<div
+								style={{
+									display: "flex",
+									width: BAR_WIDTH,
+									height: 22,
+									background: "#262626",
+								}}
+							>
+								<div
+									style={{
+										display: "flex",
+										width: ((score ?? 0) / PERFECT_SCORE) * BAR_WIDTH,
+										height: 22,
+										background: tone(score),
+									}}
+								/>
+							</div>
+						</div>
+					</div>
+
+					<div style={{ display: "flex", gap: 26, flexWrap: "wrap" }}>
+						{facts.map((fact) => (
+							<Fact key={fact.label} {...fact} />
+						))}
+					</div>
+
+					<div
+						style={{
+							display: "flex",
+							alignItems: "flex-end",
+							justifyContent: "space-between",
+						}}
+					>
+						<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+							<div
+								style={{
+									display: "flex",
+									width: 150,
+									height: 3,
+									background: palette.nestRed,
+								}}
+							/>
+							<div
+								style={{ display: "flex", fontSize: 20, color: palette.muted }}
+							>
+								{signed}
+							</div>
+							<div
+								style={{ display: "flex", fontSize: 20, color: palette.dim }}
+							>
+								npx -y nestjs-doctor@latest .
+							</div>
+						</div>
+						<Seal score={score} />
+					</div>
+				</div>
+			</div>
+		</div>,
+		{ ...CERTIFICATE_IMAGE_SIZE, fonts }
+	);
+}

--- a/packages/website/src/app/share/certificate-screen.tsx
+++ b/packages/website/src/app/share/certificate-screen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { track } from "@/lib/analytics";
 import {
@@ -18,9 +19,14 @@ import {
 	scoreColor,
 } from "@/lib/tui-theme";
 import AnimatedScore from "./animated-score";
+import {
+	type CertificateValues,
+	certificateFromQuery,
+	certificateTitle,
+} from "./certificate";
 
 const COMMAND = "npx -y nestjs-doctor@latest .";
-const SHARE_BASE_URL = `${SITE_URL}/share`;
+const LEADERBOARD_PATH = "/leaderboard";
 const COPIED_RESET_MS = 1600;
 const SEAL_SIZE = 96;
 const SEAL_LEGEND = "NESTJS-DOCTOR · DETERMINISTIC · SAME OUTPUT EVERY RUN";
@@ -130,70 +136,38 @@ interface MenuItem {
 	hint: string;
 	href?: string;
 	icon?: string;
+	internal?: boolean;
 	label: string;
 }
 
-export const CertificateScreen = () => {
-	const searchParams = useSearchParams();
+export const CertificateScreen = ({
+	certificate,
+}: {
+	certificate: CertificateValues;
+}) => {
+	const router = useRouter();
 	const [menuIndex, setMenuIndex] = useState(0);
 	const [toast, setToast] = useState<string | null>(null);
 	const menuRefs = useRef<(HTMLElement | null)[]>([]);
 	const frameRef = useRef<HTMLDivElement>(null);
 
-	const raw = (key: string): string | null =>
-		searchParams.get(key)?.trim() || null;
-	const count = (key: string): number | null => {
-		const value = raw(key);
-		if (value === null) {
-			return null;
-		}
-		const parsed = Number(value);
-		return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
-	};
-
-	const parsedScore = count("s");
-	const score =
-		parsedScore === null ? null : Math.min(PERFECT_SCORE, parsedScore);
-	const errorCount = count("e");
-	const warningCount = count("w");
-	const infoCount = count("i");
-	const fileCount = count("f");
-	const moduleCount = count("m");
-	const packageName = raw("p");
-	const repoName = raw("r");
-	const nestVersion = raw("n");
-	const orm = raw("o");
-	const commit = raw("c");
-	const scanDate = raw("d");
-	const toolVersion = raw("v");
-	const displayName = repoName ?? packageName ?? "Your NestJS codebase";
-
-	/** Every parameter the certificate re-shares, in order, parsed values only. */
-	const shareValues: [string, number | string | null][] = [
-		["p", packageName],
-		["s", score],
-		["e", errorCount],
-		["w", warningCount],
-		["f", fileCount],
-		["i", infoCount],
-		["m", moduleCount],
-		["n", nestVersion],
-		["o", orm],
-		["c", commit],
-		["d", scanDate],
-		["v", toolVersion],
-		["r", repoName],
-	];
-	const shareSearchParams = new URLSearchParams();
-	for (const [key, value] of shareValues) {
-		if (value !== null) {
-			shareSearchParams.set(key, String(value));
-		}
-	}
-	const shareQuery = shareSearchParams.toString();
-	const shareUrl = shareQuery
-		? `${SHARE_BASE_URL}?${shareQuery}`
-		: SHARE_BASE_URL;
+	const {
+		score,
+		errorCount,
+		warningCount,
+		infoCount,
+		fileCount,
+		moduleCount,
+		packageName,
+		repoName,
+		nestVersion,
+		orm,
+		commit,
+		scanDate,
+		toolVersion,
+	} = certificate;
+	const displayName = certificateTitle(certificate);
+	const shareUrl = `${SITE_URL}${certificate.sharePath}`;
 
 	const tweetText =
 		score === null
@@ -275,6 +249,12 @@ export const CertificateScreen = () => {
 		},
 		{ label: "Copy link", hint: shareUrl, copy: shareUrl },
 		{ label: "Run it on your codebase", hint: COMMAND, copy: COMMAND },
+		{
+			label: "Back to the leaderboard",
+			hint: "Every project we measured",
+			href: LEADERBOARD_PATH,
+			internal: true,
+		},
 	];
 	const labelWidth = Math.max(...items.map((item) => item.label.length));
 	const menuCount = items.length;
@@ -305,6 +285,15 @@ export const CertificateScreen = () => {
 				menuRefs.current[next]?.focus();
 				return;
 			}
+			if (
+				event.key === "Escape" ||
+				event.key === "ArrowLeft" ||
+				event.key === "h"
+			) {
+				event.preventDefault();
+				router.push(LEADERBOARD_PATH);
+				return;
+			}
 			if (event.key === "Enter") {
 				const onMenuRow = menuRefs.current.some((node) => node === active);
 				if (!onMenuRow && isInteractiveTarget(active)) {
@@ -320,7 +309,7 @@ export const CertificateScreen = () => {
 
 		window.addEventListener("keydown", onKeyDown);
 		return () => window.removeEventListener("keydown", onKeyDown);
-	}, [menuIndex, menuCount]);
+	}, [menuIndex, menuCount, router]);
 
 	return (
 		<div className={FRAME_CLASS} ref={frameRef} style={{ color: palette.text }}>
@@ -439,6 +428,24 @@ export const CertificateScreen = () => {
 						</>
 					);
 
+					if (item.internal && item.href) {
+						return (
+							<Link
+								className={MENU_ROW_CLASS}
+								href={item.href}
+								key={item.label}
+								onFocus={() => setMenuIndex(index)}
+								onMouseEnter={() => setMenuIndex(index)}
+								ref={(node) => {
+									menuRefs.current[index] = node;
+								}}
+								style={rowStyle}
+							>
+								{body}
+							</Link>
+						);
+					}
+
 					if (item.href) {
 						return (
 							<a
@@ -482,8 +489,20 @@ export const CertificateScreen = () => {
 				{toast ? (
 					<div style={{ color: palette.success }}>{`✓ ${toast}`}</div>
 				) : null}
-				<div style={{ color: palette.dim }}>↑↓ move · enter open</div>
+				<div style={{ color: palette.dim }}>
+					↑↓ move · enter open · esc back
+				</div>
 			</div>
 		</div>
+	);
+};
+
+/** The certificate described by the query string. Needs a Suspense boundary. */
+export const QueryCertificateScreen = () => {
+	const searchParams = useSearchParams();
+	return (
+		<CertificateScreen
+			certificate={certificateFromQuery((key) => searchParams.get(key))}
+		/>
 	);
 };

--- a/packages/website/src/app/share/certificate-screen.tsx
+++ b/packages/website/src/app/share/certificate-screen.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { track } from "@/lib/analytics";
+import {
+	isFocusInFrame,
+	isInteractiveTarget,
+	isTypingTarget,
+} from "@/lib/keyboard";
+import { SITE_URL } from "@/lib/site";
+import {
+	getNestBirds,
+	MENU_CLASS,
+	MENU_ROW_CLASS,
+	PERFECT_SCORE,
+	palette,
+	scoreColor,
+} from "@/lib/tui-theme";
+import AnimatedScore from "./animated-score";
+
+const COMMAND = "npx -y nestjs-doctor@latest .";
+const SHARE_BASE_URL = `${SITE_URL}/share`;
+const COPIED_RESET_MS = 1600;
+const SEAL_SIZE = 96;
+const SEAL_LEGEND = "NESTJS-DOCTOR · DETERMINISTIC · SAME OUTPUT EVERY RUN";
+const SIGNATURE_PATH =
+	"M 4 34 C 14 6, 26 4, 28 16 C 30 28, 18 34, 16 22 C 14 10, 30 8, 40 20 C 46 27, 52 30, 58 18 C 62 10, 70 12, 72 22 C 74 32, 84 30, 96 14 C 104 4, 118 6, 126 18";
+const X_ICON_PATH =
+	"M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z";
+const LINKEDIN_ICON_PATH =
+	"M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z";
+
+const FRAME_CLASS =
+	"flex flex-col gap-4 px-4 py-4 text-[13px] leading-[1.5] sm:px-6";
+/** The certificate's border: a CSS double rule in the score colour. */
+const CERTIFICATE_CLASS = "flex flex-col gap-4 border-4 border-double p-6";
+
+const ThinRule = () => <div className="border-white/15 border-t" />;
+
+/** The face a certificate wears when its link carried no usable score. */
+const NO_SCORE_EYES = "- - -";
+const NO_SCORE_MOUTH = "╰───╯";
+
+const scoreTone = (score: number | null): string =>
+	score === null ? palette.muted : scoreColor(score);
+
+const scoreFace = (score: number | null): [string, string] =>
+	score === null ? [NO_SCORE_EYES, NO_SCORE_MOUTH] : getNestBirds(score);
+
+const NestFace = ({ score }: { score: number | null }) => {
+	const [eyes, mouth] = scoreFace(score);
+	return (
+		<pre
+			aria-hidden="true"
+			className="m-0 leading-tight"
+			style={{ color: scoreTone(score) }}
+		>
+			{`┌───────┐\n│ ${eyes} │\n│ ${mouth} │\n└───────┘`}
+		</pre>
+	);
+};
+
+/** A circular stamp: two rings, the legend on the rim, the face at the centre. */
+const Seal = ({ score }: { score: number | null }) => {
+	const [eyes] = scoreFace(score);
+	return (
+		<svg
+			aria-hidden="true"
+			height={SEAL_SIZE}
+			style={{ color: scoreTone(score), transform: "rotate(-8deg)" }}
+			viewBox="0 0 100 100"
+			width={SEAL_SIZE}
+		>
+			<defs>
+				<path
+					d="M 50 50 m -38 0 a 38 38 0 1 1 76 0 a 38 38 0 1 1 -76 0"
+					fill="none"
+					id="seal-rim"
+				/>
+			</defs>
+			<circle
+				cx="50"
+				cy="50"
+				fill="none"
+				r="47"
+				stroke="currentColor"
+				strokeWidth="1.5"
+			/>
+			<circle
+				cx="50"
+				cy="50"
+				fill="none"
+				r="30"
+				stroke="currentColor"
+				strokeWidth="0.75"
+			/>
+			<text fill="currentColor" fontSize="5.5" letterSpacing="0.4">
+				<textPath href="#seal-rim" startOffset="50%" textAnchor="middle">
+					{SEAL_LEGEND}
+				</textPath>
+			</text>
+			<text fill="currentColor" fontSize="10" textAnchor="middle" x="50" y="54">
+				{eyes}
+			</text>
+		</svg>
+	);
+};
+
+const Signature = () => (
+	<svg aria-hidden="true" height="34" viewBox="0 0 140 44" width="110">
+		<path
+			d={SIGNATURE_PATH}
+			fill="none"
+			stroke={palette.nestRed}
+			strokeLinecap="round"
+			strokeWidth="2"
+		/>
+	</svg>
+);
+
+interface Fact {
+	color?: string;
+	label: string;
+	value: string;
+}
+
+interface MenuItem {
+	copy?: string;
+	hint: string;
+	href?: string;
+	icon?: string;
+	label: string;
+}
+
+export const CertificateScreen = () => {
+	const searchParams = useSearchParams();
+	const [menuIndex, setMenuIndex] = useState(0);
+	const [toast, setToast] = useState<string | null>(null);
+	const menuRefs = useRef<(HTMLElement | null)[]>([]);
+	const frameRef = useRef<HTMLDivElement>(null);
+
+	const raw = (key: string): string | null =>
+		searchParams.get(key)?.trim() || null;
+	const count = (key: string): number | null => {
+		const value = raw(key);
+		if (value === null) {
+			return null;
+		}
+		const parsed = Number(value);
+		return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+	};
+
+	const parsedScore = count("s");
+	const score =
+		parsedScore === null ? null : Math.min(PERFECT_SCORE, parsedScore);
+	const errorCount = count("e");
+	const warningCount = count("w");
+	const infoCount = count("i");
+	const fileCount = count("f");
+	const moduleCount = count("m");
+	const packageName = raw("p");
+	const repoName = raw("r");
+	const nestVersion = raw("n");
+	const orm = raw("o");
+	const commit = raw("c");
+	const scanDate = raw("d");
+	const toolVersion = raw("v");
+	const displayName = repoName ?? packageName ?? "Your NestJS codebase";
+
+	/** Every parameter the certificate re-shares, in order, parsed values only. */
+	const shareValues: [string, number | string | null][] = [
+		["p", packageName],
+		["s", score],
+		["e", errorCount],
+		["w", warningCount],
+		["f", fileCount],
+		["i", infoCount],
+		["m", moduleCount],
+		["n", nestVersion],
+		["o", orm],
+		["c", commit],
+		["d", scanDate],
+		["v", toolVersion],
+		["r", repoName],
+	];
+	const shareSearchParams = new URLSearchParams();
+	for (const [key, value] of shareValues) {
+		if (value !== null) {
+			shareSearchParams.set(key, String(value));
+		}
+	}
+	const shareQuery = shareSearchParams.toString();
+	const shareUrl = shareQuery
+		? `${SHARE_BASE_URL}?${shareQuery}`
+		: SHARE_BASE_URL;
+
+	const tweetText =
+		score === null
+			? `${displayName} was scanned with nestjs-doctor. Run it on yours:`
+			: `${displayName} scored ${score}/${PERFECT_SCORE} on nestjs-doctor. Run it on yours:`;
+	const twitterShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}&url=${encodeURIComponent(shareUrl)}`;
+	const linkedinShareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
+
+	const facts: Fact[] = [];
+	if (errorCount !== null) {
+		facts.push({
+			label: "Errors",
+			value: String(errorCount),
+			color: palette.error,
+		});
+	}
+	if (warningCount !== null) {
+		facts.push({
+			label: "Warnings",
+			value: String(warningCount),
+			color: palette.warning,
+		});
+	}
+	if (infoCount !== null) {
+		facts.push({
+			label: "Info",
+			value: String(infoCount),
+			color: palette.info,
+		});
+	}
+	if (fileCount !== null) {
+		facts.push({ label: "Files", value: String(fileCount) });
+	}
+	if (moduleCount !== null) {
+		facts.push({ label: "Modules", value: String(moduleCount) });
+	}
+	if (nestVersion) {
+		facts.push({ label: "Nest version", value: nestVersion });
+	}
+	if (orm) {
+		facts.push({ label: "ORM", value: orm });
+	}
+	if (repoName && packageName) {
+		facts.push({ label: "Package", value: packageName });
+	}
+	if (commit) {
+		facts.push({ label: "Commit", value: commit });
+	}
+	if (scanDate) {
+		facts.push({ label: "Scan date", value: scanDate });
+	}
+	if (toolVersion) {
+		facts.push({ label: "Tool version", value: toolVersion });
+	}
+
+	const handleCopy = useCallback(async (value: string, label: string) => {
+		try {
+			await navigator.clipboard.writeText(value);
+			track("command_copied", { command: value, surface: "certificate" });
+			setToast(`Copied ${label}`);
+			setTimeout(() => setToast(null), COPIED_RESET_MS);
+		} catch {
+			// Clipboard is unavailable outside a secure context.
+		}
+	}, []);
+
+	const items: MenuItem[] = [
+		{
+			label: "Share on X",
+			hint: "Post this certificate",
+			href: twitterShareUrl,
+			icon: X_ICON_PATH,
+		},
+		{
+			label: "Share on LinkedIn",
+			hint: "Post this certificate",
+			href: linkedinShareUrl,
+			icon: LINKEDIN_ICON_PATH,
+		},
+		{ label: "Copy link", hint: shareUrl, copy: shareUrl },
+		{ label: "Run it on your codebase", hint: COMMAND, copy: COMMAND },
+	];
+	const labelWidth = Math.max(...items.map((item) => item.label.length));
+	const menuCount = items.length;
+
+	useEffect(() => {
+		const onKeyDown = (event: globalThis.KeyboardEvent) => {
+			if (event.metaKey || event.ctrlKey || event.altKey) {
+				return;
+			}
+			if (isTypingTarget(event.target)) {
+				return;
+			}
+			const active = document.activeElement;
+			if (!isFocusInFrame(active, frameRef.current)) {
+				return;
+			}
+			if (event.key === "ArrowDown" || event.key === "j") {
+				event.preventDefault();
+				const next = (menuIndex + 1) % menuCount;
+				setMenuIndex(next);
+				menuRefs.current[next]?.focus();
+				return;
+			}
+			if (event.key === "ArrowUp" || event.key === "k") {
+				event.preventDefault();
+				const next = menuIndex === 0 ? menuCount - 1 : menuIndex - 1;
+				setMenuIndex(next);
+				menuRefs.current[next]?.focus();
+				return;
+			}
+			if (event.key === "Enter") {
+				const onMenuRow = menuRefs.current.some((node) => node === active);
+				if (!onMenuRow && isInteractiveTarget(active)) {
+					return;
+				}
+				const row = menuRefs.current[menuIndex];
+				if (row) {
+					event.preventDefault();
+					row.click();
+				}
+			}
+		};
+
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [menuIndex, menuCount]);
+
+	return (
+		<div className={FRAME_CLASS} ref={frameRef} style={{ color: palette.text }}>
+			<div
+				className={CERTIFICATE_CLASS}
+				style={{ borderColor: `${scoreTone(score)}99` }}
+			>
+				<div className="flex flex-col items-center gap-1 text-center">
+					<div
+						className="font-bold text-sm tracking-[0.4em] sm:text-base"
+						style={{ color: palette.bright }}
+					>
+						CERTIFICATE OF HEALTH
+					</div>
+					<div style={{ color: palette.muted }}>
+						Issued by nestjs-doctor, the deterministic NestJS analyzer
+					</div>
+				</div>
+
+				<ThinRule />
+
+				<div
+					className="break-words font-bold text-xl sm:text-2xl"
+					style={{ color: palette.bright }}
+				>
+					{displayName}
+				</div>
+
+				<div className="flex flex-wrap items-center gap-4">
+					<NestFace score={score} />
+					<AnimatedScore targetScore={score} />
+				</div>
+
+				{facts.length > 0 ? (
+					<dl className="grid grid-cols-[max-content_1fr] gap-x-6">
+						{facts.map((fact) => (
+							<div className="contents" key={fact.label}>
+								<dt style={{ color: palette.dim }}>{fact.label}</dt>
+								<dd
+									className="break-all"
+									style={{ color: fact.color ?? palette.text }}
+								>
+									{fact.value}
+								</dd>
+							</div>
+						))}
+					</dl>
+				) : null}
+
+				<div className="flex flex-wrap items-end justify-between gap-4">
+					<div className="flex flex-col gap-1">
+						<Signature />
+						<div style={{ color: palette.muted }}>
+							{toolVersion
+								? `Signed, nestjs-doctor ${toolVersion}`
+								: "Signed, nestjs-doctor"}
+						</div>
+					</div>
+					<Seal score={score} />
+				</div>
+
+				<ThinRule />
+
+				<div className="flex flex-wrap items-center gap-3">
+					<span style={{ color: palette.muted }}>{`Verify: ${COMMAND}`}</span>
+					<button
+						className="border px-2 py-0.5 transition-colors hover:bg-white hover:text-black"
+						onClick={() => handleCopy(COMMAND, "the command")}
+						style={{ borderColor: palette.border }}
+						type="button"
+					>
+						Copy
+					</button>
+				</div>
+			</div>
+
+			<div className={MENU_CLASS} style={{ borderColor: palette.nestRed }}>
+				{items.map((item, index) => {
+					const active = index === menuIndex;
+					const rowStyle = {
+						backgroundColor: active ? palette.washRed : undefined,
+					};
+					const labelStyle = {
+						color: active ? palette.bright : palette.text,
+						fontWeight: active ? 700 : 400,
+						minWidth: `${labelWidth}ch`,
+					};
+					const body = (
+						<>
+							<span
+								className="w-[3px] self-stretch"
+								style={{
+									backgroundColor: active ? palette.nestRed : "transparent",
+								}}
+							/>
+							<span className="flex items-baseline gap-2" style={labelStyle}>
+								{item.icon ? (
+									<svg
+										aria-hidden="true"
+										fill="currentColor"
+										height="12"
+										viewBox="0 0 24 24"
+										width="12"
+									>
+										<path d={item.icon} />
+									</svg>
+								) : null}
+								{item.label}
+							</span>
+							<span
+								className="min-w-0 truncate"
+								style={{ color: active ? palette.muted : palette.dim }}
+							>
+								{item.hint}
+							</span>
+						</>
+					);
+
+					if (item.href) {
+						return (
+							<a
+								className={MENU_ROW_CLASS}
+								href={item.href}
+								key={item.label}
+								onFocus={() => setMenuIndex(index)}
+								onMouseEnter={() => setMenuIndex(index)}
+								ref={(node) => {
+									menuRefs.current[index] = node;
+								}}
+								rel="noreferrer"
+								style={rowStyle}
+								target="_blank"
+							>
+								{body}
+							</a>
+						);
+					}
+
+					return (
+						<button
+							className={MENU_ROW_CLASS}
+							key={item.label}
+							onClick={() => item.copy && handleCopy(item.copy, item.copy)}
+							onFocus={() => setMenuIndex(index)}
+							onMouseEnter={() => setMenuIndex(index)}
+							ref={(node) => {
+								menuRefs.current[index] = node;
+							}}
+							style={rowStyle}
+							type="button"
+						>
+							{body}
+						</button>
+					);
+				})}
+			</div>
+
+			<div className="flex flex-col">
+				{toast ? (
+					<div style={{ color: palette.success }}>{`✓ ${toast}`}</div>
+				) : null}
+				<div style={{ color: palette.dim }}>↑↓ move · enter open</div>
+			</div>
+		</div>
+	);
+};

--- a/packages/website/src/app/share/certificate.ts
+++ b/packages/website/src/app/share/certificate.ts
@@ -1,0 +1,103 @@
+import {
+	type ResolvedLeaderboardEntry,
+	SCANNED_WITH,
+} from "@/app/leaderboard/leaderboard-entries";
+import { PERFECT_SCORE } from "@/lib/tui-theme";
+
+const SHORT_COMMIT_LENGTH = 7;
+
+/** One certificate's facts. Null means the source carried no usable value. */
+export interface CertificateValues {
+	commit: string | null;
+	errorCount: number | null;
+	fileCount: number | null;
+	infoCount: number | null;
+	moduleCount: number | null;
+	nestVersion: string | null;
+	orm: string | null;
+	packageName: string | null;
+	repoName: string | null;
+	scanDate: string | null;
+	score: number | null;
+	/** The site-relative path this certificate re-shares. */
+	sharePath: string;
+	toolVersion: string | null;
+	warningCount: number | null;
+}
+
+export const certificateFromEntry = (
+	entry: ResolvedLeaderboardEntry
+): CertificateValues => ({
+	commit: entry.commit ? entry.commit.slice(0, SHORT_COMMIT_LENGTH) : null,
+	errorCount: entry.errorCount,
+	fileCount: entry.fileCount,
+	infoCount: entry.infoCount ?? null,
+	moduleCount: entry.moduleCount ?? null,
+	nestVersion: entry.nestVersion ?? null,
+	orm: entry.orm ?? null,
+	packageName: entry.packageName,
+	repoName: entry.name,
+	scanDate: entry.scannedAt,
+	score: entry.score,
+	sharePath: entry.shareUrl,
+	toolVersion: SCANNED_WITH,
+	warningCount: entry.warningCount,
+});
+
+const parseCount = (value: string | null): number | null => {
+	if (value === null) {
+		return null;
+	}
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+};
+
+/** Reads a certificate from a query string, keeping only values that parse. */
+export const certificateFromQuery = (
+	get: (key: string) => string | null
+): CertificateValues => {
+	const raw = (key: string): string | null => get(key)?.trim() || null;
+	const parsedScore = parseCount(raw("s"));
+	const values = {
+		packageName: raw("p"),
+		score: parsedScore === null ? null : Math.min(PERFECT_SCORE, parsedScore),
+		errorCount: parseCount(raw("e")),
+		warningCount: parseCount(raw("w")),
+		fileCount: parseCount(raw("f")),
+		infoCount: parseCount(raw("i")),
+		moduleCount: parseCount(raw("m")),
+		nestVersion: raw("n"),
+		orm: raw("o"),
+		commit: raw("c"),
+		scanDate: raw("d"),
+		toolVersion: raw("v"),
+		repoName: raw("r"),
+	};
+	const query = new URLSearchParams();
+	const keys: [string, keyof typeof values][] = [
+		["p", "packageName"],
+		["s", "score"],
+		["e", "errorCount"],
+		["w", "warningCount"],
+		["f", "fileCount"],
+		["i", "infoCount"],
+		["m", "moduleCount"],
+		["n", "nestVersion"],
+		["o", "orm"],
+		["c", "commit"],
+		["d", "scanDate"],
+		["v", "toolVersion"],
+		["r", "repoName"],
+	];
+	for (const [key, field] of keys) {
+		const value = values[field];
+		if (value !== null) {
+			query.set(key, String(value));
+		}
+	}
+	const search = query.toString();
+	return { ...values, sharePath: search ? `/share?${search}` : "/share" };
+};
+
+export const certificateTitle = (values: CertificateValues): string =>
+	values.repoName ?? values.packageName ?? "Your NestJS codebase";

--- a/packages/website/src/app/share/opengraph-image.tsx
+++ b/packages/website/src/app/share/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { CERTIFICATE_IMAGE_SIZE, certificateImage } from "./certificate-image";
+
+export const dynamic = "force-static";
+export const alt = "Certificate of health, issued by nestjs-doctor";
+export const size = CERTIFICATE_IMAGE_SIZE;
+export const contentType = "image/png";
+
+export default function Image() {
+	return certificateImage(null);
+}

--- a/packages/website/src/app/share/page.tsx
+++ b/packages/website/src/app/share/page.tsx
@@ -1,172 +1,25 @@
-"use client";
-
-import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
-import { SITE_URL } from "@/lib/site";
-import AnimatedScore from "./animated-score";
+import { Desktop } from "@/components/macos/desktop";
+import { CertificateScreen } from "./certificate-screen";
 
-const PERFECT_SCORE = 100;
-const SCORE_GOOD_THRESHOLD = 75;
-const SCORE_OK_THRESHOLD = 50;
-const COMMAND = "npx -y nestjs-doctor@latest .";
-const SHARE_BASE_URL = `${SITE_URL}/share`;
-const X_ICON_PATH =
-	"M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z";
-const LINKEDIN_ICON_PATH =
-	"M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z";
-
-const clampScore = (value: number): number =>
-	Math.max(0, Math.min(PERFECT_SCORE, value));
-
-const getScoreColorClass = (score: number): string => {
-	if (score >= SCORE_GOOD_THRESHOLD) {
-		return "text-green-400";
-	}
-	if (score >= SCORE_OK_THRESHOLD) {
-		return "text-yellow-500";
-	}
-	return "text-red-400";
-};
-
-const getNestBirds = (score: number): [string, string] => {
-	if (score >= SCORE_GOOD_THRESHOLD) {
-		return ["\u25E0 \u25E0 \u25E0", "\u2570\u2500\u2500\u2500\u256F"];
-	}
-	if (score >= SCORE_OK_THRESHOLD) {
-		return ["\u2022 \u2022 \u2022", "\u2570\u2500\u2500\u2500\u256F"];
-	}
-	return ["x x x", "\u2570\u2500\u2500\u2500\u256F"];
-};
-
-const NestFace = ({ score }: { score: number }) => {
-	const [eyes, mouth] = getNestBirds(score);
-	const colorClass = getScoreColorClass(score);
-
-	return (
-		<pre className={`${colorClass} leading-tight`}>
-			{`  \u250C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n  \u2502 ${eyes} \u2502\n  \u2502 ${mouth} \u2502\n  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518`}
-		</pre>
-	);
-};
-
-const ShareContent = () => {
-	const searchParams = useSearchParams();
-	const projectName = searchParams.get("p") ?? null;
-	const score = clampScore(Number(searchParams.get("s")) || 0);
-	const errorCount = Math.max(0, Number(searchParams.get("e")) || 0);
-	const warningCount = Math.max(0, Number(searchParams.get("w")) || 0);
-	const fileCount = Math.max(0, Number(searchParams.get("f")) || 0);
-
-	const shareSearchParams = new URLSearchParams();
-	if (searchParams.get("p")) {
-		shareSearchParams.set("p", searchParams.get("p")!);
-	}
-	if (searchParams.get("s")) {
-		shareSearchParams.set("s", searchParams.get("s")!);
-	}
-	if (searchParams.get("e")) {
-		shareSearchParams.set("e", searchParams.get("e")!);
-	}
-	if (searchParams.get("w")) {
-		shareSearchParams.set("w", searchParams.get("w")!);
-	}
-	if (searchParams.get("f")) {
-		shareSearchParams.set("f", searchParams.get("f")!);
-	}
-	const shareUrl = `${SHARE_BASE_URL}?${shareSearchParams.toString()}`;
-
-	const projectLabel = projectName ? `${projectName} ` : "My NestJS codebase ";
-	const tweetText = `${projectLabel}scored ${score}/100 on NestJS Doctor. Run it on yours:`;
-	const twitterShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}&url=${encodeURIComponent(shareUrl)}`;
-	const linkedinShareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
-
-	return (
-		<div className="mx-auto min-h-screen w-full max-w-3xl bg-[#0a0a0a] p-6 pb-32 font-mono text-base text-neutral-300 leading-relaxed sm:p-8 sm:pb-40 sm:text-lg">
-			<div className="mb-6">
-				{projectName && (
-					<div className="mb-4 text-white text-xl">{projectName}</div>
-				)}
-				<NestFace score={score} />
-				<div className="mt-2 text-neutral-500">
-					NestJS Doctor{" "}
-					<span className="text-neutral-600">(www.nestjs.doctor)</span>
-				</div>
-			</div>
-
-			<AnimatedScore targetScore={score} />
-
-			{(errorCount > 0 || warningCount > 0 || fileCount > 0) && (
-				<div className="mb-8 pl-2">
-					{errorCount > 0 && (
-						<span className="text-red-400">
-							{errorCount} error{errorCount === 1 ? "" : "s"}
-						</span>
-					)}
-					{warningCount > 0 && (
-						<span className="text-yellow-500">
-							{"  "}
-							{warningCount} warning{warningCount === 1 ? "" : "s"}
-						</span>
-					)}
-					{fileCount > 0 && (
-						<span className="text-neutral-500">
-							{"  "}across {fileCount} file{fileCount === 1 ? "" : "s"}
-						</span>
-					)}
-				</div>
-			)}
-
-			<div className="text-neutral-500">Run it on your codebase:</div>
-			<div className="mt-2">
-				<span className="border border-white/20 px-3 py-1.5 text-white">
-					{COMMAND}
-				</span>
-			</div>
-
-			<div className="mt-8 flex flex-wrap items-center gap-3">
-				<a
-					className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap border border-white/20 bg-white px-3 py-1.5 text-black transition-[background-color,transform] hover:bg-white/90 active:scale-[0.98]"
-					href={twitterShareUrl}
-					rel="noreferrer"
-					target="_blank"
-				>
-					<svg
-						aria-hidden="true"
-						fill="currentColor"
-						height="16"
-						viewBox="0 0 24 24"
-						width="16"
-					>
-						<path d={X_ICON_PATH} />
-					</svg>
-					Share on X
-				</a>
-				<a
-					className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap border border-white/20 bg-white px-3 py-1.5 text-black transition-[background-color,transform] hover:bg-white/90 active:scale-[0.98]"
-					href={linkedinShareUrl}
-					rel="noreferrer"
-					target="_blank"
-				>
-					<svg
-						aria-hidden="true"
-						fill="currentColor"
-						height="16"
-						viewBox="0 0 24 24"
-						width="16"
-					>
-						<path d={LINKEDIN_ICON_PATH} />
-					</svg>
-					Share on LinkedIn
-				</a>
-			</div>
-		</div>
-	);
-};
+const WINDOW_TITLE = "nestjs-doctor — certificate";
 
 const SharePage = () => (
-	<Suspense>
-		<ShareContent />
-	</Suspense>
+	<div className="h-dvh w-full bg-[#0a0a0a] font-mono text-base text-neutral-300 leading-relaxed">
+		<h1 className="sr-only">Certificate of health</h1>
+		<p className="sr-only">
+			A health score that nestjs-doctor measured for one NestJS codebase.
+		</p>
+		<Desktop
+			reopenLabel="Open certificate"
+			section="Certificate"
+			title={WINDOW_TITLE}
+		>
+			<Suspense>
+				<CertificateScreen />
+			</Suspense>
+		</Desktop>
+	</div>
 );
 
 export default SharePage;

--- a/packages/website/src/app/share/page.tsx
+++ b/packages/website/src/app/share/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { Desktop } from "@/components/macos/desktop";
-import { CertificateScreen } from "./certificate-screen";
+import { QueryCertificateScreen } from "./certificate-screen";
 
 const WINDOW_TITLE = "nestjs-doctor — certificate";
 
@@ -16,7 +16,7 @@ const SharePage = () => (
 			title={WINDOW_TITLE}
 		>
 			<Suspense>
-				<CertificateScreen />
+				<QueryCertificateScreen />
 			</Suspense>
 		</Desktop>
 	</div>

--- a/packages/website/src/app/sitemap.ts
+++ b/packages/website/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { LEADERBOARD_ENTRIES } from "@/app/leaderboard/leaderboard-entries";
 import { DOCS_NAV } from "@/lib/docs-navigation";
 import { SITE_URL } from "@/lib/site";
 
@@ -12,6 +13,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			priority: 0.7,
 		}))
 	);
+
+	const certificateRoutes = LEADERBOARD_ENTRIES.map((entry) => ({
+		url: `${SITE_URL}${entry.shareUrl}`,
+		changeFrequency: "weekly" as const,
+		priority: 0.6,
+	}));
 
 	return [
 		{
@@ -30,5 +37,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			priority: 0.8,
 		},
 		...docRoutes,
+		...certificateRoutes,
 	];
 }

--- a/packages/website/src/components/macos/desktop.tsx
+++ b/packages/website/src/components/macos/desktop.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Dock } from "./dock";
+import { MenuBar } from "./menu-bar";
+import { ReopenCard } from "./reopen";
+import { TerminalWindow } from "./terminal-window";
+import { useWindow } from "./use-window";
+import { MacOSWallpaper } from "./wallpaper";
+
+const STAGE_CLASS =
+	"relative flex min-h-0 flex-1 items-center-safe justify-center overflow-auto p-4 sm:p-6";
+const WINDOW_BASE_CLASS =
+	"transition-[max-width] duration-300 motion-reduce:transition-none";
+const WINDOW_NORMAL_CLASS = "w-full max-w-3xl";
+const WINDOW_FULLSCREEN_CLASS = "w-full max-w-none self-stretch";
+
+/** A macOS desktop: wallpaper, menu bar, and one terminal window holding the
+ * children. The window stays mounted while minimised or closed. */
+export const Desktop = ({
+	children,
+	reopenLabel,
+	section,
+	title,
+}: {
+	children: ReactNode;
+	reopenLabel: string;
+	section: string;
+	title: string;
+}) => {
+	const {
+		animationState,
+		handleClose,
+		handleMaximize,
+		handleMinimize,
+		handleRestore,
+		windowRef,
+		windowState,
+	} = useWindow();
+
+	const isIdle = animationState === "idle";
+	const isAway = windowState === "minimized" || windowState === "closed";
+	const isPutAway = isAway && isIdle;
+	const isFullscreen = windowState === "fullscreen";
+
+	const windowClassName = `${WINDOW_BASE_CLASS} ${isFullscreen ? WINDOW_FULLSCREEN_CLASS : WINDOW_NORMAL_CLASS}`;
+
+	return (
+		<section className="relative flex h-dvh flex-col overflow-hidden font-mono">
+			<MacOSWallpaper className="absolute inset-0 h-full w-full" />
+			<div className="absolute inset-0 bg-black/30" />
+
+			<div className="relative z-10 flex min-h-0 flex-1 flex-col">
+				<MenuBar section={section} />
+
+				<div className={STAGE_CLASS} style={{ perspective: "1000px" }}>
+					<div
+						className={windowClassName}
+						ref={windowRef}
+						style={{
+							visibility: isPutAway ? "hidden" : "visible",
+							pointerEvents: isPutAway ? "none" : "auto",
+						}}
+					>
+						<TerminalWindow
+							busy={!isIdle}
+							className="h-full"
+							onClose={handleClose}
+							onMaximize={handleMaximize}
+							onMinimize={handleMinimize}
+							title={title}
+							windowState={windowState}
+						>
+							{children}
+						</TerminalWindow>
+					</div>
+
+					{windowState === "closed" && isIdle ? (
+						<div className="absolute inset-0 z-20 flex items-center justify-center">
+							<ReopenCard label={reopenLabel} onReopen={handleRestore} />
+						</div>
+					) : null}
+
+					{windowState === "minimized" && isIdle ? (
+						<Dock onRestore={handleRestore} title={title} />
+					) : null}
+				</div>
+			</div>
+		</section>
+	);
+};

--- a/packages/website/src/components/macos/dock.tsx
+++ b/packages/website/src/components/macos/dock.tsx
@@ -1,0 +1,42 @@
+const DOCK_CLASS =
+	"flex items-end gap-2 rounded-xl border border-white/30 bg-white/20 p-2 shadow-xl backdrop-blur-xl";
+const THUMBNAIL_CLASS =
+	"flex h-12 w-16 flex-col overflow-hidden rounded-md border border-white/15 bg-[#0a0a0a] shadow-md";
+const TOOLTIP_CLASS =
+	"-top-8 -translate-x-1/2 absolute left-1/2 whitespace-nowrap rounded-md bg-black/80 px-2 py-1 text-[11px] text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100";
+
+/** The minimised window, parked at the bottom of the desktop. */
+export const Dock = ({
+	onRestore,
+	title,
+}: {
+	onRestore: () => void;
+	title: string;
+}) => (
+	<div className="absolute bottom-6 left-1/2 z-10 -translate-x-1/2">
+		<div className={DOCK_CLASS}>
+			<button
+				className="group relative cursor-pointer p-0 transition-transform hover:scale-105"
+				onClick={onRestore}
+				type="button"
+			>
+				<div className={THUMBNAIL_CLASS}>
+					<div className="flex items-center gap-1 bg-[#2a2a2c] px-1.5 py-0.5">
+						<span className="h-1 w-1 rounded-full bg-[#FF5F57]" />
+						<span className="h-1 w-1 rounded-full bg-[#FFBD2E]" />
+						<span className="h-1 w-1 rounded-full bg-[#28CA41]" />
+					</div>
+					<div className="flex flex-1 flex-col items-center justify-center gap-0.5 p-1">
+						<span className="h-1 w-4 rounded-sm bg-white/40" />
+						<span className="h-0.5 w-6 rounded-sm bg-white/20" />
+						<span className="h-0.5 w-5 rounded-sm bg-white/20" />
+					</div>
+				</div>
+
+				<span className="absolute -bottom-1 left-1/2 h-1 w-1 -translate-x-1/2 rounded-full bg-white/60" />
+
+				<span className={TOOLTIP_CLASS}>{title}</span>
+			</button>
+		</div>
+	</div>
+);

--- a/packages/website/src/components/macos/menu-bar.tsx
+++ b/packages/website/src/components/macos/menu-bar.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+/** Rendered until the client mounts, so the server and the browser agree. */
+const CLOCK_PLACEHOLDER = "--:--";
+const TICK_MS = 15_000;
+
+const formatClock = (now: Date): string =>
+	now.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+
+const formatDate = (now: Date): string =>
+	now.toLocaleDateString("en-US", {
+		weekday: "short",
+		month: "short",
+		day: "numeric",
+	});
+
+const AppleGlyph = () => (
+	<svg
+		aria-hidden="true"
+		className="h-3.5 w-3.5 text-white/90"
+		fill="currentColor"
+		viewBox="0 0 24 24"
+	>
+		<path d="M17.05 12.54c-.02-2.4 1.96-3.55 2.05-3.61-1.12-1.63-2.86-1.86-3.48-1.89-1.48-.15-2.89.87-3.64.87-.75 0-1.91-.85-3.14-.83-1.61.02-3.1.94-3.93 2.38-1.68 2.91-.43 7.21 1.2 9.57.8 1.15 1.75 2.45 3 2.4 1.21-.05 1.66-.78 3.12-.78 1.46 0 1.87.78 3.14.75 1.3-.02 2.12-1.17 2.91-2.33.92-1.34 1.3-2.64 1.32-2.7-.03-.01-2.53-.97-2.55-3.85M14.7 5.4c.66-.8 1.11-1.92.99-3.03-.95.04-2.11.63-2.79 1.43-.61.71-1.15 1.85-1 2.94 1.06.08 2.14-.54 2.8-1.34" />
+	</svg>
+);
+
+/** The strip along the top of the desktop. The clock is the only live part. */
+export const MenuBar = ({ section }: { section: string }) => {
+	const [now, setNow] = useState<Date | null>(null);
+
+	useEffect(() => {
+		setNow(new Date());
+		const timer = setInterval(() => setNow(new Date()), TICK_MS);
+		return () => clearInterval(timer);
+	}, []);
+
+	return (
+		<div className="flex h-6 shrink-0 items-center gap-4 bg-black/40 px-4 text-[11px] text-white/80 backdrop-blur-xl">
+			<Link className="flex items-center" href="/">
+				<AppleGlyph />
+			</Link>
+			<Link className="font-bold text-white" href="/">
+				nestjs-doctor
+			</Link>
+			<span>{section}</span>
+			<Link className="hover:text-white" href="/docs">
+				Docs
+			</Link>
+			<a
+				className="hover:text-white"
+				href="https://github.com/RoloBits/nestjs-doctor"
+				rel="noreferrer"
+				target="_blank"
+			>
+				GitHub
+			</a>
+			<div className="ml-auto flex items-center gap-4">
+				<span>{now ? formatDate(now) : ""}</span>
+				<span>{now ? formatClock(now) : CLOCK_PLACEHOLDER}</span>
+			</div>
+		</div>
+	);
+};

--- a/packages/website/src/components/macos/reopen.tsx
+++ b/packages/website/src/components/macos/reopen.tsx
@@ -1,0 +1,40 @@
+const CARD_CLASS =
+	"flex cursor-pointer flex-col items-center gap-3 rounded-xl border border-white/30 bg-white/20 px-8 py-6 shadow-xl backdrop-blur-xl transition-colors hover:bg-white/30";
+const THUMBNAIL_CLASS =
+	"flex h-16 w-20 flex-col overflow-hidden rounded-md border border-white/15 bg-[#0a0a0a] shadow-md";
+
+/** The card that stands in for the window once it has been closed. */
+export const ReopenCard = ({
+	label,
+	onReopen,
+}: {
+	label: string;
+	onReopen: () => void;
+}) => (
+	<button className={CARD_CLASS} onClick={onReopen} type="button">
+		<span className={THUMBNAIL_CLASS}>
+			<span className="flex items-center gap-1 bg-[#2a2a2c] px-2 py-1">
+				<span className="h-1.5 w-1.5 rounded-full bg-[#FF5F57]" />
+				<span className="h-1.5 w-1.5 rounded-full bg-[#FFBD2E]" />
+				<span className="h-1.5 w-1.5 rounded-full bg-[#28CA41]" />
+			</span>
+			<span className="flex flex-1 items-center justify-center">
+				<svg
+					aria-hidden="true"
+					className="h-5 w-5 text-white/40"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+				>
+					<path
+						d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth={2}
+					/>
+				</svg>
+			</span>
+		</span>
+		<span className="font-medium text-[13px] text-black/70">{label}</span>
+	</button>
+);

--- a/packages/website/src/components/macos/terminal-window.tsx
+++ b/packages/website/src/components/macos/terminal-window.tsx
@@ -1,0 +1,156 @@
+import type { ReactNode } from "react";
+
+export type WindowState = "normal" | "minimized" | "closed" | "fullscreen";
+
+const FRAME_CLASS =
+	"flex flex-col overflow-hidden rounded-[10px] border border-white/10 bg-[#0a0a0a] shadow-2xl";
+const BAR_CLASS =
+	"flex shrink-0 items-center gap-2 border-white/10 border-b bg-gradient-to-b from-[#3a3a3c] to-[#2a2a2c] px-4 py-2.5";
+const LIGHT_CLASS =
+	"relative flex h-3 w-3 min-w-0 cursor-pointer items-center justify-center rounded-full p-0 shadow-sm transition-colors duration-100 aria-disabled:cursor-default";
+const GLYPH_CLASS =
+	"h-2 w-2 opacity-0 transition-opacity duration-100 group-hover:opacity-100";
+
+const CLOSE_CLASS = "bg-[#FF5F57] hover:bg-[#FF3B30] active:bg-[#E5352D]";
+const MINIMIZE_CLASS = "bg-[#FFBD2E] hover:bg-[#F5A623] active:bg-[#E09620]";
+const MAXIMIZE_CLASS = "bg-[#28CA41] hover:bg-[#24B33A] active:bg-[#1FA033]";
+
+/** A traffic light; clicks are ignored while busy. */
+const TrafficLight = ({
+	busy,
+	glyph,
+	glyphColor,
+	label,
+	onClick,
+	tone,
+}: {
+	busy: boolean;
+	glyph: ReactNode;
+	glyphColor: string;
+	label: string;
+	onClick: () => void;
+	tone: string;
+}) => {
+	const className = `${LIGHT_CLASS} ${tone}`;
+	const svgClassName = `${GLYPH_CLASS} ${glyphColor}`;
+	return (
+		<button
+			aria-disabled={busy}
+			aria-label={label}
+			className={className}
+			onClick={() => {
+				if (!busy) {
+					onClick();
+				}
+			}}
+			tabIndex={busy ? -1 : undefined}
+			type="button"
+		>
+			<svg
+				aria-hidden="true"
+				className={svgClassName}
+				fill="currentColor"
+				viewBox="0 0 12 12"
+			>
+				{glyph}
+			</svg>
+		</button>
+	);
+};
+
+/**
+ * A Terminal.app window: traffic lights, a centred title, and a black body.
+ * The chrome is decoration; the caller owns everything inside.
+ */
+export const TerminalWindow = ({
+	busy,
+	children,
+	className = "",
+	onClose,
+	onMaximize,
+	onMinimize,
+	title,
+	windowState,
+}: {
+	busy: boolean;
+	children: ReactNode;
+	className?: string;
+	onClose: () => void;
+	onMaximize: () => void;
+	onMinimize: () => void;
+	title: string;
+	windowState: WindowState;
+}) => {
+	const frameClassName = `${FRAME_CLASS} ${className}`;
+	const isFullscreen = windowState === "fullscreen";
+	return (
+		<div className={frameClassName}>
+			<div className={BAR_CLASS}>
+				<div className="group flex items-center gap-2">
+					<TrafficLight
+						busy={busy}
+						glyph={
+							<path
+								d="M3.5 3.5l5 5M8.5 3.5l-5 5"
+								fill="none"
+								stroke="currentColor"
+								strokeLinecap="round"
+								strokeWidth="1.5"
+							/>
+						}
+						glyphColor="text-[#4D0000]"
+						label="Close window"
+						onClick={onClose}
+						tone={CLOSE_CLASS}
+					/>
+					<TrafficLight
+						busy={busy}
+						glyph={
+							<path
+								d="M2.5 6h7"
+								fill="none"
+								stroke="currentColor"
+								strokeLinecap="round"
+								strokeWidth="1.5"
+							/>
+						}
+						glyphColor="text-[#995700]"
+						label="Minimize window"
+						onClick={onMinimize}
+						tone={MINIMIZE_CLASS}
+					/>
+					<TrafficLight
+						busy={busy}
+						glyph={
+							<path
+								d={
+									isFullscreen
+										? "M3 3l2.5 2.5M9 9l-2.5-2.5M3 9l2.5-2.5M9 3l-2.5 2.5"
+										: "M2 2l3 3M10 10l-3-3M2 10l3-3M10 2l-3 3"
+								}
+								fill="none"
+								stroke="currentColor"
+								strokeLinecap="round"
+								strokeWidth="1.2"
+							/>
+						}
+						glyphColor="text-[#006500]"
+						label={isFullscreen ? "Restore window" : "Maximize window"}
+						onClick={onMaximize}
+						tone={MAXIMIZE_CLASS}
+					/>
+				</div>
+
+				<div className="flex flex-1 justify-center">
+					<span className="max-w-[70%] truncate text-[12px] text-white/70">
+						{title}
+					</span>
+				</div>
+
+				<div className="w-[52px]" />
+			</div>
+
+			<div className="min-h-0 flex-1 overflow-auto">{children}</div>
+		</div>
+	);
+};

--- a/packages/website/src/components/macos/use-window-animations.ts
+++ b/packages/website/src/components/macos/use-window-animations.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { animate } from "motion";
+import { useCallback } from "react";
+
+/** The five window animations, keyframe for keyframe as macOS plays them. */
+export const useWindowAnimations = () => {
+	const minimizeWindow = useCallback(
+		(element: HTMLElement) =>
+			animate(
+				element,
+				{
+					transform: [
+						"scale(1) translateY(0px) rotateX(0deg)",
+						"scale(0.8) translateY(40px) rotateX(-2deg)",
+						"scale(0.6) translateY(100px) rotateX(-3deg)",
+						"scale(0.4) translateY(180px) rotateX(-4deg)",
+						"scale(0.25) translateY(280px) rotateX(-3deg)",
+						"scale(0.15) translateY(360px) rotateX(-1deg)",
+						"scale(0.08) translateY(420px) rotateX(0deg)",
+					],
+					opacity: [1, 0.95, 0.9, 0.8, 0.5, 0.25, 0],
+					filter: ["blur(0px)", "blur(0px)", "blur(2px)", "blur(4px)"],
+				},
+				{ ease: [0.16, 1, 0.3, 1], duration: 0.35 }
+			),
+		[]
+	);
+
+	const restoreWindow = useCallback(
+		(element: HTMLElement) =>
+			animate(
+				element,
+				{
+					transform: [
+						"scale(0.08) translateY(420px) rotateX(0deg)",
+						"scale(0.15) translateY(360px) rotateX(-1deg)",
+						"scale(0.25) translateY(280px) rotateX(-3deg)",
+						"scale(0.4) translateY(180px) rotateX(-4deg)",
+						"scale(0.6) translateY(100px) rotateX(-3deg)",
+						"scale(0.8) translateY(40px) rotateX(-2deg)",
+						"scale(1.02) translateY(-5px) rotateX(0deg)",
+						"scale(1) translateY(0px) rotateX(0deg)",
+					],
+					opacity: [0, 0.25, 0.5, 0.8, 0.9, 0.95, 1, 1],
+					filter: ["blur(4px)", "blur(2px)", "blur(0px)", "blur(0px)"],
+				},
+				{ ease: [0.34, 1.56, 0.64, 1], duration: 0.3 }
+			),
+		[]
+	);
+
+	const closeWindow = useCallback(
+		(element: HTMLElement) =>
+			animate(
+				element,
+				{
+					transform: ["scale(1)", "scale(0.94)", "scale(0.87)", "scale(0.8)"],
+					opacity: [1, 0.7, 0.3, 0],
+					filter: ["blur(0px)", "blur(1px)", "blur(2px)"],
+				},
+				{ ease: [0.25, 0.46, 0.45, 0.94], duration: 0.2 }
+			),
+		[]
+	);
+
+	const openWindow = useCallback(
+		(element: HTMLElement) =>
+			animate(
+				element,
+				{
+					transform: [
+						"scale(0.8)",
+						"scale(0.87)",
+						"scale(0.94)",
+						"scale(1.01)",
+						"scale(1)",
+					],
+					opacity: [0, 0.3, 0.7, 1, 1],
+					filter: ["blur(2px)", "blur(1px)", "blur(0px)", "blur(0px)"],
+				},
+				{ ease: [0.34, 1.56, 0.64, 1], duration: 0.2 }
+			),
+		[]
+	);
+
+	const maximizeWindow = useCallback(
+		(element: HTMLElement) =>
+			animate(
+				element,
+				{ transform: ["scale(1)", "scale(1.015)", "scale(1)"] },
+				{ ease: [0.25, 0.46, 0.45, 0.94], duration: 0.25 }
+			),
+		[]
+	);
+
+	return {
+		closeWindow,
+		maximizeWindow,
+		minimizeWindow,
+		openWindow,
+		restoreWindow,
+	};
+};

--- a/packages/website/src/components/macos/use-window.ts
+++ b/packages/website/src/components/macos/use-window.ts
@@ -1,0 +1,172 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { WindowState } from "./terminal-window";
+import { useWindowAnimations } from "./use-window-animations";
+
+export type AnimationState =
+	| "idle"
+	| "minimizing"
+	| "maximizing"
+	| "restoring"
+	| "closing";
+
+type AnimationFn = (element: HTMLElement) => { finished: Promise<unknown> };
+
+/** Someone who asked for less motion gets the state change and no keyframes. */
+const prefersReducedMotion = (): boolean =>
+	typeof window !== "undefined" &&
+	typeof window.matchMedia === "function" &&
+	window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+interface RunAnimationParams {
+	animationFn: AnimationFn;
+	animationState: AnimationState;
+	busyRef: { current: boolean };
+	element: HTMLElement | null;
+	isMountedRef: { current: boolean };
+	setAnimationState: (state: AnimationState) => void;
+	setWindowState: (state: WindowState) => void;
+	successState: WindowState;
+}
+
+/** Plays one animation, then commits the state it was leading to. */
+const runWindowAnimation = async ({
+	animationFn,
+	animationState,
+	busyRef,
+	element,
+	isMountedRef,
+	setAnimationState,
+	setWindowState,
+	successState,
+}: RunAnimationParams): Promise<void> => {
+	if (!element || busyRef.current) {
+		return;
+	}
+	busyRef.current = true;
+	try {
+		if (prefersReducedMotion()) {
+			setWindowState(successState);
+			setAnimationState("idle");
+			return;
+		}
+
+		setAnimationState(animationState);
+		try {
+			await animationFn(element).finished;
+			if (isMountedRef.current) {
+				setWindowState(successState);
+				setAnimationState("idle");
+			}
+		} catch {
+			// The animation was cancelled, or the component went away mid-flight.
+			if (isMountedRef.current) {
+				setAnimationState("idle");
+			}
+		}
+	} finally {
+		busyRef.current = false;
+	}
+};
+
+/** Holds the window state and plays each animation before the state change it
+ * commits. */
+export const useWindow = () => {
+	const [windowState, setWindowState] = useState<WindowState>("normal");
+	const [animationState, setAnimationState] = useState<AnimationState>("idle");
+	const windowRef = useRef<HTMLDivElement>(null);
+	const isMountedRef = useRef(true);
+	const busyRef = useRef(false);
+
+	useEffect(() => {
+		isMountedRef.current = true;
+		return () => {
+			isMountedRef.current = false;
+		};
+	}, []);
+
+	const animations = useWindowAnimations();
+
+	const handleClose = useCallback(
+		() =>
+			runWindowAnimation({
+				animationFn: animations.closeWindow,
+				animationState: "closing",
+				busyRef,
+				element: windowRef.current,
+				isMountedRef,
+				setAnimationState,
+				setWindowState,
+				successState: "closed",
+			}),
+		[animations]
+	);
+
+	const handleMinimize = useCallback(
+		() =>
+			runWindowAnimation({
+				animationFn: animations.minimizeWindow,
+				animationState: "minimizing",
+				busyRef,
+				element: windowRef.current,
+				isMountedRef,
+				setAnimationState,
+				setWindowState,
+				successState: "minimized",
+			}),
+		[animations]
+	);
+
+	const handleMaximize = useCallback(() => {
+		const isFullscreen = windowState === "fullscreen";
+		return runWindowAnimation({
+			animationFn: animations.maximizeWindow,
+			animationState: isFullscreen ? "restoring" : "maximizing",
+			busyRef,
+			element: windowRef.current,
+			isMountedRef,
+			setAnimationState,
+			setWindowState,
+			successState: isFullscreen ? "normal" : "fullscreen",
+		});
+	}, [animations, windowState]);
+
+	const handleRestore = useCallback(() => {
+		if (windowState === "minimized") {
+			return runWindowAnimation({
+				animationFn: animations.restoreWindow,
+				animationState: "restoring",
+				busyRef,
+				element: windowRef.current,
+				isMountedRef,
+				setAnimationState,
+				setWindowState,
+				successState: "normal",
+			});
+		}
+		if (windowState === "closed") {
+			return runWindowAnimation({
+				animationFn: animations.openWindow,
+				animationState: "restoring",
+				busyRef,
+				element: windowRef.current,
+				isMountedRef,
+				setAnimationState,
+				setWindowState,
+				successState: "normal",
+			});
+		}
+		return Promise.resolve();
+	}, [animations, windowState]);
+
+	return {
+		animationState,
+		handleClose,
+		handleMaximize,
+		handleMinimize,
+		handleRestore,
+		windowRef,
+		windowState,
+	};
+};

--- a/packages/website/src/components/macos/wallpaper.tsx
+++ b/packages/website/src/components/macos/wallpaper.tsx
@@ -1,0 +1,51 @@
+/** The macOS desert-stripe wallpaper, as flat SVG paths. */
+const GRADIENT_ID = "leaderboard-sky";
+
+export const MacOSWallpaper = ({ className }: { className?: string }) => (
+	<svg
+		aria-hidden="true"
+		className={className}
+		preserveAspectRatio="xMidYMid slice"
+		viewBox="0 0 1000 600"
+	>
+		<defs>
+			<linearGradient id={GRADIENT_ID} x1="0%" x2="0%" y1="0%" y2="100%">
+				<stop offset="0%" stopColor="#c9e4f6" />
+				<stop offset="100%" stopColor="#e6f0f7" />
+			</linearGradient>
+		</defs>
+		<rect fill={`url(#${GRADIENT_ID})`} height="100%" width="100%" />
+		<path
+			d="M0,180 Q150,120 350,160 T700,140 T1000,170 V600 H0 Z"
+			fill="#a8d4e6"
+		/>
+		<path
+			d="M0,220 Q200,170 400,210 T750,190 T1000,220 V600 H0 Z"
+			fill="#8ec4d6"
+		/>
+		<path
+			d="M0,280 Q180,230 380,260 T720,240 T1000,270 V600 H0 Z"
+			fill="#7cb5aa"
+		/>
+		<path
+			d="M0,330 Q220,290 420,320 T780,300 T1000,330 V600 H0 Z"
+			fill="#9cc98e"
+		/>
+		<path
+			d="M0,380 Q160,340 360,370 T700,350 T1000,380 V600 H0 Z"
+			fill="#e8d17d"
+		/>
+		<path
+			d="M0,430 Q200,400 400,420 T750,400 T1000,430 V600 H0 Z"
+			fill="#df9255"
+		/>
+		<path
+			d="M0,480 Q180,450 380,470 T720,455 T1000,480 V600 H0 Z"
+			fill="#d97046"
+		/>
+		<path
+			d="M0,530 Q220,500 420,520 T780,505 T1000,530 V600 H0 Z"
+			fill="#c65d3b"
+		/>
+	</svg>
+);

--- a/packages/website/src/components/score-bar.tsx
+++ b/packages/website/src/components/score-bar.tsx
@@ -1,0 +1,20 @@
+import {
+	PERFECT_SCORE,
+	palette,
+	SCORE_BAR_WIDTH,
+	scoreColor,
+} from "@/lib/tui-theme";
+
+/** The block/shade score gauge shared by the leaderboard and the share screen. */
+export const ScoreBar = ({ score }: { score: number }) => {
+	const safeScore = Math.max(0, Math.min(PERFECT_SCORE, score));
+	const filled = Math.round((safeScore / PERFECT_SCORE) * SCORE_BAR_WIDTH);
+	return (
+		<div className="whitespace-pre">
+			<span style={{ color: scoreColor(safeScore) }}>{"█".repeat(filled)}</span>
+			<span style={{ color: palette.dim }}>
+				{"░".repeat(SCORE_BAR_WIDTH - filled)}
+			</span>
+		</div>
+	);
+};

--- a/packages/website/src/lib/keyboard.ts
+++ b/packages/website/src/lib/keyboard.ts
@@ -1,0 +1,38 @@
+const TYPING_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+/** Keys belong to the page while someone is typing into it. */
+export const isTypingTarget = (target: EventTarget | null): boolean => {
+	const element = target as HTMLElement | null;
+	return Boolean(
+		element &&
+			(TYPING_TAGS.has(element.tagName) || element.isContentEditable === true)
+	);
+};
+
+/** Elements that handle Enter themselves. */
+const INTERACTIVE_SELECTOR =
+	'a[href], button, input, select, textarea, [contenteditable]:not([contenteditable="false"])';
+
+export const isInteractiveTarget = (target: Element | null): boolean =>
+	target instanceof HTMLElement && target.matches(INTERACTIVE_SELECTOR);
+
+/** True when the frame is visible and focus is on the body or inside it. */
+export const isFocusInFrame = (
+	active: Element | null,
+	frame: HTMLElement | null
+): boolean => {
+	if (typeof document === "undefined") {
+		return false;
+	}
+	if (!frame) {
+		return false;
+	}
+	const visible =
+		typeof frame.checkVisibility === "function"
+			? frame.checkVisibility({ visibilityProperty: true })
+			: frame.getClientRects().length > 0;
+	if (!visible) {
+		return false;
+	}
+	return active === document.body || frame.contains(active);
+};

--- a/packages/website/src/lib/og-font.ts
+++ b/packages/website/src/lib/og-font.ts
@@ -1,0 +1,43 @@
+const FONT_CSS =
+	"https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap";
+const FONT_URL_RE = /url\((https:[^)]+)\)/;
+
+export interface OgFont {
+	data: ArrayBuffer;
+	name: string;
+	weight: 400 | 600;
+}
+
+/** Downloads one weight of IBM Plex Mono through the same host next/font uses. */
+async function plexMono(weight: 400 | 600): Promise<OgFont | null> {
+	try {
+		const cssRes = await fetch(FONT_CSS, {
+			headers: { "User-Agent": "Mozilla/5.0" },
+		});
+		if (!cssRes.ok) {
+			return null;
+		}
+		const css = await cssRes.text();
+		const block = css
+			.split("@font-face")
+			.find((part) => part.includes(`font-weight: ${weight}`));
+		const url = block?.match(FONT_URL_RE)?.[1];
+		if (!url) {
+			return null;
+		}
+		const fontRes = await fetch(url);
+		if (!fontRes.ok) {
+			return null;
+		}
+		return { name: "IBM Plex Mono", data: await fontRes.arrayBuffer(), weight };
+	} catch {
+		return null;
+	}
+}
+
+/** The regular and semibold weights that resolved, for ImageResponse. */
+export async function loadPlexMono(): Promise<OgFont[] | undefined> {
+	const fonts = await Promise.all([plexMono(400), plexMono(600)]);
+	const loaded = fonts.filter((font): font is OgFont => font !== null);
+	return loaded.length > 0 ? loaded : undefined;
+}

--- a/packages/website/src/lib/tui-theme.ts
+++ b/packages/website/src/lib/tui-theme.ts
@@ -1,0 +1,58 @@
+/** The TUI palette: black surfaces, hairline borders, nest red as the accent. */
+export const palette = {
+	nestRed: "#ea2845",
+	bright: "#f2f1ef",
+	text: "#e8e8e8",
+	muted: "#888888",
+	dim: "#666666",
+	border: "#3a3a3a",
+	washRed: "#1f0c10",
+	error: "#ef4444",
+	warning: "#f59e0b",
+	info: "#3b82f6",
+	success: "#4ade80",
+} as const;
+
+export const PERFECT_SCORE = 100;
+export const SCORE_BAR_WIDTH = 30;
+const SCORE_GOOD_THRESHOLD = 75;
+const SCORE_OK_THRESHOLD = 50;
+
+export const scoreColor = (score: number): string => {
+	if (score >= SCORE_GOOD_THRESHOLD) {
+		return palette.success;
+	}
+	if (score >= SCORE_OK_THRESHOLD) {
+		return palette.warning;
+	}
+	return palette.error;
+};
+
+export const SCORE_TIERS: { label: string; minimum: number; stars: string }[] =
+	[
+		{ minimum: 90, stars: "★★★★★", label: "Excellent" },
+		{ minimum: 75, stars: "★★★★☆", label: "Good" },
+		{ minimum: 50, stars: "★★★☆☆", label: "Fair" },
+		{ minimum: 25, stars: "★★☆☆☆", label: "Poor" },
+		{ minimum: 0, stars: "★☆☆☆☆", label: "Critical" },
+	];
+
+export const scoreTier = (score: number) =>
+	SCORE_TIERS.find((tier) => score >= tier.minimum) ?? SCORE_TIERS[0];
+
+/** The two inner lines of the ASCII face the console reporter prints. */
+export const getNestBirds = (score: number): [string, string] => {
+	if (score >= SCORE_GOOD_THRESHOLD) {
+		return ["◠ ◠ ◠", "╰───╯"];
+	}
+	if (score >= SCORE_OK_THRESHOLD) {
+		return ["• • •", "╰───╯"];
+	}
+	return ["x x x", "╰───╯"];
+};
+
+/** The TUI menu box: red border when focused, hairline when not. */
+export const MENU_CLASS = "flex flex-col border";
+export const MENU_LIST_CLASS = "flex flex-col border border-white/15";
+export const MENU_ROW_CLASS =
+	"flex w-full items-baseline gap-3 py-1 pr-3 text-left transition-colors focus:outline-none focus-visible:outline-none";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       lucide-react:
         specifier: ^1.35.0
         version: 1.35.0(react@19.2.8)
+      motion:
+        specifier: 12.23.24
+        version: 12.23.24(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nestjs-doctor:
         specifier: workspace:^
         version: link:../nestjs-doctor
@@ -2156,6 +2159,20 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  framer-motion@12.43.0:
+    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2731,6 +2748,26 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  motion-dom@12.43.0:
+    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.23.24:
+    resolution: {integrity: sha512-Rc5E7oe2YZ72N//S3QXGzbnXgqNrTESv8KKxABR20q2FLch9gHLo0JLyYo2hZ238bZ9Gx6cWhj9VO0IgwbMjCw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5280,6 +5317,15 @@ snapshots:
       fd-package-json: 2.0.0
       package-manager-detector: 1.8.0
 
+  framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      motion-dom: 12.43.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   fsevents@2.3.3:
     optional: true
 
@@ -6194,6 +6240,20 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4
+
+  motion-dom@12.43.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.23.24(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      framer-motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Context

The leaderboard listed six repos with scores that had no scan date, no commit and no CLI version, and one of them was not a NestJS project. Improvement plan row 3.6 asked for a refresh with a Nest 11 versus 12 dimension. The founder then asked for three more things: apps built on NestJS only (not the framework), the most popular ones, and the page rendered as the CLI's interactive score screen rather than a list.

## Problem

- `nestjs/nest` at 8 files was not a scan of that repo; `medusajs/medusa` has no `@nestjs/*` dependency and scored 100 over 6,910 files with zero modules.
- The six repos were not the most popular apps built on Nest: immich (113k stars), hoppscotch (80k), AFFiNE (72k), nocodb (65k), twenty (56k) were absent.
- A list of names and bars said nothing about what the tool found.

## Possible flows

| Flow | Before | After |
|---|---|---|
| Visitor lands on `/leaderboard` | six rows, a bar each | a desktop with a menu bar and wallpaper, and a terminal window holding the TUI score screen: header, the selected project's score line and severity counts, `PROJECTS` on the left, its `TOP RULES` on the right, the red menu box |
| Arrow keys, j/k | nothing | move the selection; the score line and the right pane follow; the page does not scroll |
| Left/right, h/l, Tab, Enter | nothing | move the menu highlight, switch panes, open the highlighted action (copy the command, open GitHub, share the score, add a project) |
| Click a row | nothing | selects it |
| Screen reader or crawler | the list | the same text, server-rendered: `role="listbox"` with `aria-selected`, the right pane `aria-live` |
| Reproducing a row | impossible | `git checkout <commit>`, no dependency install, `nestjs-doctor .` at 0.9.5 from `main` (ddc6bed) |
| "Share this score" on a leaderboard row | `/share?p=…&s=…` with five params | `/share/<owner>/<repo>`, a static page per entry exported at build time, indexable and in the sitemap |
| Posting a certificate link on X or LinkedIn | the site's generic card | the certificate itself: a 1200x630 image drawn from the same facts (`og:image`, `twitter:card` large) at `/share/<owner>/<repo>/opengraph-image` |
| `/share?p=…&s=…` links | derived from the entry | still render, `noindex`, and unfurl with a blank certificate image; a static export has no server to draw one per query |
| A hand-edited or malformed `/share` link (`?s=abc`, `?e=1.5`, `?w=1e30`) | rendered as "0" | the score reads `--/100` with a muted face and no stars, an invalid count has no row, and the copied link and both share intents carry only the values that parsed |
| Keyboard on `/share` | none | ↑↓ move the menu, Enter opens the highlighted row; Esc, ← or h go back to the leaderboard (a menu row does the same for the mouse); Enter follows the highlight even when focus sits on another menu row; Enter on a focused button or link (Copy, a menu-bar link, a traffic light) activates that control instead; the keys work on load with nothing focused and go quiet while the window is closed or minimised |
| Clicking a traffic light mid-animation | second animation interrupts the first (Motion never settles it) | ignored until the window is idle; the light stays focusable |
| Narrow screens | truncated names | the frame scrolls inside itself; names never truncate |
