### PR TITLE
feat(website): the desktop has interaction sounds

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -21,6 +21,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "@xyflow/react": "12.11.5",
     "codemirror": "6.0.2",
+    "cuelume": "^0.2.2",
     "dagre": "0.8.5",
     "lucide-react": "^1.35.0",
     "motion": "12.23.24",

--- a/packages/website/src/app/leaderboard/leaderboard-screen.tsx
+++ b/packages/website/src/app/leaderboard/leaderboard-screen.tsx
@@ -9,6 +9,7 @@ import {
 	isInteractiveTarget,
 	isTypingTarget,
 } from "@/lib/keyboard";
+import { play } from "@/lib/sounds";
 import {
 	getNestBirds,
 	MENU_CLASS,
@@ -180,6 +181,7 @@ export const LeaderboardScreen = ({
 		try {
 			await navigator.clipboard.writeText(command);
 			track("command_copied", { command, surface: "leaderboard" });
+			play("success");
 			setToast(`Copied ${command}`);
 			setTimeout(() => setToast(null), COPIED_RESET_MS);
 		} catch {
@@ -217,6 +219,7 @@ export const LeaderboardScreen = ({
 
 			if (event.key === "ArrowDown" || event.key === "j") {
 				event.preventDefault();
+				play("tick");
 				if (focus === "list") {
 					setSelected((current) => Math.min(current + 1, projectCount - 1));
 				} else {
@@ -228,6 +231,7 @@ export const LeaderboardScreen = ({
 			}
 			if (event.key === "ArrowUp" || event.key === "k") {
 				event.preventDefault();
+				play("tick");
 				if (focus === "list") {
 					setSelected((current) => Math.max(current - 1, 0));
 				} else {
@@ -245,6 +249,7 @@ export const LeaderboardScreen = ({
 				event.key === "h"
 			) {
 				event.preventDefault();
+				play("tick");
 				if (focus === "list") {
 					setFocus("menu");
 					menuRefs.current[menuIndex]?.focus();
@@ -359,6 +364,9 @@ export const LeaderboardScreen = ({
 								<button
 									aria-selected={active}
 									className={ROW_CLASS}
+									data-cuelume-hover="tick"
+									data-cuelume-press="press"
+									data-cuelume-release="release"
 									id={optionId(index)}
 									key={row.name}
 									onClick={() => {
@@ -506,6 +514,9 @@ export const LeaderboardScreen = ({
 						return (
 							<Link
 								className={MENU_ROW_CLASS}
+								data-cuelume-hover="tick"
+								data-cuelume-press="press"
+								data-cuelume-release="release"
 								href={item.href}
 								key={item.label}
 								onFocus={() => {
@@ -527,6 +538,9 @@ export const LeaderboardScreen = ({
 						return (
 							<a
 								className={MENU_ROW_CLASS}
+								data-cuelume-hover="tick"
+								data-cuelume-press="press"
+								data-cuelume-release="release"
 								href={item.href}
 								key={item.label}
 								onFocus={() => {
@@ -549,6 +563,9 @@ export const LeaderboardScreen = ({
 					return (
 						<button
 							className={MENU_ROW_CLASS}
+							data-cuelume-hover="tick"
+							data-cuelume-press="press"
+							data-cuelume-release="release"
 							key={item.label}
 							onClick={() => item.copy && handleCopy(item.copy)}
 							onFocus={() => {

--- a/packages/website/src/app/leaderboard/leaderboard-screen.tsx
+++ b/packages/website/src/app/leaderboard/leaderboard-screen.tsx
@@ -104,6 +104,13 @@ const scrollWindow = (
 
 const optionId = (index: number): string => `leaderboard-project-${index}`;
 
+/** A key tick, once per press; held keys stay quiet. */
+const tick = (event: globalThis.KeyboardEvent) => {
+	if (!event.repeat) {
+		play("tick");
+	}
+};
+
 /** Pluralises like the TUI's countLabel. */
 const countLabel = (count: number, singular: string): string =>
 	`${count} ${singular}${count === 1 ? "" : "s"}`;
@@ -219,11 +226,15 @@ export const LeaderboardScreen = ({
 
 			if (event.key === "ArrowDown" || event.key === "j") {
 				event.preventDefault();
-				play("tick");
 				if (focus === "list") {
-					setSelected((current) => Math.min(current + 1, projectCount - 1));
+					const next = Math.min(selected + 1, projectCount - 1);
+					if (next !== selected) {
+						tick(event);
+						setSelected(next);
+					}
 				} else {
 					const next = (menuIndex + 1) % menuCount;
+					tick(event);
 					setMenuIndex(next);
 					menuRefs.current[next]?.focus();
 				}
@@ -231,11 +242,15 @@ export const LeaderboardScreen = ({
 			}
 			if (event.key === "ArrowUp" || event.key === "k") {
 				event.preventDefault();
-				play("tick");
 				if (focus === "list") {
-					setSelected((current) => Math.max(current - 1, 0));
+					const next = Math.max(selected - 1, 0);
+					if (next !== selected) {
+						tick(event);
+						setSelected(next);
+					}
 				} else {
 					const next = menuIndex === 0 ? menuCount - 1 : menuIndex - 1;
+					tick(event);
 					setMenuIndex(next);
 					menuRefs.current[next]?.focus();
 				}
@@ -249,7 +264,7 @@ export const LeaderboardScreen = ({
 				event.key === "h"
 			) {
 				event.preventDefault();
-				play("tick");
+				tick(event);
 				if (focus === "list") {
 					setFocus("menu");
 					menuRefs.current[menuIndex]?.focus();
@@ -274,7 +289,7 @@ export const LeaderboardScreen = ({
 
 		window.addEventListener("keydown", onKeyDown);
 		return () => window.removeEventListener("keydown", onKeyDown);
-	}, [focus, projectCount, menuCount, menuIndex]);
+	}, [focus, projectCount, menuCount, menuIndex, selected]);
 
 	return (
 		<div className={FRAME_CLASS} ref={frameRef} style={{ color: palette.text }}>

--- a/packages/website/src/app/share/certificate-screen.tsx
+++ b/packages/website/src/app/share/certificate-screen.tsx
@@ -275,7 +275,9 @@ export const CertificateScreen = ({
 			}
 			if (event.key === "ArrowDown" || event.key === "j") {
 				event.preventDefault();
-				play("tick");
+				if (!event.repeat) {
+					play("tick");
+				}
 				const next = (menuIndex + 1) % menuCount;
 				setMenuIndex(next);
 				menuRefs.current[next]?.focus();
@@ -283,7 +285,9 @@ export const CertificateScreen = ({
 			}
 			if (event.key === "ArrowUp" || event.key === "k") {
 				event.preventDefault();
-				play("tick");
+				if (!event.repeat) {
+					play("tick");
+				}
 				const next = menuIndex === 0 ? menuCount - 1 : menuIndex - 1;
 				setMenuIndex(next);
 				menuRefs.current[next]?.focus();

--- a/packages/website/src/app/share/certificate-screen.tsx
+++ b/packages/website/src/app/share/certificate-screen.tsx
@@ -10,6 +10,7 @@ import {
 	isTypingTarget,
 } from "@/lib/keyboard";
 import { SITE_URL } from "@/lib/site";
+import { play } from "@/lib/sounds";
 import {
 	getNestBirds,
 	MENU_CLASS,
@@ -227,6 +228,7 @@ export const CertificateScreen = ({
 		try {
 			await navigator.clipboard.writeText(value);
 			track("command_copied", { command: value, surface: "certificate" });
+			play("success");
 			setToast(`Copied ${label}`);
 			setTimeout(() => setToast(null), COPIED_RESET_MS);
 		} catch {
@@ -273,6 +275,7 @@ export const CertificateScreen = ({
 			}
 			if (event.key === "ArrowDown" || event.key === "j") {
 				event.preventDefault();
+				play("tick");
 				const next = (menuIndex + 1) % menuCount;
 				setMenuIndex(next);
 				menuRefs.current[next]?.focus();
@@ -280,6 +283,7 @@ export const CertificateScreen = ({
 			}
 			if (event.key === "ArrowUp" || event.key === "k") {
 				event.preventDefault();
+				play("tick");
 				const next = menuIndex === 0 ? menuCount - 1 : menuIndex - 1;
 				setMenuIndex(next);
 				menuRefs.current[next]?.focus();
@@ -432,6 +436,9 @@ export const CertificateScreen = ({
 						return (
 							<Link
 								className={MENU_ROW_CLASS}
+								data-cuelume-hover="tick"
+								data-cuelume-press="press"
+								data-cuelume-release="release"
 								href={item.href}
 								key={item.label}
 								onFocus={() => setMenuIndex(index)}
@@ -450,6 +457,9 @@ export const CertificateScreen = ({
 						return (
 							<a
 								className={MENU_ROW_CLASS}
+								data-cuelume-hover="tick"
+								data-cuelume-press="press"
+								data-cuelume-release="release"
 								href={item.href}
 								key={item.label}
 								onFocus={() => setMenuIndex(index)}
@@ -469,6 +479,9 @@ export const CertificateScreen = ({
 					return (
 						<button
 							className={MENU_ROW_CLASS}
+							data-cuelume-hover="tick"
+							data-cuelume-press="press"
+							data-cuelume-release="release"
 							key={item.label}
 							onClick={() => item.copy && handleCopy(item.copy, item.copy)}
 							onFocus={() => setMenuIndex(index)}

--- a/packages/website/src/components/landing/command-block.tsx
+++ b/packages/website/src/components/landing/command-block.tsx
@@ -3,6 +3,7 @@
 import { Check, Copy } from "lucide-react";
 import { useCallback, useState } from "react";
 import { track } from "@/lib/analytics";
+import { play } from "@/lib/sounds";
 
 const COPIED_RESET_MS = 1600;
 
@@ -13,6 +14,7 @@ export const CommandBlock = ({ command }: { command: string }) => {
 		try {
 			await navigator.clipboard.writeText(command);
 			track("command_copied", { command, surface: "landing" });
+			play("success");
 			setCopied(true);
 			setTimeout(() => setCopied(false), COPIED_RESET_MS);
 		} catch {
@@ -31,6 +33,8 @@ export const CommandBlock = ({ command }: { command: string }) => {
 			<button
 				aria-label={`Copy: ${command}`}
 				className="flex items-center border-white/30 border-l px-4 text-white/70 transition-colors hover:bg-white hover:text-black"
+				data-cuelume-press="press"
+				data-cuelume-release="release"
 				onClick={handleCopy}
 				type="button"
 			>

--- a/packages/website/src/components/macos/desktop.tsx
+++ b/packages/website/src/components/macos/desktop.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
+import { bindSounds } from "@/lib/sounds";
 import { Dock } from "./dock";
 import { MenuBar } from "./menu-bar";
 import { ReopenCard } from "./reopen";
@@ -42,6 +43,10 @@ export const Desktop = ({
 		windowRef,
 		windowState,
 	} = useWindow();
+
+	useEffect(() => {
+		bindSounds();
+	}, []);
 
 	const isIdle = animationState === "idle";
 	const isAway = windowState === "minimized" || windowState === "closed";

--- a/packages/website/src/components/macos/dock.tsx
+++ b/packages/website/src/components/macos/dock.tsx
@@ -17,6 +17,8 @@ export const Dock = ({
 		<div className={DOCK_CLASS}>
 			<button
 				className="group relative cursor-pointer p-0 transition-transform hover:scale-105"
+				data-cuelume-press="press"
+				data-cuelume-release="release"
 				onClick={onRestore}
 				type="button"
 			>

--- a/packages/website/src/components/macos/menu-bar.tsx
+++ b/packages/website/src/components/macos/menu-bar.tsx
@@ -2,8 +2,13 @@
 
 import { Volume2, VolumeX } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { play, setSoundsEnabled, soundsEnabled } from "@/lib/sounds";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import {
+	play,
+	setSoundsEnabled,
+	soundsEnabled,
+	subscribeSounds,
+} from "@/lib/sounds";
 
 /** Rendered until the client mounts, so the server and the browser agree. */
 const CLOCK_PLACEHOLDER = "--:--";
@@ -30,24 +35,22 @@ const AppleGlyph = () => (
 	</svg>
 );
 
-/** The strip along the top of the desktop. The clock is the only live part. */
+/** The strip along the top of the desktop: a clock and a mute switch. */
 export const MenuBar = ({ section }: { section: string }) => {
 	const [now, setNow] = useState<Date | null>(null);
-	const [sounds, setSounds] = useState(true);
-
-	useEffect(() => {
-		setSounds(soundsEnabled());
-	}, []);
+	const sounds = useSyncExternalStore(
+		subscribeSounds,
+		soundsEnabled,
+		() => true
+	);
 
 	const toggleSounds = () => {
-		const next = !sounds;
-		setSounds(next);
-		if (next) {
-			setSoundsEnabled(true);
-			play("toggle");
-		} else {
+		if (sounds) {
 			play("toggle");
 			setSoundsEnabled(false);
+		} else {
+			setSoundsEnabled(true);
+			play("toggle");
 		}
 	};
 

--- a/packages/website/src/components/macos/menu-bar.tsx
+++ b/packages/website/src/components/macos/menu-bar.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { Volume2, VolumeX } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { play, setSoundsEnabled, soundsEnabled } from "@/lib/sounds";
 
 /** Rendered until the client mounts, so the server and the browser agree. */
 const CLOCK_PLACEHOLDER = "--:--";
@@ -31,6 +33,23 @@ const AppleGlyph = () => (
 /** The strip along the top of the desktop. The clock is the only live part. */
 export const MenuBar = ({ section }: { section: string }) => {
 	const [now, setNow] = useState<Date | null>(null);
+	const [sounds, setSounds] = useState(true);
+
+	useEffect(() => {
+		setSounds(soundsEnabled());
+	}, []);
+
+	const toggleSounds = () => {
+		const next = !sounds;
+		setSounds(next);
+		if (next) {
+			setSoundsEnabled(true);
+			play("toggle");
+		} else {
+			play("toggle");
+			setSoundsEnabled(false);
+		}
+	};
 
 	useEffect(() => {
 		setNow(new Date());
@@ -43,15 +62,20 @@ export const MenuBar = ({ section }: { section: string }) => {
 			<Link className="flex items-center" href="/">
 				<AppleGlyph />
 			</Link>
-			<Link className="font-bold text-white" href="/">
+			<Link className="font-bold text-white" data-cuelume-hover="tick" href="/">
 				nestjs-doctor
 			</Link>
 			<span>{section}</span>
-			<Link className="hidden hover:text-white sm:inline" href="/docs">
+			<Link
+				className="hidden hover:text-white sm:inline"
+				data-cuelume-hover="tick"
+				href="/docs"
+			>
 				Docs
 			</Link>
 			<a
 				className="hidden hover:text-white sm:inline"
+				data-cuelume-hover="tick"
 				href="https://github.com/RoloBits/nestjs-doctor"
 				rel="noreferrer"
 				target="_blank"
@@ -59,6 +83,15 @@ export const MenuBar = ({ section }: { section: string }) => {
 				GitHub
 			</a>
 			<div className="ml-auto flex items-center gap-4">
+				<button
+					aria-label="Sounds"
+					aria-pressed={sounds}
+					className="flex cursor-pointer items-center hover:text-white"
+					onClick={toggleSounds}
+					type="button"
+				>
+					{sounds ? <Volume2 size={12} /> : <VolumeX size={12} />}
+				</button>
 				<span className="hidden sm:inline">{now ? formatDate(now) : ""}</span>
 				<span>{now ? formatClock(now) : CLOCK_PLACEHOLDER}</span>
 			</div>

--- a/packages/website/src/components/macos/reopen.tsx
+++ b/packages/website/src/components/macos/reopen.tsx
@@ -11,7 +11,13 @@ export const ReopenCard = ({
 	label: string;
 	onReopen: () => void;
 }) => (
-	<button className={CARD_CLASS} onClick={onReopen} type="button">
+	<button
+		className={CARD_CLASS}
+		data-cuelume-press="press"
+		data-cuelume-release="release"
+		onClick={onReopen}
+		type="button"
+	>
 		<span className={THUMBNAIL_CLASS}>
 			<span className="flex items-center gap-1 bg-[#2a2a2c] px-2 py-1">
 				<span className="h-1.5 w-1.5 rounded-full bg-[#FF5F57]" />

--- a/packages/website/src/components/macos/terminal-window.tsx
+++ b/packages/website/src/components/macos/terminal-window.tsx
@@ -38,6 +38,8 @@ const TrafficLight = ({
 			aria-disabled={busy}
 			aria-label={label}
 			className={className}
+			data-cuelume-press="press"
+			data-cuelume-release="release"
 			onClick={() => {
 				if (!busy) {
 					onClick();

--- a/packages/website/src/components/macos/terminal-window.tsx
+++ b/packages/website/src/components/macos/terminal-window.tsx
@@ -38,8 +38,8 @@ const TrafficLight = ({
 			aria-disabled={busy}
 			aria-label={label}
 			className={className}
-			data-cuelume-press="press"
-			data-cuelume-release="release"
+			data-cuelume-press={busy ? undefined : "press"}
+			data-cuelume-release={busy ? undefined : "release"}
 			onClick={() => {
 				if (!busy) {
 					onClick();

--- a/packages/website/src/components/macos/use-window.ts
+++ b/packages/website/src/components/macos/use-window.ts
@@ -27,7 +27,8 @@ interface RunAnimationParams {
 	successState: WindowState;
 }
 
-/** Plays one sound and one animation, then commits the state it was leading to. */
+/** Plays one sound, then the animation unless motion is reduced, then commits
+ * the state it was leading to. */
 const runWindowAnimation = async ({
 	animationFn,
 	animationState,
@@ -129,7 +130,7 @@ export const useWindow = () => {
 			isMountedRef,
 			setAnimationState,
 			setWindowState,
-			sound: isFullscreen ? "minimize" : "maximize",
+			sound: isFullscreen ? "unmaximize" : "maximize",
 			successState: isFullscreen ? "normal" : "fullscreen",
 		});
 	}, [animations, windowState]);

--- a/packages/website/src/components/macos/use-window.ts
+++ b/packages/website/src/components/macos/use-window.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { prefersReducedMotion } from "@/lib/motion";
+import { type Cue, play } from "@/lib/sounds";
 import type { WindowState } from "./terminal-window";
 import { useWindowAnimations } from "./use-window-animations";
 
@@ -22,10 +23,11 @@ interface RunAnimationParams {
 	isMountedRef: { current: boolean };
 	setAnimationState: (state: AnimationState) => void;
 	setWindowState: (state: WindowState) => void;
+	sound: Cue;
 	successState: WindowState;
 }
 
-/** Plays one animation, then commits the state it was leading to. */
+/** Plays one sound and one animation, then commits the state it was leading to. */
 const runWindowAnimation = async ({
 	animationFn,
 	animationState,
@@ -34,12 +36,14 @@ const runWindowAnimation = async ({
 	isMountedRef,
 	setAnimationState,
 	setWindowState,
+	sound,
 	successState,
 }: RunAnimationParams): Promise<void> => {
 	if (!element || busyRef.current) {
 		return;
 	}
 	busyRef.current = true;
+	play(sound);
 	try {
 		if (prefersReducedMotion()) {
 			setWindowState(successState);
@@ -93,6 +97,7 @@ export const useWindow = () => {
 				isMountedRef,
 				setAnimationState,
 				setWindowState,
+				sound: "close",
 				successState: "closed",
 			}),
 		[animations]
@@ -108,6 +113,7 @@ export const useWindow = () => {
 				isMountedRef,
 				setAnimationState,
 				setWindowState,
+				sound: "minimize",
 				successState: "minimized",
 			}),
 		[animations]
@@ -123,6 +129,7 @@ export const useWindow = () => {
 			isMountedRef,
 			setAnimationState,
 			setWindowState,
+			sound: isFullscreen ? "minimize" : "maximize",
 			successState: isFullscreen ? "normal" : "fullscreen",
 		});
 	}, [animations, windowState]);
@@ -137,6 +144,7 @@ export const useWindow = () => {
 				isMountedRef,
 				setAnimationState,
 				setWindowState,
+				sound: "open",
 				successState: "normal",
 			});
 		}
@@ -149,6 +157,7 @@ export const useWindow = () => {
 				isMountedRef,
 				setAnimationState,
 				setWindowState,
+				sound: "open",
 				successState: "normal",
 			});
 		}

--- a/packages/website/src/lib/sounds.ts
+++ b/packages/website/src/lib/sounds.ts
@@ -1,6 +1,12 @@
 import { bind, play as cuelume, type SoundName, setEnabled } from "cuelume";
 
-export type Cue = SoundName | "open" | "maximize" | "minimize" | "close";
+export type Cue =
+	| SoundName
+	| "open"
+	| "maximize"
+	| "unmaximize"
+	| "minimize"
+	| "close";
 
 const STORAGE_KEY = "nestjs-doctor:sounds";
 const SILENT = 0.0001;
@@ -8,6 +14,7 @@ const SILENT = 0.0001;
 let context: AudioContext | null = null;
 let noise: AudioBuffer | null = null;
 let enabled: boolean | null = null;
+const listeners = new Set<() => void>();
 
 /** The stored preference; unknown or unreadable storage counts as on. */
 export const soundsEnabled = (): boolean => {
@@ -27,9 +34,19 @@ export const bindSounds = () => {
 	setEnabled(soundsEnabled());
 };
 
+export const subscribeSounds = (listener: () => void) => {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+};
+
 export const setSoundsEnabled = (on: boolean) => {
 	enabled = on;
 	setEnabled(on);
+	for (const listener of listeners) {
+		listener();
+	}
 	try {
 		localStorage.setItem(STORAGE_KEY, on ? "on" : "off");
 	} catch {
@@ -41,7 +58,7 @@ const audio = (): AudioContext => {
 	if (!context) {
 		context = new AudioContext();
 	}
-	if (context.state === "suspended") {
+	if (context.state !== "running") {
 		context.resume().catch(() => undefined);
 	}
 	return context;
@@ -115,7 +132,8 @@ const WINDOW_CUES: Record<
 	(c: AudioContext) => void
 > = {
 	open: (c) => whoosh(c, 320, 1900, 230, 0.6),
-	maximize: (c) => whoosh(c, 500, 2400, 170, 0.5),
+	maximize: (c) => whoosh(c, 600, 2600, 90, 0.5),
+	unmaximize: (c) => whoosh(c, 2600, 600, 90, 0.5),
 	minimize: (c) => whoosh(c, 1900, 280, 260, 0.45),
 	close: (c) => {
 		whoosh(c, 1300, 140, 210, 0.5);
@@ -128,14 +146,14 @@ const isWindowCue = (cue: Cue): cue is keyof typeof WINDOW_CUES =>
 
 /** Plays one cue now; a silent no-op without Web Audio or when muted. */
 export const play = (cue: Cue) => {
+	if (typeof window === "undefined" || !soundsEnabled()) {
+		return;
+	}
 	if (!isWindowCue(cue)) {
 		cuelume(cue);
 		return;
 	}
-	if (typeof window === "undefined" || !("AudioContext" in window)) {
-		return;
-	}
-	if (!soundsEnabled()) {
+	if (!("AudioContext" in window)) {
 		return;
 	}
 	try {

--- a/packages/website/src/lib/sounds.ts
+++ b/packages/website/src/lib/sounds.ts
@@ -1,0 +1,146 @@
+import { bind, play as cuelume, type SoundName, setEnabled } from "cuelume";
+
+export type Cue = SoundName | "open" | "maximize" | "minimize" | "close";
+
+const STORAGE_KEY = "nestjs-doctor:sounds";
+const SILENT = 0.0001;
+
+let context: AudioContext | null = null;
+let noise: AudioBuffer | null = null;
+let enabled: boolean | null = null;
+
+/** The stored preference; unknown or unreadable storage counts as on. */
+export const soundsEnabled = (): boolean => {
+	if (enabled === null) {
+		try {
+			enabled = localStorage.getItem(STORAGE_KEY) !== "off";
+		} catch {
+			enabled = true;
+		}
+	}
+	return enabled;
+};
+
+/** Wires the data-cuelume attributes once and applies the stored preference. */
+export const bindSounds = () => {
+	bind();
+	setEnabled(soundsEnabled());
+};
+
+export const setSoundsEnabled = (on: boolean) => {
+	enabled = on;
+	setEnabled(on);
+	try {
+		localStorage.setItem(STORAGE_KEY, on ? "on" : "off");
+	} catch {
+		// Storage is unavailable; the choice lasts for this page.
+	}
+};
+
+const audio = (): AudioContext => {
+	if (!context) {
+		context = new AudioContext();
+	}
+	if (context.state === "suspended") {
+		context.resume().catch(() => undefined);
+	}
+	return context;
+};
+
+const noiseBuffer = (c: AudioContext): AudioBuffer => {
+	if (!noise) {
+		noise = c.createBuffer(1, c.sampleRate, c.sampleRate);
+		const data = noise.getChannelData(0);
+		for (let i = 0; i < data.length; i++) {
+			data[i] = Math.random() * 2 - 1;
+		}
+	}
+	return noise;
+};
+
+const envelope = (
+	c: AudioContext,
+	peak: number,
+	attack: number,
+	ms: number
+) => {
+	const gain = c.createGain();
+	const t = c.currentTime;
+	gain.gain.setValueAtTime(SILENT, t);
+	gain.gain.exponentialRampToValueAtTime(peak, t + attack / 1000);
+	gain.gain.exponentialRampToValueAtTime(SILENT, t + ms / 1000);
+	gain.connect(c.destination);
+	return gain;
+};
+
+/** Band-passed air sweeping from one frequency to another. */
+const whoosh = (
+	c: AudioContext,
+	from: number,
+	to: number,
+	ms: number,
+	peak: number
+) => {
+	const source = c.createBufferSource();
+	source.buffer = noiseBuffer(c);
+	const filter = c.createBiquadFilter();
+	filter.type = "bandpass";
+	filter.Q.value = 1.4;
+	filter.frequency.setValueAtTime(from, c.currentTime);
+	filter.frequency.exponentialRampToValueAtTime(to, c.currentTime + ms / 1000);
+	source.connect(filter);
+	filter.connect(envelope(c, peak, ms / 4, ms));
+	source.start();
+	source.stop(c.currentTime + ms / 1000);
+};
+
+/** A short, low, pitch-dropping sine: a key bottoming out. */
+const thock = (
+	c: AudioContext,
+	from: number,
+	to: number,
+	ms: number,
+	peak: number
+) => {
+	const osc = c.createOscillator();
+	osc.frequency.setValueAtTime(from, c.currentTime);
+	osc.frequency.exponentialRampToValueAtTime(to, c.currentTime + ms / 1000);
+	osc.connect(envelope(c, peak, 3, ms));
+	osc.start();
+	osc.stop(c.currentTime + ms / 1000);
+};
+
+const WINDOW_CUES: Record<
+	Exclude<Cue, SoundName>,
+	(c: AudioContext) => void
+> = {
+	open: (c) => whoosh(c, 320, 1900, 230, 0.6),
+	maximize: (c) => whoosh(c, 500, 2400, 170, 0.5),
+	minimize: (c) => whoosh(c, 1900, 280, 260, 0.45),
+	close: (c) => {
+		whoosh(c, 1300, 140, 210, 0.5);
+		thock(c, 120, 45, 70, 0.18);
+	},
+};
+
+const isWindowCue = (cue: Cue): cue is keyof typeof WINDOW_CUES =>
+	cue in WINDOW_CUES;
+
+/** Plays one cue now; a silent no-op without Web Audio or when muted. */
+export const play = (cue: Cue) => {
+	if (!isWindowCue(cue)) {
+		cuelume(cue);
+		return;
+	}
+	if (typeof window === "undefined" || !("AudioContext" in window)) {
+		return;
+	}
+	if (!soundsEnabled()) {
+		return;
+	}
+	try {
+		WINDOW_CUES[cue](audio());
+	} catch {
+		// Autoplay was refused; the action still happens.
+	}
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       codemirror:
         specifier: 6.0.2
         version: 6.0.2
+      cuelume:
+        specifier: ^0.2.2
+        version: 0.2.2
       dagre:
         specifier: 0.8.5
         version: 0.8.5
@@ -1937,6 +1940,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cuelume@0.2.2:
+    resolution: {integrity: sha512-TiNzJRjhddjC4jy4M7sv63V/86VaFhdIs6iHUCrc4CKhqypaxRBv1aedCBGebrz/cO7nroPkEfqHe/P7fOE2GQ==}
 
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
@@ -5062,6 +5068,8 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  cuelume@0.2.2: {}
 
   d3-color@3.1.0: {}
 


### PR DESCRIPTION
## Context

The desktop pages (`/`, `/leaderboard`, `/share`) draw a macOS terminal window with traffic lights, a genie minimise, a dock and a reopen card, all silent. Builds on #393 (the landing demo), now merged.

## Problem

Window actions had no feedback beyond the animation, and the TUI rows and copy buttons none at all. A first pass with cuelume's full palette (bloom, whisper, droplet) on window actions read as playful next to the genie; the button cues (press, release, tick, toggle) felt right.

## Possible flows

| Flow | Sound |
|---|---|
| Pointer down and up on any button: traffic lights, dock, reopen card, copy buttons, leaderboard and certificate rows | cuelume `press`, `release` |
| Hover over menu bar links or TUI rows (fine pointer only) | cuelume `tick` |
| Arrow keys, `j`, `k`, pane switch inside the leaderboard or certificate | cuelume `tick`, once per press; held keys and the list edges stay quiet |
| Copy a command | cuelume `success` |
| Mute switch in the menu bar | cuelume `toggle`, both directions |
| Open, restore | in-house rising air whoosh, about 130 ms |
| Maximize, leave fullscreen | 90 ms rising or falling air, matched to the 250 ms pulse |
| Minimize | falling air |
| Close | falling air plus a low thock |
| Before the first interaction, or with Web Audio blocked | silent |
| Docs pages | unchanged, no `Desktop` there |

## Solution

- `cuelume` (0.2.2, MIT, under 5 kB, synthesised, no files) for the button feel. `data-cuelume-*` attributes on the buttons, `bind()` once in `Desktop`.
- `lib/sounds.ts` wraps it: `play(cue)` routes cuelume names to cuelume and the five window cues to its own Web Audio recipes (band-passed noise sweeps, a pitch-dropping sine). `useWindow` plays one cue per action, so every desktop page gets them.
- Speaker toggle in the menu bar; `setSoundsEnabled` mutes both sources and stores the choice in `localStorage`.

Not done: no sounds on docs pages, no volume control.

## Before vs after

| | Before | After |
|---|---|---|
| Click a traffic light | animation only | press, release, then the window's air; silent while an animation runs |
| Hover a menu bar link | nothing | tick |
| Copy a command | toast | toast plus success |
| Reduced motion | no animation | sounds still play; motion and sound are separate settings |
| Muted visitor on load | speaker icon on for one frame | correct from the first paint via `useSyncExternalStore` |
| Docs pages | silent | silent |

## Example

Rendered offline through `OfflineAudioContext` to check the in-house cues sit in one loudness band:

```
press    peak 0.254  30 ms   (cuelume)
open     peak 0.120  132 ms
maximize peak 0.114  97 ms   (before the 90 ms cut)
minimize peak 0.176  146 ms
close    peak 0.156  110 ms
```

Not verified by ear from the automation browser; it cannot start audio. The attributes resolve through cuelume's `isSoundName`, and `bind()` delegates on the document in capture phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
