### PR TITLE
chore: local test runs are capped at four vitest workers and run the packages one at a time

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "knip": "knip",
     "prepare": "husky",
     "release": "pnpm build && changeset publish",
-    "test": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run test",
+    "test": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run --sequential test",
     "typecheck": "pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp --filter nestjs-doctor-vscode run typecheck",
     "version": "changeset version && pnpm install --no-frozen-lockfile && node scripts/sync-skill-version.mjs"
   },

--- a/packages/nestjs-doctor-lsp/vitest.config.ts
+++ b/packages/nestjs-doctor-lsp/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		globals: true,
+		maxWorkers: process.env.CI ? undefined : 4,
 		include: ["tests/**/*.test.ts"],
 	},
 });

--- a/packages/nestjs-doctor/vitest.config.ts
+++ b/packages/nestjs-doctor/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	test: {
 		css: true,
 		globals: true,
+		maxWorkers: process.env.CI ? undefined : 4,
 		include: ["tests/**/*.test.{ts,tsx}"],
 		testTimeout: 30_000,
 	},


### PR DESCRIPTION
## Context

The root `test` script runs `pnpm --filter nestjs-doctor --filter nestjs-doctor-lsp run test`. pnpm starts both packages' `vitest run` at the same time, and vitest 4 defaults to one worker per core.

## Problem

On a 10-core, 16 GB MacBook the two runs together spawned around ten node workers at 40 to 70% CPU each, with a load average over 100. The laptop freezes until the run ends. Observed on 2026-09-02 with `ps` during a run.
