### PR TITLE
fix(website): the window cues are short clicks, and each button plays one sound

### DIFF
--- a/packages/website/src/components/macos/dock.tsx
+++ b/packages/website/src/components/macos/dock.tsx
@@ -17,8 +17,6 @@ export const Dock = ({
 		<div className={DOCK_CLASS}>
 			<button
 				className="group relative cursor-pointer p-0 transition-transform hover:scale-105"
-				data-cuelume-press="press"
-				data-cuelume-release="release"
 				onClick={onRestore}
 				type="button"
 			>

--- a/packages/website/src/components/macos/reopen.tsx
+++ b/packages/website/src/components/macos/reopen.tsx
@@ -11,13 +11,7 @@ export const ReopenCard = ({
 	label: string;
 	onReopen: () => void;
 }) => (
-	<button
-		className={CARD_CLASS}
-		data-cuelume-press="press"
-		data-cuelume-release="release"
-		onClick={onReopen}
-		type="button"
-	>
+	<button className={CARD_CLASS} onClick={onReopen} type="button">
 		<span className={THUMBNAIL_CLASS}>
 			<span className="flex items-center gap-1 bg-[#2a2a2c] px-2 py-1">
 				<span className="h-1.5 w-1.5 rounded-full bg-[#FF5F57]" />

--- a/packages/website/src/components/macos/terminal-window.tsx
+++ b/packages/website/src/components/macos/terminal-window.tsx
@@ -38,8 +38,6 @@ const TrafficLight = ({
 			aria-disabled={busy}
 			aria-label={label}
 			className={className}
-			data-cuelume-press={busy ? undefined : "press"}
-			data-cuelume-release={busy ? undefined : "release"}
 			onClick={() => {
 				if (!busy) {
 					onClick();

--- a/packages/website/src/lib/sounds.ts
+++ b/packages/website/src/lib/sounds.ts
@@ -127,16 +127,22 @@ const thock = (
 	osc.stop(c.currentTime + ms / 1000);
 };
 
+/** A noise tick over a short damped sine body: a switch snapping. */
+const click = (c: AudioContext, tick: number, body: number, ms: number) => {
+	whoosh(c, tick, tick * 0.6, 12, 0.45);
+	thock(c, body, body * 0.65, ms, 0.3);
+};
+
 const WINDOW_CUES: Record<
 	Exclude<Cue, SoundName>,
 	(c: AudioContext) => void
 > = {
-	open: (c) => whoosh(c, 320, 1900, 230, 0.6),
-	maximize: (c) => whoosh(c, 600, 2600, 90, 0.5),
-	unmaximize: (c) => whoosh(c, 2600, 600, 90, 0.5),
-	minimize: (c) => whoosh(c, 1900, 280, 260, 0.45),
+	open: (c) => click(c, 2200, 800, 45),
+	maximize: (c) => whoosh(c, 3400, 2000, 12, 0.5),
+	unmaximize: (c) => click(c, 3000, 1100, 40),
+	minimize: (c) => click(c, 1600, 520, 55),
 	close: (c) => {
-		whoosh(c, 1300, 140, 210, 0.5);
+		click(c, 1300, 400, 60);
 		thock(c, 120, 45, 70, 0.18);
 	},
 };


### PR DESCRIPTION

## Before vs after

| Cue | Before | After |
|---|---|---|
| open | noise sweep 320→1900 Hz, 230 ms | click, 2.2 kHz tick, 800 Hz body, 45 ms |
| maximize | noise sweep 600→2600 Hz, 90 ms | bare tick, 3.4 kHz, 12 ms |
| unmaximize | noise sweep 2600→600 Hz, 90 ms | click, 3 kHz tick, 1.1 kHz body, 40 ms |
| minimize | noise sweep 1900→280 Hz, 260 ms | click, 1.6 kHz tick, 520 Hz body, 55 ms |
| close | noise sweep 1300→140 Hz, 210 ms + thud | click, 1.3 kHz tick, 400 Hz body, 60 ms + thud |
| key tick, hover | cuelume | unchanged |

