### PR TITLE
feat(website): desktop sounds default to a third of the volume and get a slider

### DIFF
--- a/packages/website/src/components/macos/menu-bar.tsx
+++ b/packages/website/src/components/macos/menu-bar.tsx
@@ -2,11 +2,13 @@
 
 import { Volume2, VolumeX } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import {
 	play,
 	setSoundsEnabled,
+	setSoundsVolume,
 	soundsEnabled,
+	soundsVolume,
 	subscribeSounds,
 } from "@/lib/sounds";
 
@@ -35,14 +37,17 @@ const AppleGlyph = () => (
 	</svg>
 );
 
-/** The strip along the top of the desktop: a clock and a mute switch. */
+/** The strip along the top of the desktop: a clock and a volume control. */
 export const MenuBar = ({ section }: { section: string }) => {
 	const [now, setNow] = useState<Date | null>(null);
+	const [volumeOpen, setVolumeOpen] = useState(false);
+	const volumeRef = useRef<HTMLDivElement>(null);
 	const sounds = useSyncExternalStore(
 		subscribeSounds,
 		soundsEnabled,
 		() => true
 	);
+	const volume = useSyncExternalStore(subscribeSounds, soundsVolume, () => 1);
 
 	const toggleSounds = () => {
 		if (sounds) {
@@ -53,6 +58,19 @@ export const MenuBar = ({ section }: { section: string }) => {
 			play("toggle");
 		}
 	};
+
+	useEffect(() => {
+		if (!volumeOpen) {
+			return;
+		}
+		const close = (event: PointerEvent) => {
+			if (!volumeRef.current?.contains(event.target as Node)) {
+				setVolumeOpen(false);
+			}
+		};
+		document.addEventListener("pointerdown", close);
+		return () => document.removeEventListener("pointerdown", close);
+	}, [volumeOpen]);
 
 	useEffect(() => {
 		setNow(new Date());
@@ -86,15 +104,47 @@ export const MenuBar = ({ section }: { section: string }) => {
 				GitHub
 			</a>
 			<div className="ml-auto flex items-center gap-4">
-				<button
-					aria-label="Sounds"
-					aria-pressed={sounds}
-					className="flex cursor-pointer items-center hover:text-white"
-					onClick={toggleSounds}
-					type="button"
-				>
-					{sounds ? <Volume2 size={12} /> : <VolumeX size={12} />}
-				</button>
+				<div className="relative flex items-center" ref={volumeRef}>
+					<button
+						aria-expanded={volumeOpen}
+						aria-label="Volume"
+						className="flex cursor-pointer items-center hover:text-white"
+						onClick={() => setVolumeOpen((open) => !open)}
+						type="button"
+					>
+						{sounds && volume > 0 ? (
+							<Volume2 size={12} />
+						) : (
+							<VolumeX size={12} />
+						)}
+					</button>
+					{volumeOpen && (
+						<div className="absolute top-full right-0 mt-1 flex items-center gap-2 rounded-md border border-white/10 bg-black/70 px-2 py-1.5 backdrop-blur-xl">
+							<button
+								aria-label={sounds ? "Mute" : "Unmute"}
+								aria-pressed={!sounds}
+								className="flex cursor-pointer items-center hover:text-white"
+								onClick={toggleSounds}
+								type="button"
+							>
+								{sounds ? <Volume2 size={12} /> : <VolumeX size={12} />}
+							</button>
+							<input
+								aria-label="Volume level"
+								className="h-1 w-20 cursor-pointer accent-white"
+								max={100}
+								min={0}
+								onChange={(event) =>
+									setSoundsVolume(Number(event.target.value) / 100)
+								}
+								onKeyUp={() => play("tick")}
+								onPointerUp={() => play("tick")}
+								type="range"
+								value={Math.round(volume * 100)}
+							/>
+						</div>
+					)}
+				</div>
 				<span className="hidden sm:inline">{now ? formatDate(now) : ""}</span>
 				<span>{now ? formatClock(now) : CLOCK_PLACEHOLDER}</span>
 			</div>

--- a/packages/website/src/components/macos/menu-bar.tsx
+++ b/packages/website/src/components/macos/menu-bar.tsx
@@ -125,7 +125,6 @@ export const MenuBar = ({ section }: { section: string }) => {
 						<div className="absolute top-full right-0 mt-1 flex items-center gap-2 rounded-md border border-white/10 bg-black/70 px-2 py-1.5 backdrop-blur-xl">
 							<button
 								aria-label={sounds ? "Mute" : "Unmute"}
-								aria-pressed={!sounds}
 								className="flex cursor-pointer items-center hover:text-white"
 								onClick={toggleSounds}
 								type="button"

--- a/packages/website/src/components/macos/menu-bar.tsx
+++ b/packages/website/src/components/macos/menu-bar.tsx
@@ -79,7 +79,7 @@ export const MenuBar = ({ section }: { section: string }) => {
 	}, []);
 
 	return (
-		<div className="flex h-6 shrink-0 items-center gap-4 whitespace-nowrap bg-black/40 px-4 text-[11px] text-white/80 backdrop-blur-xl">
+		<div className="relative z-30 flex h-6 shrink-0 items-center gap-4 whitespace-nowrap bg-black/40 px-4 text-[11px] text-white/80 backdrop-blur-xl">
 			<Link className="flex items-center" href="/">
 				<AppleGlyph />
 			</Link>
@@ -109,7 +109,10 @@ export const MenuBar = ({ section }: { section: string }) => {
 						aria-expanded={volumeOpen}
 						aria-label="Volume"
 						className="flex cursor-pointer items-center hover:text-white"
-						onClick={() => setVolumeOpen((open) => !open)}
+						onClick={() => {
+							play("toggle");
+							setVolumeOpen((open) => !open);
+						}}
 						type="button"
 					>
 						{sounds && volume > 0 ? (
@@ -131,7 +134,7 @@ export const MenuBar = ({ section }: { section: string }) => {
 							</button>
 							<input
 								aria-label="Volume level"
-								className="h-1 w-20 cursor-pointer accent-white"
+								className="h-4 w-24 cursor-pointer accent-white"
 								max={100}
 								min={0}
 								onChange={(event) =>

--- a/packages/website/src/lib/sounds.ts
+++ b/packages/website/src/lib/sounds.ts
@@ -1,4 +1,10 @@
-import { bind, play as cuelume, type SoundName, setEnabled } from "cuelume";
+import {
+	bind,
+	play as cuelume,
+	type SoundName,
+	setEnabled,
+	setVolume,
+} from "cuelume";
 
 export type Cue =
 	| SoundName
@@ -9,11 +15,14 @@ export type Cue =
 	| "close";
 
 const STORAGE_KEY = "nestjs-doctor:sounds";
+const VOLUME_KEY = "nestjs-doctor:volume";
+const DEFAULT_VOLUME = 1 / 3;
 const SILENT = 0.0001;
 
 let context: AudioContext | null = null;
 let noise: AudioBuffer | null = null;
 let enabled: boolean | null = null;
+let volume: number | null = null;
 const listeners = new Set<() => void>();
 
 /** The stored preference; unknown or unreadable storage counts as on. */
@@ -28,10 +37,27 @@ export const soundsEnabled = (): boolean => {
 	return enabled;
 };
 
-/** Wires the data-cuelume attributes once and applies the stored preference. */
+const clamp = (value: number): number =>
+	Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : DEFAULT_VOLUME;
+
+/** The stored master volume from 0 to 1; unknown or unreadable storage is the default. */
+export const soundsVolume = (): number => {
+	if (volume === null) {
+		try {
+			const stored = localStorage.getItem(VOLUME_KEY);
+			volume = stored === null ? DEFAULT_VOLUME : clamp(Number(stored));
+		} catch {
+			volume = DEFAULT_VOLUME;
+		}
+	}
+	return volume;
+};
+
+/** Wires the data-cuelume attributes once and applies the stored preferences. */
 export const bindSounds = () => {
 	bind();
 	setEnabled(soundsEnabled());
+	setVolume(soundsVolume());
 };
 
 export const subscribeSounds = (listener: () => void) => {
@@ -49,6 +75,19 @@ export const setSoundsEnabled = (on: boolean) => {
 	}
 	try {
 		localStorage.setItem(STORAGE_KEY, on ? "on" : "off");
+	} catch {
+		// Storage is unavailable; the choice lasts for this page.
+	}
+};
+
+export const setSoundsVolume = (value: number) => {
+	volume = clamp(value);
+	setVolume(volume);
+	for (const listener of listeners) {
+		listener();
+	}
+	try {
+		localStorage.setItem(VOLUME_KEY, String(volume));
 	} catch {
 		// Storage is unavailable; the choice lasts for this page.
 	}
@@ -84,7 +123,10 @@ const envelope = (
 	const gain = c.createGain();
 	const t = c.currentTime;
 	gain.gain.setValueAtTime(SILENT, t);
-	gain.gain.exponentialRampToValueAtTime(peak, t + attack / 1000);
+	gain.gain.exponentialRampToValueAtTime(
+		Math.max(peak * soundsVolume(), SILENT),
+		t + attack / 1000
+	);
 	gain.gain.exponentialRampToValueAtTime(SILENT, t + ms / 1000);
 	gain.connect(c.destination);
 	return gain;

--- a/packages/website/src/lib/sounds.ts
+++ b/packages/website/src/lib/sounds.ts
@@ -67,30 +67,32 @@ export const subscribeSounds = (listener: () => void) => {
 	};
 };
 
-export const setSoundsEnabled = (on: boolean) => {
-	enabled = on;
-	setEnabled(on);
+const notify = () => {
 	for (const listener of listeners) {
 		listener();
 	}
+};
+
+const persist = (key: string, value: string) => {
 	try {
-		localStorage.setItem(STORAGE_KEY, on ? "on" : "off");
+		localStorage.setItem(key, value);
 	} catch {
 		// Storage is unavailable; the choice lasts for this page.
 	}
 };
 
+export const setSoundsEnabled = (on: boolean) => {
+	enabled = on;
+	setEnabled(on);
+	notify();
+	persist(STORAGE_KEY, on ? "on" : "off");
+};
+
 export const setSoundsVolume = (value: number) => {
 	volume = clamp(value);
 	setVolume(volume);
-	for (const listener of listeners) {
-		listener();
-	}
-	try {
-		localStorage.setItem(VOLUME_KEY, String(volume));
-	} catch {
-		// Storage is unavailable; the choice lasts for this page.
-	}
+	notify();
+	persist(VOLUME_KEY, String(volume));
 };
 
 const audio = (): AudioContext => {


### PR DESCRIPTION
## Context

#394 and #396 gave the landing desktop interaction sounds: cuelume cues on buttons, links and keys, and in-house Web Audio clicks on window actions. Both sources play at full gain and the only control is the mute switch in the menu bar.

## Problem

The sounds are too loud on first visit and there is no way to turn them down short of muting. Clicking the speaker icon was the only volume UI.

## Possible flows

| Path | Affected |
|---|---|
| First visit, nothing stored | Yes: volume now defaults to 1/3 |
| Returning visit with `nestjs-doctor:volume` stored | Uses the stored value |
| Mute stored `off` | Unchanged: nothing plays |
| cuelume cues (press, tick, toggle, success) | Scaled through `setVolume` |
| Window cues (open, maximize, minimize, close) | Scaled in `envelope()` |

## Solution

- `lib/sounds.ts`: a `volume` preference next to `enabled`, stored under `nestjs-doctor:volume`, default `1/3`, clamped to `[0, 1]`. cuelume gets it through `setVolume`; the window cues multiply their envelope peak by it. `bindSounds` applies it on mount.
- `menu-bar.tsx`: the speaker icon opens a popover with the mute button and a 0–100 range slider. Clicking the icon still plays the `toggle` cue. The popover closes on a pointerdown outside it.
- The menu bar gets `relative z-30`. Without it the stage, a later sibling, painted the terminal window over the popover, which is why the first cut of the slider could not be clicked. Verified with `elementFromPoint` and a real pointer drag against a dev server.

Not done: no per-cue volumes, no keyboard shortcut. cuelume's own `volume` option is untouched.

## Before vs after

| | Before | After |
|---|---|---|
| Default gain | 1.0 | 0.33 |
| Speaker icon click | Toggles mute, plays `toggle` | Opens popover, plays `toggle` |
| Mute | In the bar | In the popover, same behaviour |
| Volume slider | None | 0–100, stored per browser |
| Stored mute `off` | Silent | Silent |

## Example

Fresh browser, `localStorage` empty, click the speaker icon: the popover opens with the slider at 33. Drag it to 43: `localStorage["nestjs-doctor:volume"]` becomes `"0.43"` and the next window cue plays at 0.43 of its peak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
