### PR TITLE
chore: release notes in one-line style, every pending bump a patch

### DIFF
--- a/.changeset/console-not-scored-heading.md
+++ b/.changeset/console-not-scored-heading.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-Console reports now print findings from rules that do not carry the `score` surface under a `Not scored` heading, after every finding that moves the score. The interactive view lists those rules last too. No score, exit code, or machine-readable output changes.
+Print findings from rules without the `score` surface under a `Not scored` heading after every scored finding in the console report, and last in the interactive view; scores, exit codes and machine-readable output are unchanged.

--- a/.changeset/custom-provider-export-consumers.md
+++ b/.changeset/custom-provider-export-consumers.md
@@ -2,6 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-### Fixed
-
-`performance/no-unused-module-exports` no longer flags an export consumed only through an object-literal custom provider. A consumer registered as `{ provide: 'TOKEN', useClass: Notifier }` (or `useExisting`) now counts: the target itself is treated as used, and the rule reads its constructor the same way it already does for a plain `providers: [Notifier]` entry. So `{ provide: 'MAILER', useExisting: MailService }` in a module importing `MailModule` no longer reports `MailService` as unused.
+Stop `performance/no-unused-module-exports` flagging an export consumed only through an object-literal provider: `{ provide: 'MAILER', useExisting: MailService }` or `useClass` in a module importing `MailModule` now counts `MailService` as used.

--- a/.changeset/interactive-report-telemetry-gate.md
+++ b/.changeset/interactive-report-telemetry-gate.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-A report generated from the post-scan menu now honours `--no-telemetry`, `DO_NOT_TRACK`, and the `telemetry` and `report.telemetry` config keys. Before, the interactive path always embedded the report beacon; `--report` and the Node API already respected them. Also adds a NestJS 12 ESM fixture to the integration suite and documents a clean scan as an expected result.
+Honour `--no-telemetry`, `DO_NOT_TRACK` and the `telemetry` and `report.telemetry` config keys for a report generated from the post-scan menu, which always embedded the report beacon before; the integration suite gains a NestJS 12 ESM fixture.

--- a/.changeset/module-graph-cycles-per-declaration.md
+++ b/.changeset/module-graph-cycles-per-declaration.md
@@ -2,12 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-### Fixed
-
-`architecture/no-circular-module-deps` no longer reports a cycle that exists in no file. Two `@Module()` classes sharing a name are analyzed as one module, and cycle detection walked the union of their imports, so two acyclic files — one declaring `CoreModule` importing `UsersModule`, another declaring `UsersModule` importing `CoreModule` — reported `CoreModule -> UsersModule` at `error` severity.
-
-Cycle detection now walks each declaration separately and picks the target of an imported name by following the import statement that reaches it: the declaration in the resolved file, else one in the importing file, else every declaration carrying the name. So a cycle is reported only when one declaration chain actually closes, in the one-module-per-file layout as well as in files declaring several modules. A real cycle whose member is also declared elsewhere is still reported, once.
-
-Not covered: file attribution of a real cycle among same-name modules still anchors to the first declaration, and the HTML report's module picture still draws the union of every declaration's edges, so it can show an edge the rule no longer flags.
-
-This is a regression from 0.9.x, where same-name modules started merging instead of overwriting each other. `no-circular-module-deps` was the only rule affected; the module graph's `edges`, the report's graph, and the other five rules reading it are unchanged. Scores rise wherever this phantom cycle was firing.
+Stop `architecture/no-circular-module-deps` reporting a cycle that exists in no file: two `@Module()` classes sharing a name were analysed as one module with their imports unioned, so two acyclic files reported `CoreModule -> UsersModule` at `error`. Detection now walks each declaration and follows each import statement to the file it resolves to; a real cycle is still reported once. A regression from 0.9.x, and scores rise wherever it fired.

--- a/.changeset/module-imports-one-record.md
+++ b/.changeset/module-imports-one-record.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-`ModuleNode.importsByFile` now holds, per declaration file, both the imported module names and the file each import statement resolves to (`{ names, targets }`); the separate `importTargetsByFile` field is gone. Both fields were added in this release cycle, so nothing published changes shape, and no diagnostic changes. Custom rules that read `moduleGraph.modules` see the same `imports`, `exports` and `providers` as before.
+Fold `ModuleNode.importTargetsByFile` into `importsByFile` as `{ names, targets }` per declaration file; both fields are new this cycle, so no published shape or diagnostic changes.

--- a/.changeset/no-hardcoded-secrets-identifier-shape.md
+++ b/.changeset/no-hardcoded-secrets-identifier-shape.md
@@ -2,14 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-### Fixed
-
-`security/no-hardcoded-secrets` no longer flags identifier-shaped strings assigned to a suspicious name: header names (`x-api-key`), config/cache keys (`apikey:lookup:v2`), storage keys (`auth_token_storage`), file paths (`my-app/prod/db-credentials`), constant names (`JWT_SECRET_TOKEN_PROVIDER`, `DATABASE_PASSWORD`), password-strength regexes, and single title-cased words such as `Authorization`. A value with a digit segment still fires unless that segment is a version tag like `v2`. A value counts as a regex source only when it is anchored with `^`, or contains `(?` or a backslash escape (`\d`, `\w`, `\s`, …), so passwords carrying symbols — `P@ssw0rd(2024)!`, `Xk9*mQ2*vL7wRt4z`, `a7Fk92Lm3Qp0Zx8w$`, `S3cure[Pass]word` — still report.
-
-The 64-character hex digest is no longer a pattern of its own. It is reported only through a suspicious binding name, and then once, so a SHA-256 fixture digest, a TypeORM migration id, or a GraphQL persisted-query hash no longer reports as a secret, and `apiSecret` holding one no longer reports twice on the same line.
-
-A `user:pass` or `user/pass` credential pair under a suspicious name still reports (`authToken = 'admin:supersecret'`, `password = 'admin/administrator'`), unless its first segment names the binding the way a permission scope does (`password: 'password:update'`).
-
-The rule accepts a false negative on a purely alphabetic value of three or more words joined by hyphens, underscores or dots, and on two-word values not joined by a colon or slash, when assigned to a suspicious name: `correct-horse-battery-staple`, `super-secret-key-value`, `super_secret_password`, `my-super-secret-jwt-key`, `SuperSecret_Value`. They read as config keys or low-entropy placeholders, and the vendor-format patterns (`sk_live_`, `ghp_`, `AKIA`, JWT, …) still catch a real credential regardless of what it is assigned to.
-
-Scores rise wherever this rule was previously firing on non-secrets.
+Stop `security/no-hardcoded-secrets` flagging identifier-shaped strings under a suspicious name: header names (`x-api-key`), config and storage keys, file paths, constant names (`JWT_SECRET_TOKEN_PROVIDER`), password-strength regexes and single title-cased words, and stop reporting a bare 64-character hex digest on its own, so migration ids and persisted-query hashes are quiet. Vendor formats (`sk_live_`, `ghp_`, `AKIA`, JWT), `user:pass` pairs and symbol-bearing passwords such as `P@ssw0rd(2024)!` still report; a purely alphabetic phrase like `correct-horse-battery-staple` is an accepted false negative. Scores rise wherever the rule fired on non-secrets.

--- a/.changeset/quiet-guards-bound-globally.md
+++ b/.changeset/quiet-guards-bound-globally.md
@@ -2,8 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-### Fixed
-
-`security/require-guards-on-endpoints` no longer reports every endpoint in an app that binds its guard with `app.useGlobalGuards(guard)`, and no longer reports a controller that inherits a guard from the base class it extends. The call counts only with at least one argument and only on the HTTP app: a `NestFactory.create()` result, or a variable or parameter typed as a Nest application such as `INestApplication`. A guard bound on a microservice handle, or an empty `app.useGlobalGuards()`, leaves HTTP endpoints reported.
-
-Scores rise on any project that binds its guard globally or inherits it: the rule fired once per handler at 2.25 points each, which makes this the largest score mover of the four fixes in this release.
+Stop `security/require-guards-on-endpoints` reporting every endpoint in an app that binds its guard with `app.useGlobalGuards(guard)` on a `NestFactory.create()` result or an `INestApplication`-typed variable, or a controller inheriting a guard from its base class; an empty call or one on a microservice handle still leaves endpoints reported. At 2.25 points per handler this is the largest score mover in the release.

--- a/.changeset/quiet-moons-jump.md
+++ b/.changeset/quiet-moons-jump.md
@@ -3,6 +3,4 @@
 "nestjs-doctor-lsp": patch
 ---
 
-The first console scan on a machine now prints one line pointing at the VS Code extension and the `nestjs-doctor-lsp` language server, then never again. It is never printed in CI, inside a coding agent, in a machine-readable format, when stderr is not a TTY, once the language server has already run, or on a machine where the marker could not be written.
-
-The first-run telemetry notice is gone. It printed the same once-per-install line budget on a message nobody had asked for; [the telemetry page](https://nestjs.doctor/docs/telemetry) still documents every field and every opt-out.
+Print one line on the first console scan on a machine pointing at the VS Code extension and the `nestjs-doctor-lsp` language server, then never again, and never in CI, inside a coding agent, in a machine-readable format, off a TTY, or once the language server has run. The first-run telemetry notice is gone; [the telemetry page](https://nestjs.doctor/docs/telemetry) still documents every field and every opt-out.

--- a/.changeset/rules-timestamps-orm-narrowed.md
+++ b/.changeset/rules-timestamps-orm-narrowed.md
@@ -2,8 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-### Changed
-
-`schema/require-timestamps` drops from `warning` to `info`. Each entity it reports now costs `0.5 × 1.1 = 0.55` penalty points instead of `1.5 × 1.1 = 1.65`, so schema-heavy projects' scores rise. Runs gated with `--blocking warning` no longer fail on this rule. Join tables, entities whose every column is a primary key or a relation's own column, are no longer reported at all.
-
-`architecture/no-orm-in-services` no longer reports `PrismaService`/`PrismaClient`, so the official NestJS Prisma recipe is quiet. The "you can disable this rule" sentence is gone from its `help`.
+Drop `schema/require-timestamps` from `warning` to `info` (0.55 points per entity instead of 1.65, and `--blocking warning` no longer fails on it) and skip join tables; `architecture/no-orm-in-services` no longer reports `PrismaService` or `PrismaClient`, so the official Prisma recipe is quiet.

--- a/.changeset/tagline-one-string.md
+++ b/.changeset/tagline-one-string.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-One tagline everywhere the package describes itself. The npm description, the `--help` header and the agent skill's opening line now all lead with "The deterministic NestJS devtool that catches AI mistakes." The `--help` header also loses its em dash.
+Lead the npm description, the `--help` header and the agent skill with one tagline: "The deterministic NestJS devtool that catches AI mistakes."

--- a/.changeset/tagline-vscode.md
+++ b/.changeset/tagline-vscode.md
@@ -2,4 +2,4 @@
 "nestjs-doctor-vscode": patch
 ---
 
-The extension's marketplace description and its README both lead with the tagline the rest of the project uses.
+Lead the marketplace description and the README with the tagline the rest of the project uses.

--- a/.changeset/telemetry-norm-engine.md
+++ b/.changeset/telemetry-norm-engine.md
@@ -1,11 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
-Bring scan telemetry up to the norm other JS CLIs follow.
-
-A scan run in CI now reports as `ci.<provider>.<hash>`, where the hash is a one-way digest of the numeric repository id the runner provides (`GITHUB_REPOSITORY_ID`, or `CI_PROJECT_ID` on GitLab). Every run of one repository counted as one anonymous install before, and every repository in CI shared a single id per provider. The salt ships in the package, so this id is pseudonymous rather than anonymous: it is derived from an opaque number, never from the repository name, the checkout path, a remote URL, or a commit sha, and no project id is sent from CI.
-
-`NESTJS_DOCTOR_TELEMETRY_DEBUG=1` prints the exact scan payload to stderr and sends nothing, so what a scan reports can be read before it leaves the machine.
-
-The `--telemetry` help text and the GitHub Action's `telemetry` input now name all three opt-outs, the debug variable, and the repository hash.
+Report a CI scan as `ci.<provider>.<hash>`, a one-way digest of the runner's numeric repository id (`GITHUB_REPOSITORY_ID`, `CI_PROJECT_ID`), instead of one shared anonymous id per provider; it is never derived from the repository name, path, remote URL or commit sha. `NESTJS_DOCTOR_TELEMETRY_DEBUG=1` prints the exact scan payload to stderr and sends nothing, and the `--telemetry` help and the Action's `telemetry` input name every opt-out.

--- a/.changeset/telemetry-scan-shape.md
+++ b/.changeset/telemetry-scan-shape.md
@@ -1,18 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
-### Added
-
-Six fields on the `scan_completed` payload:
-
-| Field | Value |
-|---|---|
-| `trigger` | How the run started: `action`, `ci`, `hook`, `agent`, `script`, `npx` or `global` |
-| `scan_id` | A random UUID per run, shared with the HTML report's beacon |
-| `output_format` | The `--format` value, plus `report` for a `--report` run |
-| `report_requested` | Whether the run was a `--report` run |
-| `total_ms` | Wall time for the whole run; `duration_ms` still covers the rules on a single project and the whole scan on a monorepo |
-| `suppressed_inline` | Built-in rule id to a count of findings silenced by an inline comment |
-
-A `--report` run now reports `scan_completed`, where it previously sent nothing.
+Add `trigger`, `scan_id`, `output_format`, `report_requested`, `total_ms` and `suppressed_inline` to the `scan_completed` payload, and send it for `--report` runs, which reported nothing before.


### PR DESCRIPTION
## Context

The changesets bot keeps PR #382 (Version Packages) in sync with the changesets on main: it runs `changeset version`, force-pushes `changeset-release/main`, and rewrites the PR body from the generated changelog. The notes for 0.9.4 and 0.9.5 are one-line bullets under `### Patch Changes`; 0.9.2 was folded the same way on main in c3b84304 before release.

## Problem

The fourteen pending changesets carry `### Fixed` headings, a table and multi-paragraph bodies, so #382 nests each under a bullet with a heading inside it, unlike every recent release. Two of them are `minor`, so #382 proposes `nestjs-doctor@0.10.0` for a release that is fixes, telemetry fields and copy.

## Possible flows

| Path | Effect |
|---|---|
| Merge this PR | bot regenerates #382 as 0.9.6 / 4.1.2 / 0.1.5 with one-line entries |
| Merge #382 after that | publishes those versions with these notes |
| Any other PR merged to main first | bot regenerates #382 either way; this PR still applies |

## Solution

Rewrote each changeset as one entry in the 0.9.5 style, keeping what still fires and what moves the score, and set the two `minor` changesets to `patch`. No code changes. `changeset status` reports all three packages as patch.

Not done: the bot prefixes each bullet with a commit hash. 0.9.4 and 0.9.5 had those stripped on the release branch right before merging (0e6730ec); that is a follow-up on `changeset-release/main` once the bot has regenerated it, since anything pushed there earlier is overwritten.

## Before vs after

| | Before | After |
|---|---|---|
| `nestjs-doctor` | 0.10.0 (minor) | 0.9.6 (patch) |
| `nestjs-doctor-lsp` | 4.1.2 | 4.1.2 |
| `nestjs-doctor-vscode` | 0.1.5 | 0.1.5 |
| Entry shape | heading + paragraphs, one table | one entry each |
| Changeset count | 14 | 14 |

## Example

`security/require-guards-on-endpoints` before:

```
- 04fdd28: ### Fixed

  `security/require-guards-on-endpoints` no longer reports every endpoint in an app that binds its guard with `app.useGlobalGuards(guard)`, and no longer reports a controller that inherits a guard from the base class it extends. The call counts only with at least one argument and only on the HTTP app: a `NestFactory.create()` result, or a variable or parameter typed as a Nest application such as `INestApplication`. A guard bound on a microservice handle, or an empty `app.useGlobalGuards()`, leaves HTTP endpoints reported.

  Scores rise on any project that binds its guard globally or inherits it: the rule fired once per handler at 2.25 points each, which makes this the largest score mover of the four fixes in this release.
```

After:

```
- Stop `security/require-guards-on-endpoints` reporting every endpoint in an app that binds its guard with `app.useGlobalGuards(guard)` on a `NestFactory.create()` result or an `INestApplication`-typed variable, or a controller inheriting a guard from its base class; an empty call or one on a microservice handle still leaves endpoints reported. At 2.25 points per handler this is the largest score mover in the release.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjSReP4FCbUcwjtdgWn4iV