### PR TITLE
fix(engine): a decorator composing UseGuards counts as a guard

### DIFF
--- a/.changeset/composed-guard-decorators.md
+++ b/.changeset/composed-guard-decorators.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-A decorator that composes `UseGuards` now counts as a guard even when it returns the call directly instead of wrapping it in `applyDecorators`, when it is written as `export const X = function () {...}`, and when it is declared in one package and used in another. `security/require-guards-on-endpoints` drops from 246 findings to 22 on a 249-route monorepo whose auth decorator lives in a shared library.
+A decorator that composes `UseGuards` now counts as a guard even when it returns the call directly instead of wrapping it in `applyDecorators`, when it is written as `export const X = function () {...}`, and when it is declared in one package and used in another. A decorator only counts when every path out of it returns a guard, so one that guards on a single branch no longer clears a route. `security/require-guards-on-endpoints` drops from 246 findings to 22 on a 249-route monorepo whose auth decorator lives in a shared library.

--- a/.changeset/composed-guard-decorators.md
+++ b/.changeset/composed-guard-decorators.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+A decorator that composes `UseGuards` now counts as a guard even when it returns the call directly instead of wrapping it in `applyDecorators`, when it is written as `export const X = function () {...}`, and when it is declared in one package and used in another. `security/require-guards-on-endpoints` drops from 246 findings to 22 on a 249-route monorepo whose auth decorator lives in a shared library.

--- a/packages/nestjs-doctor/src/engine/diagnostician.ts
+++ b/packages/nestjs-doctor/src/engine/diagnostician.ts
@@ -5,7 +5,10 @@ import type { Diagnostic } from "../common/diagnostic.js";
 import type { RuleErrorInfo } from "../common/result.js";
 import type { AnalysisContext } from "./analysis-context.js";
 import { filterIgnoredDiagnostics } from "./filter-diagnostics.js";
-import { guardDecoratorNames } from "./graph/guard-decorators.js";
+import {
+	guardDecoratorNames,
+	isGuardDecorator,
+} from "./graph/guard-decorators.js";
 import { posixDirname } from "./graph/module-graph.js";
 import { filterSuppressedDiagnostics } from "./inline-suppressions.js";
 import { baseClassName, isInjectable } from "./nest-class-inspector.js";
@@ -211,10 +214,7 @@ function fileRuleFacts(context: AnalysisContext): FileRuleFacts {
 		for (const cls of sourceFile.getClasses()) {
 			const guarded = cls
 				.getDecorators()
-				.some(
-					(d) =>
-						d.getName() === "UseGuards" || composedDecorators.has(d.getName())
-				);
+				.some((d) => isGuardDecorator(d, composedDecorators));
 			if (!guarded) {
 				continue;
 			}

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -1,4 +1,4 @@
-import type { Node, Project, SourceFile } from "ts-morph";
+import type { Decorator, Node, Project, SourceFile } from "ts-morph";
 import { SyntaxKind } from "ts-morph";
 import { YIELD_INTERVAL, yieldToEventLoop } from "../yield.js";
 
@@ -42,9 +42,15 @@ function argumentApplies(argument: Node): boolean {
 	return elements ? elements.some(argumentApplies) : false;
 }
 
-/** True when an argument of `applyDecorators(...)` always applies a guard. */
+/** True for `UseGuards(...)` itself, or an `applyDecorators(...)` that applies one. */
 function appliesGuards(expression: Node | undefined): boolean {
-	const call = expression?.asKind(SyntaxKind.CallExpression);
+	if (!expression) {
+		return false;
+	}
+	if (isUseGuardsCall(expression)) {
+		return true;
+	}
+	const call = expression.asKind(SyntaxKind.CallExpression);
 	if (call?.getExpression().getText() !== "applyDecorators") {
 		return false;
 	}
@@ -81,6 +87,65 @@ function returnedExpressions(fn: Node): Node[] {
 	return expressions;
 }
 
+/** The function a declaration implements: itself, or its initialiser. */
+function declaredFunction(declaration: Node): Node | undefined {
+	if (declaration.isKind(SyntaxKind.FunctionDeclaration)) {
+		return declaration;
+	}
+	const initializer = declaration
+		.asKind(SyntaxKind.VariableDeclaration)
+		?.getInitializer();
+	return (
+		initializer?.asKind(SyntaxKind.ArrowFunction) ??
+		initializer?.asKind(SyntaxKind.FunctionExpression)
+	);
+}
+
+/** Verdicts keyed by declaration position, so each implementation is read once. */
+const compositionCache = new Map<string, boolean>();
+
+/**
+ * True when this decorator's implementation applies a guard. Resolves the name
+ * to its declaration, so a decorator declared in another project still counts.
+ */
+export function decoratorAppliesGuards(decorator: Decorator): boolean {
+	const symbol = decorator.getNameNode().getSymbol();
+	const declarations = (
+		symbol?.getAliasedSymbol() ?? symbol
+	)?.getDeclarations();
+	if (!declarations?.length) {
+		return false;
+	}
+	const first = declarations[0];
+	const key = `${first.getSourceFile().getFilePath()}:${first.getPos()}:${first.getEnd()}:${declarations.length}`;
+	const cached = compositionCache.get(key);
+	if (cached !== undefined) {
+		return cached;
+	}
+	const applies = declarations.some((declaration) => {
+		const fn = declaredFunction(declaration);
+		return fn ? returnedExpressions(fn).some(appliesGuards) : false;
+	});
+	compositionCache.set(key, applies);
+	return applies;
+}
+
+/**
+ * True when a decorator binds a guard: `@UseGuards`, a name the index already
+ * knows, or a composition its declaration spells out.
+ */
+export function isGuardDecorator(
+	decorator: Decorator,
+	composed: ReadonlySet<string> | undefined
+): boolean {
+	const name = decorator.getName();
+	return (
+		name === "UseGuards" ||
+		composed?.has(name) === true ||
+		decoratorAppliesGuards(decorator)
+	);
+}
+
 /** Names in one file whose implementation composes `UseGuards`. */
 function namesInFile(sourceFile: SourceFile): Set<string> {
 	const names = new Set<string>();
@@ -93,10 +158,8 @@ function namesInFile(sourceFile: SourceFile): Set<string> {
 	}
 
 	for (const declaration of sourceFile.getVariableDeclarations()) {
-		const arrow = declaration
-			.getInitializer()
-			?.asKind(SyntaxKind.ArrowFunction);
-		if (arrow && returnedExpressions(arrow).some(appliesGuards)) {
+		const fn = declaredFunction(declaration);
+		if (fn && returnedExpressions(fn).some(appliesGuards)) {
 			names.add(declaration.getName());
 		}
 	}

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -87,6 +87,12 @@ function returnedExpressions(fn: Node): Node[] {
 	return expressions;
 }
 
+/** True when every path out of `fn` returns a guard, and there is at least one. */
+function functionAppliesGuards(fn: Node): boolean {
+	const returns = returnedExpressions(fn);
+	return returns.length > 0 && returns.every(appliesGuards);
+}
+
 /** The function a declaration implements: itself, or its initialiser. */
 function declaredFunction(declaration: Node): Node | undefined {
 	if (declaration.isKind(SyntaxKind.FunctionDeclaration)) {
@@ -101,12 +107,12 @@ function declaredFunction(declaration: Node): Node | undefined {
 	);
 }
 
-/** Verdicts keyed by declaration position, so each implementation is read once. */
-const compositionCache = new Map<string, boolean>();
+/** Verdicts keyed by the declaration node. */
+const compositionCache = new WeakMap<Node, boolean>();
 
 /**
  * True when this decorator's implementation applies a guard. Resolves the name
- * to its declaration, so a decorator declared in another project still counts.
+ * to its declaration through the type checker.
  */
 export function decoratorAppliesGuards(decorator: Decorator): boolean {
 	const symbol = decorator.getNameNode().getSymbol();
@@ -117,16 +123,15 @@ export function decoratorAppliesGuards(decorator: Decorator): boolean {
 		return false;
 	}
 	const first = declarations[0];
-	const key = `${first.getSourceFile().getFilePath()}:${first.getPos()}:${first.getEnd()}:${declarations.length}`;
-	const cached = compositionCache.get(key);
+	const cached = compositionCache.get(first);
 	if (cached !== undefined) {
 		return cached;
 	}
 	const applies = declarations.some((declaration) => {
 		const fn = declaredFunction(declaration);
-		return fn ? returnedExpressions(fn).some(appliesGuards) : false;
+		return fn ? functionAppliesGuards(fn) : false;
 	});
-	compositionCache.set(key, applies);
+	compositionCache.set(first, applies);
 	return applies;
 }
 
@@ -152,14 +157,14 @@ function namesInFile(sourceFile: SourceFile): Set<string> {
 
 	for (const fn of sourceFile.getFunctions()) {
 		const name = fn.getName();
-		if (name && returnedExpressions(fn).some(appliesGuards)) {
+		if (name && functionAppliesGuards(fn)) {
 			names.add(name);
 		}
 	}
 
 	for (const declaration of sourceFile.getVariableDeclarations()) {
 		const fn = declaredFunction(declaration);
-		if (fn && returnedExpressions(fn).some(appliesGuards)) {
+		if (fn && functionAppliesGuards(fn)) {
 			names.add(declaration.getName());
 		}
 	}

--- a/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
+++ b/packages/nestjs-doctor/src/engine/graph/guard-decorators.ts
@@ -58,10 +58,11 @@ function appliesGuards(expression: Node | undefined): boolean {
 }
 
 /**
- * Expressions `fn` itself hands back. Returns belonging to a nested function
- * are skipped, since they say nothing about what `fn` returns.
+ * What `fn` itself hands back, one entry per return, `undefined` for a bare
+ * one. Returns belonging to a nested function are skipped, since they say
+ * nothing about what `fn` returns.
  */
-function returnedExpressions(fn: Node): Node[] {
+function returnedExpressions(fn: Node): (Node | undefined)[] {
 	const body = fn.getChildrenOfKind(SyntaxKind.Block)[0];
 	if (!body) {
 		const arrow = fn.asKind(SyntaxKind.ArrowFunction);
@@ -69,7 +70,7 @@ function returnedExpressions(fn: Node): Node[] {
 		return concise && !concise.isKind(SyntaxKind.Block) ? [concise] : [];
 	}
 
-	const expressions: Node[] = [];
+	const expressions: (Node | undefined)[] = [];
 	for (const statement of body.getDescendantsOfKind(
 		SyntaxKind.ReturnStatement
 	)) {
@@ -79,10 +80,7 @@ function returnedExpressions(fn: Node): Node[] {
 		if (owner !== fn) {
 			continue;
 		}
-		const expression = statement.getExpression();
-		if (expression) {
-			expressions.push(expression);
-		}
+		expressions.push(statement.getExpression());
 	}
 	return expressions;
 }

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -1,4 +1,5 @@
 import type { ClassDeclaration, MethodDeclaration } from "ts-morph";
+import { isGuardDecorator } from "../../../graph/guard-decorators.js";
 import {
 	baseClassName,
 	declaresRoutes,
@@ -21,10 +22,8 @@ function hasGuard(
 ): boolean {
 	return node
 		.getDecorators()
-		.some(
-			(decorator) =>
-				decorator.getName() === "UseGuards" ||
-				guards?.composedDecorators.has(decorator.getName())
+		.some((decorator) =>
+			isGuardDecorator(decorator, guards?.composedDecorators)
 		);
 }
 

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -34,7 +34,7 @@ export const requireGuardsOnEndpoints: Rule = {
 		severity: "warning",
 		description:
 			"Controller endpoints should be protected by @UseGuards() at class or method level",
-		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD or app.useGlobalGuards(), inherited from a guarded base class, or applied by a decorator built with applyDecorators(UseGuards(...)), already counts — but APP_GUARD only when the token is written as APP_GUARD, not through an aliased import.",
+		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD or app.useGlobalGuards(), inherited from a guarded base class, or applied by a decorator whose every return is UseGuards(...), directly or through applyDecorators(...), already counts — but APP_GUARD only when the token is written as APP_GUARD, not through an aliased import.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -34,7 +34,7 @@ export const requireGuardsOnEndpoints: Rule = {
 		severity: "warning",
 		description:
 			"Controller endpoints should be protected by @UseGuards() at class or method level",
-		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD or app.useGlobalGuards(), inherited from a guarded base class, or applied by a decorator whose every return is UseGuards(...), directly or through applyDecorators(...), already counts — but APP_GUARD only when the token is written as APP_GUARD, not through an aliased import.",
+		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD or app.useGlobalGuards(), inherited from a guarded base class, or applied by a decorator whose every return is UseGuards(...), directly or through applyDecorators(...), already counts — but APP_GUARD only when the token is written as APP_GUARD, not through an aliased import, and a decorator imported from a package is only read when that package is installed.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/lib/auth.decorators.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/lib/auth.decorators.ts
@@ -1,0 +1,26 @@
+import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+import { AuthGuard } from './auth.guard';
+
+// Returns UseGuards directly, written as a function expression.
+export const IsAuthnAuthz = function () {
+  return UseGuards(AuthGuard);
+};
+
+// Returns UseGuards directly from a concise arrow body.
+export const StripeAuthorizer = () => UseGuards(AuthGuard);
+
+// Wraps UseGuards in applyDecorators, the long supported shape.
+export function Auth() {
+  return applyDecorators(SetMetadata('audited', true), UseGuards(AuthGuard));
+}
+
+// Composes decorators but binds no guard.
+export const Documented = () => applyDecorators(SetMetadata('documented', true));
+
+// Binds a guard on one path out and nothing on the other.
+export function MaybeAuth(secure: boolean) {
+  if (secure) {
+    return UseGuards(AuthGuard);
+  }
+  return applyDecorators(SetMetadata('public', true));
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/lib/auth.guard.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/lib/auth.guard.ts
@@ -1,0 +1,8 @@
+import { CanActivate, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate() {
+    return true;
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "composed-guard-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/core": "^11.1.18",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/app.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { ApplyDecoratorsController } from './apply-decorators.controller';
+import { ConciseArrowController } from './concise-arrow.controller';
+import { DocumentedController } from './documented.controller';
+import { FunctionExpressionController } from './function-expression.controller';
+import { HandlerLevelController } from './handler-level.controller';
+import { MaybeAuthController } from './maybe-auth.controller';
+import { UnguardedController } from './unguarded.controller';
+
+@Module({
+  controllers: [
+    ApplyDecoratorsController,
+    ConciseArrowController,
+    DocumentedController,
+    FunctionExpressionController,
+    HandlerLevelController,
+    MaybeAuthController,
+    UnguardedController,
+  ],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/apply-decorators.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/apply-decorators.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { Auth } from '../lib/auth.decorators';
+
+@Auth()
+@Controller('apply-decorators')
+export class ApplyDecoratorsController {
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/concise-arrow.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/concise-arrow.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { StripeAuthorizer } from '../lib/auth.decorators';
+
+@StripeAuthorizer()
+@Controller('concise-arrow')
+export class ConciseArrowController {
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/documented.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/documented.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { Documented } from '../lib/auth.decorators';
+
+@Documented()
+@Controller('documented')
+export class DocumentedController {
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/function-expression.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/function-expression.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { IsAuthnAuthz } from '../lib/auth.decorators';
+
+@IsAuthnAuthz()
+@Controller('function-expression')
+export class FunctionExpressionController {
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/handler-level.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/handler-level.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { IsAuthnAuthz } from '../lib/auth.decorators';
+
+@Controller('handler-level')
+export class HandlerLevelController {
+  @IsAuthnAuthz()
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/maybe-auth.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/maybe-auth.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { MaybeAuth } from '../lib/auth.decorators';
+
+@MaybeAuth(false)
+@Controller('maybe-auth')
+export class MaybeAuthController {
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/unguarded.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/composed-guard-app/src/unguarded.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('unguarded')
+export class UnguardedController {
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-guard-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/package-guard-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-guard-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@fixture/auth": "workspace:*",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^11.1.18"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-guard-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-guard-app/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { OrdersController } from './orders.controller';
+
+@Module({
+  controllers: [OrdersController],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/package-guard-app/src/orders.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-guard-app/src/orders.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { PackageAuth } from '@fixture/auth';
+
+@PackageAuth()
+@Controller('orders')
+export class OrdersController {
+  @Get()
+  findAll() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-guard-app/vendor/auth/index.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-guard-app/vendor/auth/index.ts
@@ -1,0 +1,11 @@
+import { UseGuards } from '@nestjs/common';
+
+export class PackageGuard {
+  canActivate() {
+    return true;
+  }
+}
+
+export const PackageAuth = function () {
+  return UseGuards(PackageGuard);
+};

--- a/packages/nestjs-doctor/tests/fixtures/package-guard-app/vendor/auth/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/package-guard-app/vendor/auth/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/auth",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "types": "index.ts"
+}

--- a/packages/nestjs-doctor/tests/integration/global-guards.test.ts
+++ b/packages/nestjs-doctor/tests/integration/global-guards.test.ts
@@ -72,4 +72,32 @@ describe("global guard detection", () => {
 		);
 		expect(guardFindings.length).toBeGreaterThan(0);
 	});
+
+	it("counts a decorator that returns UseGuards from another package", async () => {
+		const { output } = await scan("composed-guard-app/src");
+		const flagged = output.diagnostics
+			.filter((diagnostic) => diagnostic.rule === GUARD_RULE)
+			.map((diagnostic) => diagnostic.filePath.split("/").pop())
+			.sort();
+		expect(flagged).toEqual([
+			"documented.controller.ts",
+			"maybe-auth.controller.ts",
+			"unguarded.controller.ts",
+		]);
+	});
+
+	it("does not count a decorator that returns a guard on only one path", async () => {
+		const { output } = await scan("composed-guard-app/src");
+		const flagged = output.diagnostics.filter(
+			(diagnostic) =>
+				diagnostic.rule === GUARD_RULE &&
+				diagnostic.filePath.endsWith("maybe-auth.controller.ts")
+		);
+		expect(flagged).toHaveLength(1);
+	});
+
+	it("finds every route in the composed decorator fixture", async () => {
+		const { context } = await scan("composed-guard-app/src");
+		expect(context.endpointGraph.endpoints).toHaveLength(7);
+	});
 });

--- a/packages/nestjs-doctor/tests/integration/global-guards.test.ts
+++ b/packages/nestjs-doctor/tests/integration/global-guards.test.ts
@@ -1,5 +1,7 @@
-import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path, { resolve } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
 import {
 	buildAnalysisContext,
 	diagnose,
@@ -99,5 +101,51 @@ describe("global guard detection", () => {
 	it("finds every route in the composed decorator fixture", async () => {
 		const { context } = await scan("composed-guard-app/src");
 		expect(context.endpointGraph.endpoints).toHaveLength(7);
+	});
+
+	// The decorator lives in a package, so the checker only reads it when that
+	// package is installed. Both directions are pinned here.
+	describe("a decorator imported from a package", () => {
+		const tempRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), "nestjs-doctor-package-guard-")
+		);
+
+		afterAll(() => {
+			fs.rmSync(tempRoot, { recursive: true, force: true });
+		});
+
+		function plant(name: string, installed: boolean) {
+			const root = path.join(tempRoot, name);
+			fs.cpSync(resolve(FIXTURES, "package-guard-app"), root, {
+				recursive: true,
+			});
+			if (installed) {
+				const target = path.join(root, "node_modules", "@fixture", "auth");
+				fs.mkdirSync(path.dirname(target), { recursive: true });
+				fs.cpSync(path.join(root, "vendor", "auth"), target, {
+					recursive: true,
+				});
+			}
+			return path.join(root, "src");
+		}
+
+		async function guardFindings(target: string) {
+			const scanConfig = await resolveScanConfig(target);
+			const context = await buildAnalysisContext(target, scanConfig);
+			const output = await diagnose(context);
+			return output.diagnostics.filter(
+				(diagnostic) => diagnostic.rule === GUARD_RULE
+			);
+		}
+
+		it("counts the guard when the package is installed", async () => {
+			expect(await guardFindings(plant("installed", true))).toEqual([]);
+		});
+
+		it("reports the endpoint when the package is missing", async () => {
+			const findings = await guardFindings(plant("bare", false));
+			expect(findings).toHaveLength(1);
+			expect(findings[0].filePath).toContain("orders.controller.ts");
+		});
 	});
 });

--- a/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
+++ b/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
@@ -279,3 +279,94 @@ describe("decoratorAppliesGuards", () => {
 		expect(decoratorAppliesGuards(decorator)).toBe(false);
 	});
 });
+
+describe("a guard the decorator does not always apply", () => {
+	it("ignores a function that returns a guard on only one path", () => {
+		const names = index(`
+      import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+      export function MaybeAuth(secure: boolean) {
+        if (secure) {
+          return UseGuards(AuthGuard);
+        }
+        return applyDecorators(SetMetadata('public', true));
+      }
+    `);
+		expect(names.size).toBe(0);
+	});
+
+	it("ignores a function expression that returns a guard on only one path", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export const MaybeAuth = function (secure: boolean) {
+        if (secure) {
+          return UseGuards(AuthGuard);
+        }
+        return () => undefined;
+      };
+    `);
+		expect(names.size).toBe(0);
+	});
+
+	it("ignores a declaration with no return at all", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export function Auth() {
+        UseGuards(AuthGuard);
+      }
+    `);
+		expect(names.size).toBe(0);
+	});
+
+	it("still counts a function whose every return applies a guard", () => {
+		const names = index(`
+      import { applyDecorators, UseGuards } from '@nestjs/common';
+      export function Auth(strict: boolean) {
+        if (strict) {
+          return UseGuards(StrictGuard);
+        }
+        return applyDecorators(UseGuards(AuthGuard));
+      }
+    `);
+		expect([...names]).toEqual(["Auth"]);
+	});
+});
+
+describe("decoratorAppliesGuards verdict reuse", () => {
+	function decoratorFor(implementation: string) {
+		const project = new Project({ useInMemoryFileSystem: true });
+		project.createSourceFile("/impl.ts", implementation);
+		project.createSourceFile(
+			"/thing.controller.ts",
+			`
+        import { Auth } from './impl';
+        @Auth()
+        export class ThingController {}
+      `
+		);
+		return project
+			.getSourceFileOrThrow("/thing.controller.ts")
+			.getClasses()[0]
+			.getDecorators()[0];
+	}
+
+	it("judges each project on its own source, even at the same path", () => {
+		// Both bodies are the same length, so a verdict keyed by file offsets
+		// would answer the second one from the first.
+		const guarded = decoratorFor(
+			"export const Auth = () => applyDecorators(UseGuards(AuthGuard));"
+		);
+		const plain = decoratorFor(
+			"export const Auth = () => applyDecorators(SetHeader(AuthGuard));"
+		);
+		expect(decoratorAppliesGuards(guarded)).toBe(true);
+		expect(decoratorAppliesGuards(plain)).toBe(false);
+	});
+
+	it("gives the same answer when asked twice", () => {
+		const decorator = decoratorFor(
+			"export const Auth = () => UseGuards(AuthGuard);"
+		);
+		expect(decoratorAppliesGuards(decorator)).toBe(true);
+		expect(decoratorAppliesGuards(decorator)).toBe(true);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
+++ b/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
@@ -370,3 +370,31 @@ describe("decoratorAppliesGuards verdict reuse", () => {
 		expect(decoratorAppliesGuards(decorator)).toBe(true);
 	});
 });
+
+describe("a return that hands back nothing", () => {
+	it("ignores a function whose disabled path returns bare", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export function Auth(enabled = true) {
+        if (!enabled) {
+          return;
+        }
+        return UseGuards(JwtGuard);
+      }
+    `);
+		expect(names.size).toBe(0);
+	});
+
+	it("ignores a function whose disabled path returns undefined", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export function Auth(enabled = true) {
+        if (!enabled) {
+          return undefined;
+        }
+        return UseGuards(JwtGuard);
+      }
+    `);
+		expect(names.size).toBe(0);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
+++ b/packages/nestjs-doctor/tests/unit/guard-decorators.test.ts
@@ -2,6 +2,7 @@ import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
 import {
 	buildGuardDecoratorIndex,
+	decoratorAppliesGuards,
 	guardDecoratorNames,
 } from "../../src/engine/graph/guard-decorators.js";
 
@@ -150,5 +151,131 @@ describe("buildGuardDecoratorIndex", () => {
 		);
 		const empty = buildGuardDecoratorIndex(project, ["/missing.ts"]);
 		expect(guardDecoratorNames(empty).size).toBe(0);
+	});
+});
+
+describe("buildGuardDecoratorIndex, guards applied without applyDecorators", () => {
+	it("indexes a function returning UseGuards(...) on its own", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export function Auth() {
+        return UseGuards(AuthGuard);
+      }
+    `);
+		expect([...names]).toEqual(["Auth"]);
+	});
+
+	it("indexes a function expression assigned to a const", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export const IsAuthnAuthz = function () {
+        return UseGuards(IsAuthnAuthzGuard);
+      };
+    `);
+		expect([...names]).toEqual(["IsAuthnAuthz"]);
+	});
+
+	it("indexes an arrow returning UseGuards(...) with a concise body", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export const StripeAuthorizer = () => UseGuards(StripeAuthorizerGuard);
+    `);
+		expect([...names]).toEqual(["StripeAuthorizer"]);
+	});
+
+	it("still ignores a UseGuards call that is not what the function returns", () => {
+		const names = index(`
+      import { UseGuards } from '@nestjs/common';
+      export function notADecorator() {
+        const x = UseGuards(AuthGuard);
+        return x;
+      }
+    `);
+		expect(names.size).toBe(0);
+	});
+});
+
+describe("decoratorAppliesGuards", () => {
+	function decoratorOn(files: Record<string, string>, entry: string) {
+		const project = new Project({ useInMemoryFileSystem: true });
+		for (const [path, code] of Object.entries(files)) {
+			project.createSourceFile(path, code);
+		}
+		const cls = project.getSourceFileOrThrow(entry).getClasses()[0];
+		return cls.getDecorators()[0];
+	}
+
+	it("credits a decorator declared in another file", () => {
+		const decorator = decoratorOn(
+			{
+				"/libs/auth/guard.ts": `
+          import { UseGuards } from '@nestjs/common';
+          export const IsAuthnAuthz = function () {
+            return UseGuards(IsAuthnAuthzGuard);
+          };
+        `,
+				"/apps/api/thing.controller.ts": `
+          import { IsAuthnAuthz } from '../../libs/auth/guard';
+          @IsAuthnAuthz()
+          export class ThingController {}
+        `,
+			},
+			"/apps/api/thing.controller.ts"
+		);
+		expect(decoratorAppliesGuards(decorator)).toBe(true);
+	});
+
+	it("credits a decorator built with applyDecorators in another file", () => {
+		const decorator = decoratorOn(
+			{
+				"/libs/auth/guard.ts": `
+          import { applyDecorators, UseGuards } from '@nestjs/common';
+          export function Auth() {
+            return applyDecorators(UseGuards(AuthGuard));
+          }
+        `,
+				"/apps/api/thing.controller.ts": `
+          import { Auth } from '../../libs/auth/guard';
+          @Auth()
+          export class ThingController {}
+        `,
+			},
+			"/apps/api/thing.controller.ts"
+		);
+		expect(decoratorAppliesGuards(decorator)).toBe(true);
+	});
+
+	it("does not credit a decorator that applies no guard", () => {
+		const decorator = decoratorOn(
+			{
+				"/libs/docs/api.ts": `
+          import { applyDecorators } from '@nestjs/common';
+          export function Documented() {
+            return applyDecorators(ApiOperation());
+          }
+        `,
+				"/apps/api/thing.controller.ts": `
+          import { Documented } from '../../libs/docs/api';
+          @Documented()
+          export class ThingController {}
+        `,
+			},
+			"/apps/api/thing.controller.ts"
+		);
+		expect(decoratorAppliesGuards(decorator)).toBe(false);
+	});
+
+	it("does not credit a decorator whose declaration it cannot find", () => {
+		const decorator = decoratorOn(
+			{
+				"/apps/api/thing.controller.ts": `
+          import { Mystery } from '@some/package';
+          @Mystery()
+          export class ThingController {}
+        `,
+			},
+			"/apps/api/thing.controller.ts"
+		);
+		expect(decoratorAppliesGuards(decorator)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Context

`security/require-guards-on-endpoints` accepts a guard bound four ways: `@UseGuards()` on the class or the handler, a global `APP_GUARD` or `useGlobalGuards()`, a guarded base class, or a custom decorator that composes `UseGuards` inside itself. That last one is found by `buildGuardDecoratorIndex`, which reads every scanned file, records the names whose implementation composes a guard, and flattens them into one set the rule matches by name.

In a monorepo the composed decorator is the normal case. It is declared once in a shared library and imported by every app.

## Problem

The index never sees those declarations, and it rejects two common shapes even when it does.

A monorepo with 249 routes, where a single `@IsAuthnAuthz()` guards 219 of them, reported 246 unguarded endpoints. That was 61% of its whole report, on a security rule, and all of it wrong.

Three separate causes:

1. `appliesGuards` required the returned call to be `applyDecorators`. A decorator that returns `UseGuards(...)` on its own got no credit.
2. `namesInFile` read function declarations and arrow initialisers, but not `export const X = function () {...}`. `FunctionExpression` was already in `FUNCTION_KINDS` two lines above, so this was an omission rather than a decision.
3. Each sub-project builds its index over its own file list. A decorator declared in `libs/auth` and used in `apps/*-api` is in nobody's index, so even a correctly shaped one is missed.

Cause 3 accounts for 220 of the 224 wrong findings. Fixing only the first two moves the number from 246 to 242.

## Possible flows

| How the decorator is written | Before | After |
|---|---|---|
| `@UseGuards(Guard)` directly | counted | counted |
| `function A() { return applyDecorators(UseGuards(G)); }`, same project | counted | counted |
| `const A = () => applyDecorators(UseGuards(G))`, same project | counted | counted |
| `function A() { return UseGuards(G); }` | missed | counted |
| `const A = function () { return UseGuards(G); }` | missed | counted |
| `const A = () => UseGuards(G)` | missed | counted |
| any of the above, declared in another package | missed | counted |
| `function A(x) { if (!x) return; return UseGuards(G); }` | counted | not counted |
| `function A(x) { if (x) return UseGuards(G); return applyDecorators(SetMetadata(...)); }` | counted | not counted |
| `function A() { const x = UseGuards(G); return x; }` | not counted | not counted |
| `applyDecorators(ApiOperation())` with no guard | not counted | not counted |
| ternary guarding one branch only | not counted | not counted |

## Solution

`appliesGuards` now takes a bare `UseGuards(...)` as well as an `applyDecorators(...)` that applies one, and `namesInFile` reads a function-expression initialiser through a new `declaredFunction` helper.

For cause 3, `decoratorAppliesGuards` resolves the decorator name to its declaration through the type checker and tests that declaration with the same predicate. `resolveDecoratorWrapper` already works this way to find controllers hiding behind wrapper decorators, and it reaches declarations in files the sub-project never parsed, so no file-set union or context restructuring is needed. Verdicts live in a `WeakMap` on the declaration node, which a reparse replaces and the collector reclaims.

The name check that `diagnostician.ts` and the rule each wrote separately is now one `isGuardDecorator`, ordered cheapest first: literal `@UseGuards`, then the index, then symbol resolution.

A decorator counts only when every path out of it returns a guard, and only when there is at least one such path. A bare `return;` is one of those paths, so a factory that bails out early no longer clears a route. The same check stops an overload signature with no body counting as guarded.

Two things I left alone. The file index stays, so the cheap path still answers most decorators and its thirteen tests keep running. `super.m()` and an aliased `UseGuards as UG` are still unrecognised.

## Before vs after

Same monorepo, `--json`, nothing else changed:

| | Before | After |
|---|---|---|
| `require-guards-on-endpoints` findings | 246 | 22 |
| total diagnostics | 401 | 177 |
| score | 95 | 98 |
| routes discovered | 249 | 249 |
| every other rule | unchanged | unchanged |

The 22 survivors are the auth controller's login routes, health checks, webhook receivers, the gateway proxy, and one patients controller that really has no guard. A second repo whose decorators are all in-project stays at 18 findings.

One consequence worth knowing. Resolution goes through the type checker, which reads from disk, so a decorator imported by package name is only read when that package is installed. Without the install the endpoint is reported instead, which errs toward more findings rather than fewer. The rule's help text says this, and `package-guard-app` pins both directions by planting the package into `node_modules` for one copy of the fixture and leaving the other bare.

## Example

```ts
// libs/auth/src/lib/guards/authn-authz.guard.ts
export const IsAuthnAuthz = function () {
  return UseGuards(IsAuthnAuthzGuard);
};

// apps/appointments/appointments-api/src/controllers/care-plan-versions.controller.ts
@IsAuthnAuthz()
@CompassRestController({ path: 'patients/:patientId/care-plans' })
export class CarePlanVersionsController {
  @Post('draft')
  createDraft(...) {}
}
```

Before:

```
warning  security/require-guards-on-endpoints
  Controller endpoints should be protected by @UseGuards()
  care-plan-versions.controller.ts:33
```

After: nothing. The route is guarded and the report agrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcDqSoqXMLYxNVQNpRrdcQ
