### PR TITLE
perf(engine): stop typing installed packages

### DIFF
--- a/.changeset/context-phase-timings.md
+++ b/.changeset/context-phase-timings.md
@@ -2,4 +2,4 @@
 "nestjs-doctor": patch
 ---
 
-Setting `NESTJS_DOCTOR_PHASE_TIMINGS=1` prints how long each stage of the analysis context took to stderr: collect, parse, modules, providers, endpoints, schema, guards. Nothing changes without the variable, and the scan output is untouched either way.
+Setting `NESTJS_DOCTOR_PHASE_TIMINGS=1` prints how long each stage of the analysis context took to stderr. A single project marks collect, parse, modules, providers, endpoints, schema and guards; a monorepo sub-project marks detect instead of collect, since its files were gathered for every project at once beforehand. Nothing changes without the variable, and the scan output is untouched either way.

--- a/.changeset/context-phase-timings.md
+++ b/.changeset/context-phase-timings.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+Setting `NESTJS_DOCTOR_PHASE_TIMINGS=1` prints how long each stage of the analysis context took to stderr: collect, parse, modules, providers, endpoints, schema, guards. Nothing changes without the variable, and the scan output is untouched either way.

--- a/.changeset/fire-and-forget-declared-receiver.md
+++ b/.changeset/fire-and-forget-declared-receiver.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+`correctness/no-fire-and-forget-async` no longer guesses from a method name when the receiver's type is written down. A call like `this.socket.send(data)`, where `socket` is declared as a type the scan cannot read, was reported as an unawaited promise even though the method returns void. A receiver the class never declares still falls back to the name, which is what the check was for.

--- a/.changeset/source-only-type-resolution.md
+++ b/.changeset/source-only-type-resolution.md
@@ -1,0 +1,5 @@
+---
+"nestjs-doctor": patch
+---
+
+The scan no longer reads installed packages when resolving types. A 354-file project spent 7.3 of its 8.0 seconds having TypeScript parse and type 182 MB of `node_modules`; it now takes 0.7 seconds, and a 45-project monorepo went from 76 to 12 seconds. Workspace packages linked into `node_modules` stay visible, so a decorator or base class in your own library still resolves. A type that only an installed dependency knows now reads as `any`, which affects rules that inspect a return type rather than a declaration.

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -227,7 +227,7 @@ async function buildSubProjectContext(
 		detectProject(projectPath),
 		loadConfigWithFallback(projectPath, rootConfig),
 	]);
-	mark("collect");
+	mark("detect");
 
 	const { aliases: pathAliases, baseUrl } = loadTsconfigResolution(projectPath);
 	const astProject = await createAstParser(

--- a/packages/nestjs-doctor/src/engine/analysis-context.ts
+++ b/packages/nestjs-doctor/src/engine/analysis-context.ts
@@ -31,6 +31,7 @@ import {
 	resolveProvidersAsync,
 	updateProvidersForFile,
 } from "./graph/type-resolver.js";
+import { startPhaseTimer } from "./phase-timer.js";
 import { detectProject, type MonorepoInfo } from "./project-detector.js";
 import { filterRules, separateRules } from "./rules/rule-pipeline.js";
 import type { ProjectRule, Rule, SchemaRule } from "./rules/types.js";
@@ -88,11 +89,13 @@ export async function buildAnalysisContext(
 	onProgress?: AnalysisProgress
 ): Promise<AnalysisContext> {
 	const { config, fileRules, projectRules, schemaRules } = scanConfig;
+	const mark = startPhaseTimer(targetPath);
 	onProgress?.("collecting");
 	const [files, project] = await Promise.all([
 		collectFiles(targetPath, config),
 		detectProject(targetPath),
 	]);
+	mark("collect");
 	const { aliases: pathAliases, baseUrl } = loadTsconfigResolution(targetPath);
 	const astProject = await createAstParser(
 		files,
@@ -100,6 +103,7 @@ export async function buildAnalysisContext(
 		baseUrl,
 		(parsed, total) => onProgress?.("parsing", parsed, total)
 	);
+	mark("parse");
 	onProgress?.("analyzing");
 	await yieldToEventLoop();
 	const moduleGraph = await buildModuleGraphAsync(
@@ -108,8 +112,10 @@ export async function buildAnalysisContext(
 		pathAliases
 	);
 	warnDuplicateModuleNames(moduleGraph, scanConfig.customRuleWarnings);
+	mark("modules");
 	await yieldToEventLoop();
 	const providers = await resolveProvidersAsync(astProject, files);
+	mark("providers");
 	await yieldToEventLoop();
 	const endpointGraph = await buildEndpointGraphWithProgress(
 		astProject,
@@ -117,9 +123,16 @@ export async function buildAnalysisContext(
 		providers,
 		(traced, total) => onProgress?.("analyzing", traced, total)
 	);
+	mark("endpoints");
 	await yieldToEventLoop();
 	const schemaGraph = extractSchema(astProject, files, project.orm, targetPath);
+	mark("schema");
 	await yieldToEventLoop();
+	const guardDecorators = await buildGuardDecoratorIndexAsync(
+		astProject,
+		files
+	);
+	mark("guards");
 
 	return {
 		astProject,
@@ -127,7 +140,7 @@ export async function buildAnalysisContext(
 		endpointGraph,
 		fileRules,
 		files,
-		guardDecorators: await buildGuardDecoratorIndexAsync(astProject, files),
+		guardDecorators,
 		moduleGraph,
 		pathAliases,
 		project,
@@ -209,10 +222,12 @@ async function buildSubProjectContext(
 ): Promise<AnalysisContext> {
 	const { config: rootConfig, combinedRules } = scanConfig;
 	const projectPath = join(targetPath, monorepo.projects.get(name)!);
+	const mark = startPhaseTimer(name);
 	const [project, projectConfig] = await Promise.all([
 		detectProject(projectPath),
 		loadConfigWithFallback(projectPath, rootConfig),
 	]);
+	mark("collect");
 
 	const { aliases: pathAliases, baseUrl } = loadTsconfigResolution(projectPath);
 	const astProject = await createAstParser(
@@ -221,6 +236,7 @@ async function buildSubProjectContext(
 		baseUrl,
 		(parsed, total) => onProgress?.("parsing", parsed, total)
 	);
+	mark("parse");
 	onProgress?.("analyzing");
 	await yieldToEventLoop();
 	const moduleGraph = await buildModuleGraphAsync(
@@ -229,8 +245,10 @@ async function buildSubProjectContext(
 		pathAliases
 	);
 	warnDuplicateModuleNames(moduleGraph, scanConfig.customRuleWarnings);
+	mark("modules");
 	await yieldToEventLoop();
 	const providers = await resolveProvidersAsync(astProject, files);
+	mark("providers");
 	await yieldToEventLoop();
 	const endpointGraph = await buildEndpointGraphWithProgress(
 		astProject,
@@ -238,6 +256,7 @@ async function buildSubProjectContext(
 		providers,
 		(traced, total) => onProgress?.("analyzing", traced, total)
 	);
+	mark("endpoints");
 	await yieldToEventLoop();
 	let schemaGraph = extractSchema(astProject, files, project.orm, projectPath);
 	// Falls back to the workspace root, where a monorepo usually keeps its schema.
@@ -248,8 +267,14 @@ async function buildSubProjectContext(
 	) {
 		schemaGraph = rootSchemaFor(project.orm, astProject, files);
 	}
+	mark("schema");
 	const rules = filterRules(projectConfig, combinedRules);
 	const { fileRules, projectRules, schemaRules } = separateRules(rules);
+	const guardDecorators = await buildGuardDecoratorIndexAsync(
+		astProject,
+		files
+	);
+	mark("guards");
 
 	return {
 		astProject,
@@ -257,7 +282,7 @@ async function buildSubProjectContext(
 		endpointGraph,
 		fileRules,
 		files,
-		guardDecorators: await buildGuardDecoratorIndexAsync(astProject, files),
+		guardDecorators,
 		moduleGraph,
 		pathAliases,
 		project,

--- a/packages/nestjs-doctor/src/engine/graph/ast-parser.ts
+++ b/packages/nestjs-doctor/src/engine/graph/ast-parser.ts
@@ -1,5 +1,6 @@
 import { Project } from "ts-morph";
 import { YIELD_INTERVAL, yieldToEventLoop } from "../yield.js";
+import { createSourceOnlyHost } from "./source-only-host.js";
 import type { PathAliasMap } from "./tsconfig-paths.js";
 
 export async function createAstParser(
@@ -20,6 +21,7 @@ export async function createAstParser(
 					? Object.fromEntries(pathAliases)
 					: undefined,
 		},
+		fileSystem: createSourceOnlyHost(files),
 		skipAddingFilesFromTsConfig: true,
 	});
 

--- a/packages/nestjs-doctor/src/engine/graph/source-only-host.ts
+++ b/packages/nestjs-doctor/src/engine/graph/source-only-host.ts
@@ -6,6 +6,11 @@ const NODE_MODULES = /[\\/]node_modules[\\/]/;
 /** `node_modules/name` or `node_modules/@scope/name`, whichever the path has. */
 const PACKAGE_ROOT = /^(.*[\\/]node_modules[\\/](?:@[^\\/]+[\\/])?[^\\/]+)/;
 
+/** The shape ts-morph recognises as a missing file. */
+function notFound(filePath: string): Error {
+	return Object.assign(new Error(`${filePath} not found`), { code: "ENOENT" });
+}
+
 const HIDDEN_READS = new Set([
 	"directoryExists",
 	"directoryExistsSync",
@@ -15,10 +20,7 @@ const HIDDEN_READS = new Set([
 	"readFileSync",
 ]);
 
-/**
- * True when the path resolves to an installed package. A workspace package
- * symlinked into node_modules resolves back out of it and stays visible.
- */
+/** True when the path resolves inside node_modules, or resolves to nothing. */
 function installedPackage(filePath: string, cache: Map<string, boolean>) {
 	const root = PACKAGE_ROOT.exec(filePath)?.[1];
 	if (!root) {
@@ -28,7 +30,7 @@ function installedPackage(filePath: string, cache: Map<string, boolean>) {
 	if (cached !== undefined) {
 		return cached;
 	}
-	let installed = true;
+	let installed: boolean;
 	try {
 		installed = NODE_MODULES.test(realpathSync(root));
 	} catch {
@@ -39,9 +41,8 @@ function installedPackage(filePath: string, cache: Map<string, boolean>) {
 }
 
 /**
- * A file system that reports installed packages as absent, so the type checker
- * resolves the scanned sources and stops before their dependencies. Paths the
- * scan collected are always readable, whatever they contain.
+ * A file system that reports installed packages as absent. A file the scan
+ * collected stays readable.
  */
 export function createSourceOnlyHost(collected: Iterable<string>) {
 	const real = new Project({
@@ -65,10 +66,10 @@ export function createSourceOnlyHost(collected: Iterable<string>) {
 					return Reflect.apply(value, target, [filePath, ...rest]);
 				}
 				if (property === "readFile") {
-					return Promise.reject(new Error(`${filePath} not found`));
+					return Promise.reject(notFound(filePath));
 				}
 				if (property === "readFileSync") {
-					throw new Error(`${filePath} not found`);
+					throw notFound(filePath);
 				}
 				return property === "fileExists" || property === "directoryExists"
 					? Promise.resolve(false)

--- a/packages/nestjs-doctor/src/engine/graph/source-only-host.ts
+++ b/packages/nestjs-doctor/src/engine/graph/source-only-host.ts
@@ -1,0 +1,79 @@
+import { realpathSync } from "node:fs";
+import type { FileSystemHost } from "ts-morph";
+import { Project } from "ts-morph";
+
+const NODE_MODULES = /[\\/]node_modules[\\/]/;
+/** `node_modules/name` or `node_modules/@scope/name`, whichever the path has. */
+const PACKAGE_ROOT = /^(.*[\\/]node_modules[\\/](?:@[^\\/]+[\\/])?[^\\/]+)/;
+
+const HIDDEN_READS = new Set([
+	"directoryExists",
+	"directoryExistsSync",
+	"fileExists",
+	"fileExistsSync",
+	"readFile",
+	"readFileSync",
+]);
+
+/**
+ * True when the path resolves to an installed package. A workspace package
+ * symlinked into node_modules resolves back out of it and stays visible.
+ */
+function installedPackage(filePath: string, cache: Map<string, boolean>) {
+	const root = PACKAGE_ROOT.exec(filePath)?.[1];
+	if (!root) {
+		return NODE_MODULES.test(filePath);
+	}
+	const cached = cache.get(root);
+	if (cached !== undefined) {
+		return cached;
+	}
+	let installed = true;
+	try {
+		installed = NODE_MODULES.test(realpathSync(root));
+	} catch {
+		installed = true;
+	}
+	cache.set(root, installed);
+	return installed;
+}
+
+/**
+ * A file system that reports installed packages as absent, so the type checker
+ * resolves the scanned sources and stops before their dependencies. Paths the
+ * scan collected are always readable, whatever they contain.
+ */
+export function createSourceOnlyHost(collected: Iterable<string>) {
+	const real = new Project({
+		skipAddingFilesFromTsConfig: true,
+	}).getFileSystem();
+	const keep = new Set(collected);
+	const roots = new Map<string, boolean>();
+	const hidden = (filePath: string) =>
+		!keep.has(filePath) &&
+		NODE_MODULES.test(filePath) &&
+		installedPackage(filePath, roots);
+
+	return new Proxy(real, {
+		get(target, property, receiver) {
+			const value = Reflect.get(target, property, receiver);
+			if (typeof value !== "function" || !HIDDEN_READS.has(String(property))) {
+				return typeof value === "function" ? value.bind(target) : value;
+			}
+			return (filePath: string, ...rest: unknown[]) => {
+				if (!hidden(filePath)) {
+					return Reflect.apply(value, target, [filePath, ...rest]);
+				}
+				if (property === "readFile") {
+					return Promise.reject(new Error(`${filePath} not found`));
+				}
+				if (property === "readFileSync") {
+					throw new Error(`${filePath} not found`);
+				}
+				return property === "fileExists" || property === "directoryExists"
+					? Promise.resolve(false)
+					: false;
+			};
+		},
+	}) as FileSystemHost;
+}

--- a/packages/nestjs-doctor/src/engine/graph/source-only-host.ts
+++ b/packages/nestjs-doctor/src/engine/graph/source-only-host.ts
@@ -6,18 +6,11 @@ const NODE_MODULES = /[\\/]node_modules[\\/]/;
 /** `node_modules/name` or `node_modules/@scope/name`, whichever the path has. */
 const PACKAGE_ROOT = /^(.*[\\/]node_modules[\\/](?:@[^\\/]+[\\/])?[^\\/]+)/;
 
-/** The shape ts-morph recognises as a missing file. */
-function notFound(filePath: string): Error {
-	return Object.assign(new Error(`${filePath} not found`), { code: "ENOENT" });
-}
-
-const HIDDEN_READS = new Set([
+const HIDDEN_LOOKUPS = new Set([
 	"directoryExists",
 	"directoryExistsSync",
 	"fileExists",
 	"fileExistsSync",
-	"readFile",
-	"readFileSync",
 ]);
 
 /** True when the path resolves inside node_modules, or resolves to nothing. */
@@ -41,8 +34,8 @@ function installedPackage(filePath: string, cache: Map<string, boolean>) {
 }
 
 /**
- * A file system that reports installed packages as absent. A file the scan
- * collected stays readable.
+ * A file system that reports installed packages as absent, so module
+ * resolution stops at them. Reading a path outright still works.
  */
 export function createSourceOnlyHost(collected: Iterable<string>) {
 	const real = new Project({
@@ -58,18 +51,15 @@ export function createSourceOnlyHost(collected: Iterable<string>) {
 	return new Proxy(real, {
 		get(target, property, receiver) {
 			const value = Reflect.get(target, property, receiver);
-			if (typeof value !== "function" || !HIDDEN_READS.has(String(property))) {
+			if (
+				typeof value !== "function" ||
+				!HIDDEN_LOOKUPS.has(String(property))
+			) {
 				return typeof value === "function" ? value.bind(target) : value;
 			}
 			return (filePath: string, ...rest: unknown[]) => {
 				if (!hidden(filePath)) {
 					return Reflect.apply(value, target, [filePath, ...rest]);
-				}
-				if (property === "readFile") {
-					return Promise.reject(notFound(filePath));
-				}
-				if (property === "readFileSync") {
-					throw notFound(filePath);
 				}
 				return property === "fileExists" || property === "directoryExists"
 					? Promise.resolve(false)

--- a/packages/nestjs-doctor/src/engine/phase-timer.ts
+++ b/packages/nestjs-doctor/src/engine/phase-timer.ts
@@ -1,0 +1,25 @@
+/** How long a stage took, and how long the build has run, in milliseconds. */
+export type PhaseMark = (phase: string) => void;
+
+const NO_MARKS: PhaseMark = () => {
+	// Timing is off, so a mark costs nothing.
+};
+
+/**
+ * Writes one line per stage to stderr when NESTJS_DOCTOR_PHASE_TIMINGS is set,
+ * and does nothing otherwise.
+ */
+export function startPhaseTimer(label: string): PhaseMark {
+	if (!process.env.NESTJS_DOCTOR_PHASE_TIMINGS) {
+		return NO_MARKS;
+	}
+	const started = performance.now();
+	let previous = started;
+	return (phase: string) => {
+		const now = performance.now();
+		process.stderr.write(
+			`[timing] ${label} ${phase} ${Math.round(now - previous)}ms (${Math.round(now - started)}ms)\n`
+		);
+		previous = now;
+	};
+}

--- a/packages/nestjs-doctor/src/engine/phase-timer.ts
+++ b/packages/nestjs-doctor/src/engine/phase-timer.ts
@@ -1,13 +1,13 @@
-/** How long a stage took, and how long the build has run, in milliseconds. */
+/** Records that a named stage finished. */
 export type PhaseMark = (phase: string) => void;
 
 const NO_MARKS: PhaseMark = () => {
-	// Timing is off, so a mark costs nothing.
+	// Discards the mark.
 };
 
 /**
- * Writes one line per stage to stderr when NESTJS_DOCTOR_PHASE_TIMINGS is set,
- * and does nothing otherwise.
+ * Writes one line per stage to stderr when NESTJS_DOCTOR_PHASE_TIMINGS holds a
+ * non-empty value, and does nothing otherwise.
  */
 export function startPhaseTimer(label: string): PhaseMark {
 	if (!process.env.NESTJS_DOCTOR_PHASE_TIMINGS) {

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
@@ -1,4 +1,9 @@
-import { type CallExpression, type Node, SyntaxKind } from "ts-morph";
+import {
+	type CallExpression,
+	type ClassDeclaration,
+	type Node,
+	SyntaxKind,
+} from "ts-morph";
 import { isHttpHandler } from "../../../nest-class-inspector.js";
 import type { Rule } from "../../types.js";
 
@@ -36,6 +41,45 @@ const ASYNC_PREFIXES = new Set([
 	"download",
 	"process",
 ]);
+
+/** The class member a `this.member.method()` call reads, if the class declares one. */
+function declaredReceiver(callExpr: CallExpression, cls: ClassDeclaration) {
+	const access = callExpr
+		.getExpression()
+		.asKind(SyntaxKind.PropertyAccessExpression)
+		?.getExpression()
+		.asKind(SyntaxKind.PropertyAccessExpression);
+	if (access?.getExpression().getKind() !== SyntaxKind.ThisKeyword) {
+		return;
+	}
+	const name = access.getName();
+	return (
+		cls.getProperty(name) ??
+		cls
+			.getConstructors()[0]
+			?.getParameters()
+			.find((parameter) => parameter.getName() === name)
+	);
+}
+
+/**
+ * True when the name suggests an async call and the receiver's type is not
+ * written down. A declared type that still resolves to `any` belongs to a
+ * package the scan does not read, so the name is not evidence.
+ */
+function nameMayBeAsync(callExpr: CallExpression, methodName: string): boolean {
+	const cls = callExpr.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
+	if (cls && declaredReceiver(callExpr, cls)?.getTypeNode()) {
+		return false;
+	}
+	const lowerName = methodName.toLowerCase();
+	return (
+		ASYNC_PREFIXES.has(lowerName) ||
+		[...ASYNC_PREFIXES].some(
+			(prefix) => lowerName.startsWith(prefix) && lowerName !== prefix
+		)
+	);
+}
 
 /**
  * A handler that ends by throwing leaves the rejection unhandled. Only an
@@ -158,17 +202,11 @@ export const noFireAndForgetAsync: Rule = {
 						continue;
 					}
 
-					if (promiseCheck === "unknown") {
-						// Type is unresolvable (any) — fall back to name heuristic
-						const lowerName = methodName.toLowerCase();
-						const isLikelyAsync =
-							ASYNC_PREFIXES.has(lowerName) ||
-							[...ASYNC_PREFIXES].some(
-								(prefix) => lowerName.startsWith(prefix) && lowerName !== prefix
-							);
-						if (!isLikelyAsync) {
-							continue;
-						}
+					if (
+						promiseCheck === "unknown" &&
+						!nameMayBeAsync(callExpr, methodName)
+					) {
+						continue;
 					}
 
 					// Check the call is inside a non-arrow, non-nested function scope

--- a/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/correctness/no-fire-and-forget-async.ts
@@ -42,34 +42,38 @@ const ASYNC_PREFIXES = new Set([
 	"process",
 ]);
 
-/** The class member a `this.member.method()` call reads, if the class declares one. */
-function declaredReceiver(callExpr: CallExpression, cls: ClassDeclaration) {
-	const access = callExpr
+/** The member name in `this.member.method()`, when the call has that shape. */
+function thisMemberName(callExpr: CallExpression): string | undefined {
+	const receiver = callExpr
 		.getExpression()
 		.asKind(SyntaxKind.PropertyAccessExpression)
 		?.getExpression()
 		.asKind(SyntaxKind.PropertyAccessExpression);
-	if (access?.getExpression().getKind() !== SyntaxKind.ThisKeyword) {
-		return;
-	}
-	const name = access.getName();
-	return (
+	return receiver?.getExpression().getKind() === SyntaxKind.ThisKeyword
+		? receiver.getName()
+		: undefined;
+}
+
+/** True when the class declares the member, as a property or a constructor parameter. */
+function declaresMember(cls: ClassDeclaration, name: string): boolean {
+	return Boolean(
 		cls.getProperty(name) ??
-		cls
-			.getConstructors()[0]
-			?.getParameters()
-			.find((parameter) => parameter.getName() === name)
+			cls
+				.getConstructors()[0]
+				?.getParameters()
+				.find((parameter) => parameter.getName() === name)
 	);
 }
 
 /**
- * True when the name suggests an async call and the receiver's type is not
- * written down. A declared type that still resolves to `any` belongs to a
- * package the scan does not read, so the name is not evidence.
+ * True when the name suggests an async call on a member the class never
+ * declares. A written-down type that resolves to nothing belongs to a package
+ * the scan does not read, so the name is not evidence.
  */
 function nameMayBeAsync(callExpr: CallExpression, methodName: string): boolean {
 	const cls = callExpr.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
-	if (cls && declaredReceiver(callExpr, cls)?.getTypeNode()) {
+	const member = thisMemberName(callExpr);
+	if (!(cls && member) || declaresMember(cls, member)) {
 		return false;
 	}
 	const lowerName = methodName.toLowerCase();

--- a/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
+++ b/packages/nestjs-doctor/src/engine/rules/definitions/security/require-guards-on-endpoints.ts
@@ -34,7 +34,7 @@ export const requireGuardsOnEndpoints: Rule = {
 		severity: "warning",
 		description:
 			"Controller endpoints should be protected by @UseGuards() at class or method level",
-		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD or app.useGlobalGuards(), inherited from a guarded base class, or applied by a decorator whose every return is UseGuards(...), directly or through applyDecorators(...), already counts — but APP_GUARD only when the token is written as APP_GUARD, not through an aliased import, and a decorator imported from a package is only read when that package is installed.",
+		help: "Add @UseGuards(AuthGuard) to the controller class or individual route handlers, or mark routes as @Public(). A guard bound through APP_GUARD or app.useGlobalGuards(), inherited from a guarded base class, or applied by a decorator whose every return is UseGuards(...), directly or through applyDecorators(...), already counts — but APP_GUARD only when the token is written as APP_GUARD, not through an aliased import, and a decorator imported from another package is read when that package is a workspace link, not when it is an installed copy.",
 	},
 
 	check(context) {

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-types-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@fixture/rest": "workspace:*",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^11.1.18"
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/app.module.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/app.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { DispatchService } from './dispatch.service';
+import { LocalController } from './local.controller';
+import { LocalRepo } from './local.repo';
+import { PlainController } from './plain.controller';
+import { QueueService } from './queue.service';
+import { ReportsController } from './reports.controller';
+import { UsersController } from './users.controller';
+
+@Module({
+  controllers: [
+    LocalController,
+    PlainController,
+    ReportsController,
+    UsersController,
+  ],
+  providers: [DispatchService, LocalRepo, QueueService],
+})
+export class AppModule {}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/dispatch.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/dispatch.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { QueueService } from './queue.service';
+
+@Injectable()
+export class DispatchService {
+  constructor(private readonly queue: QueueService) {}
+
+  run() {
+    this.queue.enqueue('now');
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/local.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/local.controller.ts
@@ -1,5 +1,4 @@
 import { Controller, Get } from '@nestjs/common';
-import { LocalEntity } from './local.entity';
 import { LocalRepo } from './local.repo';
 
 @Controller('local')

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/local.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/local.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { LocalEntity } from './local.entity';
+import { LocalRepo } from './local.repo';
+
+@Controller('local')
+export class LocalController {
+  constructor(private readonly repo: LocalRepo) {}
+
+  @Get()
+  find() {
+    return this.repo.findOne();
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/local.entity.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/local.entity.ts
@@ -1,0 +1,4 @@
+export class LocalEntity {
+  id!: string;
+  secret!: string;
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/local.repo.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/local.repo.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { LocalEntity } from './local.entity';
+
+@Injectable()
+export class LocalRepo {
+  findOne(): Promise<LocalEntity> {
+    return Promise.resolve(new LocalEntity());
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/plain.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/plain.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('plain')
+export class PlainController {
+  @Get()
+  list() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/queue.service.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/queue.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class QueueService {
+  async enqueue(job: string): Promise<void> {
+    await Promise.resolve(job);
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/reports.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/reports.controller.ts
@@ -1,0 +1,9 @@
+import { ApiController, ReadAll } from '@fixture/rest';
+
+@ApiController('reports')
+export class ReportsController {
+  @ReadAll()
+  list() {
+    return [];
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/src/users.controller.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/src/users.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { UserRepo } from '@fixture/rest';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly repo: UserRepo) {}
+
+  @Get()
+  find() {
+    return this.repo.findOne();
+  }
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/vendor/rest/index.ts
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/vendor/rest/index.ts
@@ -1,0 +1,18 @@
+import { applyDecorators, Controller, Get } from '@nestjs/common';
+
+export const ApiController = (path: string) => applyDecorators(Controller(path));
+
+export const ReadAll = () => applyDecorators(Get());
+
+export declare class UserEntity {
+  id: string;
+  passwordHash: string;
+}
+
+export declare class AddressEntity {
+  city: string;
+}
+
+export declare class UserRepo {
+  findOne(): Promise<UserEntity>;
+}

--- a/packages/nestjs-doctor/tests/fixtures/package-types-app/vendor/rest/package.json
+++ b/packages/nestjs-doctor/tests/fixtures/package-types-app/vendor/rest/package.json
@@ -1,0 +1,1 @@
+{ "name": "@fixture/rest", "version": "1.0.0", "main": "index.ts", "types": "index.ts" }

--- a/packages/nestjs-doctor/tests/integration/global-guards.test.ts
+++ b/packages/nestjs-doctor/tests/integration/global-guards.test.ts
@@ -103,8 +103,8 @@ describe("global guard detection", () => {
 		expect(context.endpointGraph.endpoints).toHaveLength(7);
 	});
 
-	// The decorator lives in a package, so the checker only reads it when that
-	// package is installed. Both directions are pinned here.
+	// The decorator lives in a package, so the checker reads it through a
+	// workspace link but not through an installed copy.
 	describe("a decorator imported from a package", () => {
 		const tempRoot = fs.mkdtempSync(
 			path.join(os.tmpdir(), "nestjs-doctor-package-guard-")

--- a/packages/nestjs-doctor/tests/integration/global-guards.test.ts
+++ b/packages/nestjs-doctor/tests/integration/global-guards.test.ts
@@ -152,6 +152,22 @@ describe("global guard detection", () => {
 			expect(findings[0].filePath).toContain("orders.controller.ts");
 		});
 
+		it("still reads a file inside a package when asked outright", async () => {
+			const src = plant("outright", "copy");
+			const scanConfig = await resolveScanConfig(src);
+			const context = await buildAnalysisContext(src, scanConfig);
+			const inside = path.join(
+				path.dirname(src),
+				"node_modules",
+				"@fixture",
+				"auth",
+				"index.ts"
+			);
+			expect(() =>
+				context.astProject.addSourceFileAtPath(inside)
+			).not.toThrow();
+		});
+
 		it("reports the endpoint when the package is missing", async () => {
 			const findings = await guardFindings(plant("bare", "none"));
 			expect(findings).toHaveLength(1);

--- a/packages/nestjs-doctor/tests/integration/global-guards.test.ts
+++ b/packages/nestjs-doctor/tests/integration/global-guards.test.ts
@@ -114,17 +114,21 @@ describe("global guard detection", () => {
 			fs.rmSync(tempRoot, { recursive: true, force: true });
 		});
 
-		function plant(name: string, installed: boolean) {
+		function plant(name: string, how: "link" | "copy" | "none") {
 			const root = path.join(tempRoot, name);
 			fs.cpSync(resolve(FIXTURES, "package-guard-app"), root, {
 				recursive: true,
 			});
-			if (installed) {
-				const target = path.join(root, "node_modules", "@fixture", "auth");
+			const source = path.join(root, "vendor", "auth");
+			const target = path.join(root, "node_modules", "@fixture", "auth");
+			if (how !== "none") {
 				fs.mkdirSync(path.dirname(target), { recursive: true });
-				fs.cpSync(path.join(root, "vendor", "auth"), target, {
-					recursive: true,
-				});
+			}
+			if (how === "link") {
+				fs.symlinkSync(source, target, "dir");
+			}
+			if (how === "copy") {
+				fs.cpSync(source, target, { recursive: true });
 			}
 			return path.join(root, "src");
 		}
@@ -138,12 +142,18 @@ describe("global guard detection", () => {
 			);
 		}
 
-		it("counts the guard when the package is installed", async () => {
-			expect(await guardFindings(plant("installed", true))).toEqual([]);
+		it("counts a guard from a workspace package linked into node_modules", async () => {
+			expect(await guardFindings(plant("linked", "link"))).toEqual([]);
+		});
+
+		it("reports the endpoint when the decorator is only an installed copy", async () => {
+			const findings = await guardFindings(plant("installed", "copy"));
+			expect(findings).toHaveLength(1);
+			expect(findings[0].filePath).toContain("orders.controller.ts");
 		});
 
 		it("reports the endpoint when the package is missing", async () => {
-			const findings = await guardFindings(plant("bare", false));
+			const findings = await guardFindings(plant("bare", "none"));
 			expect(findings).toHaveLength(1);
 			expect(findings[0].filePath).toContain("orders.controller.ts");
 		});

--- a/packages/nestjs-doctor/tests/integration/installed-packages.test.ts
+++ b/packages/nestjs-doctor/tests/integration/installed-packages.test.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import os from "node:os";
+import path, { resolve } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+	buildAnalysisContext,
+	diagnose,
+	resolveScanConfig,
+} from "../../src/engine/scanner.js";
+
+const FIXTURES = resolve(import.meta.dirname, "../fixtures");
+const tempRoot = fs.mkdtempSync(
+	path.join(os.tmpdir(), "nestjs-doctor-installed-")
+);
+
+afterAll(() => {
+	fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+/** Copies the fixture and puts its vendored package in node_modules, or not. */
+function plant(name: string, how: "link" | "copy" | "none") {
+	const root = path.join(tempRoot, name);
+	fs.cpSync(resolve(FIXTURES, "package-types-app"), root, { recursive: true });
+	const source = path.join(root, "vendor", "rest");
+	const target = path.join(root, "node_modules", "@fixture", "rest");
+	if (how !== "none") {
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+	}
+	if (how === "link") {
+		fs.symlinkSync(source, target, "dir");
+	}
+	if (how === "copy") {
+		fs.cpSync(source, target, { recursive: true });
+	}
+	return path.join(root, "src");
+}
+
+async function scan(target: string) {
+	const scanConfig = await resolveScanConfig(target);
+	const context = await buildAnalysisContext(target, scanConfig);
+	return { context, output: await diagnose(context) };
+}
+
+describe("a decorator that composes @Controller", () => {
+	it("finds the routes when the package is a workspace link", async () => {
+		const { context } = await scan(plant("linked", "link"));
+		const routes = context.endpointGraph.endpoints.map((e) => e.routePath);
+		expect(routes).toContain("/reports");
+	});
+
+	// A package installed as its own copy is not read, so the routes it wraps
+	// are not discovered. Controllers written with @Controller are unaffected.
+	it("finds only the plain controller when the package is an installed copy", async () => {
+		const { context } = await scan(plant("copied", "copy"));
+		const routes = context.endpointGraph.endpoints.map((e) => e.routePath);
+		expect(routes).toContain("/plain");
+		expect(routes).not.toContain("/reports");
+	});
+
+	it("finds only the plain controller when the package is missing", async () => {
+		const { context } = await scan(plant("bare", "none"));
+		const routes = context.endpointGraph.endpoints.map((e) => e.routePath);
+		expect(routes).toContain("/plain");
+		expect(routes).not.toContain("/reports");
+	});
+});
+
+describe("a promise the scan can see", () => {
+	it("is still reported when it is not awaited", async () => {
+		const { output } = await scan(plant("promise", "link"));
+		const findings = output.diagnostics.filter(
+			(diagnostic) => diagnostic.rule === "correctness/no-fire-and-forget-async"
+		);
+		expect(findings).toHaveLength(1);
+		expect(findings[0].filePath).toContain("dispatch.service.ts");
+	});
+});
+
+describe("an entity type a rule has to read", () => {
+	it("is reported when the entity is first-party", async () => {
+		const { output } = await scan(plant("entity-local", "link"));
+		const flagged = output.diagnostics
+			.filter(
+				(diagnostic) => diagnostic.rule === "security/no-raw-entity-in-response"
+			)
+			.map((diagnostic) => diagnostic.filePath.split("/").pop());
+		expect(flagged).toContain("local.controller.ts");
+	});
+
+	// The entity is declared in an installed package, so the return type reads
+	// as `any` and the rule has nothing to match against.
+	it("is not reported when the entity comes from an installed copy", async () => {
+		const { output } = await scan(plant("entity-copy", "copy"));
+		const flagged = output.diagnostics
+			.filter(
+				(diagnostic) => diagnostic.rule === "security/no-raw-entity-in-response"
+			)
+			.map((diagnostic) => diagnostic.filePath.split("/").pop());
+		expect(flagged).toContain("local.controller.ts");
+		expect(flagged).not.toContain("users.controller.ts");
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/phase-timer.test.ts
+++ b/packages/nestjs-doctor/tests/unit/phase-timer.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startPhaseTimer } from "../../src/engine/phase-timer.js";
+
+const COLLECT_LINE = /^\[timing] \/repo collect \d+ms \(\d+ms\)\n$/;
+const PARSE_LINE = /^\[timing] \/repo parse \d+ms \(\d+ms\)\n$/;
+
+function captureStderr() {
+	const lines: string[] = [];
+	const spy = vi
+		.spyOn(process.stderr, "write")
+		.mockImplementation((chunk: string | Uint8Array) => {
+			lines.push(String(chunk));
+			return true;
+		});
+	return { lines, spy };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.env.NESTJS_DOCTOR_PHASE_TIMINGS = undefined;
+	process.env.NESTJS_DOCTOR_PHASE_TIMINGS = "";
+});
+
+describe("startPhaseTimer", () => {
+	it("writes nothing when the variable is unset", () => {
+		process.env.NESTJS_DOCTOR_PHASE_TIMINGS = "";
+		const { lines } = captureStderr();
+		const mark = startPhaseTimer("/repo");
+		mark("collect");
+		mark("parse");
+		expect(lines).toEqual([]);
+	});
+
+	it("writes one line per phase, with the label and the running total", () => {
+		process.env.NESTJS_DOCTOR_PHASE_TIMINGS = "1";
+		const { lines } = captureStderr();
+		const mark = startPhaseTimer("/repo");
+		mark("collect");
+		mark("parse");
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toMatch(COLLECT_LINE);
+		expect(lines[1]).toMatch(PARSE_LINE);
+	});
+});

--- a/packages/nestjs-doctor/tests/unit/phase-timer.test.ts
+++ b/packages/nestjs-doctor/tests/unit/phase-timer.test.ts
@@ -17,7 +17,6 @@ function captureStderr() {
 
 afterEach(() => {
 	vi.restoreAllMocks();
-	process.env.NESTJS_DOCTOR_PHASE_TIMINGS = undefined;
 	process.env.NESTJS_DOCTOR_PHASE_TIMINGS = "";
 });
 

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1282,6 +1282,40 @@ describe("no-fire-and-forget-async", () => {
 		expect(diags[0].message).toContain("sendConfirmation");
 	});
 
+	it("does not guess from the name for a parameter receiver", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      import { Injectable } from '@nestjs/common';
+      import { Response } from 'express';
+      @Injectable()
+      export class FileService {
+        stream(res: Response) {
+          res.sendFile('/tmp/a.pdf');
+        }
+      }
+    `
+		);
+		expect(diags).toEqual([]);
+	});
+
+	it("does not guess from the name for a local receiver", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      import { Injectable } from '@nestjs/common';
+      @Injectable()
+      export class WorkerService {
+        run() {
+          const child = spawn('node');
+          child.send('go');
+        }
+      }
+    `
+		);
+		expect(diags).toEqual([]);
+	});
+
 	it("does not guess from the name when the receiver type is declared", () => {
 		const diags = runRule(
 			noFireAndForgetAsync,

--- a/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
+++ b/packages/nestjs-doctor/tests/unit/rules/correctness-rules.test.ts
@@ -1282,6 +1282,24 @@ describe("no-fire-and-forget-async", () => {
 		expect(diags[0].message).toContain("sendConfirmation");
 	});
 
+	it("does not guess from the name when the receiver type is declared", () => {
+		const diags = runRule(
+			noFireAndForgetAsync,
+			`
+      import { Injectable } from '@nestjs/common';
+      import { WebSocket } from 'ws';
+      @Injectable()
+      export class NotifyService {
+        constructor(private readonly socket: WebSocket) {}
+        notify(message: string) {
+          this.socket.send(message);
+        }
+      }
+    `
+		);
+		expect(diags).toEqual([]);
+	});
+
 	it("allows awaited calls", () => {
 		const diags = runRule(
 			noFireAndForgetAsync,

--- a/packages/nestjs-doctor/tests/unit/source-only-host.test.ts
+++ b/packages/nestjs-doctor/tests/unit/source-only-host.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { createAstParser } from "../../src/engine/graph/ast-parser.js";
+import { createSourceOnlyHost } from "../../src/engine/graph/source-only-host.js";
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "nestjs-doctor-host-"));
+
+afterAll(() => {
+	fs.rmSync(root, { recursive: true, force: true });
+});
+
+/** Writes a file and every directory above it, returning the posix path. */
+function write(relative: string, contents = "export const a = 1;\n") {
+	const full = path.join(root, relative);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, contents);
+	return full.split(path.sep).join("/");
+}
+
+function link(from: string, to: string) {
+	const target = path.join(root, from);
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.symlinkSync(path.join(root, to), target, "dir");
+	return target.split(path.sep).join("/");
+}
+
+describe("createSourceOnlyHost", () => {
+	it("hides a file inside an installed package", () => {
+		const dep = write("app/node_modules/dep/index.d.ts");
+		const host = createSourceOnlyHost([]);
+		expect(host.fileExistsSync(dep)).toBe(false);
+	});
+
+	it("hides the directories of an installed package", () => {
+		write("dirs/node_modules/dep/index.d.ts");
+		const host = createSourceOnlyHost([]);
+		expect(
+			host.directoryExistsSync(
+				`${root}/dirs/node_modules/dep`.split(path.sep).join("/")
+			)
+		).toBe(false);
+	});
+
+	it("shows a package linked out of node_modules", () => {
+		const source = write("ws/packages/lib/index.ts");
+		link("ws/app/node_modules/@acme/lib", "ws/packages/lib");
+		const host = createSourceOnlyHost([]);
+		const through = `${root}/ws/app/node_modules/@acme/lib/index.ts`
+			.split(path.sep)
+			.join("/");
+		expect(fs.existsSync(source)).toBe(true);
+		expect(host.fileExistsSync(through)).toBe(true);
+	});
+
+	it("hides a package linked to another place inside node_modules", () => {
+		write("pnpm/node_modules/.pnpm/dep@1/node_modules/dep/index.d.ts");
+		link(
+			"pnpm/node_modules/dep",
+			"pnpm/node_modules/.pnpm/dep@1/node_modules/dep"
+		);
+		const host = createSourceOnlyHost([]);
+		const through = `${root}/pnpm/node_modules/dep/index.d.ts`
+			.split(path.sep)
+			.join("/");
+		expect(host.fileExistsSync(through)).toBe(false);
+	});
+
+	it("reads a file the scan collected, wherever it sits", () => {
+		const inside = write("kept/node_modules/pkg/src/a.ts");
+		const host = createSourceOnlyHost([inside]);
+		expect(host.fileExistsSync(inside)).toBe(true);
+		expect(host.readFileSync(inside)).toContain("export const a");
+	});
+
+	it("reads a file inside a hidden package when handed the path", () => {
+		const dep = write("read/node_modules/dep/index.d.ts");
+		const host = createSourceOnlyHost([]);
+		expect(host.fileExistsSync(dep)).toBe(false);
+		expect(host.readFileSync(dep)).toContain("export const a");
+	});
+
+	it("leaves a directory whose name only starts with node_modules alone", () => {
+		const near = write("near/node_modules_helper/index.ts");
+		const host = createSourceOnlyHost([]);
+		expect(host.fileExistsSync(near)).toBe(true);
+	});
+
+	it("gives the same answer every time it is asked", () => {
+		const dep = write("stable/node_modules/dep/index.d.ts");
+		const host = createSourceOnlyHost([]);
+		const answers = [1, 2, 3].map(() => host.fileExistsSync(dep));
+		expect(answers).toEqual([false, false, false]);
+	});
+});
+
+describe("the parser built on that host", () => {
+	it("still types the standard library", async () => {
+		const file = write(
+			"lib/app.ts",
+			`
+      export const list = [1, 2, 3].map((n) => n + 1);
+      export const later = Promise.resolve("done");
+      export const text = "a,b".split(",").join("-");
+    `
+		);
+		const project = await createAstParser([file]);
+		const source = project.getSourceFileOrThrow(file);
+		const typeOf = (name: string) =>
+			source.getVariableDeclarationOrThrow(name).getType().getText();
+		expect(typeOf("list")).toBe("number[]");
+		expect(typeOf("later")).toBe("Promise<string>");
+		expect(typeOf("text")).toBe("string");
+	});
+
+	it("keeps the name of a type it cannot read", async () => {
+		write(
+			"named/node_modules/dep/index.d.ts",
+			"export declare class Client { run(): Promise<void>; }\n"
+		);
+		const file = write(
+			"named/src/app.ts",
+			`
+      import { Client } from 'dep';
+      export class Service {
+        constructor(private readonly client: Client) {}
+      }
+    `
+		);
+		const project = await createAstParser([file]);
+		const parameter = project
+			.getSourceFileOrThrow(file)
+			.getClassOrThrow("Service")
+			.getConstructors()[0]
+			.getParameters()[0];
+		expect(parameter.getTypeNode()?.getText()).toBe("Client");
+		expect(parameter.getType().getText()).toBe("Client");
+	});
+});


### PR DESCRIPTION
## Context

Most of the scan is syntactic, but some questions need TypeScript's type checker. Which class a wrapper decorator composes, what a base class is, what a decorator declared in another package does. `resolveDecoratorWrapper` uses it to find controllers, and `decoratorAppliesGuards` uses it to credit composed guards across packages.

Asking the checker one question builds a whole program. TypeScript follows every import out of every scanned file, reads those files off disk, and types them. `skipFileDependencyResolution` only stops ts-morph from adding them to the project; the program still resolves them.

## Problem

On a 354-file project that program is 3324 files and 182 MB. `googleapis` alone is 895 files and 164 MB, then Prisma, the AWS SDK, and the rest. The scanned source is 361 files and 1.4 MB.

Building it took 7.3 seconds of an 8.0 second context build. A 45-project monorepo took 76 seconds.

Two things kept it hidden. `elapsedMs` only ever covered the rule phase, so the context build appeared in no number the tool reported. And the cost lands on whichever pass first touches a symbol, which is endpoint discovery, so every profile said the endpoint trace was slow. It is 398 ms.

Compiler options do not help. Measured on the same project: `skipLibCheck` 5431 ms, `noLib` 5740 ms, `types: []` 5629 ms, against a 5556 ms baseline. All noise.

## Possible flows

Where a resolved declaration lives, and whether the scan still reads it:

| Import | Resolves to | Before | After |
|---|---|---|---|
| `./service` | scanned source | read | read |
| `@myorg/lib` via tsconfig paths | workspace source | read | read |
| `@myorg/lib` linked into node_modules | workspace source, through a symlink | read | read |
| `@myorg/lib` installed as a copy | node_modules | read | not read |
| `@nestjs/common` | node_modules | read | not read |
| TypeScript's own lib files | ts-morph's bundled libs | read | read |

## Solution

`createAstParser` now passes a file system that reports installed packages as absent. Module resolution stops at the boundary of your own code.

Link-aware, because a monorepo usually links its own packages into `node_modules`. The check follows the real path of the package root: if it leads back out of `node_modules` the package stays visible, so `@crocova/logger` and compass's `libs/` still resolve. The package root is resolved once and cached, so the syscall count is the number of packages rather than the number of probes.

A path the scan collected is never hidden, so overriding `exclude` to scan inside `node_modules` still works.

## Before vs after

| | Before | After |
|---|---|---|
| crocova context build | 7971 ms | 711 ms |
| crocova endpoints phase | 7306 ms | 371 ms |
| compass full scan | 76 s | 12 s |
| crocova diagnostics | 275 | 275 |
| TREK diagnostics, 593 files | 491 | 491 |
| compass diagnostics | 167 | 166 |
| compass routes found | 249 | 249 |
| compass `require-guards-on-endpoints` | 22 | 22 |

One finding moves, on compass. `$disconnect()` is not awaited, and only Prisma's types know that call returns a promise, so the rule no longer has grounds to report it.

It also fixes a disagreement the scan already had with itself. On TREK, main reports 491 findings with dependencies installed and 502 without. This branch reports 491 either way. That gap lands on `--scope changed`, which scans the base revision in a throwaway worktree with no install, so those 11 findings read as introduced by whichever pull request touched the file.

Two rules changed to get there, both because a type that a dependency owns now reads as `any`.

`correctness/no-fire-and-forget-async` guessed from the method name whenever a return type was unresolvable. That used to be rare and is now every call into a package, so `res.sendFile()`, `child.send()` and `socket.send()` were reported as unawaited promises: ten of them on TREK. It now guesses only for `this.member.method()` where the class declares no such member, which is the unanalysable case the guess was written for.

`security/require-guards-on-endpoints` says in its help text that a decorator from another package counts through a workspace link and not through an installed copy.

Rules that read a declaration rather than a value are unaffected, which is why the module graph, the provider map and the route list do not move. An unresolved import still yields a type named after the identifier, so `getTypeNode()` and name-based lookups see what they saw before.

## Example

```
$ NESTJS_DOCTOR_PHASE_TIMINGS=1 nestjs-doctor apps/api --json
```

Before:

```
[timing] apps/api parse 252ms (260ms)
[timing] apps/api modules 386ms (646ms)
[timing] apps/api endpoints 7306ms (7963ms)
[timing] apps/api guards 5ms (7971ms)
```

After:

```
[timing] apps/api parse 165ms (173ms)
[timing] apps/api modules 129ms (302ms)
[timing] apps/api endpoints 398ms (705ms)
[timing] apps/api guards 4ms (711ms)
```

Same 275 diagnostics, same 157 endpoints, same score.

One guard case changes, and the fixture pins all three sides of it. A composed guard decorator in a workspace package linked into `node_modules` is still credited. One that exists only as an installed copy is not, and the endpoint is reported rather than quietly cleared. The rule's help text says which is which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcDqSoqXMLYxNVQNpRrdcQ
