### PR TITLE
chore: release the code graph and the endpoints tab as a patch

### DIFF
--- a/.changeset/code-graph-in-report.md
+++ b/.changeset/code-graph-in-report.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Build the code graph during a scan and embed it in the report artifact, so `--report` and `--format report-json` carry one node per declared method with each call site as an edge. Calls to functions and static methods the project declares are now nodes too, which on a 1444-file monorepo adds 142 nodes and 1048 edges. Nothing else builds it: a console scan, `--format json` and `--score` are unchanged and pay nothing.

--- a/.changeset/project-code-graph.md
+++ b/.changeset/project-code-graph.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Add the project-wide code graph to the Node API: one node per declared method of every Nest class, with each call site as an edge, so a method reached by two endpoints is one node instead of one subtree per path. Each node carries its ordered body, so a consumer can replay what an endpoint does: the conditions enclosing each call, which arms are mutually exclusive, where control returns or throws, whether a call is awaited, and which `try` covers it. `encodeCodeGraph` and `decodeCodeGraph` round-trip it through a compact form that is under a third of the size. Building it costs a pass over every indexed method, so only a caller that reads the report artifact pays for it.

--- a/.changeset/report-descent-tab.md
+++ b/.changeset/report-descent-tab.md
@@ -1,5 +1,5 @@
 ---
-"nestjs-doctor": minor
+"nestjs-doctor": patch
 ---
 
 Replace the report's Endpoints canvas with a walk of the code graph: every method a route reaches laid out by call depth with one wire per call site, a player that steps the execution walk, a one-line verdict on whether the route's first database call is a read or a write, and a source pane that opens a method beside the map (a database or external node opens at the call site that reached it). The interactive menu's HTML report now carries the code graph, and the artifact gains an optional `root`, the posix path the scan ran from. A report saved before the code graph existed shows no Endpoints tab instead of the old canvas. A share written from the report's own dialog carries the code graph, with file paths relative to the scan root, so its Endpoints tab opens; a share from the command line or the menu does not.


### PR DESCRIPTION
## Context

Eight changesets are pending on main. Three are `minor` (the project code graph, the code graph in the report, the Descent endpoints tab), so the open Version Packages PR bumps `nestjs-doctor` from 0.9.8 to 0.10.0.

## Problem

The next release should be a patch. The release branch is rebuilt by the changesets bot from main on every push, so editing it directly is overwritten.

## Possible flows

| Path | Effect |
|---|---|
| Edit `changeset-release/main` directly | Overwritten on the next push to main |
| Flip the three changesets to `patch` on main | The bot regenerates the release PR as 0.9.9 |

## Solution

Change the bump type on the three `minor` changesets to `patch`. Text unchanged.

## Before vs after

| | Before | After |
|---|---|---|
| Next version | 0.10.0 | 0.9.9 |
| Changeset text | Unchanged | Unchanged |
| Other five changesets | patch | patch |

## Example

```
-"nestjs-doctor": minor
+"nestjs-doctor": patch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
