### PR TITLE
ci: skip the marketplace upload when it already has the extension version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,25 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter nestjs-doctor-lsp build
       - run: pnpm --filter nestjs-doctor-vscode build
+      - name: Check whether the marketplace already has this version
+        id: marketplace
+        run: |
+          set -euo pipefail
+          local_version="$(node -p "require('./packages/nestjs-doctor-vscode/package.json').version")"
+          published="$(curl -sS --max-time 30 -X POST \
+            "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json;api-version=3.0-preview.1" \
+            -d '{"filters":[{"criteria":[{"filterType":7,"value":"rolobits.nestjs-doctor-vscode"}]}],"flags":1}' \
+            | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).results[0].extensions[0]?.versions[0]?.version ?? ''")"
+          echo "local=$local_version marketplace=$published"
+          if [ "$local_version" = "$published" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish to VS Code Marketplace
+        if: steps.marketplace.outputs.publish == 'true'
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## Context

The Release workflow publishes npm packages through changesets, then a second job uploads the VS Code extension whenever anything was published, relying on the action's `skipDuplicate` to no-op when the marketplace already has that version.

## Problem

Since 2026-09-08 that duplicate upload hangs on the gallery API for three minutes and fails the job. The extension has been 0.1.5 since 2026-09-03 throughout.

| Run | Date | Extension job |
|---|---|---|
| 33699169558 | 09-03 | success, published 0.1.5 |
| 34056815219 | 09-06 | success, "Version 0.1.5 is already published. Skipping publish." in 8 s |
| 34281130223 | 09-08 | failure, `Request timeout: /_apis/gallery` after 3 min |
| 34706310114 | 09-12 | failure, same, twice (re-run) |

npm publishes were unaffected; 0.9.9 is live.

## Possible flows

| Path | Before | After |
|---|---|---|
| npm release, extension version unchanged | Upload attempted, times out, red job | Query says versions match, upload skipped |
| npm release, extension version bumped | Upload runs | Query says local is ahead, upload runs |
| Nothing published | Job skipped | Unchanged |
| Marketplace query itself fails | n/a | `set -e` fails the step; the upload does not run blind |

## Solution

One step before the upload asks the public `extensionquery` endpoint, which still answers in under a second, for the latest published version and compares it with `package.json`. The upload runs only when they differ. `skipDuplicate` stays as a second net.

Not done: no retry on the upload, since the hang reproduces on every attempt, and no change to the npm side.

## Before vs after

| | Before | After |
|---|---|---|
| Release with no extension bump | Extension job red after 3 min | Extension job green in seconds, upload skipped |
| Release with an extension bump | Upload | Upload |
| npm publish | Unchanged | Unchanged |

## Example

Run locally against the current marketplace:

```
local=0.1.5 marketplace=0.1.5
```

so the upload step would be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
